### PR TITLE
Fix deprecated calls to `importlib.resources`

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master

--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -10,6 +10,7 @@ esmf={{ esmf }}={{ mpi_prefix }}_*
 ffmpeg
 geometric_features={{ geometric_features }}
 git
+importlib_resources
 ipython
 jigsaw={{ jigsaw }}
 jigsawpy={{ jigsawpy }}

--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -23,7 +23,7 @@ mpi = nompi
 geometric_features = 1.0.1
 jigsaw = 0.9.14
 jigsawpy = 0.3.3
-mache = 1.12.0
+mache = 1.13.0
 mpas_tools = 0.18.0
 otps = 2021.10
 

--- a/polaris/cache.py
+++ b/polaris/cache.py
@@ -5,11 +5,11 @@ import pickle
 import shutil
 import sys
 from datetime import datetime
-from importlib import resources
 from typing import Dict, List
 
 from polaris import Step
 from polaris.config import PolarisConfigParser
+from polaris.io import imp_res
 
 
 def update_cache(step_paths, date_string=None, dry_run=False):
@@ -72,9 +72,9 @@ def update_cache(step_paths, date_string=None, dry_run=False):
             # we don't have a local version of the file yet, let's see if
             # there's a remote one for this component
             try:
-                with resources.path(package, 'cached_files.json') as path:
-                    with open(path) as data_file:
-                        cached_files = json.load(data_file)
+                pkg_file = imp_res.files(package).joinpath('cached_files.json')
+                with pkg_file.open('r') as data_file:
+                    cached_files = json.load(data_file)
             except FileNotFoundError:
                 # no cached files yet for this core
                 cached_files = dict()

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -1,5 +1,6 @@
 import json
-from importlib import resources
+
+from polaris.io import imp_res
 
 
 class Component:
@@ -66,9 +67,9 @@ class Component:
         package = f'polaris.{self.name}'
         filename = 'cached_files.json'
         try:
-            with resources.path(package, filename) as path:
-                with open(path) as data_file:
-                    self.cached_files = json.load(data_file)
+            pkg_file = imp_res.files(package).joinpath(filename)
+            with pkg_file.open('r') as data_file:
+                self.cached_files = json.load(data_file)
         except FileNotFoundError:
             # no cached files for this core
             pass

--- a/polaris/io.py
+++ b/polaris/io.py
@@ -1,7 +1,14 @@
-import importlib.resources
 import os
+import sys
 import tempfile
+from typing import TYPE_CHECKING  # noqa: F401
 from urllib.parse import urlparse
+
+if TYPE_CHECKING or sys.version_info >= (3, 9, 0):
+    import importlib.resources as imp_res  # noqa: F401
+else:
+    # python <= 3.8
+    import importlib_resources as imp_res  # noqa: F401
 
 import progressbar
 import requests
@@ -188,26 +195,6 @@ def symlink(target, link_name, overwrite=True):
         if os.path.islink(temp_link_name):
             os.remove(temp_link_name)
         raise
-
-
-def package_path(package, resource):
-    """
-    A replacement for deprecated ``importlib.resources.path()``:
-    https://github.com/python/importlib_resources/blob/7e9020a1b84726fdc6ba71ee2893119d1ee61e02/importlib_resources/_legacy.py
-
-    Parameters
-    ----------
-    package : Package
-        The python package for the resource
-    resource : Resource
-        The file within the package
-    """
-    parent, file_name = os.path.split(str(resource))
-    if parent:
-        raise ValueError(f'{resource!r} must be only a file name')
-
-    return importlib.resources.as_file(
-        importlib.resources.files(package) / file_name)
 
 
 # From https://stackoverflow.com/a/1094933/7728169

--- a/polaris/job/__init__.py
+++ b/polaris/job/__init__.py
@@ -1,8 +1,9 @@
 import os
-from importlib import resources
 
 import numpy as np
 from jinja2 import Template
