### PR TITLE
Update step inputs attribute with input filenames

### DIFF
--- a/polaris/step.py
+++ b/polaris/step.py
@@ -468,7 +468,7 @@ class Step:
         target = f'{step.path}/step_after_run.pickle'
         self.add_input_file(filename=filename, work_dir_target=target)
 
-    def process_inputs_and_outputs(self):  # noqa: C901
+    def process_inputs_and_outputs(self):
         """
         Process the inputs to and outputs from a step added with
         :py:meth:`polaris.Step.add_input_file` and
@@ -505,6 +505,7 @@ class Step:
             if database_subdirs is not None:
                 databases_with_downloads.update(database_subdirs)
             inputs.append(input_file)
+        self.inputs = inputs
 
         if len(databases_with_downloads) > 0:
             self._fix_permissions(databases_with_downloads)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This fixes a bug that occurs in the process of giving a step its input files. The inputs list is never actually updated with the filenames of the input files, which would cause missing files to go unnoticed.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
closes https://github.com/E3SM-Project/polaris/issues/91