### PR TITLE
Make versions of cosine bell with and without viz steps

### DIFF
--- a/docs/developers_guide/framework/remapping.md
+++ b/docs/developers_guide/framework/remapping.md
@@ -75,7 +75,7 @@ class VizMap(MappingFileStep):
         dlat = section.getfloat('dlat')
         method = section.get('remap_method')
         self.src_from_mpas(filename='mesh.nc', mesh_name=self.mesh_name)
-        self.dst_global_lon_lat(dlon=dlon, dlat=dlat)
+        self.dst_global_lon_lat(dlon=dlon, dlat=dlat, lon_min=0.)
         self.method = method
 
         super().runtime_setup()

--- a/docs/developers_guide/ocean/test_groups/global_convergence.md
+++ b/docs/developers_guide/ocean/test_groups/global_convergence.md
@@ -57,6 +57,10 @@ at each resolution and plotting them in `convergence.png`.
 
 ### viz
 
+Two visualization steps are available only in the `cosine_bell_with_viz`
+test cases.  They are not included in the `cosine_bell` test cases in order
+to not slow down regression testing when visualization is not desired.
+
 The class {py:class}`polaris.ocean.tests.global_convergence.cosine_bell.viz.VizMap`
 defines a step for creating a mapping file from the MPAS mesh at a given
 resolution to a lon-lat grid at a resolution and interpolation method 

--- a/docs/users_guide/ocean/test_groups/global_convergence.md
+++ b/docs/users_guide/ocean/test_groups/global_convergence.md
@@ -7,17 +7,17 @@ full globe.  Currently, the only test case is the advection of a cosine bell.
 
 (ocean-global-convergence-cosine-bell)=
 
-## cosine_bell
+## cosine_bell and cosine_bell_with_viz
 
 ### Description
 
