### PR TITLE
Find netcdf/pnetcdf with env vars on Chicoma and PM

### DIFF
--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -376,11 +376,18 @@ def get_env_vars(machine, compiler, mpilib):
                    f'export MV2_ENABLE_AFFINITY=0\n' \
                    f'export MV2_SHOW_CPU_BINDING=1\n'
 
-    env_vars = \
-        f'{env_vars}' \
-        f'export NETCDF=$(dirname $(dirname $(which nc-config)))\n' \
-        f'export NETCDFF=$(dirname $(dirname $(which nf-config)))\n' \
-        f'export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))\n'
+    if machine.startswith('chicoma') or machine.startswith('pm'):
+        env_vars = \
+            f'{env_vars}' \
+            f'export NETCDF=${{CRAY_NETCDF_HDF5PARALLEL_PREFIX}}\n' \
+            f'export NETCDFF=${{CRAY_NETCDF_HDF5PARALLEL_PREFIX}}\n' \
+            f'export PNETCDF=${{CRAY_PARALLEL_NETCDF_PREFIX}}\n'
+    else:
+        env_vars = \
+            f'{env_vars}' \
+            f'export NETCDF=$(dirname $(dirname $(which nc-config)))\n' \
+            f'export NETCDFF=$(dirname $(dirname $(which nf-config)))\n' \
+            f'export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))\n'
 
     return env_vars
 


### PR DESCRIPTION
This is necessary because the `nc-config` executable cannot be used to locate the correct path for the libraries.

Same as https://github.com/MPAS-Dev/compass/pull/531 from compass.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
