### PR TITLE
Use shorter imports for Component, TestGroup, etc.

### DIFF
--- a/docs/developers_guide/framework/remapping.md
+++ b/docs/developers_guide/framework/remapping.md
@@ -23,7 +23,7 @@ method:
 
 ```python
 
-from polaris.testcase import TestCase
+from polaris import TestCase
 from polaris.remap import MappingFileStep
 
 class MyTestCase(TestCase):

--- a/docs/developers_guide/framework/visualization.md
+++ b/docs/developers_guide/framework/visualization.md
@@ -68,7 +68,7 @@ Typical usage might be:
 import cmocean  # noqa: F401
 import xarray as xr
 
-from polaris.step import Step
+from polaris import Step
 from polaris.viz.globe import plot_global
 
 class Viz(Step):

--- a/docs/developers_guide/organization/components.md
+++ b/docs/developers_guide/organization/components.md
@@ -32,7 +32,7 @@ core.  Then, it creates objects for each test group and adds them to itself, as
 in this example from {py:class}`polaris.ocean.Ocean`:
 
 ```python
-from polaris.component import Component
+from polaris import Component
 from polaris.ocean.tests.baroclinic_channel import BaroclinicChannel
 from polaris.ocean.tests.global_ocean import GlobalOcean
 from polaris.ocean.tests.ice_shelf_2d import IceShelf2d

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -172,7 +172,7 @@ mesh type as an attribute:
 
 ```python
 from polaris.model_step import make_graph_file
-from polaris.step import Step
+from polaris import Step
 
 
 class SetupMesh(Step):
@@ -433,7 +433,7 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 
 from polaris.ocean.vertical import generate_grid
-from polaris.step import Step
+from polaris import Step
 
 
 class InitialState(Step):

--- a/docs/developers_guide/organization/test_cases.md
+++ b/docs/developers_guide/organization/test_cases.md
@@ -189,7 +189,7 @@ As an example, here is the constructor from
 {py:class}`polaris.ocean.tests.baroclinic_channel.rpe_test.RpeTest`:
 
 ```python
-from polaris.testcase import TestCase
+from polaris import TestCase
 from polaris.ocean.tests.baroclinic_channel.initial_state import InitialState
 from polaris.ocean.tests.baroclinic_channel.forward import Forward
 from polaris.ocean.tests.baroclinic_channel.rpe_test.analysis import Analysis

