### PR TITLE
Add User's Guide template for test groups

### DIFF
--- a/docs/developers_guide/docs.md
+++ b/docs/developers_guide/docs.md
@@ -89,7 +89,7 @@ case, including:
   - A list of (commented) config options that apply to all test cases
   - A (typically brief) description of each test case
   - The following sections as described in the template: description, mesh,
-vertical grid, initial conditions, forcing, time step, config, and cores
+    vertical grid, initial conditions, forcing, time step, config, and cores
 
 - A description of any common framework within the component that the test 
   group or test case pages may need to refer to.  This should only include

--- a/docs/developers_guide/docs.md
+++ b/docs/developers_guide/docs.md
@@ -88,6 +88,8 @@ case, including:
   - An image showing typical output from one of the test cases
   - A list of (commented) config options that apply to all test cases
   - A (typically brief) description of each test case
+  - The following sections as described in the template: description, mesh,
+vertical grid, initial conditions, forcing, time step, config, and cores
 
 - A description of any common framework within the component that the test 
   group or test case pages may need to refer to.  This should only include
@@ -95,6 +97,9 @@ case, including:
   {ref}`config-files` or namelist options they may wish to edit.
 
 - A description of each test suite, including which test cases are included
+
+A template is available for test groups and test cases in the User's Guide:
+{ref}`component-test-group-name`
 
 The Developer's guide for each component should contain:
 

--- a/docs/users_guide/ocean/test_groups/global_convergence.md
+++ b/docs/users_guide/ocean/test_groups/global_convergence.md
@@ -9,30 +9,18 @@ full globe.  Currently, the only test case is the advection of a cosine bell.
 
 ## cosine_bell
 
