### PR TITLE
Adjust ny for baroclinic channel to give 500 km domain

### DIFF
--- a/docs/users_guide/ocean/test_groups/baroclinic_channel.md
+++ b/docs/users_guide/ocean/test_groups/baroclinic_channel.md
@@ -55,6 +55,10 @@ min_pc_fraction = 0.1
 # config options for baroclinic channel testcases
 [baroclinic_channel]
 
+# the size of the domain in km in the x and y directions
+lx = 160.0
+ly = 500.0
+
 # the number of mesh cells in the x direction
 nx = <<<set in code>>>
 
@@ -110,6 +114,8 @@ salinity = 35.0
 coriolis_parameter = -1.2e-4
 ```
 
+The default domain size (`lx` and `ly`) is designed to be consistent with the
+literature, but can be modified by users to suit their needs.  
 The `nx`, `ny` and `dc` config options are set in the code.  While you can
 override these values with user config options, this isn't recommended. The
 `goal_cells_per_core` and `max_cells_per_core` are used to control how many

--- a/polaris/ocean/tests/baroclinic_channel/baroclinic_channel.cfg
+++ b/polaris/ocean/tests/baroclinic_channel/baroclinic_channel.cfg
@@ -22,6 +22,10 @@ min_pc_fraction = 0.1
 # config options for baroclinic channel testcases
 [baroclinic_channel]
 
+# the size of the domain in km in the x and y directions
+lx = 160.0
+ly = 500.0
+
 # the number of mesh cells in the x direction
 nx = <<<set in code>>>
 

--- a/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
+++ b/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
@@ -37,7 +37,7 @@ class BaroclinicChannelTestCase(TestCase):
         if resolution >= 1.:
             res_str = f'{resolution:g}km'
         else:
-            res_str = f'{resolution:g}m'
+            res_str = f'{resolution * 1000.:g}m'
         subdir = os.path.join(res_str, name)
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)

--- a/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
+++ b/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
@@ -1,5 +1,7 @@
 import os
 
+import numpy as np
+
 from polaris.ocean.tests.baroclinic_channel.initial_state import InitialState
 from polaris.testcase import TestCase
 from polaris.validate import compare_variables
@@ -49,14 +51,19 @@ class BaroclinicChannelTestCase(TestCase):
         """
         resolution = self.resolution
         config = self.config
+
+        lx = config.getfloat('baroclinic_channel', 'lx')
+        ly = config.getfloat('baroclinic_channel', 'ly')
+
         # these could be hard-coded as functions of specific supported
         # resolutions but it is preferable to make them algorithmic like here
         # for greater flexibility
         #
         # ny is required to be even for periodicity, and we do the same for nx
         # for consistency
-        nx = max(2 * int(0.5 * 160. / resolution + 0.5), 4)
-        ny = max(2 * int(0.5 * 500. / resolution + 0.5), 4)
+        nx = max(2 * int(0.5 * lx / resolution + 0.5), 4)
+        # factor of 2/sqrt(3) because of hexagonal mesh
+        ny = max(2 * int(0.5 * ly * (2. / np.sqrt(3)) / resolution + 0.5), 4)
         dc = 1e3 * resolution
 
         config.set('baroclinic_channel', 'nx', f'{nx}')


### PR DESCRIPTION
This is a port of https://github.com/MPAS-Dev/compass/pull/605

The following description is copied from there.

This PR adjusts the number of cells used in meshes for the baroclinic channel test case to ensure the 'standard' 160x500km domain is defined. Previously, the channel has had a shorter y-length of sqrt(3)/2 * 500 => 433km.

- When using the `make_planar_hex_mesh` routine, the number of cells along the y-axis should be scaled by `2/sqrt(3)` to account for hexagonal geometry.

The channel is a standard community test case, and use of the 160x500km domain enables model intercomparison, e.g.:

- Ilıcak, M., Adcroft, A.J., Griffies, S.M. and Hallberg, R.W., 2012. Spurious dianeutral mixing and the role of momentum closure. Ocean Modelling, 45, pp.37-58.

- Petersen, M.R., Jacobsen, D.W., Ringler, T.D., Hecht, M.W. and Maltrud, M.E., 2015. Evaluation of the arbitrary Lagrangian–Eulerian vertical coordinate method in the MPAS-Ocean model. Ocean Modelling, 86, pp.93-113.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
