### PR TITLE
Common global convergence meshes

### DIFF
--- a/polaris/ocean/suites/cosine_bell.txt
+++ b/polaris/ocean/suites/cosine_bell.txt
@@ -1,2 +1,4 @@
+ocean/global_convergence/icos/meshes
 ocean/global_convergence/icos/cosine_bell
+ocean/global_convergence/qu/meshes
 ocean/global_convergence/qu/cosine_bell

--- a/polaris/ocean/suites/cosine_bell_cached_init.txt
+++ b/polaris/ocean/suites/cosine_bell_cached_init.txt
@@ -1,7 +1,14 @@
+ocean/global_convergence/icos/meshes
+  cached: Icos60 Icos120
+  cached: Icos240 Icos480
 ocean/global_convergence/icos/cosine_bell
-  cached: Icos60_mesh Icos60_init Icos120_mesh Icos120_init
-  cached: Icos240_mesh Icos240_init Icos480_mesh Icos480_init
+  cached: Icos60_init Icos120_init
+  cached: Icos240_init Icos480_init
+ocean/global_convergence/qu/meshes
+  cached: QU60 QU90 QU120
+  cached: QU150 QU180 QU210
+  cached: QU240
 ocean/global_convergence/qu/cosine_bell
-  cached: QU60_mesh QU60_init QU90_mesh QU90_init QU120_mesh QU120_init
-  cached: QU150_mesh QU150_init QU180_mesh QU180_init QU210_mesh QU210_init
-  cached: QU240_mesh QU240_init
+  cached: QU60_init QU90_init QU120_init
+  cached: QU150_init QU180_init QU210_init
+  cached: QU240_init

--- a/polaris/ocean/tests/global_convergence/__init__.py
+++ b/polaris/ocean/tests/global_convergence/__init__.py
@@ -16,9 +16,9 @@ class GlobalConvergence(TestGroup):
         super().__init__(component=component, name='global_convergence')
 
         for icosahedral in [False, True]:
-            self.add_test_case(Meshes(test_group=self,
-                                      icosahedral=icosahedral))
+            meshes_test_case = Meshes(test_group=self, icosahedral=icosahedral)
+            self.add_test_case(meshes_test_case)
             for include_viz in [False, True]:
                 self.add_test_case(CosineBell(test_group=self,
-                                              icosahedral=icosahedral,
+                                              meshes=meshes_test_case,
                                               include_viz=include_viz))

--- a/polaris/ocean/tests/global_convergence/__init__.py
+++ b/polaris/ocean/tests/global_convergence/__init__.py
@@ -1,5 +1,6 @@
 from polaris import TestGroup
 from polaris.ocean.tests.global_convergence.cosine_bell import CosineBell
+from polaris.ocean.tests.global_convergence.meshes import Meshes
 
 
 class GlobalConvergence(TestGroup):
@@ -15,6 +16,8 @@ class GlobalConvergence(TestGroup):
         super().__init__(component=component, name='global_convergence')
 
         for icosahedral in [False, True]:
