### PR TITLE
Remove `manufactured_soluiton` test case from suites

### DIFF
--- a/polaris/ocean/suites/nightly.txt
+++ b/polaris/ocean/suites/nightly.txt
@@ -2,4 +2,4 @@ ocean/baroclinic_channel/10km/threads_test
 ocean/baroclinic_channel/10km/decomp_test
 ocean/baroclinic_channel/10km/restart_test
 ocean/inertial_gravity_wave/convergence
-ocean/manufactured_solution/convergence
+# ocean/manufactured_solution/convergence

--- a/polaris/ocean/suites/pr.txt
+++ b/polaris/ocean/suites/pr.txt
@@ -4,4 +4,4 @@ ocean/baroclinic_channel/10km/restart_test
 ocean/inertial_gravity_wave/convergence
 ocean/single_column/960km/cvmix
 ocean/single_column/960km/ideal_age
-ocean/manufactured_solution/convergence
+# ocean/manufactured_solution/convergence


### PR DESCRIPTION
I think we want to remove this test from our suites for now since it is failing "on purpose" (i.e. we know the MPAS-Ocean code needs to be fixed to allows the solution to converge at the desired rate) but this is confusing for those who are trying to use these suites to validate unrelated code.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #89 