### PR TITLE
Explicitly specify nodes in srun calls

### DIFF
--- a/polaris/parallel.py
+++ b/polaris/parallel.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import warnings
 
+import numpy as np
 from mpas_tools.logging import check_call
 
 
@@ -149,7 +150,12 @@ def run_command(args, cpus_per_task, ntasks, openmp_threads, config, logger):
     command_line_args = parallel_executable.split(' ')
     parallel_system = config.get('parallel', 'system')
     if parallel_system == 'slurm':
-        command_line_args.extend(['-c', f'{cpus_per_task}', '-n', f'{ntasks}'])
+        cores = ntasks * cpus_per_task
+        cores_per_node = config.getint('parallel', 'cores_per_node')
+        nodes = int(np.ceil(cores / cores_per_node))
+        command_line_args.extend(['-c', f'{cpus_per_task}',
+                                  '-N', f'{nodes}',
+                                  '-n', f'{ntasks}'])
     elif parallel_system == 'single_node':
         command_line_args.extend(['-n', f'{ntasks}'])
     else:


### PR DESCRIPTION
We want to explicitly specify how many nodes to use in `srun` calls for slurm steps because otherwise we may end up with a job running on more nodes than needed and an incompatible PIO task count.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
