### PR TITLE
Reorganize validation

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -132,7 +132,6 @@ seaice/api
 
    Task
    Task.configure
-   Task.validate
    Task.add_step
 ```
 
@@ -363,7 +362,6 @@ seaice/api
    :toctree: generated/
 
    compare_variables
-   compare_timers
 ```
 
 ### viz

--- a/docs/developers_guide/docs.md
+++ b/docs/developers_guide/docs.md
@@ -137,7 +137,6 @@ be added to `docs/<component>/api.md`:
 
    BaroclinicChannelTestCase
    BaroclinicChannelTestCase.configure
-   BaroclinicChannelTestCase.validate
    
    forward.Forward
    forward.Forward.compute_cell_count

--- a/docs/developers_guide/framework/commands.md
+++ b/docs/developers_guide/framework/commands.md
@@ -83,11 +83,12 @@ Output from tasks and their steps are stored in log files in the
 `case_output` subdirectory of the base work directory. If the function is
 used for a single task, it will run the steps of that task, writing
 output for each step to a log file starting with the step's name. In either
-case (suite or individual test), it displays a `PASS` or `FAIL` message for
-the test execution, as well as similar messages for validation involving output
-within the task or suite and validation against a baseline (depending on
-the implementation of the `validate()` method in the task and whether a
-baseline was provided during setup).
+case (suite or individual test), it displays a `SUCCESS` or `ERROR` message for
+the execution of each step, indicates whether baseline comparisons `PASS` or
+`FAIL` for any steps that include them (and if a baseline was provided), 
+and finally indicates if the overall task execution was `SUCCESS` or `ERROR`.
+Execution times are provided for individual steps, tasks and the suite as a
+whole.
 
 {py:func}`polaris.run.run_single_step()` runs only the selected step from a
 given task, skipping any others, displaying the output in the terminal

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -22,7 +22,6 @@
    add_baroclinic_channel_tasks
 
    BaroclinicChannelTestCase
-   BaroclinicChannelTestCase.validate
    
    forward.Forward
    forward.Forward.compute_cell_count
@@ -32,27 +31,25 @@
    init.Init.setup
    init.Init.run
 
+   validate.Validate
+   validate.Validate.run
+   
    viz.Viz
    viz.Viz.run
 
    default.Default
-   default.Default.validate
 
    decomp.Decomp
-   decomp.Decomp.validate
 
    restart.Restart
-   restart.Restart.validate
 
    restart.restart_step.RestartStep
    restart.restart_step.RestartStep.dynamic_model_config
 
    threads.Threads
-   threads.Threads.validate
 
    rpe.Rpe
    rpe.Rpe.configure
-   rpe.Rpe.validate
    rpe.analysis.Analysis
    rpe.analysis.Analysis.setup
    rpe.analysis.Analysis.run
@@ -86,7 +83,6 @@
    viz.Viz.run
 
    convergence.Convergence
-   convergence.Convergence.validate
 ```
 
 ### global_convergence
@@ -110,7 +106,6 @@
 
    CosineBell
    CosineBell.configure
-   CosineBell.validate
 
    init.Init
    init.Init.run
@@ -158,7 +153,6 @@
    viz.Viz.run
 
    convergence.Convergence
-   convergence.Convergence.validate
 ```
 
 ### single_column
@@ -180,10 +174,8 @@
    viz.Viz.run
 
    cvmix.CVMix
-   cvmix.CVMix.validate
 
    ideal_age.IdealAge
-   ideal_age.IdealAge.validate
 ```
 
 ## Ocean Framework

--- a/docs/developers_guide/ocean/tasks/baroclinic_channel.md
+++ b/docs/developers_guide/ocean/tasks/baroclinic_channel.md
@@ -24,11 +24,9 @@ and `output` streams.
 The class {py:class}`polaris.ocean.tasks.baroclinic_channel.BaroclinicChannelTestCase`
 defines a superclass for all baroclinic channel test cases.  This class sets
 up the appropriate subdirectory for the given resolution, adds an initial
-state step (see the following) used by all test cases, sets some config options
+state step (see the following) used by all test cases, and sets some config options
 related to the mesh size and resolution in the
 {py:meth}`polaris.ocean.tasks.baroclinic_channel.BaroclinicChannelTestCase.configure()`
-method, and performs validation of the initial condition in the
-{py:meth}`polaris.ocean.tasks.baroclinic_channel.BaroclinicChannelTestCase.validate()`
 method.
 
 ### init

--- a/docs/developers_guide/organization/categories_of_tasks.md
+++ b/docs/developers_guide/organization/categories_of_tasks.md
@@ -114,7 +114,6 @@ import os
 
 from polaris import Task
 from polaris.ocean.tasks.baroclinic_channel.init import Init
-from polaris.validate import compare_variables
 
 
 class BaroclinicChannelTestCase(Task):
@@ -134,12 +133,6 @@ class BaroclinicChannelTestCase(Task):
     def configure(self):
         self.config.add_from_package('polaris.ocean.tasks.baroclinic_channel',
                                      'baroclinic_channel.cfg')
-
-    def validate(self):
-        super().validate()
-        variables = ['temperature', 'salinity', 'layerThickness']
-        compare_variables(task=self, variables=variables,
-                          filename1='init/initial_state.nc')
 ```
 
 This parent class takes care of defining the subdirectory for other tests,

--- a/docs/developers_guide/organization/tasks.md
+++ b/docs/developers_guide/organization/tasks.md
@@ -10,14 +10,8 @@ A task can be a module but is usually a python package so it can
 incorporate modules for its steps and/or config files, namelists, and streams
 files.  The task must include a class that descends from
 {py:class}`polaris.Task`.  In addition to a constructor (`__init__()`),
