### PR TITLE
Check available parallel resources only once

### DIFF
--- a/polaris/default.cfg
+++ b/polaris/default.cfg
@@ -28,6 +28,9 @@ verify = True
 # the program to use for graph partitioning
 partition_executable = gpmetis
 
+# the number of cores a user can use on a login node
+login_cores = 4
+
 
 # The io section describes options related to file i/o
 [io]

--- a/polaris/parallel.py
+++ b/polaris/parallel.py
@@ -7,7 +7,7 @@ import numpy as np
 from mpas_tools.logging import check_call
 
 
-def get_available_cores_and_nodes(config):
+def get_available_parallel_resources(config):
     """
     Get the number of total cores and nodes available for running steps
 
@@ -18,14 +18,15 @@ def get_available_cores_and_nodes(config):
 
     Returns
     -------
-    cores : int
-        The number of cores available for running steps
-
-    nodes : int
-        The number of cores available for running steps
+    available_resources : dict
+        A dictionary containing available resources (cores, tasks, nodes
+        and cores_per_node)
     """
 
     parallel_system = config.get('parallel', 'system')
+    if parallel_system == 'slurm' and 'SLURM_JOB_ID' not in os.environ:
+        parallel_system = 'login'
+
     if parallel_system == 'slurm':
         job_id = os.environ['SLURM_JOB_ID']
         node = os.environ['SLURMD_NODENAME']
@@ -42,18 +43,30 @@ def get_available_cores_and_nodes(config):
         args = ['squeue', '--noheader', '-j', job_id, '-o', '%D']
         nodes = _get_subprocess_int(args)
         cores = cores_per_node * nodes
+        mpi_allowed = True
+    elif parallel_system == 'login':
+        cores = min(multiprocessing.cpu_count(),
+                    config.getint('parallel', 'login_cores'))
+        cores_per_node = cores
+        nodes = 1
+        mpi_allowed = False
     elif parallel_system == 'single_node':
         cores = multiprocessing.cpu_count()
         if config.has_option('parallel', 'cores_per_node'):
-            cores_per_node = config.getint('parallel', 'cores_per_node')
-            cores = min(cores, cores_per_node)
-        else:
-            cores_per_node = cores
+            cores = min(cores, config.getint('parallel', 'cores_per_node'))
+        cores_per_node = cores
         nodes = 1
+        mpi_allowed = True
     else:
         raise ValueError(f'Unexpected parallel system: {parallel_system}')
 
-    return cores, nodes, cores_per_node
+    available_resources = dict(
+        cores=cores,
+        nodes=nodes,
+        cores_per_node=cores_per_node,
+        mpi_allowed=mpi_allowed
+    )
+    return available_resources
 
 
 def check_parallel_system(config):
@@ -85,7 +98,7 @@ def check_parallel_system(config):
         raise ValueError(f'Unexpected parallel system: {parallel_system}')
 
 
-def set_cores_per_node(config):
+def set_cores_per_node(config, cores_per_node):
     """
     If the system has Slurm, find out the ``cpus_per_node`` and set the config
     option accordingly.
@@ -96,7 +109,6 @@ def set_cores_per_node(config):
         Configuration options
     """
     parallel_system = config.get('parallel', 'system')
-    _, nodes, cores_per_node = get_available_cores_and_nodes(config)
     if parallel_system == 'slurm':
         old_cores_per_node = config.getint('parallel', 'cores_per_node')
         config.set('parallel', 'cores_per_node', f'{cores_per_node}')

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -294,16 +294,23 @@ class Step:
         if max_memory is not None:
             self.max_memory = max_memory
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Constrain ``cpus_per_task`` and ``ntasks`` based on the number of
         cores available to this step
 
         Parameters
         ----------
-        available_cores : int
+        available_resources : dict
             The total number of cores available to the step
         """
+        mpi_allowed = available_resources['mpi_allowed']
+        if not mpi_allowed and self.ntasks > 1:
+            raise ValueError(
+                'You are trying to run an MPI job on a login node.\n'
+                'Please switch to a compute node.')
+
+        available_cores = available_resources['cores']
         if self.ntasks == 1:
             # just one task so only need to worry about cpus_per_task
             self.cpus_per_task = min(self.cpus_per_task, available_cores)


### PR DESCRIPTION
This is a port from changes made in Compass:
https://github.com/MPAS-Dev/compass/pull/538

This merge changes `run.serial` and `parallel` so we only poll for slrum resources once and use that information for all test cases and steps.

This merge also removes the error message when you run on a login node.  Instead, a login node is allocated a small number of cores (4 by default) and isn't allowed to run MPI jobs (it only supports one task).

To accommodate this, the `Step.constrain_resources()` method takes a dictionary of available resources instead of just the number of available cores.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
