### PR TITLE
Add dependencies to Step class

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -159,6 +159,7 @@ ocean/api
    Step.run
    Step.add_input_file
    Step.add_output_file
+   Step.add_dependency
 ```
 
 

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -427,6 +427,8 @@ def _run_step(test_case, step, new_log_file):
             f'{step.component.name}/{step.test_group.name}/'
             f'{step.test_case.subdir}: {missing_files}')
 
+    _load_dependencies(test_case, step)
+
     test_name = step.path.replace('/', '_')
     if new_log_file:
         log_filename = f'{cwd}/{step.name}.log'
@@ -473,6 +475,8 @@ def _run_step(test_case, step, new_log_file):
             f'{step.component.name}/{step.test_group.name}/'
             f'{step.test_case.subdir}: {missing_files}')
 
+    _pickle_step_after_run(test_case, step)
+
 
 def _run_step_as_subprocess(test_case, step, new_log_file):
     """
@@ -494,3 +498,36 @@ def _run_step_as_subprocess(test_case, step, new_log_file):
         os.chdir(step.work_dir)
         step_args = ['polaris', 'serial', '--step_is_subprocess']
         check_call(step_args, step_logger)
+
+
+def _load_dependencies(test_case, step):
+    """
+    Load each dependency from its pickle file to pick up changes that may have
+    happened since it ran
+    """
+    for name, old_dependency in step.dependencies.items():
+        if old_dependency.cached:
+            continue
+
+        pickle_filename = os.path.join(old_dependency.work_dir,
+                                       'step_after_run.pickle')
+        if not os.path.exists(pickle_filename):
+            raise ValueError(f'The dependency {name} of '
+                             f'{test_case.path} step {step.name} was '
+                             f'not run.')
+
+        with open(pickle_filename, 'rb') as handle:
+            dep_test_case, dependency = pickle.load(handle)
+            step.dependencies[name] = dependency
+
+
+def _pickle_step_after_run(test_case, step):
+    """
+    Picle a step after it has run so its dependencies will pick up the changes.
+    """
+    if step.is_dependency:
+        # pickle the test case and step for use at runtime
+        pickle_filename = os.path.join(step.work_dir, 'step_after_run.pickle')
+        with open(pickle_filename, 'wb') as handle:
+            pickle.dump((test_case, step), handle,
+                        protocol=pickle.HIGHEST_PROTOCOL)

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -109,6 +109,8 @@ def setup_cases(work_dir, tests=None, numbers=None, config_file=None,
                    cached_steps=cached_steps[path],
                    copy_executable=copy_executable)
 
+    _check_dependencies(test_cases)
+
     test_suite = {'name': suite_name,
                   'test_cases': test_cases,
                   'work_dir': work_dir}
@@ -486,3 +488,13 @@ def _symlink_load_script(work_dir):
         script_filename = os.environ['LOAD_POLARIS_ENV']
         symlink(script_filename,
                 os.path.join(work_dir, 'load_polaris_env.sh'))
+
+
+def _check_dependencies(tests):
+    for test_case in tests.values():
+        for step in test_case.steps.values():
+            for name, dependency in step.dependencies.items():
+                if dependency.work_dir == '':
+                    raise ValueError(f'The dependency {name} of '
+                                     f'{test_case.path} step {step.name} was '
+                                     f'not set up.')


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

A step can now have a list of other steps that it depends on.  This is useful when file-base dependencies cannot be used (e.g. the file names cannot be known at setup time).

This merge adds a dictionary of dependencies to each step (empty by default) and a method, `add_dependency()` for adding another step as a dependency.

As fleshed out in the documentation, the dependency *must* run before the dependent step.  The results of running the dependency are pickled at the end of the run (each dependency is identified by its `is_dependency` attribute being `True`), and then unpickled along with the dependent step before the dependent step runs.  This allows the dependent step to access all attributes of the dependency, including any changes during the dependency's run.

We check to make sure all dependencies of all the steps being set up at a given time have also been set up.  This prevents failures at runtime when a dependency belong s to a different test case than the dependent step, and the user has forgotten to set up the dependency's test case (or doesn't know that it, too, is required).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