-the class will often override the `configure()` and `validate()` methods of
-the base class, as described below.
-
-The `run()` method in {py:class}`polaris.Task` is deprecated; behaviors
-at runtime can instead be handled by individual steps by overriding the
-{py:meth}`polaris.Step.constrain_resources()` and
-{py:meth}`polaris.Step.runtime_setup()` methods.  Details about these methods
-are described further in {ref}`dev-steps`.
+the class will often override the `configure()` method of the base class, as 
+described below.
 
 (dev-task-class)=
 
@@ -375,48 +369,3 @@ in their own `setup()` or `runtime_setup()` methods.
 
 Tasks that don't need to change config options don't need to override
 `configure()` at all.
-
-(dev-task-validate)=
-
-## validate()
-
-The base class's {py:meth}`polaris.Task.validate()` can be overridden to
-perform {ref}`dev-validation` of variables in output files from a step and/or
-timers from the E3SM component.
-
-In  {py:meth}`polaris.ocean.tasks.global_ocean.init.Init.validate()`, we see
-examples of validation of variables from output files:
-
-```python
-def validate(self):
-    """
-    Tasks can override this method to perform validation of variables
-    and timers
-    """
-    steps = self.steps_to_run
-
-    variables = ['temperature', 'salinity', 'layerThickness']
-    compare_variables(task=self, variables=variables,
-                      filename1='init/initial_state.nc')
-
-    if self.with_bgc:
-        variables = [
-            'temperature', 'salinity', 'layerThickness', 'PO4', 'NO3',
-            'SiO3', 'NH4', 'Fe', 'O2', 'DIC', 'DIC_ALT_CO2', 'ALK',
-            'DOC', 'DON', 'DOFe', 'DOP', 'DOPr', 'DONr', 'zooC',
-            'spChl', 'spC', 'spFe', 'spCaCO3', 'diatChl', 'diatC',
-            'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe',
-            'phaeoChl', 'phaeoC', 'phaeoFe', 'DMS', 'DMSP', 'PROT',
-            'POLY', 'LIP']
-        compare_variables(task=self, variables=variables,
-                          filename1='init/initial_state.nc')
-
-    if self.mesh.with_ice_shelf_cavities:
-        variables = ['ssh', 'landIcePressure']
-        compare_variables(task=self, variables=variables,
-                          filename1='ssh_adjustment/adjusted_init.nc')
-```
-
-If you leave the default keyword argument `skip_if_step_not_run=True`,
-comparison will be skipped (logging a message) if one or more of the steps
-involved in the comparison was not run.

--- a/docs/developers_guide/seaice/api.md
+++ b/docs/developers_guide/seaice/api.md
@@ -24,10 +24,11 @@
    forward.Forward
 
    exact_restart.ExactRestart
-   exact_restart.ExactRestart.validate
+
+   exact_restart.validate.Validate
+   exact_restart.validate.Validate.run
 
    standard_physics.StandardPhysics
-   standard_physics.StandardPhysics.validate
 
    standard_physics.viz.Viz
    standard_physics.viz.Viz.run

--- a/polaris/io.py
+++ b/polaris/io.py
@@ -191,7 +191,7 @@ def symlink(target, link_name, overwrite=True):
             raise IsADirectoryError(
                 f"Cannot symlink over existing directory: '{link_name}'")
         os.replace(temp_link_name, link_name)
-    except BaseException:
+    except Exception:
         if os.path.islink(temp_link_name):
             os.remove(temp_link_name)
         raise

--- a/polaris/ocean/tasks/baroclinic_channel/baroclinic_channel_test_case.py
+++ b/polaris/ocean/tasks/baroclinic_channel/baroclinic_channel_test_case.py
@@ -2,7 +2,6 @@ import os
 
 from polaris import Task
 from polaris.ocean.tasks.baroclinic_channel.init import Init
-from polaris.validate import compare_variables
 
 
 class BaroclinicChannelTestCase(Task):