+            self.add_test_case(Meshes(test_group=self,
+                                      icosahedral=icosahedral))
             for include_viz in [False, True]:
                 self.add_test_case(CosineBell(test_group=self,
                                               icosahedral=icosahedral,

--- a/polaris/ocean/tests/global_convergence/cosine_bell/analysis.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/analysis.py
@@ -13,8 +13,9 @@ class Analysis(Step):
 
     Attributes
     ----------
-    resolutions : list of int
-        The resolutions of the meshes that have been run
+    resolutions : dict
+        A dictionary with mesh names as the keys and resolutions in km as the
+        values
 
     icosahedral : bool
         Whether to use icosahedral, as opposed to less regular, JIGSAW
@@ -29,8 +30,9 @@ class Analysis(Step):
         test_case : polaris.ocean.tests.global_convergence.cosine_bell.CosineBell  # noqa: E501
             The test case this step belongs to
 
-        resolutions : list of int
-            The resolutions of the meshes that have been run
+        resolutions : dict
+            A dictionary with mesh names as the keys and resolutions in km as
+            the values
 
         icosahedral : bool
             Whether to use icosahedral, as opposed to less regular, JIGSAW
@@ -40,14 +42,10 @@ class Analysis(Step):
         self.resolutions = resolutions
         self.icosahedral = icosahedral
 
-        for resolution in resolutions:
-            if icosahedral:
-                mesh_name = f'Icos{resolution}'
-            else:
-                mesh_name = f'QU{resolution}'
+        for mesh_name, resolution in resolutions.items():
             self.add_input_file(
                 filename=f'{mesh_name}_mesh.nc',
-                target=f'../{mesh_name}/mesh/mesh.nc')
+                target=f'../../meshes/{mesh_name}/mesh.nc')
             self.add_input_file(
                 filename=f'{mesh_name}_init.nc',
                 target=f'../{mesh_name}/init/initial_state.nc')
@@ -65,11 +63,7 @@ class Analysis(Step):
         resolutions = self.resolutions
         xdata = list()
         ydata = list()
-        for res in resolutions:
-            if self.icosahedral:
-                mesh_name = f'Icos{res}'
-            else:
-                mesh_name = f'QU{res}'
+        for mesh_name in resolutions.keys():
             rmseValue, nCells = self.rmse(mesh_name)
             xdata.append(nCells)
             ydata.append(rmseValue)

--- a/polaris/ocean/tests/global_convergence/cosine_bell/forward.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/forward.py
@@ -49,7 +49,7 @@ class Forward(OceanModelStep):
         self.add_input_file(filename='init.nc',
                             target='../init/initial_state.nc')
         self.add_input_file(filename='graph.info',
-                            target='../mesh/graph.info')
+                            target=f'../../../meshes/{mesh_name}/graph.info')
 
         self.add_output_file(filename='output.nc')
 

--- a/polaris/ocean/tests/global_convergence/cosine_bell/init.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/init.py
@@ -10,7 +10,7 @@ class Init(Step):
     """
     A step for an initial condition for for the cosine bell test case
     """
-    def __init__(self, test_case, mesh_name):
+    def __init__(self, test_case, mesh_step):
         """
         Create the step
 
@@ -19,17 +19,20 @@ class Init(Step):
         test_case : polaris.ocean.tests.global_convergence.cosine_bell.CosineBell  # noqa: E501
             The test case this step belongs to
 
-        mesh_name : str
-            The name of the mesh
+        mesh_step : polaris.mesh.spherical.SphericalBaseStep
+            The step that creates the mesh
         """
 
+        mesh_name = mesh_step.name
         super().__init__(test_case=test_case,
                          name=f'{mesh_name}_init',
                          subdir=f'{mesh_name}/init')
 
-        self.add_input_file(filename='mesh.nc', target='../mesh/mesh.nc')
+        self.add_input_file(filename='mesh.nc',
+                            target=f'../../../meshes/{mesh_name}/mesh.nc')
 
-        self.add_input_file(filename='graph.info', target='../mesh/graph.info')
+        self.add_input_file(filename='graph.info',
+                            target=f'../../../meshes/{mesh_name}/graph.info')
 
         self.add_output_file(filename='initial_state.nc')
 

--- a/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
+++ b/polaris/ocean/tests/global_convergence/cosine_bell/viz.py
@@ -36,7 +36,8 @@ class VizMap(MappingFileStep):
         super().__init__(test_case=test_case, name=name, subdir=subdir,
                          ntasks=128, min_tasks=1)
         self.mesh_name = mesh_name
