### PR TITLE
Fix cosine bell viz step

### DIFF
--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -19,7 +19,7 @@ lxml
 {% if include_mache %}
 mache={{ mache }}
 {% endif %}
-matplotlib-base
+matplotlib-base >=3.6.0,!=3.7.2
 metis
 mpas_tools={{ mpas_tools }}
 nco

--- a/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
@@ -112,13 +112,12 @@ class Viz(Step):
 
         remapper = viz_map.get_remapper()
 
-        ds_mesh = xr.open_dataset('mesh.nc')
         ds_init = xr.open_dataset('initial_state.nc')
         ds_init = ds_init[['tracer1', ]].isel(Time=0, nVertLevels=0)
         ds_init = remapper.remap(ds_init)
         ds_init.to_netcdf('remapped_init.nc')
 
-        plot_global(ds_mesh.lon.values, ds_mesh.lat.values,
+        plot_global(ds_init.lon.values, ds_init.lat.values,
                     ds_init.tracer1.values,
                     out_filename='init.png', config=config,
                     colormap_section='cosine_bell_viz',
@@ -129,7 +128,7 @@ class Viz(Step):
         ds_out = remapper.remap(ds_out)
         ds_out.to_netcdf('remapped_final.nc')
 
-        plot_global(ds_mesh.lon.values, ds_mesh.lat.values,
+        plot_global(ds_init.lon.values, ds_init.lat.values,
                     ds_out.tracer1.values,
                     out_filename='final.png', config=config,
                     colormap_section='cosine_bell_viz',

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     jigsawpy==0.3.3
     jupyter
     lxml
-    matplotlib
+    matplotlib>=3.6.0,!=3.7.2
     netcdf4
     numpy
     progressbar2


### PR DESCRIPTION
The `lon` and `lat` fields are not available in the MPAS mesh file, but rather come from remapping to a regular lat-lon grid.

We also need to skip `matplotlib` version 3.7.2 because of a known bug: https://github.com/matplotlib/matplotlib/pull/26291

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
