### PR TITLE
Fix dependencies in inertial gravity wave convergence test

### DIFF
--- a/polaris/ocean/tests/inertial_gravity_wave/init.py
+++ b/polaris/ocean/tests/inertial_gravity_wave/init.py
@@ -38,6 +38,9 @@ class Init(Step):
                          name=f'init_{resolution}km',
                          subdir=f'{resolution}km/init')
         self.resolution = float(resolution)
+        for filename in ['culled_mesh.nc', 'initial_state.nc',
+                         'culled_graph.info']:
+            self.add_output_file(filename=filename)
 
     def run(self):
         """


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
The output files for the init step aren't being added to the step's outputs attribute, which is causing issues when running in task parallel.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
