### PR TITLE
Fixup cosine bell test: Allow user changes to vert_levels cfg option

### DIFF
--- a/polaris/ocean/tests/global_convergence/cosine_bell/forward.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/forward.py
@@ -44,7 +44,6 @@ class Forward(OceanModelStep):
 
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
-        self.add_yaml_file('polaris.ocean.config', 'single_layer.yaml')
         self.add_yaml_file(
             'polaris.ocean.tests.global_convergence.cosine_bell',
             'forward.yaml')
@@ -95,6 +94,14 @@ class Forward(OceanModelStep):
         super().dynamic_model_config(at_setup=at_setup)
 
         config = self.config
+
+        vert_levels = config.getfloat('vertical_grid', 'vert_levels')
+        if not at_setup and vert_levels == 1:
+            self.add_yaml_file('polaris.ocean.config', 'single_layer.yaml')
+            self.add_yaml_file(
+                'polaris.ocean.tests.global_convergence.cosine_bell',
+                'forward.yaml')
+
         # dt is proportional to resolution: default 30 seconds per km
         dt_per_km = config.getfloat('cosine_bell', 'dt_per_km')
 


### PR DESCRIPTION
This PR allows users to change the number of vertical levels in either the cfg file in the repo or the cfg file in a test case that is already set up.

Checklist
* [X] `Testing` comment in the PR documents testing used to verify the changes