### PR TITLE
Clean up baroclinic channel

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -240,6 +240,8 @@ ocean/api
 
 .. autosummary::
    :toctree: generated/
+   
+   planar.compute_planar_hex_nx_ny
 
    spherical.SphericalBaseStep
    spherical.SphericalBaseStep.setup

--- a/docs/developers_guide/framework/mesh.md
+++ b/docs/developers_guide/framework/mesh.md
@@ -28,7 +28,7 @@ icosahedron.  The following table shows the approximate resolution of a mesh
 with a given number of subdivisions:
 
 | subdivisions | cell width (km) |
-| ------------ | --------------- |
+|--------------|-----------------|
 | 5            | 240             |
 | 6            | 120             |
 | 7            | 60              |
@@ -96,12 +96,23 @@ resolution `dc` in km (`dc` is the distance between adjacent cell centers),
 and some (admittedly oddly named) parameters for determining which directions
 (if any) are periodic, `nonperiodic_x` and `nonperiodic_y`.
 
-There are a few considerations for determining `nx` and `ny`.  Typically,
-we need at least 4 grid cells in each direction for MPAS-Ocean to be well
-behaved, and similar restrictions may apply to other components.  Second,
-`ny` needs to be an even number because of the staggering of the hexagons used
-to create the mesh.  (We typically also use even numbers for `nx` but that is
-not strictly necessary.)
+There are a few considerations for determining `nx` and `ny`. There is a 
+framework level function {py:func}`polaris.mesh.planar.compute_planar_hex_nx_ny()`
+to take care of this for you:
+
+```python
+from polaris.mesh.planar import compute_planar_hex_nx_ny
+
+
+nx, ny = compute_planar_hex_nx_ny(lx, ly, resolution)
+```
+
+What follows is an explanation of the subtleties that are accounted for in that
+function. Typically, we need at least 4 grid cells in each direction for 
+MPAS-Ocean to be well behaved, and similar restrictions may apply to other 
+components.  Second, `ny` needs to be an even number because of the staggering 
+of the hexagons used to create the mesh.  (We typically also use even numbers 
+for `nx` but that is not strictly necessary.)
 
 Another important consideration is that the physical size of the mesh in the x
 direction is `lx = nx * dc`.  However, the physical extent in the y direction 

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -22,7 +22,6 @@
    BaroclinicChannel
 
    BaroclinicChannelTestCase
-   BaroclinicChannelTestCase.configure
    BaroclinicChannelTestCase.validate
    
    forward.Forward

--- a/docs/users_guide/ocean/test_groups/baroclinic_channel.md
+++ b/docs/users_guide/ocean/test_groups/baroclinic_channel.md
@@ -59,22 +59,6 @@ min_pc_fraction = 0.1
 lx = 160.0
 ly = 500.0
 
-# the number of mesh cells in the x direction
-nx = <<<set in code>>>
-
-# the number of mesh cells in the y direction
-ny = <<<set in code>>>
-
-# the distance between adjacent cell centers
-dc = <<<set in code>>>
-
-# the number of cells per core to aim for
-goal_cells_per_core = 200
-
-# the approximate maximum number of cells per core (the test will fail if too
-# few cores are available)
-max_cells_per_core = 2000
-
 # time step per resolution (s/km), since dt is proportional to resolution
 dt_per_km = 30
 
@@ -100,11 +84,11 @@ bottom_temperature = 10.1
 temperature_difference = 1.2
 
 # Fraction of domain in Y direction the temperature gradient should be linear
-# over.
+# over. Used when use_distances = False.
 gradient_width_frac = 0.08
 
 # Width of the temperature gradient around the center sin wave. Default value
-# is relative to a 500km domain in Y.
+# is relative to a 500km domain in Y. Used when use_distances = True.
 gradient_width_dist = 40e3
 
 # Salinity of the water in the entire domain.

