### PR TITLE
Logger cleanup and clarification

### DIFF
--- a/docs/tutorials/dev_add_test_group.md
+++ b/docs/tutorials/dev_add_test_group.md
@@ -678,13 +678,13 @@ $ cat polaris.o${SLURM_JOBID}
      Done.
      
      ocean/yet_another_channel/10km/default
-     compass calling: polaris.run.serial._run_test()
+     polaris calling: polaris.run.serial._run_test()
        in /gpfs/fs1/home/ac.cbegeman/polaris-repo/main/polaris/run/serial.py
      
      Running steps: initial_state
        * step: initial_state
      
-     compass calling: polaris.ocean.tests.yet_another_channel.default.Default.validate()
+     polaris calling: polaris.ocean.tests.yet_another_channel.default.Default.validate()
        inherited from: polaris.testcase.TestCase.validate()
        in /gpfs/fs1/home/ac.cbegeman/polaris-repo/main/polaris/testcase.py
      

--- a/polaris/logging.py
+++ b/polaris/logging.py
@@ -5,8 +5,8 @@ def log_method_call(method, logger):
     """
     Log the module path and file path of a call to a method, e.g.::
 
-      compass calling: compass.landice.tests.dome.decomposition_test.DecompositionTest.run()  # noqa: E501
-        in /turquoise/usr/projects/climate/mhoffman/mpas/compass/compass/landice/tests/dome/decomposition_test/__init__.py  # noqa: E501
+      polaris calling: polaris.landice.tests.dome.decomposition_test.DecompositionTest.run()  # noqa: E501
+        in /turquoise/usr/projects/climate/mhoffman/mpas/polaris/polaris/landice/tests/dome/decomposition_test/__init__.py  # noqa: E501
 
     Parameters
     ----------
@@ -49,14 +49,14 @@ def log_method_call(method, logger):
     actual_location = f'{actual_class.__module__}.{actual_class.__name__}'
 
     # not every class is defined in a file (e.g. python intrinsics) but we
-    # expect they always are in compass.  Still we'll check to make sure.
+    # expect they always are in polaris.  Still we'll check to make sure.
     try:
         class_file = inspect.getfile(actual_class)
     except TypeError:
         class_file = None
 
     # log what we found out
-    logger.info(f'compass calling: {child_location}.{method_name}()')
+    logger.info(f'polaris calling: {child_location}.{method_name}()')
     if child_location != actual_location:
         # okay, so we're inheriting this method from somewhere else.  Better
         # let the user know.
@@ -69,8 +69,8 @@ def log_function_call(function, logger):
     """
     Log the module path and file path of a call to a function, e.g.::
 
-      compass calling: compass.parallel.set_cores_per_node()
-        in /home/xylar/code/compass/compass/compass/parallel.py
+      polaris calling: polaris.parallel.set_cores_per_node()
+        in /home/xylar/code/polaris/polaris/polaris/parallel.py
 
     Parameters
     ----------
@@ -86,6 +86,6 @@ def log_function_call(function, logger):
     filename = inspect.getfile(function)
 
     # log what we found out
-    logger.info(f'compass calling: '
+    logger.info(f'polaris calling: '
                 f'{function.__module__}.{function.__name__}()')
     logger.info(f'  in {filename}')

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -377,8 +377,8 @@ def _log_and_run_test(test_case, stdout_logger, test_logger, quiet,
         secs = round(test_time)
         mins = secs // 60
         secs -= 60 * mins
-        stdout_logger.info(f'  test runtime:        \
-                           {start_time_color}{mins:02d}:{secs:02d}{end}')
+        stdout_logger.info(f'  test runtime:        '
+                           f'{start_time_color}{mins:02d}:{secs:02d}{end}')
 
         return success_str, success, test_time
 
@@ -466,8 +466,10 @@ def _run_step(test_case, step, new_log_file):
         step.runtime_setup()
 
         if step.args is not None:
-            step_logger.info('\nBypassing run() and running with command line \
-                             args\n')
+            step_logger.info('\nBypassing step\'s run() method and running '
+                             'with command line args\n')
+            log_function_call(function=run_command, logger=step_logger)
+            step_logger.info('')
             run_command(step.args, step.cpus_per_task, step.ntasks,
                         step.openmp_threads, step.config, step.logger)
         else:

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -236,7 +236,7 @@ class Step:
 
         # these will be set before running the step, dummy placeholders for now
         self.logger = logging.getLogger('dummy')
-        self.log_filename = ""
+        self.log_filename = None
 
         # output caching
         self.cached = cached


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR changes a few things concerning loggers. Some loggers in `run/serial.py` have been renamed for better code readability, indicating when they are logging to stdout vs an internal file. The `log_filename` attribute in `Step` has been explicitly set to None by default, as opposed to an empty string. And in general, some "compass" wording needed to be changed to "polaris".
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
