### PR TITLE
Assume mesh variables only in mesh file

### DIFF
--- a/polaris/ocean/tests/baroclinic_channel/init.py
+++ b/polaris/ocean/tests/baroclinic_channel/init.py
@@ -140,7 +140,7 @@ class Init(Step):
 
         temperature = temperature.expand_dims(dim='Time', axis=0)
 
-        normal_velocity = xr.zeros_like(ds.xEdge)
+        normal_velocity = xr.zeros_like(ds_mesh.xEdge)
         normal_velocity, _ = xr.broadcast(normal_velocity, ds.refBottomDepth)
         normal_velocity = normal_velocity.transpose('nEdges', 'nVertLevels')
         normal_velocity = normal_velocity.expand_dims(dim='Time', axis=0)
@@ -149,8 +149,8 @@ class Init(Step):
         ds['salinity'] = salinity * xr.ones_like(temperature)
         ds['normalVelocity'] = normal_velocity
         ds['fCell'] = coriolis_parameter * xr.ones_like(x_cell)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds.xVertex)
+        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
+        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
 
         ds.attrs['nx'] = nx
         ds.attrs['ny'] = ny

--- a/polaris/ocean/tests/baroclinic_channel/rpe/analysis.py
+++ b/polaris/ocean/tests/baroclinic_channel/rpe/analysis.py
@@ -149,5 +149,4 @@ def _plot(nx, ny, lx, ly, filename, nus, rpe):
             ax.set_ylabel('y, km')
         if iCol == num_files - 1:
             fig.colorbar(dis, ax=axs[num_files - 1], aspect=40)
-
     plt.savefig(filename)

