### PR TITLE
Get Slurm options in a separate function

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -222,6 +222,17 @@ ocean/api
    imp_res
 ```
 
+### job
+```{eval-rst}
+.. currentmodule:: polaris.job
+
+.. autosummary::
+   :toctree: generated/
+
+   write_job_script
+   get_slurm_options
+```
+
 ### logging
 
 ```{eval-rst}


### PR DESCRIPTION
I made this change so that we can access the Slurm options without actually writing a job script, which may be useful for task parallelism.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
