### PR TITLE
Ignore nonexistent `step_after_run.pickle` file

### DIFF
--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -492,7 +492,10 @@ def _run_step(test_case, step, new_log_file, available_resources,
 
     if len(missing_files) > 0:
         # We want to indicate that the step failed by removing the pickle
-        os.remove('step_after_run.pickle')
+        try:
+            os.remove('step_after_run.pickle')
+        except FileNotFoundError:
+            pass
         raise OSError(
             f'output file(s) missing in step {step.name} of '
             f'{step.component.name}/{step.test_group.name}/'


### PR DESCRIPTION
If a step fails, we want to remove its `step_after_run.pickle` file to indicate its failure. However, the file might be nonexistent, so in that case we should just go on to report the error and skip the removal.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #85 