+
+from polaris.io import imp_res
 
 
 def write_job_script(config, machine, target_cores, min_cores, work_dir,
@@ -82,8 +83,8 @@ def write_job_script(config, machine, target_cores, min_cores, work_dir,
             job_name = f'polaris_{suite}'
     wall_time = config.get('job', 'wall_time')
 
-    template = Template(resources.read_text(
-        'polaris.job', 'job_script.template'))
+    template = Template(imp_res.files('polaris.job').joinpath(
+        'job_script.template').read_text())
 
     text = template.render(job_name=job_name, account=account,
                            nodes=f'{nodes}', wall_time=wall_time, qos=qos,

--- a/polaris/namelist.py
+++ b/polaris/namelist.py
@@ -1,5 +1,6 @@
-from importlib import resources
 from typing import Dict
+
+from polaris.io import imp_res
 
 
 def parse_replacements(package, namelist):
@@ -20,7 +21,7 @@ def parse_replacements(package, namelist):
         A dictionary of replacement namelist options
     """
 
-    lines = resources.read_text(package, namelist).split('\n')
+    lines = imp_res.files(package).joinpath(namelist).read_text().split('\n')
     replacements = dict()
     for line in lines:
         if '=' in line:
@@ -52,7 +53,7 @@ def ingest(defaults_filename):
 def replace(namelist, replacements):
     """ Replace entries in the namelist using the replacements dict """
     new = dict(namelist)
-    is_not_replaced = [True for key in replacements.keys()]
+    is_not_replaced = [True for _ in replacements.keys()]
     for record in new:
         for idx, key in enumerate(replacements):
             if key in new[record]:

--- a/polaris/ocean/vertical/grid_1d.py
+++ b/polaris/ocean/vertical/grid_1d.py
@@ -1,10 +1,11 @@
 import json
-from importlib import resources
 
 import numpy
 import numpy as np
 from netCDF4 import Dataset
 from scipy.optimize import root_scalar
+
+from polaris.io import imp_res
 
 
 def generate_1d_grid(config):
@@ -129,8 +130,9 @@ def _generate_uniform(vert_levels):
 def _read_json(grid_type):
     """ Read the grid interfaces from a json file """
 
-    filename = '{grid_type}.json'
-    with resources.open_text("polaris.ocean.vertical", filename) as data_file:
+    package = 'polaris.ocean.vertical'
+    filename = f'{grid_type}.json'
+    with imp_res.files(package).joinpath(filename).open('r') as data_file:
         data = json.load(data_file)
         interfaces = numpy.array(data)
 

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -8,7 +8,7 @@ import progressbar
 from mache import MachineInfo
 
 from polaris.config import PolarisConfigParser
-from polaris.io import download, package_path, symlink
+from polaris.io import download, imp_res, symlink
 
 
 class Step:
@@ -493,8 +493,8 @@ class Step:
         if package is not None:
             if target is None:
                 target = filename
-            with package_path(package, target) as path:
-                target = str(path)
+            target = str(imp_res.as_file(
+                imp_res.files(package).joinpath(target)))
 
         if work_dir_target is not None:
             target = os.path.join(base_work_dir, work_dir_target)

--- a/polaris/streams.py
+++ b/polaris/streams.py
@@ -1,8 +1,9 @@
 from copy import deepcopy
-from importlib import resources
 
 from jinja2 import Template
 from lxml import etree
+
+from polaris.io import imp_res
 
 
 def read(package, streams_filename, tree=None, replacements=None):
@@ -30,10 +31,9 @@ def read(package, streams_filename, tree=None, replacements=None):
         A tree of XML data describing MPAS i/o streams with the content from
         the given streams file
     """
-    if replacements is None:
-        text = resources.read_text(package, streams_filename)
-    else:
-        template = Template(resources.read_text(package, streams_filename))
+    text = imp_res.files(package).joinpath(streams_filename).read_text()
+    if replacements is not None:
+        template = Template(text)
         text = template.render(**replacements)
 
     new_tree = etree.fromstring(text)

--- a/polaris/suite.py
+++ b/polaris/suite.py
@@ -1,8 +1,8 @@
 import argparse
 import sys
-from importlib import resources
 from typing import List
 
+from polaris.io import imp_res
 from polaris.setup import setup_cases
 
 
@@ -44,8 +44,9 @@ def setup_suite(component, suite_name, work_dir, config_file=None,
     copy_executable : bool, optional
         Whether to copy the MPAS executable to the work directory
     """
-    text = resources.read_text(f'polaris.{component}.suites',
-                               f'{suite_name}.txt')
+
+    text = imp_res.files(f'polaris.{component}.suites').joinpath(
+        f'{suite_name}.txt').read_text()
 
     tests, cached = _parse_suite(text)
 

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.1.0-alpha.1'
+__version__ = '0.1.0-alpha.2'

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ python_requires = >=3.8,<3.12
 install_requires =
     cartopy
     cmocean
+    importlib_resources
     ipython
     jigsawpy==0.3.3
     jupyter


### PR DESCRIPTION
To save a little trouble, an import shortcut has been added to polaris.io for `imp_res` that handles both different imports for python <=3.8 and the complaints that mypy has about these imports.

This merge also includes an update to `mache 1.13.0` and to `polaris 0.1.0-alpha.2`.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
