### PR TITLE
Remove steps from `steps_to_run` in `baroclinic_channel` RPE

### DIFF
--- a/polaris/ocean/tests/baroclinic_channel/rpe/__init__.py
+++ b/polaris/ocean/tests/baroclinic_channel/rpe/__init__.py
@@ -68,6 +68,7 @@ class Rpe(BaroclinicChannelTestCase):
             if step.startswith('rpe') or step == 'analysis':
                 # remove previous RPE forward or analysis steps
                 self.steps.pop(step)
+                self.steps_to_run.remove(step)
 
         resolution = self.resolution
 


### PR DESCRIPTION
Without this, each step is listed twice in steps_to_run after setup.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