+### Description
+
 The `cosine_bell` test case implements the Cosine Bell test case as first
 described in [Williamson et al. 1992](<https://doi.org/10.1016/S0021-9991(05)80016-6>)
 but using the variant from Sec. 3a of
 [Skamarock and Gassmann](https://doi.org/10.1175/MWR-D-10-05056.1).  A flow
 field representing solid-body rotation transports a bell-shaped perturbation
 in a tracer $psi$ once around the sphere, returning to its initial
-location.  The bell is defined by:
+location.
 
-$$
-\psi =
-    \begin{cases}
-        \left( \psi_0/2 \right) \left[ 1 + \cos(\pi r/R )\right] &
-            \text{if } r < R \\
-        0 & \text{if } r \ge R
-    \end{cases}
-$$
-
-where $\psi_0 = 1$, the bell radius $R = a/3$, and $a$ is
-the radius of the sphere.  The equatorial velocity
-$u_0 = 2 \pi a/ (\text{24 days})$. The time step is proportional to the
-grid-cell size.
-
-By default, the resolution is varied from 60 km to 240 km in steps of 30 km.
-The result of the `analysis` step of the test case is a plot like the
+The test is a convergence test with time step varying proportionately to grid
+size. The result of the `analysis` step of the test case is a plot like the
 following showing convergence as a function of the number of cells:
 
 ```{image} images/cosine_bell_convergence.png
@@ -40,9 +28,38 @@ following showing convergence as a function of the number of cells:
 :width: 500 px
 ```
 
-### config options
+### mesh
 
-The `cosine_bell` config options include:
+Two global mesh variants are tested, quasi-uniform (QU) and icosohydral. The
+default resolutions used in the test case depends on the mesh type.
+
+For the `icos` mesh type, the defaults are:
+
+```cfg
+resolutions = 60, 120, 240, 480
+```
+
+for the `qu` mesh type, they are:
+
+```cfg
+resolutions = 60, 90, 120, 150, 180, 210, 240
+```
+
+To alter the resolutions used in this test, you will need to create your own
+config file (or add a `cosine_bell` section to a config file if you're
+already using one).  The resolutions are a comma-separated list of the
+resolution of the mesh in km.  If you specify a different list
+before setting up `cosine_bell`, steps will be generated with the requested
+resolutions.  (If you alter `resolutions` in the test case's config file in
+the work directory, nothing will happen.)  For `icos` meshes, make sure you
+use a resolution close to those listed in {ref}`dev-spherical-meshes`.  Each
+resolution will be rounded to the nearest allowed icosahedral resolution.
+
+### vertical grid
+
+This test case only exercises the shallow water dynamics. As such, the minimum
+number of vertical levels may be used. The bottom depth is constant and the
+results should be insensitive to the choice of `bottom_depth`.
 
 ```cfg
 # Options related to the vertical grid
@@ -65,7 +82,59 @@ partial_cell_type = None
 
 # The minimum fraction of a layer for partial cells
 min_pc_fraction = 0.1
+```
 
+### initial conditions
+
+The initial bell is defined by any passive tracer $\psi$:
+
+$$
+\psi =
+    \begin{cases}
+        \left( \psi_0/2 \right) \left[ 1 + \cos(\pi r/R )\right] &
+            \text{if } r < R \\
+        0 & \text{if } r \ge R
+    \end{cases}
+$$
+
+where $\psi_0 = 1$, the bell radius $R = a/3$, and $a$ is the radius of the
+sphere. `psi_0` and `radius`, $R$, are given as config options and may be
+altered by the user. In the `initial_state step` we assign `debug_tracers_1`
+to $\psi$.
+
+The initial velocity is equatorial:
+
+$$
+u_0 = 2 \pi a/ \tau
+$$
+
+Where $\tau$ is the time it takes to transit the equator. The default is 24
+days, and can be altered by the user using the config option `vel_pd`.
+
+Temperature and salinity are not evolved in this test case and are given
+constant values determined by config options `temperature` and `salinity`.
+
+The Coriolis parameters `fCell`, `fEdge`, and `fVertex` do not need to be
+specified for a global mesh and are initialized as zeros.
+
+### forcing
+
+N/A. This case is run with all velocity tendencies disabled so the velocity
+field remains at the initial velocity $u_0$.
+
+### time step and run duration
+
+The time step for forward integration is determined by multiplying the
+resolution by `dt_per_km`, so that coarser meshes have longer time steps.
+You can alter this before setup (in a user config file) or before running the
+test case (in the config file in the work directory). The run duration is 24
+days.
+
+### config options
+
+The `cosine_bell` config options include:
+
+```cfg
 # options for cosine bell convergence test case
 [cosine_bell]
 
@@ -130,70 +199,21 @@ norm_args = {'vmin': 0., 'vmax': 1.}
 # colorbar_ticks = np.linspace(0., 1., 9)
 ```
 
-The config options in `[vertical_grid]` define the vertical grid, as described
-in {ref}`ocean-vertical`.
-
 The `dt_per_km` option `[cosine_bell]` is used to control the time step, as
-discussed below in more detail.
+discussed above in more detail.
 
 The 7 options from `temperature` to `vel_pd` are used to control properties of
-the cosine bell and the rest of the sphere, as well as the advection.  The
-options `qu_conv_thresh` to `icos_conv_max` are thresholds for determining
-when the convergence rates are not within the expected range.  The options
-in the `cosine_bell_viz` section are used in visualizing the initial and
-final states on a lon-lat grid.
+the cosine bell and the rest of the sphere, as well as the advection.
 
-### resolutions
+The options `qu_conv_thresh` to `icos_conv_max` are thresholds for determining
+when the convergence rates are not within the expected range.
 
-The default resolutions used in the test case depends on the mesh type. For
-the `icos` mesh type, the defaults are:
-
-```cfg
-resolutions = 60, 120, 240, 480
-```
-
-for the `qu` mesh type, they are:
-
-```cfg
-resolutions = 60, 90, 120, 150, 180, 210, 240
-```
-
-To alter the resolutions used in this test, you will need to create your own
-config file (or add a `cosine_bell` section to a config file if you're
-already using one).  The resolutions are a comma-separated list of the
-resolution of the mesh in km.  If you specify a different list
-before setting up `cosine_bell`, steps will be generated with the requested
-resolutions.  (If you alter `resolutions` in the test case's config file in
-the work directory, nothing will happen.)  For `icos` meshes, make sure you
-use a resolution close to those listed in {ref}`dev-spherical-meshes`.  Each
-resolution will be rounded to the nearest allowed icosahedral resolution.
-
-### time step
-
-The time step for forward integration is determined by multiplying the
-resolution by `dt_per_km`, so that coarser meshes have longer time steps.
-You can alter this before setup (in a user config file) or before running the
-test case (in the config file in the work directory).
+The options in the `cosine_bell_viz` section are used in visualizing the
+initial and final states on a lon-lat grid.
 
 ### cores
 
-The number of cores (and the minimum) is proportional to the number of cells,
-so that the number of cells per core is roughly constant.  You can alter how
-many cells are allocated to each core with `goal_cells_per_core` in the 
-`[ocean]` config section.  You can  control the maximum number of cells that 
-are allowed  to be placed on a single  core (before the test case will fail) 
-with `max_cells_per_core` also in `[ocean]`.  If there  aren't enough 
-processors to handle the finest resolution, you will see that  the step (and 
-therefore the  test case) has failed.
-
-```cfg
-# Options related the ocean component
-[ocean]
-
-# the number of cells per core to aim for
-goal_cells_per_core = 200
-
-# the approximate maximum number of cells per core (the test will fail if too
-# few cores are available)
-max_cells_per_core = 2000
-```
+The target and minimum number of cores are determined by `goal_cells_per_core`
+and `max_cells_per_core` from the `ocean` section of the config file,
+respectively. This ensures that the number of cells per core is roughly
+constant across the different resolutions in the convergence study.

--- a/docs/users_guide/ocean/test_groups/template.md
+++ b/docs/users_guide/ocean/test_groups/template.md
@@ -1,0 +1,124 @@
+(component-test-group-name)=
+
+# test_group_name
+
+Description of the test group.
+
+(component-test-group-name-test-case-name)=
+
+## test_case_name
+
+In cases where the test cases within a test group share many characteristics,
+it may be more appropriate to move the following sections up one level to the
+test group, and only specify here the differences between each test case.
+
+### description
+
+Description of the test case. Images that show the test case configuration or
+results are particularly welcome here.
+
+```{image} images/cosine_bell_convergence.png
+:align: center
+:width: 500 px
+```
+
+### mesh
+
+Specify whether the mesh is global or planar and the resolution(s) tested. If
+planar, specify the mesh size. If global, specify whether the mesh is
+icosohedral or quasi-uniform. Specify any relevant options in the config file
+pertaining to setting up the mesh.
+
+### vertical grid
+
+If there are no restrictions on the vertical grid specifications inherent to
+the test case, then the config section may be provided without any further
+description.
+
+Examples of restrictions or special conditions warranting description may
+include:
+
+* Whether the topography is variable
+* Whether the test pertains to shallow water dynamics, in which case the
+minimum number of vertical levels may be used
+* Whether there are several test cases in the test group investigating the
+effects of different vertical coordinates (`coord_type`)
+
+```cfg
+# Options related to the vertical grid
+[vertical_grid]
+
+# the type of vertical grid
+grid_type = uniform
+
+# Number of vertical levels
+vert_levels = 3
+
+# Depth of the bottom of the ocean
+bottom_depth = 300.0
+
+# The type of vertical coordinate (e.g. z-level, z-star)
+coord_type = z-level
+
+# Whether to use "partial" or "full", or "None" to not alter the topography
+partial_cell_type = None
+
+# The minimum fraction of a layer for partial cells
+min_pc_fraction = 0.1
+```
+
+### initial conditions
+
+The initial conditions should be specified for all variables requiring
+initial conditions (see
+[Models](https://e3sm-project.github.io/polaris/main/developers_guide/ocean/models/index.html)).
+
+### forcing
+
+If applicable, specify the forcing applied at each time step of the simulation
+(in MPAS-Ocean, these are the variables contained in the `forcing` stream).
+If not applicable, keep this section with the notation N/A.
+
+### time step
+
+The time step for forward integration should be specified here for the test
+case's resolution.
+
+### config options
+
+Here, include the config section(s) that is specific to this test case. E.g.,
+
+```cfg
+# options for cosine bell convergence test case
+[cosine_bell]
+
+# time step per resolution (s/km), since dt is proportional to resolution
+dt_per_km = 30
+
+# the constant temperature of the domain
+temperature = 15.0
+
+# the constant salinity of the domain
+salinity = 35.0
+...
+
+
+# options for visualization for the cosine bell convergence test case
+[cosine_bell_viz]
+
+# visualization latitude and longitude resolution
+dlon = 0.5
+dlat = 0.5
+
+# remapping method ('bilinear', 'neareststod', 'conserve')
+remap_method = conserve
+```
+
+Include here any further description of each of the config options.
+
+### cores
+
+Specify whether the number of cores is determined by `goal_cells_per_core` and
+`max_cells_per_core` in the `ocean` section of the config file or whether the
+default and minimum number of cores is given in arguments to the forward step,
+and what those defaults are.

--- a/docs/users_guide/ocean/test_groups/template.md
+++ b/docs/users_guide/ocean/test_groups/template.md
@@ -72,8 +72,7 @@ min_pc_fraction = 0.1
 ### initial conditions
 
 The initial conditions should be specified for all variables requiring
-initial conditions (see
-[Models](https://e3sm-project.github.io/polaris/main/developers_guide/ocean/models/index.html)).
+initial conditions (see {ref}`dev-ocean-models`).
 
 ### forcing
 

--- a/docs/users_guide/ocean/test_groups/template.md
+++ b/docs/users_guide/ocean/test_groups/template.md
@@ -9,8 +9,10 @@ Description of the test group.
 ## test_case_name
 
 In cases where the test cases within a test group share many characteristics,
-it may be more appropriate to move the following sections up one level to the
-test group, and only specify here the differences between each test case.
+it may be more appropriate to move the certain sections up one level to the
+test group. In that case, the respective section should still be included for
+each test case, specifying any or no differences from the section in the test
+group level.
 
 ### description
 
@@ -79,10 +81,10 @@ If applicable, specify the forcing applied at each time step of the simulation
 (in MPAS-Ocean, these are the variables contained in the `forcing` stream).
 If not applicable, keep this section with the notation N/A.
 
-### time step
+### time step and run duration
 
 The time step for forward integration should be specified here for the test
-case's resolution.
+case's resolution. The run duration should also be specified.
 
 ### config options
 


### PR DESCRIPTION
This PR adds a template for test groups for the User's Guide to help ensure all the details relevant to the configuration of a test case in a test group are provided. 

Checklist
* [X] User's Guide has been updated
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected