### PR TITLE
Modularization and cleanup

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -76,6 +76,8 @@ seaice/api
 
    unpickle_suite
    setup_config
+   load_dependencies
+   pickle_step_after_run
    serial.run_tests
    serial.run_single_step
 

--- a/polaris/run/__init__.py
+++ b/polaris/run/__init__.py
@@ -48,3 +48,53 @@ def setup_config(config_filename):
     config = PolarisConfigParser()
     config.add_from_file(config_filename)
     return config
+
+
+def load_dependencies(test_case, step):
+    """
+    Load each dependency from its pickle file to pick up changes that may have
+    happened since it ran
+
+    Parameters
+    ----------
+    test_case : polaris.testcase.TestCase
+        The test case object
+
+    step : polaris.step.Step
+        The step object
+    """
+    for name, old_dependency in step.dependencies.items():
+        if old_dependency.cached:
+            continue
+
+        pickle_filename = os.path.join(old_dependency.work_dir,
+                                       'step_after_run.pickle')
+        if not os.path.exists(pickle_filename):
+            raise ValueError(f'The dependency {name} of '
+                             f'{test_case.path} step {step.name} was '
+                             f'not run.')
+
+        with open(pickle_filename, 'rb') as handle:
+            _, dependency = pickle.load(handle)
+            step.dependencies[name] = dependency
+
+
+def pickle_step_after_run(test_case, step):
+    """
+    Pickle a step after it has run so its dependencies will pick up the
+    changes
+
+    Parameters
+    ----------
+    test_case : polaris.testcase.TestCase
+        The test case object
+
+    step : polaris.step.Step
+        The step object
+    """
+    if step.is_dependency:
+        # pickle the test case and step for use at runtime
+        pickle_filename = os.path.join(step.work_dir, 'step_after_run.pickle')
+        with open(pickle_filename, 'wb') as handle:
+            pickle.dump((test_case, step), handle,
+                        protocol=pickle.HIGHEST_PROTOCOL)

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -118,6 +118,7 @@ def run_single_step(step_is_subprocess=False):
     test_case.steps_to_run = [step.name]
     test_case.new_step_log_file = False
 
+    # This prevents infinite loop of subprocesses
     if step_is_subprocess:
         step.run_as_subprocess = False
 
@@ -169,6 +170,7 @@ def main():
                         help="Used internally by polaris to indicate that "
                              "a step is being run as a subprocess.")
     args = parser.parse_args(sys.argv[2:])
+
     if args.suite is not None:
         # Running a specified suite from the base work directory
         run_tests(args.suite, quiet=args.quiet)
@@ -513,15 +515,17 @@ def _run_step_as_subprocess(test_case, step, new_log_file):
     """
     logger = test_case.logger
     cwd = os.getcwd()
-    test_name = step.path.replace('/', '_')
+    logger_name = step.path.replace('/', '_')
     if new_log_file:
         log_filename = f'{cwd}/{step.name}.log'
-        step.log_filename = log_filename
         step_logger = None
     else:
         step_logger = logger
         log_filename = None
-    with LoggingContext(name=test_name, logger=step_logger,
+
+    step.log_filename = log_filename
+
+    with LoggingContext(name=logger_name, logger=step_logger,
                         log_filename=log_filename) as step_logger:
 
         os.chdir(step.work_dir)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR pulls out some common code that will be used between `run.serial` and `run.parallel`. I also took the chance to do a bit of cleanup and renaming for general clarity in `run.serial`. 
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