@@ -49,13 +48,3 @@ class BaroclinicChannelTestCase(Task):
         """
         self.config.add_from_package('polaris.ocean.tasks.baroclinic_channel',
                                      'baroclinic_channel.cfg')
-
-    def validate(self):
-        """
-        Compare ``temperature``, ``salinity`` and ``layerThickness`` from the
-        initial condition with a baseline if one was provided
-        """
-        super().validate()
-        variables = ['temperature', 'salinity', 'layerThickness']
-        compare_variables(task=self, variables=variables,
-                          filename1='init/initial_state.nc')

--- a/polaris/ocean/tasks/baroclinic_channel/decomp/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/decomp/__init__.py
@@ -1,6 +1,6 @@
 from polaris.ocean.tasks.baroclinic_channel import BaroclinicChannelTestCase
 from polaris.ocean.tasks.baroclinic_channel.forward import Forward
-from polaris.validate import compare_variables
+from polaris.ocean.tasks.baroclinic_channel.validate import Validate
 
 
 class Decomp(BaroclinicChannelTestCase):
@@ -25,6 +25,7 @@ class Decomp(BaroclinicChannelTestCase):
         super().__init__(component=component, resolution=resolution,
                          name='decomp')
 
+        subdirs = list()
         for procs in [4, 8]:
             name = f'{procs}proc'
 
@@ -32,16 +33,5 @@ class Decomp(BaroclinicChannelTestCase):
                 task=self, name=name, subdir=name, ntasks=procs,
                 min_tasks=procs, openmp_threads=1,
                 resolution=resolution, run_time_steps=3))
-
-    def validate(self):
-        """
-        Compare ``temperature``, ``salinity``, ``layerThickness`` and
-        ``normalVelocity`` in the ``4proc`` and ``8proc`` steps with each other
-        and with a baseline if one was provided
-        """
-        super().validate()
-        variables = ['temperature', 'salinity', 'layerThickness',
-                     'normalVelocity']
-        compare_variables(task=self, variables=variables,
-                          filename1='4proc/output.nc',
-                          filename2='8proc/output.nc')
+            subdirs.append(name)
+        self.add_step(Validate(task=self, step_subdirs=subdirs))

--- a/polaris/ocean/tasks/baroclinic_channel/default/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/default/__init__.py
@@ -31,15 +31,3 @@ class Default(BaroclinicChannelTestCase):
 
         self.add_step(
             Viz(task=self))
-
-    def validate(self):
-        """
-        Compare ``temperature``, ``salinity``, ``layerThickness`` and
-        ``normalVelocity`` in the ``forward`` step with a baseline if one was
-        provided.
-        """
-        super().validate()
-        variables = ['temperature', 'salinity', 'layerThickness',
-                     'normalVelocity']
-        compare_variables(task=self, variables=variables,
-                          filename1='forward/output.nc')

--- a/polaris/ocean/tasks/baroclinic_channel/forward.py
+++ b/polaris/ocean/tasks/baroclinic_channel/forward.py
@@ -87,7 +87,10 @@ class Forward(OceanModelStep):
         self.add_yaml_file('polaris.ocean.tasks.baroclinic_channel',
                            'forward.yaml')
 
-        self.add_output_file(filename='output.nc')
+        self.add_output_file(
+            filename='output.nc',
+            validate_vars=['temperature', 'salinity', 'layerThickness',
+                           'normalVelocity'])
 
         self.resources_fixed = (ntasks is not None)
 

--- a/polaris/ocean/tasks/baroclinic_channel/init.py
+++ b/polaris/ocean/tasks/baroclinic_channel/init.py
@@ -36,9 +36,11 @@ class Init(Step):
         super().__init__(task=task, name='init')
         self.resolution = resolution
 
-        for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info',
-                     'initial_state.nc']:
+        for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info']:
             self.add_output_file(file)
+        self.add_output_file('initial_state.nc',
+                             validate_vars=['temperature', 'salinity',
+                                            'layerThickness'])
 
     def run(self):
         """

--- a/polaris/ocean/tasks/baroclinic_channel/restart/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/restart/__init__.py
@@ -2,7 +2,7 @@ from polaris.ocean.tasks.baroclinic_channel import BaroclinicChannelTestCase
 from polaris.ocean.tasks.baroclinic_channel.restart.restart_step import (
     RestartStep,
 )
-from polaris.validate import compare_variables
+from polaris.ocean.tasks.baroclinic_channel.validate import Validate
 
 
 class Restart(BaroclinicChannelTestCase):
@@ -36,14 +36,5 @@ class Restart(BaroclinicChannelTestCase):
         restart.add_dependency(full, full.name)
         self.add_step(restart)
 
-    def validate(self):
-        """
-        Compare ``temperature``, ``salinity``, ``layerThickness`` and
-        ``normalVelocity`` in the ``full_run`` and ``restart_run`` steps with
-        each other and with a baseline if one was provided
-        """
-        variables = ['temperature', 'salinity', 'layerThickness',
-                     'normalVelocity']
-        compare_variables(task=self, variables=variables,
-                          filename1='full_run/output.nc',
-                          filename2='restart_run/output.nc')
+        self.add_step(Validate(task=self,
+                               step_subdirs=['full_run', 'restart_run']))

--- a/polaris/ocean/tasks/baroclinic_channel/rpe/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/rpe/__init__.py
@@ -36,24 +36,6 @@ class Rpe(BaroclinicChannelTestCase):
         super().configure()
         self._add_steps(config=self.config)
 
-    def validate(self):
-        """
-        Compare ``temperature``, ``salinity``, ``layerThickness`` and
-        ``normalVelocity`` in the ``forward`` step with a baseline if one was
-        provided.
-        """
-        super().validate()
-
-        config = self.config
-        variables = ['temperature', 'salinity', 'layerThickness',
-                     'normalVelocity']
-
-        nus = config.getlist('baroclinic_channel', 'viscosities', dtype=float)
-        for index, nu in enumerate(nus):
-            name = f'rpe_{index + 1}_nu_{int(nu)}'
-            compare_variables(task=self, variables=variables,
-                              filename1=f'{name}/output.nc')
-
     def _add_steps(self, config=None):
         """ Add the steps in the test case either at init or set-up """
 

--- a/polaris/ocean/tasks/baroclinic_channel/threads/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/threads/__init__.py
@@ -1,6 +1,6 @@
 from polaris.ocean.tasks.baroclinic_channel import BaroclinicChannelTestCase
 from polaris.ocean.tasks.baroclinic_channel.forward import Forward
-from polaris.validate import compare_variables
+from polaris.ocean.tasks.baroclinic_channel.validate import Validate
 
 
 class Threads(BaroclinicChannelTestCase):
@@ -25,22 +25,12 @@ class Threads(BaroclinicChannelTestCase):
         super().__init__(component=component, resolution=resolution,
                          name='threads')
 
+        subdirs = list()
         for openmp_threads in [1, 2]:
             name = f'{openmp_threads}thread'
             self.add_step(Forward(
                 task=self, name=name, subdir=name, ntasks=4,
                 min_tasks=4, openmp_threads=openmp_threads,
                 resolution=resolution, run_time_steps=3))
-
-    def validate(self):
-        """
-        Compare ``temperature``, ``salinity``, ``layerThickness`` and
-        ``normalVelocity`` in the ``1thread`` and ``2thread`` steps with each
-        other and with a baseline if one was provided
-        """
-        super().validate()
-        variables = ['temperature', 'salinity', 'layerThickness',
-                     'normalVelocity']
-        compare_variables(task=self, variables=variables,
-                          filename1='1thread/output.nc',
-                          filename2='2thread/output.nc')
+            subdirs.append(name)
+        self.add_step(Validate(task=self, step_subdirs=subdirs))