--- a/polaris/mesh/planar.py
+++ b/polaris/mesh/planar.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+
+def compute_planar_hex_nx_ny(lx, ly, resolution):
+    """
+    Compute number of grid cells in each direction for the uniform, hexagonal
+    planar mesh with the given physical sizes and resolution.  The resulting
+    ``nx`` and ``ny`` account for the staggered nature of the hexagonal grid
+    in the y direction, and are appropriate for passing to
+    :py:func:`mpas_tools.planar_hex.make_planar_hex_mesh()`.
+
+    Parameters
+    ----------
+    lx : float
+        The size of the domain in km in the x direction
+
+    ly : float
+        The size of the domain in km in the y direction
+
+    resolution : float
+        The resolution of the mesh (distance between cell centers) in km
+
+    Returns
+    -------
+    nx : int
+        The number of grid cells in the x direction
+
+    ny : int
+        The number of grid cells in the y direction
+    """
+    # these could be hard-coded as functions of specific supported
+    # resolutions but it is preferable to make them algorithmic like here
+    # for greater flexibility
+    nx = max(2 * int(0.5 * lx / resolution + 0.5), 4)
+    # factor of 2/sqrt(3) because of hexagonal mesh
+    ny = max(2 * int(0.5 * ly * (2. / np.sqrt(3)) / resolution + 0.5), 4)
+    return nx, ny

--- a/polaris/ocean/config/output.yaml
+++ b/polaris/ocean/config/output.yaml
@@ -1,4 +1,4 @@
-ocean:
+omega:
   streams:
     output:
       type: output

--- a/polaris/ocean/tests/baroclinic_channel/baroclinic_channel.cfg
+++ b/polaris/ocean/tests/baroclinic_channel/baroclinic_channel.cfg
@@ -26,15 +26,6 @@ min_pc_fraction = 0.1
 lx = 160.0
 ly = 500.0
 
-# the number of mesh cells in the x direction
-nx = <<<set in code>>>
-
-# the number of mesh cells in the y direction
-ny = <<<set in code>>>
-
-# the distance between adjacent cell centers
-dc = <<<set in code>>>
-
 # time step per resolution (s/km), since dt is proportional to resolution
 dt_per_km = 30
 

--- a/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
+++ b/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
@@ -1,7 +1,5 @@
 import os
 
-import numpy as np
-
 from polaris import TestCase
 from polaris.ocean.tests.baroclinic_channel.initial_state import InitialState
 from polaris.validate import compare_variables
@@ -44,31 +42,6 @@ class BaroclinicChannelTestCase(TestCase):
 
         self.add_step(
             InitialState(test_case=self, resolution=resolution))
-
-    def configure(self):
-        """
-        Modify the configuration options for this test case.
-        """
-        resolution = self.resolution
-        config = self.config
-
-        lx = config.getfloat('baroclinic_channel', 'lx')
-        ly = config.getfloat('baroclinic_channel', 'ly')
-
-        # these could be hard-coded as functions of specific supported
-        # resolutions but it is preferable to make them algorithmic like here
-        # for greater flexibility
-        #
-        # ny is required to be even for periodicity, and we do the same for nx
-        # for consistency
-        nx = max(2 * int(0.5 * lx / resolution + 0.5), 4)
-        # factor of 2/sqrt(3) because of hexagonal mesh
-        ny = max(2 * int(0.5 * ly * (2. / np.sqrt(3)) / resolution + 0.5), 4)
-        dc = 1e3 * resolution
-
-        config.set('baroclinic_channel', 'nx', f'{nx}')
-        config.set('baroclinic_channel', 'ny', f'{ny}')
-        config.set('baroclinic_channel', 'dc', f'{dc}')
 
     def validate(self):
         """

--- a/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
+++ b/polaris/ocean/tests/baroclinic_channel/baroclinic_channel_test_case.py
@@ -48,6 +48,7 @@ class BaroclinicChannelTestCase(TestCase):
         Compare ``temperature``, ``salinity`` and ``layerThickness`` from the
         initial condition with a baseline if one was provided
         """
+        super().validate()
         variables = ['temperature', 'salinity', 'layerThickness']
         compare_variables(test_case=self, variables=variables,
                           filename1='initial_state/initial_state.nc')

