### PR TITLE
Add planar horizontal viz

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -337,7 +337,18 @@ ocean/api
    compare_timers
 ```
 
-### validate
+#### viz
+
+```{eval-rst}
+.. currentmodule:: polaris.viz
+
+.. autosummary::
+   :toctree: generated/
+
+   plot_horiz_field
+```
+
+### yaml
 
 ```{eval-rst}
 .. currentmodule:: polaris.yaml

--- a/docs/developers_guide/framework.md
+++ b/docs/developers_guide/framework.md
@@ -471,6 +471,46 @@ from an MPAS mesh file.  Optionally, you can provide the name of an MPAS field
 on cells in the mesh file that gives different weight to different cells
 (`weight_field`) in the partitioning process.
 
+(dev-visualization)=
+
+## Visualization
+
+Visualization is an optional, but desirable aspect of test cases. Often,
+visualization is an optional step of a test case but can also be included
+as part of other steps such as `initial_state` or `analysis`.
+
+While developers can write their own visualization scripts associated with
+individual test cases, the following shared visualization routines are
+provided in `polaris.viz`:
+
+{py:func}`polaris.viz.plot_horiz_field()` produces a patches-style
+visualization of x-y fields across a single vertical level at a single time
+step. The image file (png) is saved to the directory from which
+{py:func}`polaris.viz.plot_horiz_field()` is called. The function
+automatically detects whether the field specified by its variable name is
+a cell-centered variable or an edge-variable and generates the patches, the
+polygons characterized by the field values, accordingly.
+
+```{image} images/baroclinic_channel_cell_patches.png
+:align: center
+:width: 250 px
+```
+
+```{image} images/baroclinic_channel_edge_patches.png
+:align: center
+:width: 250 px
+```
+
+An example function call that uses the default vertical level (top) is:
+
+```python
+plot_horiz_field(config, ds, ds_mesh, 'normalVelocity',
+                 'final_normalVelocity.png',
+                 t_index=t_index,
+                 vmin=-max_velocity, vmax=max_velocity,
+                 cmap='cmo.balance', show_patch_edges=True)
+```
+
 (dev-validation)=
 
 ## Validation

--- a/polaris/ocean/tests/baroclinic_channel/default/__init__.py
+++ b/polaris/ocean/tests/baroclinic_channel/default/__init__.py
@@ -1,5 +1,6 @@
 from polaris.ocean.tests.baroclinic_channel import BaroclinicChannelTestCase
 from polaris.ocean.tests.baroclinic_channel.forward import Forward
+from polaris.ocean.tests.baroclinic_channel.viz import Viz
 from polaris.validate import compare_variables
 
 
@@ -28,6 +29,9 @@ class Default(BaroclinicChannelTestCase):
         self.add_step(
             Forward(test_case=self, ntasks=4, min_tasks=4, openmp_threads=1,
                     resolution=resolution, run_time_steps=3))
