### PR TITLE
Make pickle file of dependency an input

### DIFF
--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -478,18 +478,20 @@ def _run_step(test_case, step, new_log_file, available_resources):
             step_logger.info('')
             step.run()
 
+    _pickle_step_after_run(test_case, step)
+
     missing_files = list()
     for output_file in step.outputs:
         if not os.path.exists(output_file):
             missing_files.append(output_file)
 
     if len(missing_files) > 0:
+        # We want to indicate that the step failed by removing the pickle
+        os.remove('step_after_run.pickle')
         raise OSError(
             f'output file(s) missing in step {step.name} of '
             f'{step.component.name}/{step.test_group.name}/'
             f'{step.test_case.subdir}: {missing_files}')
-
-    _pickle_step_after_run(test_case, step)
 
 
 def _run_step_as_subprocess(test_case, step, new_log_file):

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -463,6 +463,10 @@ class Step:
                              'dependencies.')
         self.dependencies[name] = step
         step.is_dependency = True
+        step.add_output_file('step_after_run.pickle')
+        filename = f'dependencies/{name}_after_run.pickle'
+        target = f'{step.path}/step_after_run.pickle'
+        self.add_input_file(filename=filename, work_dir_target=target)
 
     def process_inputs_and_outputs(self):  # noqa: C901
         """


### PR DESCRIPTION
Make pickle file of a dependency an input of the dependent step. In order for a bash app to be a dependency of another bash app, we need to use a data future, so we use the output pickle file as an input.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