-        self.add_input_file(filename='mesh.nc', target='../mesh/mesh.nc')
+        self.add_input_file(filename='mesh.nc',
+                            target=f'../../../meshes/{mesh_name}/mesh.nc')
 
     def runtime_setup(self):
         """
@@ -88,7 +89,7 @@ class Viz(Step):
         super().__init__(test_case=test_case, name=name, subdir=subdir)
         self.add_input_file(
             filename='mesh.nc',
-            target='../init/mesh.nc')
+            target=f'../../../meshes/{mesh_name}/mesh.nc')
         self.add_input_file(
             filename='initial_state.nc',
             target='../init/initial_state.nc')

--- a/polaris/ocean/tests/global_convergence/meshes/__init__.py
+++ b/polaris/ocean/tests/global_convergence/meshes/__init__.py
@@ -1,0 +1,108 @@
+from polaris import TestCase
+from polaris.config import PolarisConfigParser
+from polaris.mesh.spherical import (
+    IcosahedralMeshStep,
+    QuasiUniformSphericalMeshStep,
+)
+from polaris.validate import compare_variables
+
+
+class Meshes(TestCase):
+    """
+    A test case for creating a global MPAS-Ocean mesh
+
+    Attributes
+    ----------
+    resolutions : dict
+        A dictionary with mesh names as the keys and resolutions in km as the
+        values
+
+    icosahedral : bool
+        Whether to use icosahedral, as opposed to less regular, JIGSAW meshes
+    """
+    def __init__(self, test_group, icosahedral):
+        """
+        Create test case for creating a global MPAS-Ocean mesh
+
+        Parameters
+        ----------
+        test_group : polaris.ocean.tests.global_convergence.GlobalConvergence
+            The global ocean test group that this test case belongs to
+
+        icosahedral : bool
+            Whether to use icosahedral, as opposed to less regular, JIGSAW
+            meshes
+        """
+        if icosahedral:
+            subdir = 'icos/meshes'
+        else:
+            subdir = 'qu/meshes'
+        super().__init__(test_group=test_group, name='meshes',
+                         subdir=subdir)
+        self.resolutions = dict()
+        self.icosahedral = icosahedral
+
+        # add the steps with default resolutions so they can be listed
+        config = PolarisConfigParser()
+        package = 'polaris.ocean.tests.global_convergence.meshes'
+        config.add_from_package(package, 'meshes.cfg')
+        self._setup_steps(config)
+
+    def configure(self):
+        """
+        Set config options for the test case
+        """
+        super().configure()
+        config = self.config
+        config.add_from_package('polaris.mesh', 'mesh.cfg')
+
+        config.set('spherical_mesh', 'mpas_mesh_filename', 'mesh.nc')
+
+        # set up the steps again in case a user has provided new resolutions
+        self._setup_steps(config)
+
+    def _setup_steps(self, config):
+        """ setup steps given resolutions """
+        resolutions = self._get_resolutions(config)
+        if self.resolutions == resolutions:
+            return
+
+        # start fresh with no steps
+        self.steps = dict()
+        self.steps_to_run = list()
+
+        self.resolutions = resolutions
+
+        for mesh_name, resolution in resolutions.items():
+            if self.icosahedral:
+                self.add_step(IcosahedralMeshStep(
+                    test_case=self, name=mesh_name, cell_width=resolution))
+            else:
+                self.add_step(QuasiUniformSphericalMeshStep(
+                    test_case=self, name=mesh_name, cell_width=resolution))
+
+    def _get_resolutions(self, config):
+        """ get a dictionary of resolutions """
+        if self.icosahedral:
+            default_resolutions = '60, 120, 240, 480'
+        else:
+            default_resolutions = '60, 90, 120, 150, 180, 210, 240'
+
+        # set the default values that a user may change before setup
+        config.set('global_convergence', 'resolutions', default_resolutions,
+                   comment='a list of resolutions (km) to test')
+
+        # get the resolutions back, perhaps with values set in the user's
+        # config file, which takes priority over what we just set above
+        res_list = config.getlist('global_convergence', 'resolutions',
+                                  dtype=float)
+
+        resolutions = dict()
+        for resolution in res_list:
+            if self.icosahedral:
+                mesh_name = f'Icos{resolution:g}'
+            else:
+                mesh_name = f'QU{resolution:g}'
+            resolutions[mesh_name] = resolution
+
+        return resolutions

--- a/polaris/ocean/tests/global_convergence/meshes/meshes.cfg
+++ b/polaris/ocean/tests/global_convergence/meshes/meshes.cfg
@@ -1,0 +1,6 @@
+# options for global convergence test cases
+[global_convergence]
+
+# a list of resolutions (km) to test
+# Note: the default for icosahedral meshes is: 60, 120, 240, 480
+resolutions = 60, 90, 120, 150, 180, 210, 240


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This has meshes that can be reused by multiple subsequent test cases.  The cosine bell test cases have been updated to use meshes created in the ne `meshes` test case.

This work is in anticipation of using the same meshes for `cosine_bell` and `geostropic` (Williamson Test 2) test cases.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite
* [ ] Cache files have been updated

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