--- a/polaris/ocean/tasks/baroclinic_channel/validate.py
+++ b/polaris/ocean/tasks/baroclinic_channel/validate.py
@@ -1,0 +1,49 @@
+from polaris import Step
+from polaris.validate import compare_variables
+
+
+class Validate(Step):
+    """
+    A step for comparing outputs between steps in a baroclinic channel run
+
+    Attributes
+    ----------
+    step_subdirs : list of str
+        The number of processors used in each run
+    """
+    def __init__(self, task, step_subdirs):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        task : polaris.Task
+            The task this step belongs to
+
+        step_subdirs : list of str
+            The number of processors used in each run
+        """
+        super().__init__(task=task, name='validate')
+
+        self.step_subdirs = step_subdirs
+
+        for subdir in step_subdirs:
+            self.add_input_file(filename=f'output_{subdir}.nc',
+                                target=f'../{subdir}/output.nc')
+
+    def run(self):
+        """
+        Compare ``temperature``, ``salinity``, ``layerThickness`` and
+        ``normalVelocity`` in the outputs of two previous steps with each other
+        """
+        super().run()
+        step_subdirs = self.step_subdirs
+        variables = ['temperature', 'salinity', 'layerThickness',
+                     'normalVelocity']
+        all_pass = compare_variables(variables=variables,
+                                     filename1=self.inputs[0],
+                                     filename2=self.inputs[1],
+                                     logger=self.logger)
+        if not all_pass:
+            raise ValueError(f'Validation failed comparing outputs between '
+                             f'{step_subdirs[0]} and {step_subdirs[1]}.')

--- a/polaris/ocean/tasks/global_convergence/cosine_bell/__init__.py
+++ b/polaris/ocean/tasks/global_convergence/cosine_bell/__init__.py
@@ -10,7 +10,6 @@ from polaris.ocean.tasks.global_convergence.cosine_bell.analysis import (
 from polaris.ocean.tasks.global_convergence.cosine_bell.forward import Forward
 from polaris.ocean.tasks.global_convergence.cosine_bell.init import Init
 from polaris.ocean.tasks.global_convergence.cosine_bell.viz import Viz, VizMap
-from polaris.validate import compare_variables
 
 
 class CosineBell(Task):
@@ -74,19 +73,6 @@ class CosineBell(Task):
 
         # set up the steps again in case a user has provided new resolutions
         self._setup_steps(config)
-
-    def validate(self):
-        """
-        Validate variables against a baseline
-        """
-        for resolution in self.resolutions:
-            if self.icosahedral:
-                mesh_name = f'Icos{resolution}'
-            else:
-                mesh_name = f'QU{resolution}'
-            compare_variables(task=self,
-                              variables=['normalVelocity', 'tracer1'],
-                              filename1=f'{mesh_name}/forward/output.nc')
 
     def _setup_steps(self, config):
         """ setup steps given resolutions """

--- a/polaris/ocean/tasks/global_convergence/cosine_bell/forward.py
+++ b/polaris/ocean/tasks/global_convergence/cosine_bell/forward.py
@@ -51,7 +51,8 @@ class Forward(OceanModelStep):
         self.add_input_file(filename='graph.info',
                             target='../mesh/graph.info')
 
-        self.add_output_file(filename='output.nc')
+        self.add_output_file(filename='output.nc',
+                             validate_vars=['normalVelocity', 'tracer1'])
 
     def compute_cell_count(self):
         """

--- a/polaris/ocean/tasks/inertial_gravity_wave/convergence/__init__.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/convergence/__init__.py
@@ -3,7 +3,6 @@ from polaris.ocean.tasks.inertial_gravity_wave.analysis import Analysis
 from polaris.ocean.tasks.inertial_gravity_wave.forward import Forward
 from polaris.ocean.tasks.inertial_gravity_wave.init import Init
 from polaris.ocean.tasks.inertial_gravity_wave.viz import Viz
-from polaris.validate import compare_variables
 
 
 class Convergence(Task):
@@ -40,14 +39,3 @@ class Convergence(Task):
         self.config.add_from_package(
             'polaris.ocean.tasks.inertial_gravity_wave',
             'inertial_gravity_wave.cfg')
-
-    def validate(self):
-        """
-        Compare ``layerThickness`` and ``normalVelocity`` in the ``forward``
-        step with a baseline if one was provided.
-        """
-        super().validate()
-        variables = ['layerThickness', 'normalVelocity']
-        for res in self.resolutions:
-            compare_variables(task=self, variables=variables,
-                              filename1=f'{res}km/forward/output.nc')

--- a/polaris/ocean/tasks/inertial_gravity_wave/forward.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/forward.py
@@ -53,7 +53,9 @@ class Forward(OceanModelStep):
         self.add_input_file(filename='graph.info',
                             target='../init/culled_graph.info')
 
-        self.add_output_file(filename='output.nc')
+        self.add_output_file(
+            filename='output.nc',
+            validate_vars=['layerThickness', 'normalVelocity'])
 
         self.add_yaml_file('polaris.ocean.config',
                            'single_layer.yaml')

--- a/polaris/ocean/tasks/manufactured_solution/convergence/__init__.py
+++ b/polaris/ocean/tasks/manufactured_solution/convergence/__init__.py
@@ -44,14 +44,3 @@ class Convergence(Task):
         self.config.add_from_package(
             'polaris.ocean.tasks.manufactured_solution',
             'manufactured_solution.cfg')
-
-    def validate(self):
-        """
-        Compare ``layerThickness`` and ``normalVelocity`` in the ``forward``
-        step with a baseline if one was provided.
-        """
-        super().validate()
-        variables = ['layerThickness', 'normalVelocity']
-        for res in self.resolutions:
-            compare_variables(task=self, variables=variables,
-                              filename1=f'{res}km/forward/output.nc')

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -56,7 +56,9 @@ class Forward(OceanModelStep):
         self.add_input_file(filename='graph.info',
                             target='../init/culled_graph.info')
 