--- a/polaris/ocean/tests/baroclinic_channel/initial_state.py
+++ b/polaris/ocean/tests/baroclinic_channel/initial_state.py
@@ -80,75 +80,75 @@ class InitialState(Step):
         coriolis_parameter = section.getfloat('coriolis_parameter')
 
         ds = ds_mesh.copy()
-        xCell = ds.xCell
-        yCell = ds.yCell
+        x_cell = ds.xCell
+        y_cell = ds.yCell
 
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
 
-        ds['bottomDepth'] = bottom_depth * xr.ones_like(xCell)
-        ds['ssh'] = xr.zeros_like(xCell)
+        ds['bottomDepth'] = bottom_depth * xr.ones_like(x_cell)
+        ds['ssh'] = xr.zeros_like(x_cell)
 
         init_vertical_coord(config, ds)
 
         ds_mesh['maxLevelCell'] = ds.maxLevelCell
 
-        xMin = xCell.min().values
-        xMax = xCell.max().values
-        yMin = yCell.min().values
-        yMax = yCell.max().values
+        x_min = x_cell.min().values
+        x_max = x_cell.max().values
+        y_min = y_cell.min().values
+        y_max = y_cell.max().values
 
-        yMid = 0.5 * (yMin + yMax)
-        xPerturbMin = xMin + 4.0 * (xMax - xMin) / 6.0
-        xPerturbMax = xMin + 5.0 * (xMax - xMin) / 6.0
+        y_mid = 0.5 * (y_min + y_max)
+        x_perturb_min = x_min + 4.0 * (x_max - x_min) / 6.0
+        x_perturb_max = x_min + 5.0 * (x_max - x_min) / 6.0
 
         if use_distances:
-            perturbationWidth = gradient_width_dist
+            perturb_width = gradient_width_dist
         else:
-            perturbationWidth = (yMax - yMin) * gradient_width_frac
+            perturb_width = (y_max - y_min) * gradient_width_frac
 
-        yOffset = perturbationWidth * np.sin(
-            6.0 * np.pi * (xCell - xMin) / (xMax - xMin))
+        y_offset = perturb_width * np.sin(
+            6.0 * np.pi * (x_cell - x_min) / (x_max - x_min))
 
         temp_vert = (bottom_temperature +
                      (surface_temperature - bottom_temperature) *
                      ((ds.refZMid + bottom_depth) / bottom_depth))
 
-        frac = xr.where(yCell < yMid - yOffset, 1., 0.)
+        frac = xr.where(y_cell < y_mid - y_offset, 1., 0.)
 
-        mask = np.logical_and(yCell >= yMid - yOffset,
-                              yCell < yMid - yOffset + perturbationWidth)
+        mask = np.logical_and(y_cell >= y_mid - y_offset,
+                              y_cell < y_mid - y_offset + perturb_width)
         frac = xr.where(mask,
-                        1. - (yCell - (yMid - yOffset)) / perturbationWidth,
+                        1. - (y_cell - (y_mid - y_offset)) / perturb_width,
                         frac)
 
         temperature = temp_vert - temperature_difference * frac
         temperature = temperature.transpose('nCells', 'nVertLevels')
 
-        # Determine yOffset for 3rd crest in sin wave
-        yOffset = 0.5 * perturbationWidth * np.sin(
-            np.pi * (xCell - xPerturbMin) / (xPerturbMax - xPerturbMin))
+        # Determine y_offset for 3rd crest in sin wave
+        y_offset = 0.5 * perturb_width * np.sin(
+            np.pi * (x_cell - x_perturb_min) / (x_perturb_max - x_perturb_min))
 
         mask = np.logical_and(
-            np.logical_and(yCell >= yMid - yOffset - 0.5 * perturbationWidth,
-                           yCell <= yMid - yOffset + 0.5 * perturbationWidth),
-            np.logical_and(xCell >= xPerturbMin,
-                           xCell <= xPerturbMax))
+            np.logical_and(y_cell >= y_mid - y_offset - 0.5 * perturb_width,
+                           y_cell <= y_mid - y_offset + 0.5 * perturb_width),
+            np.logical_and(x_cell >= x_perturb_min,
+                           x_cell <= x_perturb_max))
 
         temperature = (temperature +
-                       mask * 0.3 * (1. - ((yCell - (yMid - yOffset)) /
-                                           (0.5 * perturbationWidth))))
+                       mask * 0.3 * (1. - ((y_cell - (y_mid - y_offset)) /
+                                           (0.5 * perturb_width))))
 
         temperature = temperature.expand_dims(dim='Time', axis=0)
 