+
+        self.add_step(
+            Viz(test_case=self))
 
     def validate(self):
         """

--- a/polaris/ocean/tests/baroclinic_channel/initial_state.py
+++ b/polaris/ocean/tests/baroclinic_channel/initial_state.py
@@ -1,3 +1,4 @@
+import cmocean  # noqa: F401
 import numpy as np
 import xarray as xr
 from mpas_tools.io import write_netcdf
@@ -81,6 +82,7 @@ class InitialState(Step):
         init_vertical_coord(config, ds)
 
         dsMesh['maxLevelCell'] = ds.maxLevelCell
+
         xMin = xCell.min().values
         xMax = xCell.max().values
         yMin = yCell.min().values
@@ -145,3 +147,6 @@ class InitialState(Step):
 
         plot_horiz_field(config, ds, dsMesh, 'temperature',
                          'initial_temperature.png')
+        plot_horiz_field(config, ds, dsMesh, 'normalVelocity',
+                         'initial_normalVelocity.png', cmap='cmo.balance',
+                         show_patch_edges=True)

--- a/polaris/ocean/tests/baroclinic_channel/initial_state.py
+++ b/polaris/ocean/tests/baroclinic_channel/initial_state.py
@@ -6,6 +6,7 @@ from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.ocean.vertical import init_vertical_coord
 from polaris.step import Step
+from polaris.viz import plot_horiz_field
 
 
 class InitialState(Step):
@@ -79,6 +80,7 @@ class InitialState(Step):
 
         init_vertical_coord(config, ds)
 
+        dsMesh['maxLevelCell'] = ds.maxLevelCell
         xMin = xCell.min().values
         xMax = xCell.max().values
         yMin = yCell.min().values
@@ -140,3 +142,6 @@ class InitialState(Step):
         ds['fVertex'] = coriolis_parameter * xr.ones_like(ds.xVertex)
 
         write_netcdf(ds, 'initial_state.nc')
+
+        plot_horiz_field(config, ds, dsMesh, 'temperature',
+                         'initial_temperature.png')

--- a/polaris/ocean/tests/baroclinic_channel/initial_state.py
+++ b/polaris/ocean/tests/baroclinic_channel/initial_state.py
@@ -145,8 +145,8 @@ class InitialState(Step):
 
         write_netcdf(ds, 'initial_state.nc')
 
-        plot_horiz_field(config, ds, dsMesh, 'temperature',
+        plot_horiz_field(ds, dsMesh, 'temperature',
                          'initial_temperature.png')
-        plot_horiz_field(config, ds, dsMesh, 'normalVelocity',
+        plot_horiz_field(ds, dsMesh, 'normalVelocity',
                          'initial_normalVelocity.png', cmap='cmo.balance',
                          show_patch_edges=True)

--- a/polaris/ocean/tests/baroclinic_channel/viz.py
+++ b/polaris/ocean/tests/baroclinic_channel/viz.py
@@ -37,14 +37,13 @@ class Viz(Step):
         """
         Run this step of the test case
         """
-        config = self.config
         ds_mesh = xr.load_dataset('initial_state.nc')
         ds = xr.load_dataset('output.nc')
         t_index = ds.sizes['Time'] - 1
-        plot_horiz_field(config, ds, ds_mesh, 'temperature',
+        plot_horiz_field(ds, ds_mesh, 'temperature',
                          'final_temperature.png', t_index=t_index)
         max_velocity = np.max(np.abs(ds.normalVelocity.values))
-        plot_horiz_field(config, ds, ds_mesh, 'normalVelocity',
+        plot_horiz_field(ds, ds_mesh, 'normalVelocity',
                          'final_normalVelocity.png',
                          t_index=t_index,
                          vmin=-max_velocity, vmax=max_velocity,

--- a/polaris/ocean/tests/baroclinic_channel/viz.py
+++ b/polaris/ocean/tests/baroclinic_channel/viz.py
@@ -1,0 +1,51 @@
+import cmocean  # noqa: F401
+import numpy as np
+import xarray as xr
+
+from polaris.step import Step
+from polaris.viz import plot_horiz_field
+
+
+class Viz(Step):
+    """
+    A step for plotting the results of a series of RPE runs in the baroclinic
+    channel test group
+
+    Attributes
+    ----------
+    nus : list
+        A list of viscosities
+    """
+    def __init__(self, test_case):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        test_case : polaris.TestCase
+            The test case this step belongs to
+        """
+        super().__init__(test_case=test_case, name='viz')
+        self.add_input_file(
+            filename='initial_state.nc',
+            target='../initial_state/initial_state.nc')
+        self.add_input_file(
+            filename='output.nc',
+            target='../forward/output.nc')
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        config = self.config
+        dsMesh = xr.load_dataset('initial_state.nc')
+        ds = xr.load_dataset('output.nc')
+        tIndex = ds.sizes['Time'] - 1
+        plot_horiz_field(config, ds, dsMesh, 'temperature',
+                         'final_temperature.png', tIndex=tIndex)
+        max_velocity = np.max(np.abs(ds.normalVelocity.values))
+        plot_horiz_field(config, ds, dsMesh, 'normalVelocity',
+                         'final_normalVelocity.png',
+                         tIndex=tIndex,
+                         vmin=-1 * max_velocity, vmax=max_velocity,
+                         cmap='cmo.balance', show_cell_edges=True)

