### PR TITLE
Add dependency in restart test case

### DIFF
--- a/polaris/ocean/tests/baroclinic_channel/restart/__init__.py
+++ b/polaris/ocean/tests/baroclinic_channel/restart/__init__.py
@@ -27,10 +27,14 @@ class Restart(BaroclinicChannelTestCase):
         super().__init__(test_group=test_group, resolution=resolution,
                          name='restart')
 
-        for name in ['full_run', 'restart_run']:
-            self.add_step(
-                RestartStep(test_case=self, resolution=resolution,
-                            name=name))
+        full = RestartStep(test_case=self, resolution=resolution,
+                           name='full_run')
+        self.add_step(full)
+
+        restart = RestartStep(test_case=self, resolution=resolution,
+                              name='restart_run')
+        restart.add_dependency(full, full.name)
+        self.add_step(restart)
 
     def validate(self):
         """


### PR DESCRIPTION
Because we don't know the filename of the restart file at setup time, we need to instead make the `full_run` step an explicit dependency of the `restart_run` step.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