-        normalVelocity = xr.zeros_like(ds.xEdge)
-        normalVelocity, _ = xr.broadcast(normalVelocity, ds.refBottomDepth)
-        normalVelocity = normalVelocity.transpose('nEdges', 'nVertLevels')
-        normalVelocity = normalVelocity.expand_dims(dim='Time', axis=0)
+        normal_velocity = xr.zeros_like(ds.xEdge)
+        normal_velocity, _ = xr.broadcast(normal_velocity, ds.refBottomDepth)
+        normal_velocity = normal_velocity.transpose('nEdges', 'nVertLevels')
+        normal_velocity = normal_velocity.expand_dims(dim='Time', axis=0)
 
         ds['temperature'] = temperature
         ds['salinity'] = salinity * xr.ones_like(temperature)
-        ds['normalVelocity'] = normalVelocity
-        ds['fCell'] = coriolis_parameter * xr.ones_like(xCell)
+        ds['normalVelocity'] = normal_velocity
+        ds['fCell'] = coriolis_parameter * xr.ones_like(x_cell)
         ds['fEdge'] = coriolis_parameter * xr.ones_like(ds.xEdge)
         ds['fVertex'] = coriolis_parameter * xr.ones_like(ds.xVertex)
 
@@ -161,5 +161,5 @@ class InitialState(Step):
         plot_horiz_field(ds, ds_mesh, 'temperature',
                          'initial_temperature.png')
         plot_horiz_field(ds, ds_mesh, 'normalVelocity',
-                         'initial_normalVelocity.png', cmap='cmo.balance',
+                         'initial_normal_velocity.png', cmap='cmo.balance',
                          show_patch_edges=True)

--- a/polaris/ocean/tests/baroclinic_channel/viz.py
+++ b/polaris/ocean/tests/baroclinic_channel/viz.py
@@ -10,11 +10,6 @@ class Viz(Step):
     """
     A step for plotting the results of a series of RPE runs in the baroclinic
     channel test group
-
-    Attributes
-    ----------
-    nus : list
-        A list of viscosities
     """
     def __init__(self, test_case):
         """


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge includes some clean-up to the baroclinic channel test group that I feel is important based on writing the tutorial.

First, this merge adds a framework-level function that computes `nx` and `ny` for a uniform, hexagonal planar mesh.  The function takes into account the staggered nature of the hexagons in the y direction as corrected in #37.

Then, in the baroclinic channel, instead of computing these properties in the test case and storing them in config options, they are computed using a framework-level function at setup in forward (to get the cell count) and then again at runtime in `initial_state` to make the mesh.  Initial state stores `nx` and `ny` as attributes in the initial state output file.  The RPE analysis step then reads the attributes from the initial state file rather than config options.

The reason for this change is that users should not modify these config options.  But if a user does modify the domain size (`lx` and `ly`) either before setup or before running, this should result in changes in `nx` and `ny`.  There is simply no good reason for `nx` and `ny` to be config options other than the convenience of passing them between steps, which can be accomplished more cleanly with file attributes.

The RPE analysis step previously used hard-coded values for the domain extent and tick marks.  These have been updated to use`lx` and `ly` (though that is still not entirely accurate).

This merge also changes the way that forward and analysis steps are added to the RPE test case.  They need to be added both at init and setup because we want `polaris list --verbose` to show the default steps (require addition at init) and we want the steps to change at setup if a user supplies a different list of viscosities.  Before this merge, `polaris list --verbose` only showed the `initial_state` step in the RPE tests.  Similar behavior in the compass `cosine_bell` test case had proven confusing for developers so this same approach is used in both the compass and polaris versions of that test case.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