-        self.add_output_file(filename='output.nc')
+        self.add_output_file(
+            filename='output.nc',
+            validate_vars=['layerThickness', 'normalVelocity'])
 
         self.add_yaml_file('polaris.ocean.config',
                            'single_layer.yaml')

--- a/polaris/ocean/tasks/single_column/cvmix/__init__.py
+++ b/polaris/ocean/tasks/single_column/cvmix/__init__.py
@@ -32,9 +32,11 @@ class CVMix(Task):
         self.add_step(
             Init(task=self, resolution=resolution))
 
+        validate_vars = ['temperature', 'salinity', 'layerThickness',
+                         'normalVelocity']
         self.add_step(
             Forward(task=self, ntasks=1, min_tasks=1,
-                    openmp_threads=1))
+                    openmp_threads=1, validate_vars=validate_vars))
 
         self.add_step(
             Viz(task=self))
@@ -46,15 +48,3 @@ class CVMix(Task):
         self.config.add_from_package(
             'polaris.ocean.tasks.single_column',
             'single_column.cfg')
-
-    def validate(self):
-        """
-        Compare ``temperature``, ``salinity``, ``layerThickness`` and
-        ``normalVelocity`` in the ``forward`` step with a baseline if one was
-        provided.
-        """
-        super().validate()
-        variables = ['temperature', 'salinity', 'layerThickness',
-                     'normalVelocity']
-        compare_variables(task=self, variables=variables,
-                          filename1='forward/output.nc')

--- a/polaris/ocean/tasks/single_column/forward.py
+++ b/polaris/ocean/tasks/single_column/forward.py
@@ -8,9 +8,6 @@ class Forward(OceanModelStep):
 
     Attributes
     ----------
-    resolution : float
-        The resolution of the test case in km
-
     resources_fixed : bool
         Whether resources were set already and shouldn't be updated
         algorithmically
@@ -20,14 +17,10 @@ class Forward(OceanModelStep):
 
     btr_dt : float
         The model barotropic time step in seconds
-
-    run_time_steps : int or None
-        Number of time steps to run for
-        NOTE: not currently used
     """
     def __init__(self, task, name='forward', subdir=None,
-                 ntasks=None, min_tasks=None, openmp_threads=1, nu=None,
-                 run_time_steps=None):
+                 ntasks=None, min_tasks=None, openmp_threads=1,
+                 validate_vars=None):
         """
         Create a new test case
 
@@ -35,9 +28,6 @@ class Forward(OceanModelStep):
         ----------
         task : polaris.Task
             The test case this step belongs to
-
-        resolution : km
-            The resolution of the test case in km
 
         name : str
             the name of the test case
@@ -57,6 +47,9 @@ class Forward(OceanModelStep):
         openmp_threads : int, optional
             the number of OpenMP threads the step will use
 
+        validate_vars : list, optional
+            A list of variable names to compare with a baseline (if one is
+            provided)
         """
         super().__init__(task=task, name=name, subdir=subdir,
                          ntasks=ntasks, min_tasks=min_tasks,
@@ -74,7 +67,7 @@ class Forward(OceanModelStep):
         self.add_yaml_file('polaris.ocean.tasks.single_column',
                            'forward.yaml')
 
-        self.add_output_file(filename='output.nc')
+        self.add_output_file(filename='output.nc', validate_vars=validate_vars)
 
         self.resources_fixed = (ntasks is not None)
 

--- a/polaris/ocean/tasks/single_column/ideal_age/__init__.py
+++ b/polaris/ocean/tasks/single_column/ideal_age/__init__.py
@@ -42,8 +42,9 @@ class IdealAge(Task):
             Init(task=self, resolution=resolution,
                  ideal_age=ideal_age))
 
+        validate_vars = ['temperature', 'salinity', 'iAge']
         step = Forward(task=self, ntasks=1, min_tasks=1,
-                       openmp_threads=1)
+                       openmp_threads=1, validate_vars=validate_vars)
 
         step.add_yaml_file('polaris.ocean.tasks.single_column.ideal_age',
                            'forward.yaml')
@@ -60,14 +61,3 @@ class IdealAge(Task):
         self.config.add_from_package(
             'polaris.ocean.tasks.single_column',
             'single_column.cfg')
-
-    def validate(self):
-        """
-        Compare ``temperature``, ``salinity``, and ``iAge``
-        in the ``forward`` step with a baseline if one was
-        provided.
-        """
-        super().validate()
-        variables = ['temperature', 'salinity', 'iAge']
-        compare_variables(task=self, variables=variables,
-                          filename1='forward/output.nc')

--- a/polaris/seaice/tasks/single_column/__init__.py
+++ b/polaris/seaice/tasks/single_column/__init__.py
@@ -6,6 +6,8 @@ def add_single_column_tasks(component):
     """
     Add various tasks that define single-column tests
 
