### PR TITLE
Make ocean ntasks and min_tasks a multiple of 4

### DIFF
--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -209,7 +209,10 @@ class OceanModelStep(ModelStep):
         goal_cells_per_core = config.getfloat('ocean', 'goal_cells_per_core')
         max_cells_per_core = config.getfloat('ocean', 'max_cells_per_core')
 
+        # machines (e.g. Perlmutter) seem to be happier with ntasks that
+        # are multiples of 4
         # ideally, about 200 cells per core
-        self.ntasks = max(1, round(cell_count / goal_cells_per_core + 0.5))
+        self.ntasks = max(1, 4 * round(cell_count / (4 * goal_cells_per_core)))
         # In a pinch, about 2000 cells per core
-        self.min_tasks = max(1, round(cell_count / max_cells_per_core + 0.5))
+        self.min_tasks = max(1,
+                             4 * round(cell_count / (4 * max_cells_per_core)))


### PR DESCRIPTION
This seems to work better on Perlumtter.

Also, fix rounding (remove incorrect factor of 0.5)

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
