### PR TITLE
Add config files for supported machines

### DIFF
--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -34,14 +34,20 @@ def get_config(config_file, machine):
     config.read(default_config)
 
     if machine is not None:
-        if not machine.startswith('conda'):
-            machine_config = \
-                str(importlib.resources.files('mache.machines') /
-                    f'{machine}.cfg')
+        machine_config = \
+            str(importlib.resources.files('mache.machines') /
+                f'{machine}.cfg')
+        # it's okay if a given machine isn't part of mache
+        if os.path.exists(machine_config):
             config.read(machine_config)
 
         machine_config = os.path.join(here, '..', 'polaris', 'machines',
                                       f'{machine}.cfg')
+        if not os.path.exists(machine_config):
+            raise FileNotFoundError(
+                f'Could not find a config file for this machine at '
+                f'polaris/machines/{machine}.cfg')
+
         config.read(machine_config)
 
     if config_file is not None:

--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -30,7 +30,7 @@ otps = 2021.10
 # versions of conda or spack packages (depending on machine type)
 esmf = 8.2.0
 netcdf_c = 4.8.1
-netcdf_fortran = 4.5.3
+netcdf_fortran = 4.6
 pnetcdf = 1.12.2
 scorpio = 1.3.2
 

--- a/polaris/machines/anvil.cfg
+++ b/polaris/machines/anvil.cfg
@@ -1,0 +1,29 @@
+# The paths section describes paths for data and environments
+[paths]
+
+# A shared root directory where polaris data can be found
+database_root = /lcrc/group/e3sm/public_html/polaris
+
+# the path to the base conda environment where polars environments have
+# been created
+polaris_envs = /lcrc/soft/climate/polaris/anvil/base
+
+
+# Options related to deploying a polaris conda and spack environments
+[deploy]
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use for intel compiler
+mpi_intel = impi
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = openmpi
+
+# the base path for spack environments used by polaris
+spack = /lcrc/soft/climate/polaris/anvil/spack
+
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = True

--- a/polaris/machines/chicoma-cpu.cfg
+++ b/polaris/machines/chicoma-cpu.cfg
@@ -1,0 +1,50 @@
+# The paths section describes paths for data and environments
+[paths]
+
+# A shared root directory where polaris data can be found
+database_root = /usr/projects/e3sm/polaris/
+
+# the path to the base conda environment where polaris environments have
+# been created
+polaris_envs = /usr/projects/e3sm/polaris/chicoma-cpu/conda/base
+
+
+# Options related to deploying a polaris conda and spack environments
+[deploy]
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = gnu
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = mpich
+
+# the base path for spack environments used by polaris
+spack = /usr/projects/e3sm/polaris/chicoma-cpu/spack
+
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = True
+
+
+# The parallel section describes options related to running jobs in parallel
+[parallel]
+
+# account for running diagnostics jobs
+account =
+
+# cores per node on the machine
+cores_per_node = 128
+
+# threads per core (set to 1 because trying to hyperthread seems to be causing
+# hanging on perlmutter)
+threads_per_core = 1
+
+
+# Config options related to creating a job script
+[job]
+
+# The job partition to use
+partition = standard
+
+# The job quality of service (QOS) to use
+qos = standard

--- a/polaris/machines/chrysalis.cfg
+++ b/polaris/machines/chrysalis.cfg
@@ -1,0 +1,29 @@
+# The paths section describes paths for data and environments
+[paths]
+
+# A shared root directory where polaris data can be found
+database_root = /lcrc/group/e3sm/public_html/polaris
+
+# the path to the base conda environment where polars environments have
+# been created
+polaris_envs = /lcrc/soft/climate/polaris/chrysalis/base
+
+
+# Options related to deploying a polaris conda and spack environments
+[deploy]
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use for intel compiler
+mpi_intel = openmpi
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = openmpi
+
+# the base path for spack environments used by polaris
+spack = /lcrc/soft/climate/polaris/chrysalis/spack
+
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = True