+    Parameters
+    ----------
     component : polaris.seaice.Seaice
         the component that that the tasks will be added to
     """

--- a/polaris/seaice/tasks/single_column/exact_restart/validate.py
+++ b/polaris/seaice/tasks/single_column/exact_restart/validate.py
@@ -1,0 +1,59 @@
+from polaris import Step
+from polaris.validate import compare_variables
+
+
+class Validate(Step):
+    """
+    A step for comparing outputs between steps in a single-column restart run
+
+    Attributes
+    ----------
+    step_subdirs : list of str
+        The number of processors used in each run
+
+    variables : list of str
+        The variables to validate
+    """
+    def __init__(self, task, step_subdirs, variables, restart_filename):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        task : polaris.Task
+            The task this step belongs to
+
+        step_subdirs : list of str
+            The number of processors used in each run
+
+        variables : list of str
+            The variables to validate
+
+        restart_filename : str
+            The relative path to the restart file to compare in the 2 subdirs
+        """
+        super().__init__(task=task, name='validate')
+
+        self.step_subdirs = step_subdirs
+
+        for subdir in step_subdirs:
+            self.add_input_file(
+                filename=f'{subdir}_restart.nc',
+                target=f'../{subdir}/{restart_filename}')
+
+        self.variables = variables
+
+    def run(self):
+        """
+        Compare the variables in the outputs of two previous steps with each
+        other
+        """
+        super().run()
+        step_subdirs = self.step_subdirs
+        all_pass = compare_variables(variables=self.variables,
+                                     filename1=self.inputs[0],
+                                     filename2=self.inputs[1],
+                                     logger=self.logger)
+        if not all_pass:
+            raise ValueError(f'Validation failed comparing restart between '
+                             f'{step_subdirs[0]} and {step_subdirs[1]}.')

--- a/polaris/seaice/tasks/single_column/forward.py
+++ b/polaris/seaice/tasks/single_column/forward.py
@@ -4,18 +4,16 @@ from polaris import ModelStep
 class Forward(ModelStep):
     """
     A step for staging a mesh for “single column” test cases
-
-    Attributes
-    ----------
-
     """
     def __init__(self, task, name='forward'):
         """
         Create the step
+
         Parameters
         ----------
         task : polaris.Task
           The test case this step belongs to
+
         name : str, optional
           The name of the step
         """

--- a/polaris/seaice/tasks/single_column/standard_physics/__init__.py
+++ b/polaris/seaice/tasks/single_column/standard_physics/__init__.py
@@ -3,7 +3,6 @@ import os
 from polaris import Task
 from polaris.seaice.tasks.single_column.forward import Forward
 from polaris.seaice.tasks.single_column.standard_physics.viz import Viz
-from polaris.validate import compare_variables
 
 
 class StandardPhysics(Task):
@@ -28,18 +27,9 @@ class StandardPhysics(Task):
         step.add_namelist_file(
             package='polaris.seaice.tasks.single_column.standard_physics',
             namelist='namelist.seaice')
-        step.add_output_file(filename='output/output.2000.nc')
-        self.add_step(step)
-        self.add_step(Viz(task=self))
-
-    def validate(self):
-        """
-        Compare six output variables in the ``forward`` step
-        with a baseline if one was provided.
-        """
-        super().validate()
-
         variables = ['iceAreaCell', 'iceVolumeCell', 'snowVolumeCell',
                      'surfaceTemperatureCell', 'shortwaveDown', 'longwaveDown']
