### PR TITLE
Pull out common setup between run procedures

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -68,13 +68,15 @@ ocean/api
 #### run
 
 ```{eval-rst}
-.. currentmodule:: polaris.run.serial
+.. currentmodule:: polaris.run
 
 .. autosummary::
    :toctree: generated/
 
-   run_tests
-   run_single_step
+   unpickle_suite
+   setup_config
+   serial.run_tests
+   serial.run_single_step
 
 ```
 

--- a/polaris/run/__init__.py
+++ b/polaris/run/__init__.py
@@ -1,0 +1,50 @@
+import os
+import pickle
+
+from polaris.config import PolarisConfigParser
+
+
+def unpickle_suite(suite_name):
+    """
+    Unpickle the suite
+
+    Parameters
+    ----------
+    suite_name : str
+        The name of the test suite
+
+    Returns
+    -------
+    test_suite : dict
+        The test suite
+    """
+    # Allow a suite name to either include or not the .pickle suffix
+    if suite_name.endswith('.pickle'):
+        # code below assumes no suffix, so remove it
+        suite_name = suite_name[:-len('.pickle')]
+    # Now open the the suite's pickle file
+    if not os.path.exists(f'{suite_name}.pickle'):
+        raise ValueError(f'The suite "{suite_name}" does not appear to have '
+                         f'been set up here.')
+    with open(f'{suite_name}.pickle', 'rb') as handle:
+        test_suite = pickle.load(handle)
+    return test_suite
+
+
+def setup_config(config_filename):
+    """
+    Set up the config object from the config file
+
+    Parameters
+    ----------
+    config_filename : str
+        The config filename
+
+    Returns
+    -------
+    config : polaris.config.PolarisConfigParser
+        The config object
+    """
+    config = PolarisConfigParser()
+    config.add_from_file(config_filename)
+    return config


### PR DESCRIPTION
There is a little bit of setup that is common to setting up a suite, test case, or step, and we can modularize it better. This will be further utilized during development of the parallel counterpart to `run.serial`.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
