### PR TITLE
Fix check for inputs in subdirectories

### DIFF
--- a/polaris/step.py
+++ b/polaris/step.py
@@ -500,10 +500,7 @@ class Step:
         if len(databases_with_downloads) > 0:
             self._fix_permissions(databases_with_downloads)
 
-        # convert inputs and outputs to absolute paths
-        self.inputs = [os.path.abspath(os.path.join(step_dir, filename)) for
-                       filename in inputs]
-
+        # inputs are already absolute paths, convert outputs to absolute paths
         self.outputs = [os.path.abspath(os.path.join(step_dir, filename)) for
                         filename in self.outputs]
 
@@ -565,18 +562,20 @@ class Step:
 
         if target is not None:
             filepath = os.path.join(step_dir, filename)
+            dirname = os.path.dirname(filepath)
             if copy:
                 shutil.copy(target, filepath)
             else:
-                dirname = os.path.dirname(filepath)
                 try:
                     os.makedirs(dirname)
                 except FileExistsError:
                     pass
                 symlink(target, filepath)
-            input_file = target
+            input_file = os.path.join(dirname, target)
         else:
-            input_file = filename
+            input_file = os.path.join(step_dir, filename)
+
+        input_file = os.path.abspath(input_file)
 
         return input_file, database_subdirs
 


### PR DESCRIPTION
When you add an input in a subdirectory and the target is also in the subdirectory of another step, polaris was previously incorrectly creating an absolute path to the input relative to the step's workdir, rather than the subdirectory where the symlink exists.  This merge fixes that bug.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #61 