-        compare_variables(task=self, variables=variables,
-                          filename1='forward/output/output.2000.nc')
+        step.add_output_file(filename='output/output.2000.nc',
+                             validate_vars=variables)
+        self.add_step(step)
+        self.add_step(Viz(task=self))

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -242,6 +242,10 @@ def setup_task(path, task, config_file, machine, work_dir, baseline_dir,
         # set up the step
         step.setup()
 
+        # add the baseline directory for this step
+        if baseline_dir is not None:
+            step.baseline_dir = os.path.join(baseline_dir, step.path)
+
         # process input, output, namelist and streams files
         step.process_inputs_and_outputs()
 

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -497,8 +497,8 @@ class Step:
             Whether the outputs were successfully validated against a baseline
         """
         if self.work_dir is None:
-            raise ValueError('Baselines cannot be validated before the work '
-                             'directory has been set')
+            raise ValueError('The work directory must be set before the step '
+                             'outputs can be validated against baselines.')
         compared = False
         success = True
         if self.baseline_dir is not None:

--- a/polaris/task.py
+++ b/polaris/task.py
@@ -48,7 +48,7 @@ class Task:
     base_work_dir : str
         The base work directory
 
-    baseline_dir : str, optional
+    baseline_dir : str
         Location of the same task within the baseline work directory,
         for use in comparing variables and timers
 
@@ -125,13 +125,6 @@ class Task:
         package.  If a task overrides this method, it should assume that
         the ``<self.name>.cfg`` file in its package has already been added
         to the config options prior to calling ``configure()``.
-        """
-        pass
-
-    def validate(self):
-        """
-        Tasks can override this method to perform validation of variables
-        and timers
         """
         pass
 

--- a/polaris/validate.py
+++ b/polaris/validate.py
@@ -1,26 +1,16 @@
-import fnmatch
 import os
-import re
 
-import numpy
-import xarray
+import numpy as np
+import xarray as xr
 
 
-def compare_variables(task, variables, filename1, filename2=None,
-                      l1_norm=0.0, l2_norm=0.0, linf_norm=0.0, quiet=True,
-                      check_outputs=True, skip_if_step_not_run=True):
+def compare_variables(variables, filename1, filename2, logger, l1_norm=0.0,
+                      l2_norm=0.0, linf_norm=0.0, quiet=True):
     """
-    Compare variables between files in the current task and/or with the
-    baseline results.  The results of the comparison are added to the
-    task's "validation" dictionary, which the framework can use later to
-    log the task results and/or to raise an exception to indicate that
-    the task has failed.
+    compare variables in the two files
 
     Parameters
     ----------
-    task : polaris.Task
-        An object describing a task to validate
-
     variables : list
         A list of variable names to compare
 
@@ -28,14 +18,18 @@ def compare_variables(task, variables, filename1, filename2=None,
         The relative path to a file within the ``work_dir``.  If ``filename2``
         is also given, comparison will be performed with ``variables`` in that
         file.  If a baseline directory was provided when setting up the
-        task, the ``variables`` will be compared between this task
-        and the same relative filename in the baseline version of the task.
+        test case, the ``variables`` will be compared between this test case
+        and the same relative filename in the baseline version of the test
+        case.
 
-    filename2 : str, optional
+    filename2 : str
         The relative path to another file within the ``work_dir`` if comparing
-        between files within the current task.  If a baseline directory
+        between files within the current test case.  If a baseline directory
         was provided, the ``variables`` from this file will also be compared
         with those in the corresponding baseline file.
+
+    logger: logging.Logger
+        The logger to log validation output to
 
     l1_norm : float, optional
         The maximum allowed L1 norm difference between the variables in
@@ -55,174 +49,20 @@ def compare_variables(task, variables, filename1, filename2=None,
         comparison is made.  This is generally desirable when using nonzero
         norm tolerance values.
 
-    check_outputs : bool, optional
-        Whether to check to make sure files are valid outputs of steps in
-        the task.  This should be set to ``False`` if comparing with an
-        output of a step in another task.
+    Returns
+    -------
+    all_pass : bool
+        Whether all variables passed the validation checks
 
-    skip_if_step_not_run : bool, optional
-        Whether to skip the variable comparison if a user did not run one (or
-        both) of the steps involved in the comparison.  This would happen if
-        users are running steps individually or has edited ``steps_to_run``
-        in the config file to exclude one of the steps.
     """
-    work_dir = task.work_dir
-
-    logger = task.logger
-
-    path1 = os.path.abspath(os.path.join(work_dir, filename1))
-    if filename2 is not None:
-        path2 = os.path.abspath(os.path.join(work_dir, filename2))
-    else:
-        path2 = None
-
-    if check_outputs:
-        all_steps_run = _check_for_outputs(
-            task, logger, path1, path2, filename1, filename2)
-
-    if skip_if_step_not_run and not all_steps_run:
-        return
-
-    if task.validation is not None:
-        validation = task.validation
-    else:
-        validation = {'internal_pass': None,
-                      'baseline_pass': None}
-
-    if filename2 is not None:
-        internal_pass = _compare_variables(
-            variables, path1, path2, l1_norm, l2_norm, linf_norm, quiet,
-            logger)
-
-        if validation['internal_pass'] is None:
-            validation['internal_pass'] = internal_pass
-        else:
-            validation['internal_pass'] = \
-                validation['internal_pass'] and internal_pass
-
-    if task.baseline_dir is not None:
-        baseline_root = task.baseline_dir
-        baseline_pass = True
-
-        result = _compare_variables(
-            variables, os.path.join(work_dir, filename1),
-            os.path.join(baseline_root, filename1), l1_norm=0.0, l2_norm=0.0,
-            linf_norm=0.0, quiet=quiet, logger=logger)
-        baseline_pass = baseline_pass and result
-
-        if filename2 is not None:
-            result = _compare_variables(
-                variables, os.path.join(work_dir, filename2),
-                os.path.join(baseline_root, filename2), l1_norm=0.0,
-                l2_norm=0.0, linf_norm=0.0, quiet=quiet, logger=logger)
-            baseline_pass = baseline_pass and result
-
-        if validation['baseline_pass'] is None:
-            validation['baseline_pass'] = baseline_pass
-        else:
-            validation['baseline_pass'] = \
-                validation['baseline_pass'] and baseline_pass
-
-    task.validation = validation
-
-
-def compare_timers(task, timers, rundir1, rundir2=None):
-    """
-    Compare variables between files in the current task and/or with the
-    baseline results.
-
-    Parameters
-    ----------
-    task : polaris.Task
-        An object describing a task to validate
-
-    timers : list
-        A list of timer names to compare
-
-    rundir1 : str
-        The relative path to a directory within the ``work_dir``. If
-        ``rundir2`` is also given, comparison will be performed with ``timers``
-        in that file.  If a baseline directory was provided when setting up the
-        task, the ``timers`` will be compared between this task and
-        the same relative directory under the baseline version of the task.
-
-    rundir2 : str, optional
-        The relative path to another file within the ``work_dir`` if comparing
-        between files within the current task.  If a baseline directory
-        was provided, the ``timers`` from this file will also be compared with
-        those in the corresponding baseline directory.
-    """
-
-    work_dir = task.work_dir
-    baseline_root = task.baseline_dir
-
-    if rundir2 is not None:
-        _compute_timers(os.path.join(work_dir, rundir1),
-                        os.path.join(work_dir, rundir2), timers)
-
-    if baseline_root is not None:
-        _compute_timers(os.path.join(baseline_root, rundir1),
-                        os.path.join(work_dir, rundir1), timers)
-
-        if rundir2 is not None:
-            _compute_timers(os.path.join(baseline_root, rundir2),
-                            os.path.join(work_dir, rundir2), timers)
-
-
-def _check_for_outputs(task, logger, path1, path2, filename1, filename2):
-    """ Check for outputs for each step from one or two run directories """
-
-    all_steps_run = True
-    file1_found = False
-    file2_found = False
-    step_name1 = None
-    step_name2 = None
-    for step_name, step in task.steps.items():
-        for output in step.outputs:
-            # outputs are already absolute paths combined with the step dir
-            if output == path1:
-                file1_found = True
-                step_name1 = step_name
-            if output == path2:
-                file2_found = True
-                step_name2 = step_name
-
-    if not file1_found:
-        raise ValueError(f'{filename1} does not appear to be an output of any '
-                         'step in this task.')
-    if filename2 is not None and not file2_found:
-        raise ValueError(f'{filename2} does not appear to be an output of any '
-                         'step in this task.')
-
-    step1_not_run = (file1_found and
-                     step_name1 not in task.steps_to_run)
-    step2_not_run = (file2_found and
-                     step_name2 not in task.steps_to_run)
-
-    if step1_not_run and step2_not_run:
-        logger.info(f'Skipping validation because {step_name1} and '
-                    f'{step_name2} weren\'t  run')
-    elif step1_not_run:
-        logger.info(f'Skipping validation because {step_name1} wasn\'t run')
-    elif step2_not_run:
-        logger.info(f'Skipping validation because {step_name2} wasn\'t run')
-    if step1_not_run or step2_not_run:
-        all_steps_run = False
-
-    return all_steps_run
-
-
-def _compare_variables(variables, filename1, filename2, l1_norm, l2_norm,
-                       linf_norm, quiet, logger):
-    """ compare fields in the two files """
 
     for filename in [filename1, filename2]:
         if not os.path.exists(filename):
             logger.error(f'File {filename} does not exist.')
             return False
 
-    ds1 = xarray.open_dataset(filename1)
-    ds2 = xarray.open_dataset(filename2)
+    ds1 = xr.open_dataset(filename1)
+    ds2 = xr.open_dataset(filename2)
 
     all_pass = True
 
@@ -239,7 +79,7 @@ def _compare_variables(variables, filename1, filename2, l1_norm, l2_norm,
         da1 = ds1[variable]
         da2 = ds2[variable]
 
-        if not numpy.all(da1.dims == da2.dims):
+        if not np.all(da1.dims == da2.dims):
             logger.error(f"Dimensions for variable {variable} don't match "
                          f"between files {filename1} and {filename2}.")
             all_pass = False
@@ -307,13 +147,13 @@ def _compute_norms(da1, da2, quiet, max_l1_norm, max_l2_norm, max_linf_norm,
     da2 = _rename_duplicate_dims(da2)
 
     result = True
-    diff = numpy.abs(da1 - da2).values.ravel()
+    diff = np.abs(da1 - da2).values.ravel()
     # skip entries where one field or both are a fill value
-    diff = diff[numpy.isfinite(diff)]
+    diff = diff[np.isfinite(diff)]
 
-    l1_norm = numpy.linalg.norm(diff, ord=1)
-    l2_norm = numpy.linalg.norm(diff, ord=2)
-    linf_norm = numpy.linalg.norm(diff, ord=numpy.inf)
+    l1_norm = np.linalg.norm(diff, ord=1)
+    l2_norm = np.linalg.norm(diff, ord=2)
+    linf_norm = np.linalg.norm(diff, ord=np.inf)
 
     if time_index is None:
         diff_str = ''
@@ -341,68 +181,6 @@ def _compute_norms(da1, da2, quiet, max_l1_norm, max_l2_norm, max_linf_norm,
     return result
 
 
-def _compute_timers(base_directory, comparison_directory, timers):
-    """ Find timers and compute speedup between two run directories """
-    for timer in timers:
-        timer1_found, timer1 = _find_timer_value(timer, base_directory)
-        timer2_found, timer2 = _find_timer_value(timer, comparison_directory)
-
-        if timer1_found and timer2_found:
-            if timer2 > 0.:
-                speedup = timer1 / timer2
-            else:
-                speedup = 1.0
-
-            percent = (timer2 - timer1) / timer1
-
-            print(f"Comparing timer {timer}:")
-            print(f"             Base: {timer1}")
-            print(f"          Compare: {timer2}")
-            print(f"   Percent Change: {percent * 100}%")
-            print(f"          Speedup: {speedup}")
-
-
-def _find_timer_value(timer_name, directory):
-    """ Find a timer in the given directory """
-    # Build a regular expression for any two characters with a space between
-    # them.
-    regex = re.compile(r'(\S) (\S)')
-
-    sub_timer_name = timer_name.replace(' ', '_')
-
-    timer = 0.0
-    timer_found = False
-    for file in os.listdir(directory):
-        if not timer_found:
-            # Compare files written using built in MPAS timers
-            if fnmatch.fnmatch(file, "log.*.out"):
-                timer_line_size = 6
-                name_index = 1
-                total_index = 2
-            # Compare files written using GPTL timers
-            elif fnmatch.fnmatch(file, "timing.*"):
-                timer_line_size = 6
-                name_index = 0
-                total_index = 3
-            else:
-                continue
-
-            with open(os.path.join(directory, file), "r") as stats_file:
-                for block in iter(lambda: stats_file.readline(), ""):
-                    new_block = regex.sub(r"\1_\2", block[2:])
-                    new_block_arr = new_block.split()
-                    if len(new_block_arr) >= timer_line_size:
-                        if sub_timer_name.find(new_block_arr[name_index]) >= 0:
-                            try:
-                                timer = \
-                                    timer + float(new_block_arr[total_index])
-                                timer_found = True
-                            except ValueError:
-                                pass
-
-    return timer_found, timer
-
-
 def _rename_duplicate_dims(da):
     dims = list(da.dims)
     new_dims = list(dims)
@@ -419,5 +197,5 @@ def _rename_duplicate_dims(da):
     if not duplicates:
         return da
 
-    da = xarray.DataArray(data=da.values, dims=new_dims)
+    da = xr.DataArray(data=da.values, dims=new_dims)
     return da


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge simplified how validation is handled in Polaris.

Baseline validation is handled by passing an optional argument, `validate_vars`, to the method `Step.add_output_file()`.  The variables are a list of variables to compared with the same output file in a baseline, if one is provided.

Entirely separate from baseline comparison is the comparison between outputs in two steps.  This is performed by adding a third step (e.g. `validate`) that compares the outputs and raises an error if they don't match.  Such a validate steps has been
added to baroclinic channel test cases and the sea-ice component's exact restart test.

The `validate()` method has been removed from test cases. 

For now, the unused capability to evaluate timers has been removed.  This will be revisited once test cases with the need arise, but the current capability was clumsy enough to be better purposefully revisited rather than propagated onward by default.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

Based off of #111, which is based off of #110, which is based off of #112.  (Yes, this is getting out of hand!)