### PR TITLE
Fix copying docs

### DIFF
--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -73,9 +73,10 @@ jobs:
           touch .nojekyll
           # Add `index.html` to point to the `main` branch automatically.
           printf '<meta http-equiv="refresh" content="0; url=./main/index.html" />' > index.html
-          # Only replace `main` docs with latest changes. Docs for tags should be untouched.
-          rm -rf v*.*.* main
-          cp -r ../_build/html/* .
+          # Only replace `main` docs with latest changes. Docs for releases should be untouched.
+          rm -rf main
+          # don't clobber existing release versions (in case we retroactively fixed them)
+          cp -r -n ../_build/html/* .
           # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
This merge changes the GitHub Action for building and pushing the docs to only copy release tags if they aren't already on the web page.  This way, we can retroactively modify old releases if we need to without them getting clobbered.