--- a/polaris/ocean/tests/baroclinic_channel/viz.py
+++ b/polaris/ocean/tests/baroclinic_channel/viz.py
@@ -22,8 +22,8 @@ class Viz(Step):
         """
         super().__init__(test_case=test_case, name='viz')
         self.add_input_file(
-            filename='initial_state.nc',
-            target='../init/initial_state.nc')
+            filename='mesh.nc',
+            target='../init/culled_mesh.nc')
         self.add_input_file(
             filename='output.nc',
             target='../forward/output.nc')
@@ -32,7 +32,7 @@ class Viz(Step):
         """
         Run this step of the test case
         """
-        ds_mesh = xr.load_dataset('initial_state.nc')
+        ds_mesh = xr.load_dataset('mesh.nc')
         ds = xr.load_dataset('output.nc')
         t_index = ds.sizes['Time'] - 1
         plot_horiz_field(ds, ds_mesh, 'temperature',

--- a/polaris/ocean/tests/global_convergence/cosine_bell/init.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/init.py
@@ -51,21 +51,21 @@ class Init(Step):
         section = config['vertical_grid']
         bottom_depth = section.getfloat('bottom_depth')
 
-        dsMesh = xr.open_dataset('mesh.nc')
-        angleEdge = dsMesh.angleEdge
-        latCell = dsMesh.latCell
-        latEdge = dsMesh.latEdge
-        lonCell = dsMesh.lonCell
-        sphere_radius = dsMesh.sphere_radius
+        ds_mesh = xr.open_dataset('mesh.nc')
+        angleEdge = ds_mesh.angleEdge
+        latCell = ds_mesh.latCell
+        latEdge = ds_mesh.latEdge
+        lonCell = ds_mesh.lonCell
+        sphere_radius = ds_mesh.sphere_radius
 
-        ds = dsMesh.copy()
+        ds = ds_mesh.copy()
 
         ds['bottomDepth'] = bottom_depth * xr.ones_like(latCell)
         ds['ssh'] = xr.zeros_like(latCell)
 
         init_vertical_coord(config, ds)
 
-        temperature_array = temperature * xr.ones_like(ds.latCell)
+        temperature_array = temperature * xr.ones_like(ds_mesh.latCell)
         temperature_array, _ = xr.broadcast(temperature_array, ds.refZMid)
         ds['temperature'] = temperature_array.expand_dims(dim='Time', axis=0)
         ds['salinity'] = salinity * xr.ones_like(ds.temperature)
@@ -92,8 +92,8 @@ class Init(Step):
         velocity_array, _ = xr.broadcast(velocity, ds.refZMid)
         ds['normalVelocity'] = velocity_array.expand_dims(dim='Time', axis=0)
 
-        ds['fCell'] = xr.zeros_like(ds.xCell)
-        ds['fEdge'] = xr.zeros_like(ds.xEdge)
-        ds['fVertex'] = xr.zeros_like(ds.xVertex)
+        ds['fCell'] = xr.zeros_like(ds_mesh.xCell)
+        ds['fEdge'] = xr.zeros_like(ds_mesh.xEdge)
+        ds['fVertex'] = xr.zeros_like(ds_mesh.xVertex)
 
         write_netcdf(ds, 'initial_state.nc')

--- a/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
@@ -87,6 +87,9 @@ class Viz(Step):
         """
         super().__init__(test_case=test_case, name=name, subdir=subdir)
         self.add_input_file(
+            filename='mesh.nc',
+            target='../init/mesh.nc')
+        self.add_input_file(
             filename='initial_state.nc',
             target='../init/initial_state.nc')
         self.add_input_file(
@@ -109,12 +112,13 @@ class Viz(Step):
 
         remapper = viz_map.get_remapper()
 
+        ds_mesh = xr.open_dataset('mesh.nc')
         ds_init = xr.open_dataset('initial_state.nc')
         ds_init = ds_init[['tracer1', ]].isel(Time=0, nVertLevels=0)
         ds_init = remapper.remap(ds_init)
         ds_init.to_netcdf('remapped_init.nc')
 
-        plot_global(ds_init.lon.values, ds_init.lat.values,
+        plot_global(ds_mesh.lon.values, ds_mesh.lat.values,
                     ds_init.tracer1.values,
                     out_filename='init.png', config=config,
                     colormap_section='cosine_bell_viz',
@@ -125,7 +129,7 @@ class Viz(Step):
         ds_out = remapper.remap(ds_out)
         ds_out.to_netcdf('remapped_final.nc')
 
-        plot_global(ds_out.lon.values, ds_out.lat.values,
+        plot_global(ds_mesh.lon.values, ds_mesh.lat.values,
                     ds_out.tracer1.values,
                     out_filename='final.png', config=config,
                     colormap_section='cosine_bell_viz',

--- a/polaris/ocean/tests/inertial_gravity_wave/init.py
+++ b/polaris/ocean/tests/inertial_gravity_wave/init.py
@@ -70,14 +70,14 @@ class Init(Step):
 
         ds = ds_mesh.copy()
 
-        ds['ssh'] = xr.zeros_like(ds.xCell)
-        ds['bottomDepth'] = bottom_depth * xr.ones_like(ds.xCell)
+        ds['ssh'] = xr.zeros_like(ds_mesh.xCell)
+        ds['bottomDepth'] = bottom_depth * xr.ones_like(ds_mesh.xCell)
 
         init_vertical_coord(config, ds)
 
-        ds['fCell'] = f0 * xr.ones_like(ds.xCell)
-        ds['fEdge'] = f0 * xr.ones_like(ds.xEdge)
-        ds['fVertex'] = f0 * xr.ones_like(ds.xVertex)
+        ds['fCell'] = f0 * xr.ones_like(ds_mesh.xCell)
+        ds['fEdge'] = f0 * xr.ones_like(ds_mesh.xEdge)
+        ds['fVertex'] = f0 * xr.ones_like(ds_mesh.xVertex)
 
         ds_mesh['maxLevelCell'] = ds.maxLevelCell
         exact_solution = ExactSolution(ds, config)

--- a/polaris/ocean/tests/inertial_gravity_wave/viz.py
+++ b/polaris/ocean/tests/inertial_gravity_wave/viz.py
@@ -39,6 +39,9 @@ class Viz(Step):
 
         for resolution in resolutions:
             self.add_input_file(
+                filename=f'mesh_{resolution}km.nc',
+                target=f'../{resolution}km/initial_state/culled_mesh.nc')
+            self.add_input_file(
                 filename=f'init_{resolution}km.nc',
                 target=f'../{resolution}km/init/initial_state.nc')
             self.add_input_file(
@@ -63,9 +66,10 @@ class Viz(Step):
         fig, axes = plt.subplots(nrows=nres, ncols=3, figsize=(12, 2 * nres))
         rmse = []
         for i, res in enumerate(resolutions):
-            init = xr.open_dataset(f'init_{res}km.nc')
+            ds_mesh = xr.open_dataset(f'mesh_{res}km.nc')
+            ds_init = xr.open_dataset(f'init_{res}km.nc')
             ds = xr.open_dataset(f'output_{res}km.nc')
-            exact = ExactSolution(init, config)
+            exact = ExactSolution(ds_init, config)
 
             t0 = datetime.datetime.strptime(ds.xtime.values[0].decode(),
                                             '%Y-%m-%d_%H:%M:%S')
@@ -81,13 +85,13 @@ class Viz(Step):
             if i == 0:
                 error_range = np.max(np.abs(ds.ssh_error.values))
 
-            plot_horiz_field(ds, init, 'ssh', ax=axes[i, 0],
+            plot_horiz_field(ds, ds_mesh, 'ssh', ax=axes[i, 0],
                              cmap='cmo.balance', t_index=ds.sizes["Time"] - 1,
                              vmin=-eta0, vmax=eta0, cmap_title="SSH (m)")
-            plot_horiz_field(ds, init, 'ssh_exact', ax=axes[i, 1],
+            plot_horiz_field(ds, ds_mesh, 'ssh_exact', ax=axes[i, 1],
                              cmap='cmo.balance',
                              vmin=-eta0, vmax=eta0, cmap_title="SSH (m)")
-            plot_horiz_field(ds, init, 'ssh_error', ax=axes[i, 2],
+            plot_horiz_field(ds, ds_mesh, 'ssh_error', ax=axes[i, 2],
                              cmap='cmo.balance',
                              cmap_title=r"$\Delta$ SSH (m)",
                              vmin=-error_range, vmax=error_range)

--- a/polaris/ocean/tests/manufactured_solution/init.py
+++ b/polaris/ocean/tests/manufactured_solution/init.py
@@ -70,14 +70,14 @@ class Init(Step):
 
         ds = ds_mesh.copy()
 
-        ds['ssh'] = xr.zeros_like(ds.xCell)
-        ds['bottomDepth'] = bottom_depth * xr.ones_like(ds.xCell)
+        ds['ssh'] = xr.zeros_like(ds_mesh.xCell)
+        ds['bottomDepth'] = bottom_depth * xr.ones_like(ds_mesh.xCell)
 
         init_vertical_coord(config, ds)
 
-        ds['fCell'] = coriolis_parameter * xr.ones_like(ds.xCell)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds.xVertex)
+        ds['fCell'] = coriolis_parameter * xr.ones_like(ds_mesh.xCell)
+        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
+        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
 
         ds_mesh['maxLevelCell'] = ds.maxLevelCell
 

--- a/polaris/ocean/tests/manufactured_solution/viz.py
+++ b/polaris/ocean/tests/manufactured_solution/viz.py
@@ -39,6 +39,9 @@ class Viz(Step):
 
         for resolution in resolutions:
             self.add_input_file(
+                filename=f'mesh_{resolution}km.nc',
+                target=f'../{resolution}km/initial_state/culled_mesh.nc')
+            self.add_input_file(
                 filename=f'init_{resolution}km.nc',
                 target=f'../{resolution}km/init/initial_state.nc')
             self.add_input_file(
@@ -62,9 +65,10 @@ class Viz(Step):
         fig, axes = plt.subplots(nrows=nres, ncols=3, figsize=(12, 2 * nres))
         rmse = []
         for i, res in enumerate(resolutions):
-            init = xr.open_dataset(f'init_{res}km.nc')
+            ds_mesh = xr.open_dataset(f'mesh_{res}km.nc')
+            ds_init = xr.open_dataset(f'init_{res}km.nc')
             ds = xr.open_dataset(f'output_{res}km.nc')
-            exact = ExactSolution(config, init)
+            exact = ExactSolution(config, ds_init)
 
             t0 = datetime.datetime.strptime(ds.xtime.values[0].decode(),
                                             '%Y-%m-%d_%H:%M:%S')
@@ -80,13 +84,13 @@ class Viz(Step):
             if i == 0:
                 error_range = np.max(np.abs(ds.ssh_error.values))
 
-            plot_horiz_field(ds, init, 'ssh', ax=axes[i, 0],
+            plot_horiz_field(ds, ds_mesh, 'ssh', ax=axes[i, 0],
                              cmap='cmo.balance', t_index=ds.sizes["Time"] - 1,
                              vmin=-eta0, vmax=eta0, cmap_title="SSH")
-            plot_horiz_field(ds, init, 'ssh_exact', ax=axes[i, 1],
+            plot_horiz_field(ds, ds_mesh, 'ssh_exact', ax=axes[i, 1],
                              cmap='cmo.balance',
                              vmin=-eta0, vmax=eta0, cmap_title="SSH")
-            plot_horiz_field(ds, init, 'ssh_error', ax=axes[i, 2],
+            plot_horiz_field(ds, ds_mesh, 'ssh_error', ax=axes[i, 2],
                              cmap='cmo.balance', cmap_title="dSSH",
                              vmin=-error_range, vmax=error_range)
 

--- a/polaris/ocean/tests/single_column/init.py
+++ b/polaris/ocean/tests/single_column/init.py
@@ -57,7 +57,7 @@ class Init(Step):
         write_netcdf(ds_mesh, 'culled_mesh.nc')
 
         ds = ds_mesh.copy()
-        x_cell = ds.xCell
+        x_cell = ds_mesh.xCell
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
         ds['bottomDepth'] = bottom_depth * xr.ones_like(x_cell)
         ds['ssh'] = xr.zeros_like(x_cell)
@@ -116,7 +116,7 @@ class Init(Step):
         salinity = salinity.expand_dims(dim='Time', axis=0)
 
         normal_velocity, _ = xr.broadcast(
-            xr.zeros_like(ds.xEdge), ds.refBottomDepth)
+            xr.zeros_like(ds_mesh.xEdge), ds.refBottomDepth)
         normal_velocity = normal_velocity.transpose('nEdges', 'nVertLevels')
         normal_velocity = normal_velocity.expand_dims(dim='Time', axis=0)
 
@@ -127,8 +127,8 @@ class Init(Step):
         ds['salinity'] = salinity
         ds['normalVelocity'] = normal_velocity
         ds['fCell'] = coriolis_parameter * xr.ones_like(x_cell)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds.xVertex)
+        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
+        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
 
         ds.attrs['nx'] = nx
         ds.attrs['ny'] = ny


### PR DESCRIPTION
For OMEGA, mesh variables will be located in a separate netcdf file from the output. This PR always loads mesh variables from the mesh netcdf (usually `mesh.nc` or `culled_mesh.nc`). Some of my changes from the init netcdf to the mesh netcdf file are unnecessary but I think it improves code clarity. 

Checklist
* [X] `Testing` comment in the PR documents testing used to verify the changes