### PR TITLE
Add flynt package to linter for updating format strings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,14 @@ repos:
     hooks:
       - id: isort
 
+  # Can run individually with `flynt [file]` or `flynt [source]`
+  - repo: https://github.com/ikamensh/flynt
+    rev: '0.78'
+    hooks:
+      - id: flynt
+        args: ["--fail-on-change", "--verbose"]
+        require_serial: true
+
   # Can run individually with `pre-commit run flake8 --all-files`
   # Need to use flake8 GitHub mirror due to CentOS git issue with GitLab
   # https://github.com/pre-commit/pre-commit/issues/1206

--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -45,6 +45,7 @@ types-requests
 pip
 pytest
 isort
+flynt
 flake8
 mypy
 pre-commit

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -527,8 +527,9 @@ a tools that helps to enforce this standard by checking your code each time you
 make a commit.  It will tell you about various types of problems it finds.
 Internally, it uses [flake8](https://flake8.pycqa.org/en/latest/) to check PEP8 
 compliance, [isort](https://pycqa.github.io/isort/) to sort, check and format 
-imports, and [mypy](https://mypy-lang.org/) to check for consistent variable
-types. An example error might be:
+imports, [flynt](https://github.com/ikamensh/flynt) to change any format 
+strings to f-strings, and [mypy](https://mypy-lang.org/) to check for 
+consistent variable types. An example error might be:
 
 ```bash
 example.py:77:1: E302 expected 2 blank lines, found 1


### PR DESCRIPTION
Flynt is a package that automatically converts older-style formatting strings to f-strings. I've added this to pre-commit so that any incoming changes will use f-strings by default.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