--- a/polaris/ocean/tests/baroclinic_channel/viz.py
+++ b/polaris/ocean/tests/baroclinic_channel/viz.py
@@ -38,14 +38,14 @@ class Viz(Step):
         Run this step of the test case
         """
         config = self.config
-        dsMesh = xr.load_dataset('initial_state.nc')
+        ds_mesh = xr.load_dataset('initial_state.nc')
         ds = xr.load_dataset('output.nc')
-        tIndex = ds.sizes['Time'] - 1
-        plot_horiz_field(config, ds, dsMesh, 'temperature',
-                         'final_temperature.png', tIndex=tIndex)
+        t_index = ds.sizes['Time'] - 1
+        plot_horiz_field(config, ds, ds_mesh, 'temperature',
+                         'final_temperature.png', t_index=t_index)
         max_velocity = np.max(np.abs(ds.normalVelocity.values))
-        plot_horiz_field(config, ds, dsMesh, 'normalVelocity',
+        plot_horiz_field(config, ds, ds_mesh, 'normalVelocity',
                          'final_normalVelocity.png',
-                         tIndex=tIndex,
+                         t_index=t_index,
                          vmin=-1 * max_velocity, vmax=max_velocity,
                          cmap='cmo.balance', show_cell_edges=True)

--- a/polaris/ocean/tests/baroclinic_channel/viz.py
+++ b/polaris/ocean/tests/baroclinic_channel/viz.py
@@ -47,5 +47,5 @@ class Viz(Step):
         plot_horiz_field(config, ds, ds_mesh, 'normalVelocity',
                          'final_normalVelocity.png',
                          t_index=t_index,
-                         vmin=-1 * max_velocity, vmax=max_velocity,
-                         cmap='cmo.balance', show_cell_edges=True)
+                         vmin=-max_velocity, vmax=max_velocity,
+                         cmap='cmo.balance', show_patch_edges=True)

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -1,3 +1,4 @@
+import importlib.resources as imp_res  # noqa: F401
 import os
 
 import cmocean  # noqa: F401
@@ -11,7 +12,7 @@ from matplotlib.patches import Polygon
 
 def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
                      title=None, tIndex=None, zIndex=None,
-                     vmin=None, vmax=None,
+                     vmin=None, vmax=None, show_patch_edges=False,
                      cmap=None, cmap_set_under=None, cmap_scale='linear'):
 
     """
@@ -42,6 +43,9 @@ def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
     vmin, vmax : float, optional
         The minimum and maximum values for the colorbar
 
+    show_patch_edges : boolean, optional
+        If true, patches will be plotted with visible edges
+
     tIndex, zIndex: int, optional
         The indices of 'Time' and 'nVertLevels' axes to select for plotting
 