--- a/polaris/machines/compy.cfg
+++ b/polaris/machines/compy.cfg
@@ -1,0 +1,31 @@
+# The paths section describes paths for data and environments
+[paths]
+
+# A shared root directory where polaris data can be found
+database_root = /compyfs/polaris
+
+# the path to the base conda environment where polaris environments have
+# been created
+polaris_envs = /share/apps/E3SM/polaris/conda/base
+
+
+# Options related to deploying a polaris conda and spack environments
+[deploy]
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use for intel compiler
+mpi_intel = impi
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = openmpi
+
+# the base path for spack environments used by polaris
+spack = /share/apps/E3SM/polaris/spack
+
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+#
+# We don't use them on Compy because hdf5 and netcdf were build without MPI
+use_e3sm_hdf5_netcdf = False

--- a/polaris/machines/conda-linux.cfg
+++ b/polaris/machines/conda-linux.cfg
@@ -1,0 +1,8 @@
+# Options related to deploying a polaris conda and spack environments
+[deploy]
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = gnu
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = mpich

--- a/polaris/machines/conda-osx.cfg
+++ b/polaris/machines/conda-osx.cfg
@@ -1,0 +1,8 @@
+# Options related to deploying a polaris conda and spack environments
+[deploy]
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = clang
+
+# the system MPI library to use for gnu compiler
+mpi_clang = mpich

--- a/polaris/machines/cori-haswell.cfg
+++ b/polaris/machines/cori-haswell.cfg
@@ -1,0 +1,40 @@
+# The paths section describes paths for data and environments
+[paths]
+
+# A shared root directory where polaris data can be found
+database_root = /global/cfs/cdirs/e3sm/polaris
+
+# the path to the base conda environment where polaris environments have
+# been created
+polaris_envs = /global/common/software/e3sm/polaris/cori-haswell/conda/base
+
+
+# Options related to deploying a polaris conda and spack environments
+[deploy]
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use for intel compiler
+mpi_intel = mpt
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = mpt
+
+# the base path for spack environments used by polaris
+spack = /global/cfs/cdirs/e3sm/software/polaris/cori-haswell/spack
+
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = True
+
+# the version of ESMF to build if using system compilers and MPI (don't build)
+esmf = None
+
+
+# Config options related to creating a job script
+[job]
+
+# The job constraint to use, by default, taken from the first constraint (if
+# any) provided for the  machine by mache
+constraint = haswell

--- a/polaris/machines/default.cfg
+++ b/polaris/machines/default.cfg
@@ -1,0 +1,8 @@
+# The parallel section describes options related to running tests in parallel
+[parallel]
+
+# parallel system of execution: slurm or single_node
+system = single_node
+
+# whether to use mpirun or srun to run the model
+parallel_executable = mpirun

--- a/polaris/machines/pm-cpu.cfg
+++ b/polaris/machines/pm-cpu.cfg
@@ -1,0 +1,38 @@
+# The paths section describes paths for data and environments
+[paths]
+
+# A shared root directory where polaris data can be found
+database_root = /global/cfs/cdirs/e3sm/polaris
+
+# the path to the base conda environment where polaris environments have
+# been created
+polaris_envs = /global/common/software/e3sm/polaris/pm-cpu/conda/base
+
+
+# Options related to deploying a polaris conda and spack environments
+[deploy]
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = gnu
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = mpich
+
+# the base path for spack environments used by polaris
+spack = /global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack
+
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = True
+
+# The parallel section describes options related to running jobs in parallel.
+# Most options in this section come from mache so here we just add or override
+# some defaults
+[parallel]
+
+# cores per node on the machine
+cores_per_node = 128
+
+# threads per core (set to 1 because trying to hyperthread seems to be causing
+# hanging on perlmutter)
+threads_per_core = 1


### PR DESCRIPTION
Fix netcdf-fortran version to match conda-forge pin

Fix how machine configs from mache and polaris are read during bootstrapping.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
