### PR TITLE
Rename `steps_not_to_run` and `--no-steps`

### DIFF
--- a/docs/developers_guide/command_line.md
+++ b/docs/developers_guide/command_line.md
@@ -196,7 +196,7 @@ directory:
 
 ```none
 polaris serial [-h] [--steps STEPS [STEPS ...]]
-                 [--no-steps NO_STEPS [NO_STEPS ...]]
+                 [--skip_steps SKIP_STEPS [SKIP_STEPS ...]]
                  [suite]
 ```
 
@@ -218,7 +218,7 @@ in the config file:
 steps_to_run = initial_state full_run restart_run
 ```
 
-Or you can use `--steps` to supply a list of steps to run, or `--no-steps`
+Or you can use `--steps` to supply a list of steps to run, or `--skip_steps`
 to supply a list of steps you do not want to run (from the defaults given in
 the config file).  For example,
 
@@ -229,7 +229,7 @@ polaris serial --steps initial_state full_run
 or
 
 ```none
-polaris serial --no-steps restart_run
+polaris serial --skip_steps restart_run
 ```
 
 Would both accomplish the same thing in this example -- skipping the


### PR DESCRIPTION
I renamed these to `steps_to_skip` and `--skip-steps` because it was more understandable, the former was a little confusing to read.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