@@ -54,6 +58,9 @@ def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
     cmap_scale : {'log', 'linear'}, optional
         Whether the colormap is logarithmic or linear
     """
+    style_filename = str(
+        imp_res.files('polaris.viz') / 'polaris.mplstyle')
+    plt.style.use(style_filename)
 
     try:
         os.makedirs(os.path.dirname(outFileName))
@@ -90,7 +97,10 @@ def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
         current_cmap = oceanPatches.get_cmap()
         current_cmap.set_under(cmap_set_under)
 
-    oceanPatches.set_edgecolor('face')
+    if show_patch_edges:
+        oceanPatches.set_edgecolor('black')
+    else:
+        oceanPatches.set_edgecolor('face')
     oceanPatches.set_clim(vmin=vmin, vmax=vmax)
 
     if cmap_scale == 'log':
@@ -107,6 +117,8 @@ def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
     plt.figure(figsize=figsize)
     ax = plt.subplot(111)
     ax.add_collection(oceanPatches)
+    ax.set_xlabel('x (km)')
+    ax.set_ylabel('y (km)')
     ax.set_aspect('equal')
     ax.autoscale(tight=True)
     plt.colorbar(oceanPatches, extend='both', shrink=0.7)

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -82,11 +82,11 @@ def plot_horiz_field(config, ds, ds_mesh, field_name, out_file_name,
     if 'Time' in field.dims and t_index is None:
         t_index = 0
     if t_index is not None:
-        field = field[t_index, :]
+        field = field.isel(Time=t_index)
     if 'nVertLevels' in field.dims and z_index is None:
         z_index = 0
     if z_index is not None:
-        field = field[:, z_index]
+        field = field.isel(nVertLevels=z_index)
 
     if 'nCells' in field.dims:
         ocean_mask = ds_mesh.maxLevelCell - 1 >= 0

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -10,7 +10,7 @@ from matplotlib.colors import LogNorm
 from matplotlib.patches import Polygon
 
 
-def plot_horiz_field(config, ds, ds_mesh, field_name, out_file_name,
+def plot_horiz_field(ds, ds_mesh, field_name, out_file_name,
                      title=None, t_index=None, z_index=None,
                      vmin=None, vmax=None, show_patch_edges=False,
                      cmap=None, cmap_set_under=None, cmap_scale='linear'):
@@ -21,10 +21,6 @@ def plot_horiz_field(config, ds, ds_mesh, field_name, out_file_name,
 
     Parameters
     ----------
-    config : polaris.config.PolarisConfigParser
-        Configuration options with parameters used to construct the vertical
-        grid
-
     ds : xarray.Dataset
         A data set containing fieldName
 

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -10,8 +10,8 @@ from matplotlib.colors import LogNorm
 from matplotlib.patches import Polygon
 
 
-def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
-                     title=None, tIndex=None, zIndex=None,
+def plot_horiz_field(config, ds, ds_mesh, field_name, out_file_name,
+                     title=None, t_index=None, z_index=None,
                      vmin=None, vmax=None, show_patch_edges=False,
                      cmap=None, cmap_set_under=None, cmap_scale='linear'):
 
@@ -28,13 +28,13 @@ def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
     ds : xarray.Dataset
         A data set containing fieldName
 
-    dsMesh : xarray.Dataset
+    ds_mesh : xarray.Dataset
         A data set containing mesh variables
 
-    fieldName: str
+    field_name: str
         The name of the variable to plot, which must be present in ds
 
-    outFileName: str
+    out_file_name: str
         The path to which the plot image should be written
 
     title: str, optional
@@ -46,7 +46,7 @@ def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
     show_patch_edges : boolean, optional
         If true, patches will be plotted with visible edges
 
-    tIndex, zIndex: int, optional
+    t_index, z_index: int, optional
         The indices of 'Time' and 'nVertLevels' axes to select for plotting
 
     cmap : Colormap or str, optional
@@ -63,57 +63,58 @@ def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
     plt.style.use(style_filename)
 
     try:
-        os.makedirs(os.path.dirname(outFileName))
+        os.makedirs(os.path.dirname(out_file_name))
     except OSError:
         pass
 
     if title is None:
-        title = fieldName
+        title = field_name
 
-    if 'maxLevelCell' not in dsMesh:
+    if 'maxLevelCell' not in ds_mesh:
         raise ValueError(
-            'maxLevelCell must be added to dsMesh before plotting.')
-    if fieldName not in ds:
-        raise ValueError(f'{fieldName} must be present in ds before plotting.')
+            'maxLevelCell must be added to ds_mesh before plotting.')
+    if field_name not in ds:
+        raise ValueError(
+            f'{field_name} must be present in ds before plotting.')
 
-    field = ds[fieldName]
+    field = ds[field_name]
 
-    if 'Time' in field.dims and tIndex is None:
-        tIndex = 0
-    if tIndex is not None:
-        field = field[tIndex, :]
-    if 'nVertLevels' in field.dims:
-        zIndex = 0
-    if zIndex is not None:
-        field = field[:, zIndex]
+    if 'Time' in field.dims and t_index is None:
+        t_index = 0
+    if t_index is not None:
+        field = field[t_index, :]
+    if 'nVertLevels' in field.dims and z_index is None:
+        z_index = 0
+    if z_index is not None:
+        field = field[:, z_index]
 
     if 'nCells' in field.dims:
-        oceanMask = dsMesh.maxLevelCell - 1 >= 0
-        oceanMask = _remove_boundary_cells_from_mask(dsMesh, oceanMask)
-        oceanPatches = _compute_cell_patches(dsMesh, oceanMask)
+        ocean_mask = ds_mesh.maxLevelCell - 1 >= 0
+        ocean_mask = _remove_boundary_cells_from_mask(ds_mesh, ocean_mask)
+        ocean_patches = _compute_cell_patches(ds_mesh, ocean_mask)
     elif 'nEdges' in field.dims:
-        oceanMask = np.ones_like(field, dtype='bool')
-        oceanMask = _remove_boundary_edges_from_mask(dsMesh, oceanMask)
-        oceanPatches = _compute_edge_patches(dsMesh, oceanMask)
-    oceanPatches.set_array(field[oceanMask])
+        ocean_mask = np.ones_like(field, dtype='bool')
+        ocean_mask = _remove_boundary_edges_from_mask(ds_mesh, ocean_mask)
+        ocean_patches = _compute_edge_patches(ds_mesh, ocean_mask)
+    ocean_patches.set_array(field[ocean_mask])
     if cmap is not None:
-        oceanPatches.set_cmap(cmap)
+        ocean_patches.set_cmap(cmap)
     if cmap_set_under is not None:
-        current_cmap = oceanPatches.get_cmap()
+        current_cmap = ocean_patches.get_cmap()
         current_cmap.set_under(cmap_set_under)
 
     if show_patch_edges:
-        oceanPatches.set_edgecolor('black')
+        ocean_patches.set_edgecolor('black')
     else:
-        oceanPatches.set_edgecolor('face')
-    oceanPatches.set_clim(vmin=vmin, vmax=vmax)
+        ocean_patches.set_edgecolor('face')
+    ocean_patches.set_clim(vmin=vmin, vmax=vmax)
 
     if cmap_scale == 'log':
-        oceanPatches.set_norm(LogNorm(vmin=max(1e-10, vmin),
-                              vmax=vmax, clip=False))
+        ocean_patches.set_norm(LogNorm(vmin=max(1e-10, vmin),
+                               vmax=vmax, clip=False))
 
-    width = dsMesh.xCell.max() - dsMesh.xCell.min()
-    length = dsMesh.yCell.max() - dsMesh.yCell.min()
+    width = ds_mesh.xCell.max() - ds_mesh.xCell.min()
+    length = ds_mesh.yCell.max() - ds_mesh.yCell.min()
     aspect_ratio = width.values / length.values
     fig_width = 4
     legend_width = fig_width / 5
@@ -121,88 +122,88 @@ def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
 
     plt.figure(figsize=figsize)
     ax = plt.subplot(111)
-    ax.add_collection(oceanPatches)
+    ax.add_collection(ocean_patches)
     ax.set_xlabel('x (km)')
     ax.set_ylabel('y (km)')
     ax.set_aspect('equal')
     ax.autoscale(tight=True)
-    plt.colorbar(oceanPatches, extend='both', shrink=0.7)
+    plt.colorbar(ocean_patches, extend='both', shrink=0.7)
     plt.title(title)
     plt.tight_layout(pad=0.5)
-    plt.savefig(outFileName)
+    plt.savefig(out_file_name)
     plt.close()
 
 
-def _remove_boundary_cells_from_mask(dsMesh, mask):
-    areaCell = dsMesh.areaCell.values
-    nVerticesOnCell = dsMesh.nEdgesOnCell.values
-    verticesOnCell = dsMesh.verticesOnCell.values - 1
-    xVertex = dsMesh.xVertex.values
-    yVertex = dsMesh.yVertex.values
-    for iCell in range(dsMesh.sizes['nCells']):
-        if not mask[iCell]:
+def _remove_boundary_cells_from_mask(ds, mask):
+    area_cell = ds.areaCell.values
+    num_vertices_on_cell = ds.nEdgesOnCell.values
+    vertices_on_cell = ds.verticesOnCell.values - 1
+    x_vertex = ds.xVertex.values
+    y_vertex = ds.yVertex.values
+    for cell_index in range(ds.sizes['nCells']):
+        if not mask[cell_index]:
             continue
-        nVert = nVerticesOnCell[iCell]
-        vertexIndices = verticesOnCell[iCell, :nVert]
+        num_vertices = num_vertices_on_cell[cell_index]
+        vertex_indices = vertices_on_cell[cell_index, :num_vertices]
 
         # Remove cells that span the periodic boundaries
-        dx = max(xVertex[vertexIndices]) - min(xVertex[vertexIndices])
-        dy = max(yVertex[vertexIndices]) - min(yVertex[vertexIndices])
-        if dx * dy / 10 > areaCell[iCell]:
-            mask[iCell] = 0
+        dx = max(x_vertex[vertex_indices]) - min(x_vertex[vertex_indices])
+        dy = max(y_vertex[vertex_indices]) - min(y_vertex[vertex_indices])
+        if dx * dy / 10 > area_cell[cell_index]:
+            mask[cell_index] = 0
 
     return mask
 
 
-def _remove_boundary_edges_from_mask(dsMesh, mask):
-    areaCell = dsMesh.areaCell.values
-    cellsOnEdge = dsMesh.cellsOnEdge.values - 1
-    verticesOnEdge = dsMesh.verticesOnEdge.values - 1
-    xCell = dsMesh.xCell.values
-    yCell = dsMesh.yCell.values
-    boundaryVertex = dsMesh.boundaryVertex.values
-    xVertex = dsMesh.xVertex.values
-    yVertex = dsMesh.yVertex.values
-    for iEdge in range(dsMesh.sizes['nEdges']):
-        if not mask[iEdge]:
+def _remove_boundary_edges_from_mask(ds, mask):
+    area_cell = ds.areaCell.values
+    cells_on_edge = ds.cellsOnEdge.values - 1
+    vertices_on_edge = ds.verticesOnEdge.values - 1
+    x_cell = ds.xCell.values
+    y_cell = ds.yCell.values
+    boundary_vertex = ds.boundaryVertex.values
+    x_vertex = ds.xVertex.values
+    y_vertex = ds.yVertex.values
+    for edge_index in range(ds.sizes['nEdges']):
+        if not mask[edge_index]:
             continue
-        cellIndices = cellsOnEdge[iEdge]
-        vertexIndices = verticesOnEdge[iEdge, :]
-        if any(boundaryVertex[vertexIndices]):
-            mask[iEdge] = 0
+        cell_indices = cells_on_edge[edge_index]
+        vertex_indices = vertices_on_edge[edge_index, :]
+        if any(boundary_vertex[vertex_indices]):
+            mask[edge_index] = 0
         vertices = np.zeros((4, 2))
-        vertices[0, 0] = xVertex[vertexIndices[0]]
-        vertices[0, 1] = yVertex[vertexIndices[0]]
-        vertices[1, 0] = xCell[cellIndices[0]]
-        vertices[1, 1] = yCell[cellIndices[0]]
-        vertices[2, 0] = xVertex[vertexIndices[1]]
-        vertices[2, 1] = yVertex[vertexIndices[1]]
-        vertices[3, 0] = xCell[cellIndices[1]]
-        vertices[3, 1] = yCell[cellIndices[1]]
+        vertices[0, 0] = x_vertex[vertex_indices[0]]
+        vertices[0, 1] = y_vertex[vertex_indices[0]]
+        vertices[1, 0] = x_cell[cell_indices[0]]
+        vertices[1, 1] = y_cell[cell_indices[0]]
+        vertices[2, 0] = x_vertex[vertex_indices[1]]
+        vertices[2, 1] = y_vertex[vertex_indices[1]]
+        vertices[3, 0] = x_cell[cell_indices[1]]
+        vertices[3, 1] = y_cell[cell_indices[1]]
 
         # Remove cells that span the periodic boundaries
         dx = max(vertices[:, 0]) - min(vertices[:, 0])
         dy = max(vertices[:, 1]) - min(vertices[:, 1])
-        if dx * dy / 10 > areaCell[0]:
-            mask[iEdge] = 0
+        if dx * dy / 10 > area_cell[0]:
+            mask[edge_index] = 0
 
     return mask
 
 
-def _compute_cell_patches(dsMesh, mask):
+def _compute_cell_patches(ds, mask):
     patches = []
-    nVerticesOnCell = dsMesh.nEdgesOnCell.values
-    verticesOnCell = dsMesh.verticesOnCell.values - 1
-    xVertex = dsMesh.xVertex.values
-    yVertex = dsMesh.yVertex.values
-    for iCell in range(dsMesh.sizes['nCells']):
-        if not mask[iCell]:
+    num_vertices_on_cell = ds.nEdgesOnCell.values
+    vertices_on_cell = ds.verticesOnCell.values - 1
+    x_vertex = ds.xVertex.values
+    y_vertex = ds.yVertex.values
+    for cell_index in range(ds.sizes['nCells']):
+        if not mask[cell_index]:
             continue
-        nVert = nVerticesOnCell[iCell]
-        vertexIndices = verticesOnCell[iCell, :nVert]
-        vertices = np.zeros((nVert, 2))
-        vertices[:, 0] = 1e-3 * xVertex[vertexIndices]
-        vertices[:, 1] = 1e-3 * yVertex[vertexIndices]
+        num_vertices = num_vertices_on_cell[cell_index]
+        vertex_indices = vertices_on_cell[cell_index, :num_vertices]
+        vertices = np.zeros((num_vertices, 2))
+        vertices[:, 0] = 1e-3 * x_vertex[vertex_indices]
+        vertices[:, 1] = 1e-3 * y_vertex[vertex_indices]
 
         polygon = Polygon(vertices, True)
         patches.append(polygon)
@@ -212,28 +213,28 @@ def _compute_cell_patches(dsMesh, mask):
     return p
 
 
-def _compute_edge_patches(dsMesh, mask):
+def _compute_edge_patches(ds, mask):
     patches = []
-    cellsOnEdge = dsMesh.cellsOnEdge.values - 1
-    verticesOnEdge = dsMesh.verticesOnEdge.values - 1
-    xCell = dsMesh.xCell.values
-    yCell = dsMesh.yCell.values
-    xVertex = dsMesh.xVertex.values
-    yVertex = dsMesh.yVertex.values
-    for iEdge in range(dsMesh.sizes['nEdges']):
-        if not mask[iEdge]:
+    cells_on_edge = ds.cellsOnEdge.values - 1
+    vertices_on_edge = ds.verticesOnEdge.values - 1
+    x_cell = ds.xCell.values
+    y_cell = ds.yCell.values
+    x_vertex = ds.xVertex.values
+    y_vertex = ds.yVertex.values
+    for edge_index in range(ds.sizes['nEdges']):
+        if not mask[edge_index]:
             continue
-        cellIndices = cellsOnEdge[iEdge]
-        vertexIndices = verticesOnEdge[iEdge, :]
+        cell_indices = cells_on_edge[edge_index]
+        vertex_indices = vertices_on_edge[edge_index, :]
         vertices = np.zeros((4, 2))
-        vertices[0, 0] = 1e-3 * xVertex[vertexIndices[0]]
-        vertices[0, 1] = 1e-3 * yVertex[vertexIndices[0]]
-        vertices[1, 0] = 1e-3 * xCell[cellIndices[0]]
-        vertices[1, 1] = 1e-3 * yCell[cellIndices[0]]
-        vertices[2, 0] = 1e-3 * xVertex[vertexIndices[1]]
-        vertices[2, 1] = 1e-3 * yVertex[vertexIndices[1]]
-        vertices[3, 0] = 1e-3 * xCell[cellIndices[1]]
-        vertices[3, 1] = 1e-3 * yCell[cellIndices[1]]
+        vertices[0, 0] = 1e-3 * x_vertex[vertex_indices[0]]
+        vertices[0, 1] = 1e-3 * y_vertex[vertex_indices[0]]
+        vertices[1, 0] = 1e-3 * x_cell[cell_indices[0]]
+        vertices[1, 1] = 1e-3 * y_cell[cell_indices[0]]
+        vertices[2, 0] = 1e-3 * x_vertex[vertex_indices[1]]
+        vertices[2, 1] = 1e-3 * y_vertex[vertex_indices[1]]
+        vertices[3, 0] = 1e-3 * x_cell[cell_indices[1]]
+        vertices[3, 1] = 1e-3 * y_cell[cell_indices[1]]
 
         polygon = Polygon(vertices, True)
         patches.append(polygon)

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -1,0 +1,160 @@
+import os
+
+import cmocean  # noqa: F401
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from matplotlib.collections import PatchCollection
+from matplotlib.colors import LogNorm
+from matplotlib.patches import Polygon
+
+
+def plot_horiz_field(config, ds, dsMesh, fieldName, outFileName,
+                     title=None, tIndex=None, zIndex=None,
+                     vmin=None, vmax=None,
+                     cmap=None, cmap_set_under=None, cmap_scale='linear'):
+
+    """
+    Plot a horizontal field from a planar domain using x,y coordinates at a
+    single time and depth slice.
+
+    Parameters
+    ----------
+    config : polaris.config.PolarisConfigParser
+        Configuration options with parameters used to construct the vertical
+        grid
+
+    ds : xarray.Dataset
+        A data set containing fieldName
+
+    dsMesh : xarray.Dataset
+        A data set containing mesh variables
+
+    fieldName: str
+        The name of the variable to plot, which must be present in ds
+
+    outFileName: str
+        The path to which the plot image should be written
+
+    title: str, optional
+        The title of the plot
+
+    vmin, vmax : float, optional
+        The minimum and maximum values for the colorbar
+
+    tIndex, zIndex: int, optional
+        The indices of 'Time' and 'nVertLevels' axes to select for plotting
+
+    cmap : Colormap or str, optional
+        A color map to plot
+
+    cmap_set_under : str or None, optional
+        A color for low out-of-range values
+
+    cmap_scale : {'log', 'linear'}, optional
+        Whether the colormap is logarithmic or linear
+    """
+
+    try:
+        os.makedirs(os.path.dirname(outFileName))
+    except OSError:
+        pass
+
+    if title is None:
+        title = fieldName
+
+    for var in ['maxLevelCell']:
+        if var not in dsMesh:
+            raise ValueError(f'{var} must be added to dsMesh before plotting.')
+    if fieldName not in ds:
+        raise ValueError(f'{fieldName} must be present in ds before plotting.')
+
+    field = ds[fieldName]
+
+    if 'Time' in field.dims and tIndex is None:
+        tIndex = 0
+    if tIndex is not None:
+        field = field[tIndex, :]
+    if 'nVertLevels' in field.dims:
+        zIndex = 0
+    if zIndex is not None:
+        field = field[:, zIndex]
+
+    oceanMask = dsMesh.maxLevelCell - 1 >= 0
+    oceanMask = _remove_boundary_cells_from_mask(dsMesh, oceanMask)
+    oceanPatches = _compute_cell_patches(dsMesh, oceanMask)
+    oceanPatches.set_array(field[oceanMask])
+    if cmap is not None:
+        oceanPatches.set_cmap(cmap)
+    if cmap_set_under is not None:
+        current_cmap = oceanPatches.get_cmap()
+        current_cmap.set_under(cmap_set_under)
+
+    oceanPatches.set_edgecolor('face')
+    oceanPatches.set_clim(vmin=vmin, vmax=vmax)
+
+    if cmap_scale == 'log':
+        oceanPatches.set_norm(LogNorm(vmin=max(1e-10, vmin),
+                              vmax=vmax, clip=False))
+
+    width = dsMesh.xCell.max() - dsMesh.xCell.min()
+    length = dsMesh.yCell.max() - dsMesh.yCell.min()
+    aspect_ratio = width.values / length.values
+    fig_width = 4
+    legend_width = fig_width / 5
+    figsize = (fig_width + legend_width, fig_width / aspect_ratio)
+
+    plt.figure(figsize=figsize)
+    ax = plt.subplot(111)
+    ax.add_collection(oceanPatches)
+    ax.set_aspect('equal')
+    ax.autoscale(tight=True)
+    plt.colorbar(oceanPatches, extend='both', shrink=0.7)
+    plt.title(title)
+    plt.tight_layout(pad=0.5)
+    plt.savefig(outFileName)
+    plt.close()
+
+
+def _remove_boundary_cells_from_mask(dsMesh, mask):
+    areaCell = dsMesh.areaCell.values
+    nVerticesOnCell = dsMesh.nEdgesOnCell.values
+    verticesOnCell = dsMesh.verticesOnCell.values - 1
+    xVertex = dsMesh.xVertex.values
+    yVertex = dsMesh.yVertex.values
+    for iCell in range(dsMesh.sizes['nCells']):
+        if not mask[iCell]:
+            continue
+        nVert = nVerticesOnCell[iCell]
+        vertexIndices = verticesOnCell[iCell, :nVert]
+
+        # Remove cells that span the periodic boundaries
+        dx = max(xVertex[vertexIndices]) - min(xVertex[vertexIndices])
+        dy = max(yVertex[vertexIndices]) - min(yVertex[vertexIndices])
+        if dx * dy / 10 > areaCell[iCell]:
+            mask[iCell] = 0
+
+    return mask
+
+
+def _compute_cell_patches(dsMesh, mask):
+    patches = []
+    nVerticesOnCell = dsMesh.nEdgesOnCell.values
+    verticesOnCell = dsMesh.verticesOnCell.values - 1
+    xVertex = dsMesh.xVertex.values
+    yVertex = dsMesh.yVertex.values
+    for iCell in range(dsMesh.sizes['nCells']):
+        if not mask[iCell]:
+            continue
+        nVert = nVerticesOnCell[iCell]
+        vertexIndices = verticesOnCell[iCell, :nVert]
+        vertices = np.zeros((nVert, 2))
+        vertices[:, 0] = 1e-3 * xVertex[vertexIndices]
+        vertices[:, 1] = 1e-3 * yVertex[vertexIndices]
+
+        polygon = Polygon(vertices, True)
+        patches.append(polygon)
+
+    p = PatchCollection(patches, alpha=1.)
+
+    return p

--- a/polaris/viz/polaris.mplstyle
+++ b/polaris/viz/polaris.mplstyle
@@ -1,0 +1,11 @@
+# polaris.mplstyle
+
+figure.titlesize: 16
+figure.labelsize: 14
+
+legend.fontsize: 14
+
+axes.titlesize: 16
+axes.labelsize: 14
+
+patch.linewidth: 0.5


### PR DESCRIPTION
This PR ports the `plot_horiz_field` function from `compass/ocean/tests/isomip_plus/viz/__init__.py` into a shared viz folder. There are relatively minor changes related to this being used outside `plot_horiz_series` and making the figure size match the domain aspect ratio. To demonstrate its functionality, it is added to the `initial_state` step of the `baroclinic_channel` test case.

Two functions are also needed:
* `_remove_boundary_edges_from_mask` makes sure that the periodic edges are not included (those polygons would span from one edge of the periodic domain to the other and obscure the other polygons)
* `_compute_cell_patches` is a direct port from `compass/ocean/tests/isomip_plus/viz/__init__.py`
* `_compute_edge_patches` is a new function analogous to `_compute_cell_patches`

Checklist
* [X] Developer's Guide has been updated
* [X] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes