### PR TITLE
Reformat command line help descriptions

### DIFF
--- a/deploy/shared.py
+++ b/deploy/shared.py
@@ -13,59 +13,59 @@ def parse_args(bootstrap):
         description='Deploy a compass conda environment')
     parser.add_argument("-m", "--machine", dest="machine",
                         help="The name of the machine for loading machine-"
-                             "related config options")
+                             "related config options.")
     parser.add_argument("--conda", dest="conda_base",
-                        help="Path to the conda base")
+                        help="Path to the conda base.")
     parser.add_argument("--spack", dest="spack_base",
-                        help="Path to the spack base")
+                        help="Path to the spack base.")
     parser.add_argument("--env_name", dest="env_name",
                         help="The conda environment name and activation script"
-                             " prefix")
+                             " prefix.")
     parser.add_argument("-p", "--python", dest="python", type=str,
-                        help="The python version to deploy")
+                        help="The python version to deploy.")
     parser.add_argument("-c", "--compiler", dest="compilers", type=str,
-                        nargs="*", help="The name of the compiler(s)")
+                        nargs="*", help="The name of the compiler(s).")
     parser.add_argument("-i", "--mpi", dest="mpis", type=str, nargs="*",
                         help="The MPI library (or libraries) to deploy, see "
-                             "the docs for details")
+                             "the docs for details.")
     parser.add_argument("--conda_env_only", dest="conda_env_only",
                         action='store_true',
                         help="Create only the conda environment for running "
                              "polaris tests (without compilers or libraries "
-                             "for building E3SM components)")
+                             "for building E3SM components).")
     parser.add_argument("--recreate", dest="recreate", action='store_true',
-                        help="Recreate the environment if it exists")
+                        help="Recreate the environment if it exists.")
     parser.add_argument("-f", "--config_file", dest="config_file",
                         help="Config file to override deployment config "
-                             "options")
+                             "options.")
     parser.add_argument("--check", dest="check", action='store_true',
                         help="Check the resulting environment for expected "
-                             "packages")
+                             "packages.")
     parser.add_argument("--use_local", dest="use_local", action='store_true',
                         help="Use locally built conda packages (for testing).")
     parser.add_argument("--mache_fork", dest="mache_fork",
-                        help="Point to a mache fork (and branch) for testing")
+                        help="Point to a mache fork (and branch) for testing.")
     parser.add_argument("--mache_branch", dest="mache_branch",
-                        help="Point to a mache branch (and fork) for testing")
+                        help="Point to a mache branch (and fork) for testing.")
     parser.add_argument("--update_spack", dest="update_spack",
                         action='store_true',
                         help="If the shared spack environment should be "
                              "created or recreated.")
     parser.add_argument("--tmpdir", dest="tmpdir",
                         help="A temporary directory for building spack "
-                             "packages")
+                             "packages.")
     parser.add_argument("--with_albany", dest="with_albany",
                         action='store_true',
                         help="Whether to include albany in the spack "
-                             "environment")
+                             "environment.")
     parser.add_argument("--with_netlib_lapack", dest="with_netlib_lapack",
                         action='store_true',
                         help="Whether to include Netlib-LAPACK in the spack "
-                             "environment")
+                             "environment.")
     parser.add_argument("--with_petsc", dest="with_petsc",
                         action='store_true',
                         help="Whether to include PETSc in the spack "
-                             "environment")
+                             "environment.")
     parser.add_argument("--without_openmp", dest="without_openmp",
                         action='store_true',
                         help="If this flag is included, OPENMP=false will "

--- a/polaris/cache.py
+++ b/polaris/cache.py
@@ -119,7 +119,7 @@ def main():
     parser.add_argument("-i", "--orig_steps", nargs='+', dest="orig_steps",
                         type=str,
                         help="The relative path of the original (uncached) "
-                             "steps from the base work directory",
+                             "steps from the base work directory.",
                         metavar="STEP")
     parser.add_argument("-d", "--date_string", dest="date_string", type=str,
                         help="The datestamp (YYMMDD) to use on the files.  "

--- a/polaris/list.py
+++ b/polaris/list.py
@@ -130,14 +130,15 @@ def main():
         prog='polaris list')
     parser.add_argument('-t', '--test_expr', dest='test_expr',
                         help='A regular expression for a test path name to '
-                             'search for',
+                             'search for.',
                         metavar='TEST')
     parser.add_argument('-n', '--number', dest='number', type=int,
-                        help='The number of the test to list')
+                        help='The number of the test to list.')
     parser.add_argument('--machines', dest='machines', action='store_true',
-                        help='List supported machines (instead of test cases)')
+                        help='List supported machines (instead of test '
+                             'cases).')
     parser.add_argument('--suites', dest='suites', action='store_true',
-                        help='List test suites (instead of test cases)')
+                        help='List test suites (instead of test cases).')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                         help='List details of each test case, not just the '
                              'path.  When applied to suites, verbose lists '

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -150,7 +150,7 @@ def main():
                         help="The name of a test suite to run. Can exclude "
                         "or include the .pickle filename suffix.")
     parser.add_argument("--steps", dest="steps", nargs='+',
-                        help="The steps of a test case to run")
+                        help="The steps of a test case to run.")
     parser.add_argument("--skip_steps", dest="skip_steps", nargs='+',
                         help="The steps of a test case not to run, see "
                              "steps_to_run in the config file for defaults.")
@@ -161,7 +161,7 @@ def main():
                              "their own.")
     parser.add_argument("--step_is_subprocess", dest="step_is_subprocess",
                         action="store_true",
-                        help="Used internally by polaris to indicate that"
+                        help="Used internally by polaris to indicate that "
                              "a step is being run as a subprocess.")
     args = parser.parse_args(sys.argv[2:])
     if args.suite is not None:
@@ -547,7 +547,7 @@ def _load_dependencies(test_case, step):
 
 def _pickle_step_after_run(test_case, step):
     """
-    Picle a step after it has run so its dependencies will pick up the changes.
+    Pickle a step after running so its dependencies will pick up the changes.
     """
     if step.is_dependency:
         # pickle the test case and step for use at runtime

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -295,44 +295,44 @@ def main():
     parser = argparse.ArgumentParser(
         description='Set up one or more test cases', prog='polaris setup')
     parser.add_argument("-t", "--test", dest="test",
-                        help="Relative path for a test case to set up",
+                        help="Relative path for a test case to set up.",
                         metavar="PATH")
     parser.add_argument("-n", "--case_number", nargs='+', dest="case_num",
                         type=str,
                         help="Case number(s) to setup, as listed from "
-                             "'polaris list'. Can be a space-separated"
-                             "list of case numbers.  A suffix 'c' indicates"
-                             "that all steps in the test should use cached"
+                             "'polaris list'. Can be a space-separated "
+                             "list of case numbers.  A suffix 'c' indicates "
+                             "that all steps in the test should use cached "
                              "outputs.", metavar="NUM")
     parser.add_argument("-f", "--config_file", dest="config_file",
-                        help="Configuration file for test case setup",
+                        help="Configuration file for test case setup.",
                         metavar="FILE")
     parser.add_argument("-m", "--machine", dest="machine",
                         help="The name of the machine for loading machine-"
-                             "related config options", metavar="MACH")
+                             "related config options.", metavar="MACH")
     parser.add_argument("-w", "--work_dir", dest="work_dir", required=True,
                         help="A base directory for setting up test cases.",
                         metavar="PATH")
     parser.add_argument("-b", "--baseline_dir", dest="baseline_dir",
-                        help="Location of baselines that can be compared to",
+                        help="Location of baselines that can be compared to.",
                         metavar="PATH")
     parser.add_argument("-p", "--component_path", dest="component_path",
                         help="The path where the component executable and "
                              "default namelists have been built.",
                         metavar="PATH")
     parser.add_argument("--suite_name", dest="suite_name", default="custom",
-                        help="The name to use for the 'custom' test suite"
+                        help="The name to use for the 'custom' test suite "
                              "containing all setup test cases.",
                         metavar="SUITE")
     parser.add_argument("--cached", dest="cached", nargs='+',
-                        help="A list of steps in the test case supplied with"
+                        help="A list of steps in the test case supplied with "
                              "--test that should use cached outputs, or "
-                             "'_all' if all steps should be cached",
+                             "'_all' if all steps should be cached.",
                         metavar="STEP")
     parser.add_argument("--copy_executable", dest="copy_executable",
                         action="store_true",
                         help="If the model executable should be copied to the "
-                             "work directory")
+                             "work directory.")
 
     args = parser.parse_args(sys.argv[2:])
     cached = None

--- a/polaris/suite.py
+++ b/polaris/suite.py
@@ -60,19 +60,19 @@ def main():
     parser = argparse.ArgumentParser(
         description='Set up a regression test suite', prog='polaris suite')
     parser.add_argument("-c", "--component", dest="component",
-                        help="The component for the test suite",
+                        help="The component for the test suite.",
                         metavar="COMPONENT", required=True)
     parser.add_argument("-t", "--test_suite", dest="test_suite",
-                        help="Path to file containing a test suite to setup",
+                        help="Path to file containing a test suite to setup.",
                         metavar="SUITE", required=True)
     parser.add_argument("-f", "--config_file", dest="config_file",
-                        help="Configuration file for test case setup",
+                        help="Configuration file for test case setup.",
                         metavar="FILE")
     parser.add_argument("-m", "--machine", dest="machine",
                         help="The name of the machine for loading machine-"
-                             "related config options", metavar="MACH")
+                             "related config options.", metavar="MACH")
     parser.add_argument("-b", "--baseline_dir", dest="baseline_dir",
-                        help="Location of baseslines that can be compared to",
+                        help="Location of baselines that can be compared to.",
                         metavar="PATH")
     parser.add_argument("-w", "--work_dir", dest="work_dir", required=True,
                         help="If set, script will setup the test suite in "
@@ -85,7 +85,7 @@ def main():
     parser.add_argument("--copy_executable", dest="copy_executable",
                         action="store_true",
                         help="If the model executable should be copied to the "
-                             "work directory")
+                             "work directory.")
     args = parser.parse_args(sys.argv[2:])
 
     setup_suite(component=args.component, suite_name=args.test_suite,

--- a/utils/bisect/bisect.py
+++ b/utils/bisect/bisect.py
@@ -59,7 +59,7 @@ def bisect(good, bad, e3sm_path, load_script, config_file, first_parent):
                f'  -f {config_file}'
     print('\n')
     print(72 * '-')
-    print('Biscect Initialization')
+    print('Bisect Initialization')
     print(72 * '-')
     print('\nRunning:')
     print_commands = commands.replace(' && ', '\n  ')
@@ -73,7 +73,7 @@ def main():
                     'a given test fails')
     parser.add_argument("-f", "--config_file", dest="config_file",
                         required=True,
-                        help="Configuration file with bisect options",
+                        help="Configuration file with bisect options.",
                         metavar="FILE")
 
     args = parser.parse_args()

--- a/utils/bisect/bisect_step.py
+++ b/utils/bisect/bisect_step.py
@@ -100,7 +100,7 @@ def main():
                     'E3SM commit for which a given test fails')
     parser.add_argument("-f", "--config_file", dest="config_file",
                         required=True,
-                        help="Configuration file with bisect options",
+                        help="Configuration file with bisect options.",
                         metavar="FILE")
 
     args = parser.parse_args()

--- a/utils/e3sm_update/test_e3sm_changes.py
+++ b/utils/e3sm_update/test_e3sm_changes.py
@@ -246,7 +246,7 @@ def main():
                     'E3SM-Project (or another) submodule')
     parser.add_argument("-f", "--config_file", dest="config_file",
                         required=True,
-                        help="Configuration file",
+                        help="Configuration file.",
                         metavar="FILE")
 
     args = parser.parse_args()

--- a/utils/matrix/setup_matrix.py
+++ b/utils/matrix/setup_matrix.py
@@ -311,13 +311,13 @@ def polaris_setup(script_name, setup_command, mpas_path, mpas_model, work_base,
 def main():
     parser = argparse.ArgumentParser(
         description='Build MPAS and set up polaris with a matrix of build '
-                    'configs.')
+                    'configs')
     parser.add_argument("-f", "--config_file", dest="config_file",
                         required=True,
-                        help="Configuration file with matrix build options",
+                        help="Configuration file with matrix build options.",
                         metavar="FILE")
     parser.add_argument("--submit", dest="submit", action='store_true',
-                        help="Whether to submit the job scripts for each test"
+                        help="Whether to submit the job scripts for each test "
                              "once setup is complete.")
 
     args = parser.parse_args()


### PR DESCRIPTION
While testing, I noticed that some of these descriptions had typos that made them hard to read. I went ahead and looked through other argument parsing help messages to fix some typos and generally make the formatting consistent (such as adding or removing periods).

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
