### PR TITLE
Change algorithm for constraining resources

### DIFF
--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -357,6 +357,38 @@ attributes.  Another reason might be to set these attributes using an algorithm
 When overriding `constrain_resources`, it is important to also call the base
 class' version of the method with `super().constrain_resources()`.
 
+The names of the resources are related to the
+[Slurm](https://slurm.schedmd.com/srun.html) naming conventions:
+
+`ntasks`
+
+: The target number of MPI tasks that a step will use if the resources 
+  are available.
+
+`min_tasks`
+
+: The minimum number of MPI tasks for a step.  If too few resources are
+  available, the step will not run.
+
+`cpus_per_task`
+
+: If `ntasks > 1`, this is typically a number of threads used by each
+  MPI task (e.g. with OpenMP threading).  If `ntasks == 1`, this may
+  be the number of target cores used in on-node parallelism like python or
+  c++ threading, or python multiprocessing.  `cpus_per_task` will
+  automatically be constrained to be less than or equal to the number of cores on a node
+  (and the total available cores).  So it may be appropriate to set it to a
+  high value appropriate for machines with large nodes, knowing that it will
+  be constrained to fit on one node.
+
+For MPI applications without threading, `cpus_per_task` will always be
+`1`, the default.
+
+`min_cpus_per_task`
+: The minimum number of cores for on-node parallelism (threading,
+  multiprocessing, etc.).  If too few resources are available, the step
+  will fail with an error message.
+
 (dev-step-setup)=
 
 ## setup()
@@ -576,7 +608,7 @@ explore different steps.
 ## inputs and outputs
 
 Currently, steps run in sequence in the order they are added to the test case
-(or in the order they appear in the test case's `steps_to_run` attribute.
+(or in the order they appear in the test case's `steps_to_run` attribute).
 There are plans to allow test cases and their steps to run in parallel in the
 future. For this reason, we require that each step defines a list of the
 absolute paths to all input files that could come from other steps (possibly in
@@ -766,7 +798,7 @@ files from a database belonging to another component, e.g.:
 self.add_input_file(filename='icePresent_QU60km_polar.nc',
                     target='icePresent_QU60km_polar.nc',
                     database='partition',
-                    database_component='seaice'
+                    database_component='seaice')
 ```
 
 It is also possible to download files directly from a URL and store them in

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -466,7 +466,7 @@ class Step:
         self.dependencies[name] = step
         step.is_dependency = True
 
-    def process_inputs_and_outputs(self):
+    def process_inputs_and_outputs(self):  # noqa: C901
         """
         Process the inputs to and outputs from a step added with
         :py:meth:`polaris.Step.add_input_file` and

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -302,7 +302,8 @@ class Step:
         Parameters
         ----------
         available_resources : dict
-            The total number of cores available to the step
+            A dictionary containing available resources (cores, tasks, nodes
+            and cores_per_node)
         """
         mpi_allowed = available_resources['mpi_allowed']
         if not mpi_allowed and self.ntasks > 1:
@@ -311,24 +312,21 @@ class Step:
                 'Please switch to a compute node.')
 
         available_cores = available_resources['cores']
-        if self.ntasks == 1:
-            # just one task so only need to worry about cpus_per_task
-            self.cpus_per_task = min(self.cpus_per_task, available_cores)
-            cores = self.cpus_per_task
-        elif self.cpus_per_task == self.min_cpus_per_task:
-            available_tasks = available_cores // self.cpus_per_task
-            self.ntasks = min(self.ntasks, available_tasks)
-            cores = self.ntasks * self.cpus_per_task
-        else:
-            raise ValueError('Unsupported step configuration in which '
-                             'ntasks > 1 and  '
-                             'cpus_per_task != min_cpus_per_task')
-
-        min_cores = self.min_cpus_per_task * self.min_tasks
-        if cores < min_cores:
+        cores_per_node = available_resources['cores_per_node']
+        self.cpus_per_task = min(self.cpus_per_task,
+                                 min(available_cores, cores_per_node))
+        if self.cpus_per_task < self.min_cpus_per_task:
             raise ValueError(
-                f'Available cores ({cores}) is below the minimum of '
-                f'{min_cores} for step {self.name}')
+                f'Available cpus_per_task ({self.cpus_per_task}) is below the '
+                f'minimum of {self.min_cpus_per_task} for step {self.name}')
+
+        available_tasks = available_cores // self.cpus_per_task
+        self.ntasks = min(self.ntasks, available_tasks)
+
+        if self.ntasks < self.min_tasks:
+            raise ValueError(
+                f'Available number of MPI tasks ({self.ntasks}) is below the '
+                f'minimum of {self.min_tasks} for step {self.name}')
 
     def setup(self):
         """


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This is a port from changes made in Compass:
https://github.com/MPAS-Dev/compass/pull/573

Previously, nothing was preventing `cpus_per_task` from being more than the number of cores on a node. This is inconvenient because unsafe or non-performant behavior will occur if more python threads are used than cores on a node.

This merge changes the way resources are constrained. First, `cpus_per_task` is constrained to be less than the lower of the number of cpus on a node or the number of total cores available. Then, we check to see if `cpus_per_task` is smaller than the minimum allowed for the given step. Next, we allow all tasks to have the same `cpus_per_task` and constrain the number of tasks not to exceed the total available resources. Finally, we check to make sure the number of tasks is not below the allowed minimum for the step.

There are 4 typical resource requirements for steps:

serial (1 task and 1 cpu per task)
threading or multiprocessing on a node (1 task, multiple cpus per task)
MPI jobs without threading (multiple tasks, 1 cpu per task)
MPI jobs with threading (multiple tasks, a few cpus per task)
This algorithm should handle all of these without difficulty.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