--- a/docs/developers_guide/organization/test_groups.md
+++ b/docs/developers_guide/organization/test_groups.md
@@ -77,7 +77,7 @@ determine both which component and which test group it belongs to. As an
 example, the {py:class}`polaris.landice.tests.dome.Dome` class looks like this:
 
 ```python
-from polaris.testgroup import TestGroup
+from polaris import TestGroup
 from polaris.landice.tests.dome.smoke_test import SmokeTest
 from polaris.landice.tests.dome.decomposition_test import DecompositionTest
 from polaris.landice.tests.dome.restart_test import RestartTest

--- a/polaris/components.py
+++ b/polaris/components.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from polaris.component import Component
+from polaris import Component
 # import new components here
 from polaris.ocean import Ocean
 

--- a/polaris/mesh/spherical.py
+++ b/polaris/mesh/spherical.py
@@ -15,8 +15,8 @@ from mpas_tools.ocean.inject_meshDensity import inject_spherical_meshDensity
 from mpas_tools.viz.colormaps import register_sci_viz_colormaps
 from mpas_tools.viz.paraview_extractor import extract_vtk
 
+from polaris import Step
 from polaris.model_step import make_graph_file
-from polaris.step import Step
 
 
 class SphericalBaseStep(Step):
@@ -34,7 +34,7 @@ class SphericalBaseStep(Step):
 
         Parameters
         ----------
-        test_case : polaris.testcase.TestCase
+        test_case : polaris.TestCase
             The test case this step belongs to
 
         name : str
@@ -191,7 +191,7 @@ class QuasiUniformSphericalMeshStep(SphericalBaseStep):
 
         Parameters
         ----------
-        test_case : polaris.testcase.TestCase
+        test_case : polaris.TestCase
             The test case this step belongs to
 
         name : str, optional
@@ -331,7 +331,7 @@ class IcosahedralMeshStep(SphericalBaseStep):
 
         Parameters
         ----------
-        test_case : polaris.testcase.TestCase
+        test_case : polaris.TestCase
             The test case this step belongs to
 
         name : str, optional

--- a/polaris/ocean/__init__.py
+++ b/polaris/ocean/__init__.py
@@ -1,4 +1,4 @@
-from polaris.component import Component
+from polaris import Component
 from polaris.ocean.tests.baroclinic_channel import BaroclinicChannel
 from polaris.ocean.tests.global_convergence import GlobalConvergence
 

--- a/polaris/ocean/tests/baroclinic_channel/__init__.py
+++ b/polaris/ocean/tests/baroclinic_channel/__init__.py
@@ -1,3 +1,4 @@
+from polaris import TestGroup
 from polaris.ocean.tests.baroclinic_channel.baroclinic_channel_test_case import (  # noqa: E501
     BaroclinicChannelTestCase,
 )
@@ -6,7 +7,6 @@ from polaris.ocean.tests.baroclinic_channel.default import Default
 from polaris.ocean.tests.baroclinic_channel.restart_test import RestartTest
 from polaris.ocean.tests.baroclinic_channel.rpe_test import RpeTest
 from polaris.ocean.tests.baroclinic_channel.threads_test import ThreadsTest
-from polaris.testgroup import TestGroup
 
 
 class BaroclinicChannel(TestGroup):

--- a/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
+++ b/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
@@ -2,8 +2,8 @@ import os
 
 import numpy as np
 
+from polaris import TestCase
 from polaris.ocean.tests.baroclinic_channel.initial_state import InitialState
-from polaris.testcase import TestCase
 from polaris.validate import compare_variables
 
 

--- a/polaris/ocean/tests/baroclinic_channel/initial_state.py
+++ b/polaris/ocean/tests/baroclinic_channel/initial_state.py
@@ -5,8 +5,8 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
+from polaris import Step
 from polaris.ocean.vertical import init_vertical_coord
-from polaris.step import Step
 from polaris.viz import plot_horiz_field
 
 

--- a/polaris/ocean/tests/baroclinic_channel/rpe_test/analysis.py
+++ b/polaris/ocean/tests/baroclinic_channel/rpe_test/analysis.py
@@ -3,8 +3,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import xarray
 
+from polaris import Step
 from polaris.ocean.rpe import compute_rpe
-from polaris.step import Step
 
 
 class Analysis(Step):

--- a/polaris/ocean/tests/baroclinic_channel/viz.py
+++ b/polaris/ocean/tests/baroclinic_channel/viz.py
@@ -2,7 +2,7 @@ import cmocean  # noqa: F401
 import numpy as np
 import xarray as xr
 
-from polaris.step import Step
+from polaris import Step
 from polaris.viz import plot_horiz_field
 
 

--- a/polaris/ocean/tests/global_convergence/__init__.py
+++ b/polaris/ocean/tests/global_convergence/__init__.py
@@ -1,5 +1,5 @@
+from polaris import TestGroup
 from polaris.ocean.tests.global_convergence.cosine_bell import CosineBell
-from polaris.testgroup import TestGroup
 
 
 class GlobalConvergence(TestGroup):

--- a/polaris/ocean/tests/global_convergence/cosine_bell/__init__.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/__init__.py
@@ -1,3 +1,4 @@
+from polaris import TestCase
 from polaris.config import PolarisConfigParser
 from polaris.mesh.spherical import (
     IcosahedralMeshStep,
@@ -9,7 +10,6 @@ from polaris.ocean.tests.global_convergence.cosine_bell.analysis import (
 from polaris.ocean.tests.global_convergence.cosine_bell.forward import Forward
 from polaris.ocean.tests.global_convergence.cosine_bell.init import Init
 from polaris.ocean.tests.global_convergence.cosine_bell.viz import Viz, VizMap
-from polaris.testcase import TestCase
 from polaris.validate import compare_variables
 
 

--- a/polaris/ocean/tests/global_convergence/cosine_bell/analysis.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/analysis.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 
-from polaris.step import Step
+from polaris import Step
 
 
 class Analysis(Step):

--- a/polaris/ocean/tests/global_convergence/cosine_bell/init.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/init.py
@@ -2,8 +2,8 @@ import numpy as np
 import xarray as xr
 from mpas_tools.io import write_netcdf
 
+from polaris import Step
 from polaris.ocean.vertical import init_vertical_coord
-from polaris.step import Step
 
 
 class Init(Step):

--- a/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
@@ -1,8 +1,8 @@
 import cmocean  # noqa: F401
 import xarray as xr
 
+from polaris import Step
 from polaris.remap import MappingFileStep
-from polaris.step import Step
 from polaris.viz.globe import plot_global
 
 

--- a/polaris/remap/mapping_file_step.py
+++ b/polaris/remap/mapping_file_step.py
@@ -13,7 +13,7 @@ from pyremap import (
     get_lat_lon_descriptor,
 )
 
-from polaris.step import Step
+from polaris import Step
 
 
 class MappingFileStep(Step):

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -7,12 +7,11 @@ from typing import Dict, List
 
 from mache import discover_machine
 
-from polaris import provenance
+from polaris import TestCase, provenance
 from polaris.components import get_components
 from polaris.config import PolarisConfigParser
 from polaris.io import symlink
 from polaris.job import write_job_script
-from polaris.testcase import TestCase
 
 
 def setup_cases(work_dir, tests=None, numbers=None, config_file=None,


### PR DESCRIPTION
This is more consistent with the API documentation, which uses the shorter names, and also what we want folks to use in new test groups they make.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
