### PR TITLE
Fix error when building docs on main after merge

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           source load_polaris_test.sh
           # sphinx-multiversion expects at least a "main" branch
-          git branch main
+          git branch main || echo "branch main already exists."
           cd docs
           sphinx-multiversion . _build/html
 


### PR DESCRIPTION
The GitHub Action build workflow works fine on PRs but was having trouble once the PR gets merged because now the branch `main` already exists (and the workflow tries to create it).  This merge will hopefully fix that issue.