-The `cosine_bell` test case implements the Cosine Bell test case as first
-described in [Williamson et al. 1992](<https://doi.org/10.1016/S0021-9991(05)80016-6>)
+The `cosine_bell` and `cosine_bell_with_viz` test cases implement the Cosine 
+Bell test case as first described in 
+[Williamson et al. 1992](<https://doi.org/10.1016/S0021-9991(05)80016-6>)
 but using the variant from Sec. 3a of
 [Skamarock and Gassmann](https://doi.org/10.1175/MWR-D-10-05056.1).  A flow
 field representing solid-body rotation transports a bell-shaped perturbation
-in a tracer $psi$ once around the sphere, returning to its initial
-location.
+in a tracer $psi$ once around the sphere, returning to its initial location.
 
 The test is a convergence test with time step varying proportionately to grid
 size. The result of the `analysis` step of the test case is a plot like the
@@ -27,6 +27,11 @@ following showing convergence as a function of the number of cells:
 :align: center
 :width: 500 px
 ```
+
+The `cosine_bell_with_viz` variant also includes visualization of the initial
+and final state on a lat-lon grid for each resolution.  The visualization is
+not included in the `cosine_bell` version of the test case in order to not
+slow down regression testing.
 
 ### mesh
 
@@ -209,7 +214,8 @@ The options `qu_conv_thresh` to `icos_conv_max` are thresholds for determining
 when the convergence rates are not within the expected range.
 
 The options in the `cosine_bell_viz` section are used in visualizing the
-initial and final states on a lon-lat grid.
+initial and final states on a lon-lat grid for `cosine_bell_with_viz` test
+cases.
 
 ### cores
 

--- a/polaris/ocean/tests/global_convergence/__init__.py
+++ b/polaris/ocean/tests/global_convergence/__init__.py
@@ -15,5 +15,7 @@ class GlobalConvergence(TestGroup):
         super().__init__(component=component, name='global_convergence')
 
         for icosahedral in [False, True]:
-            self.add_test_case(CosineBell(test_group=self,
-                                          icosahedral=icosahedral))
+            for include_viz in [False, True]:
+                self.add_test_case(CosineBell(test_group=self,
+                                              icosahedral=icosahedral,
+                                              include_viz=include_viz))

--- a/polaris/ocean/tests/global_convergence/cosine_bell/__init__.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/__init__.py
@@ -24,8 +24,11 @@ class CosineBell(TestCase):
 
     icosahedral : bool
         Whether to use icosahedral, as opposed to less regular, JIGSAW meshes
+
+    include_viz : bool
+        Include VizMap and Viz steps for each resolution
     """
-    def __init__(self, test_group, icosahedral):
+    def __init__(self, test_group, icosahedral, include_viz):
         """
         Create test case for creating a global MPAS-Ocean mesh
 
@@ -37,15 +40,21 @@ class CosineBell(TestCase):
         icosahedral : bool
             Whether to use icosahedral, as opposed to less regular, JIGSAW
             meshes
+
+        include_viz : bool
+            Include VizMap and Viz steps for each resolution
         """
         if icosahedral:
             subdir = 'icos/cosine_bell'
         else:
             subdir = 'qu/cosine_bell'
+        if include_viz:
+            subdir = f'{subdir}_with_viz'
         super().__init__(test_group=test_group, name='cosine_bell',
                          subdir=subdir)
         self.resolutions = list()
         self.icosahedral = icosahedral
+        self.include_viz = include_viz
 
         # add the steps with default resolutions so they can be listed
         config = PolarisConfigParser()
@@ -125,17 +134,17 @@ class CosineBell(TestCase):
             self.add_step(Forward(test_case=self, resolution=resolution,
                                   mesh_name=mesh_name))
 
-            name = f'{mesh_name}_map'
-            subdir = f'{mesh_name}/map'
-            viz_map = VizMap(test_case=self, name=name, subdir=subdir,
-                             mesh_name=mesh_name)
-            self.add_step(viz_map, run_by_default=False)
+            if self.include_viz:
+                name = f'{mesh_name}_map'
+                subdir = f'{mesh_name}/map'
+                viz_map = VizMap(test_case=self, name=name, subdir=subdir,
+                                 mesh_name=mesh_name)
+                self.add_step(viz_map)
 
-            name = f'{mesh_name}_viz'
-            subdir = f'{mesh_name}/viz'
-            self.add_step(Viz(test_case=self, name=name, subdir=subdir,
-                              viz_map=viz_map, mesh_name=mesh_name),
-                          run_by_default=False)
+                name = f'{mesh_name}_viz'
+                subdir = f'{mesh_name}/viz'
+                self.add_step(Viz(test_case=self, name=name, subdir=subdir,
+                                  viz_map=viz_map, mesh_name=mesh_name))
 
         self.add_step(Analysis(test_case=self, resolutions=resolutions,
                                icosahedral=self.icosahedral))

--- a/polaris/ocean/tests/global_convergence/cosine_bell/__init__.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/__init__.py
@@ -129,12 +129,13 @@ class CosineBell(TestCase):
             subdir = f'{mesh_name}/map'
             viz_map = VizMap(test_case=self, name=name, subdir=subdir,
                              mesh_name=mesh_name)
-            self.add_step(viz_map)
+            self.add_step(viz_map, run_by_default=False)
 
             name = f'{mesh_name}_viz'
             subdir = f'{mesh_name}/viz'
             self.add_step(Viz(test_case=self, name=name, subdir=subdir,
-                              viz_map=viz_map, mesh_name=mesh_name))
+                              viz_map=viz_map, mesh_name=mesh_name),
+                          run_by_default=False)
 
         self.add_step(Analysis(test_case=self, resolutions=resolutions,
                                icosahedral=self.icosahedral))

--- a/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
@@ -48,7 +48,7 @@ class VizMap(MappingFileStep):
         dlat = section.getfloat('dlat')
         method = section.get('remap_method')
         self.src_from_mpas(filename='mesh.nc', mesh_name=self.mesh_name)
-        self.dst_global_lon_lat(dlon=dlon, dlat=dlat)
+        self.dst_global_lon_lat(dlon=dlon, dlat=dlat, lon_min=0.)
         self.method = method
 
         super().runtime_setup()

--- a/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
@@ -112,6 +112,7 @@ class Viz(Step):
         ds_init = xr.open_dataset('initial_state.nc')
         ds_init = ds_init[['tracer1', ]].isel(Time=0, nVertLevels=0)
         ds_init = remapper.remap(ds_init)
+        ds_init.to_netcdf('remapped_init.nc')
 
         plot_global(ds_init.lon.values, ds_init.lat.values,
                     ds_init.tracer1.values,
@@ -122,6 +123,7 @@ class Viz(Step):
         ds_out = xr.open_dataset('output.nc')
         ds_out = ds_out[['tracer1', ]].isel(Time=-1, nVertLevels=0)
         ds_out = remapper.remap(ds_out)
+        ds_out.to_netcdf('remapped_final.nc')
 
         plot_global(ds_out.lon.values, ds_out.lat.values,
                     ds_out.tracer1.values,

--- a/polaris/remap/mapping_file_step.py
+++ b/polaris/remap/mapping_file_step.py
@@ -175,7 +175,7 @@ class MappingFileStep(Step):
             dst['name'] = mesh_name
         self.dst_grid_info = dst
 
-    def dst_global_lon_lat(self, dlon, dlat, mesh_name=None):
+    def dst_global_lon_lat(self, dlon, dlat, lon_min=-180., mesh_name=None):
         """
         Set the destination grid from a file with a longitude-latitude grid.
         The latitude and longitude variables can be 1D or 2D.
@@ -188,6 +188,9 @@ class MappingFileStep(Step):
         dlat : float
             The latitude resolution in degrees
 
+        lon_min : float, optional
+            The longitude for the left-hand edge of the global grid in degrees
+
         mesh_name : str, optional
             The name of the lon-lat grid (defaults to resolution and units,
             something like "0.5x0.5degree")
@@ -197,6 +200,7 @@ class MappingFileStep(Step):
         dst['type'] = 'lon-lat'
         dst['dlon'] = dlon
         dst['dlat'] = dlat
+        dst['lon_min'] = lon_min
         if mesh_name is not None:
             dst['name'] = mesh_name
         self.dst_grid_info = dst
@@ -482,8 +486,12 @@ def _get_lon_lat_descriptor(info):
     """ Get a lon-lat descriptor from the given info """
 
     if 'dlat' in info and 'dlon' in info:
+        lon_min = info['lon_min']
+        lon_max = lon_min + 360.
         descriptor = get_lat_lon_descriptor(dLon=info['dlon'],
-                                            dLat=info['dlat'])
+                                            dLat=info['dlat'],
+                                            lonMin=lon_min,
+                                            lonMax=lon_max)
     else:
         filename = info['filename']
         lon = info['lon_var']

--- a/polaris/viz/globe.py
+++ b/polaris/viz/globe.py
@@ -12,8 +12,6 @@ import cartopy
 import cmocean  # noqa: F401
 import matplotlib.colors as cols
 import matplotlib.pyplot as plt
-import matplotlib.ticker as mticker
-import numpy as np
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from pyremap.descriptor.utility import interp_extrap_corner
 
@@ -95,28 +93,26 @@ def plot_global(lon, lat, data_array, out_filename, config, colormap_section,
         fig.suptitle(title, y=0.935)
 
     subplots = [111]
-    projection = cartopy.crs.PlateCarree()
+    ref_projection = cartopy.crs.PlateCarree()
+    central_longitude = 0.5 * (lon_corner[0] + lon_corner[-1])
+    projection = cartopy.crs.PlateCarree(central_longitude=central_longitude)
 
-    extent = [-180, 180, -90, 90]
+    extent = [lon_corner[0], lon_corner[-1], lat_corner[0], lat_corner[-1]]
 
     colormap, norm, ticks = _setup_colormap(config, colormap_section)
 
     ax = plt.subplot(subplots[0], projection=projection)
 
-    ax.set_extent(extent, crs=projection)
+    ax.set_extent(extent, crs=ref_projection)
 
-    gl = ax.gridlines(crs=projection, color='gray', linestyle=':', zorder=5,
-                      draw_labels=True, linewidth=0.5)
+    gl = ax.gridlines(crs=ref_projection, color='gray', linestyle=':',
+                      zorder=5, draw_labels=True, linewidth=0.5)
     gl.right_labels = False
     gl.top_labels = False
-    gl.xlocator = mticker.FixedLocator(np.arange(-180., 181., 60.))
-    gl.ylocator = mticker.FixedLocator(np.arange(-80., 81., 20.))
-    gl.xformatter = cartopy.mpl.gridliner.LONGITUDE_FORMATTER
-    gl.yformatter = cartopy.mpl.gridliner.LATITUDE_FORMATTER
 
     plotHandle = ax.pcolormesh(lon_corner, lat_corner, data_array,
                                cmap=colormap, norm=norm,
-                               transform=projection, zorder=1)
+                               transform=ref_projection, zorder=1)
 
     if plot_land:
         _add_land_lakes_coastline(ax)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge also modifies the visualization so the central longitude is 180 degrees, not 0, so the cosine bell shape is in the center of the domain.

To accommodate this change, the remapping and global plotting has also been modified to support an arbitrary lower bound in longitude (in this case 0 degrees) rather than always using -180.  Manually placing grid lines on plots did not seem to work with these changes but automatic grid line locations seem to be fine so this merge removes manual grid line locations.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
