### PR TITLE
Add ocean model descriptions to docs

### DIFF
--- a/docs/developers_guide/ocean/index.md
+++ b/docs/developers_guide/ocean/index.md
@@ -95,4 +95,5 @@ appropriate for whichever of the {ref}`machines` you are using.
 :titlesonly: true
 
 test_groups/index
+models/index
 ```

--- a/docs/developers_guide/ocean/models/index.md
+++ b/docs/developers_guide/ocean/models/index.md
@@ -1,0 +1,15 @@
+(dev-models)=
+
+# Models
+
+Polaris is designed to support multiple ocean models.
+
+(dev-supported-models)=
+
+## Supported Models
+
+```{toctree}
+:titlesonly: true
+
+mpas_ocean
+```

--- a/docs/developers_guide/ocean/models/mpas_ocean.md
+++ b/docs/developers_guide/ocean/models/mpas_ocean.md
@@ -1,0 +1,43 @@
+# MPAS-Ocean
+
+The following are considerations that may be useful in developing a test case for MPAS-Ocean
+
+## Initial conditions
+
+The minimal set of initial state variables that must be defined in the `initial_state` step of each test case is:
+
+* `temperature`
+* `salinity`
+* `normalVelocity`
+* `fCell`
+* `fEdge`
+* `fVertex`
+
+## Boundary conditions
+
+The following horizontal boundary conditions are supported for planar domains
+
+* periodic
+* free slip (solid boundary, `normalVelocity = 0` at edges of the domain,
+tangential force is 0)
+
+These horizontal boundary conditions are enforced at the stage at which the
+planar mesh is constructed, by specifying `nonperiodic` as true or false.
+
+The following vertical boundary conditions are supported:
+
+* free slip (tangential force is 0, drag is disabled). Generally only used for
+the free surface.
+* free surface with specified flux (of mass, momentum, and/or scalars).
+Generally only possible at the top boundary.
+* rigid surface with no slip (velocity normal to the surface is zero,
+tangential force is non-zero because bottom or top drag is applied). While the
+boundary is no-slip, `normalVelocity` is solved at the mid-point of the layer
+and is generally non-zero.
+
+## Forcing
+
+Constant or time-varying forcing is possible for some properties. The forcing
+fields (generally 2-d and applied at the surface) are generally read in from a
+forcing stream. For more details, start by consulting the Registry under the
+headings `forcing` and `tidal_forcing`.

--- a/docs/users_guide/ocean/index.md
+++ b/docs/users_guide/ocean/index.md
@@ -1,6 +1,6 @@
 (ocean)=
 
-# Ocean conponent
+# Ocean component
 
 The `ocean` component in polaris contains test groups and test cases for the
 [MPAS-Ocean](https://mpas-dev.github.io/ocean/ocean.html)) and 


### PR DESCRIPTION
Add some description of the supported ocean models (now just MPAS-Ocean) to documentation. The focus here is configuration options that are most relevant to developing test cases.

Checklist
* [X] Developer's Guide has been updated
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected