### PR TITLE
Add support for shared steps

### DIFF
--- a/polaris/cache.py
+++ b/polaris/cache.py
@@ -50,7 +50,7 @@ def update_cache(step_paths, date_string=None, dry_run=False):
     steps: Dict[str, List[Step]] = dict()
     for path in step_paths:
         with open(f'{path}/step.pickle', 'rb') as handle:
-            _, step = pickle.load(handle)
+            step = pickle.load(handle)
 
         component = step.component.name
 

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -17,6 +17,10 @@ class Component:
         A dictionary of tasks in the component with the subdirectories of the
         tasks in the component as keys
 
+    steps : dict
+        A dictionary of steps in the component with the subdirectories of the
+        steps in the component as keys
+
     cached_files : dict
         A dictionary that maps from output file names in steps within tasks to
         cached files in the ``polaris_cache`` database for the component. These
@@ -36,6 +40,8 @@ class Component:
 
         # tasks are added with add_task()
         self.tasks = dict()
+        # steps are added with add_step()
+        self.steps = dict()
 
         self.cached_files = dict()
         self._read_cached_files()
@@ -49,7 +55,38 @@ class Component:
         task : polaris.Task
             The task to add
         """
+        if task.subdir in self.tasks:
+            raise ValueError(f'A task has already been added with path '
+                             f'{task.subdir}')
         self.tasks[task.subdir] = task
+
+    def add_step(self, step):
+        """
+        Add a step to the component
+
+        Parameters
+        ----------
+        step : polaris.Step
+            The step to add
+        """
+        if step.subdir in self.steps and self.steps[step.subdir] != step:
+            raise ValueError(f'A different step has already been added with '
+                             f'path {step.subdir}')
+        self.steps[step.subdir] = step
+
+    def remove_step(self, step):
+        """
+        Remove the given step from this component
+
+        Parameters
+        ----------
+        step : polaris.Step
+            The step to add if adding by Step object, not subdirectory
+        """
+        if step.subdir not in self.steps:
+            raise ValueError(f'step {step.name} not in this component '
+                             f'{self.name}')
+        self.steps.pop(step.subdir)
 
     def configure(self, config):
         """

--- a/polaris/io.py
+++ b/polaris/io.py
@@ -168,7 +168,7 @@ def symlink(target, link_name, overwrite=True):
     directory = os.path.dirname(os.path.abspath(link_name))
     try:
         os.makedirs(directory)
-    except OSError:
+    except FileExistsError:
         pass
 
     if not overwrite:

--- a/polaris/io.py
+++ b/polaris/io.py
@@ -164,6 +164,13 @@ def symlink(target, link_name, overwrite=True):
         Whether to replace an existing link if one already exists
     """
 
+    # make the directory that the link is in if it doesn't exist
+    directory = os.path.dirname(os.path.abspath(link_name))
+    try:
+        os.makedirs(directory)
+    except OSError:
+        pass
+
     if not overwrite:
         os.symlink(target, link_name)
         return

--- a/polaris/list.py
+++ b/polaris/list.py
@@ -65,7 +65,7 @@ def list_cases(task_expr=None, number=None, verbose=False):
                     if step.name == step.subdir:
                         lines.append(f'{prefix} - {step.name}')
                     else:
-                        lines.append(f'{prefix} - {step.name}: {step.subdir}')
+                        lines.append(f'{prefix} - {step.name}: {step.path}')
                 lines.append('')
                 print_string = '\n'.join(lines)
             else:

--- a/polaris/list.py
+++ b/polaris/list.py
@@ -61,11 +61,12 @@ def list_cases(task_expr=None, number=None, verbose=False):
                     if print_number:
                         prefix = '      '
                 lines.append(f'{prefix}steps:')
+                longest = 0
                 for step in task.steps.values():
-                    if step.name == step.subdir:
-                        lines.append(f'{prefix} - {step.name}')
-                    else:
-                        lines.append(f'{prefix} - {step.name}: {step.path}')
+                    longest = max(longest, len(step.name))
+                for step in task.steps.values():
+                    step_name = f'{step.name}: '.ljust(longest + 2)
+                    lines.append(f'{prefix} - {step_name}{step.path}')
                 lines.append('')
                 print_string = '\n'.join(lines)
             else:

--- a/polaris/mesh/spherical.py
+++ b/polaris/mesh/spherical.py
@@ -28,14 +28,14 @@ class SphericalBaseStep(Step):
     opts : jigsawpy.jigsaw_jig_t
         JIGSAW options for creating the mesh
     """
-    def __init__(self, task, name, subdir):
+    def __init__(self, component, name, subdir):
         """
         Create a new step
 
         Parameters
         ----------
-        task : polaris.Task
-            The task this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         name : str
             the name of the step
@@ -43,7 +43,7 @@ class SphericalBaseStep(Step):
         subdir : {str, None}
             the subdirectory for the step.  The default is ``name``
         """
-        super().__init__(task, name=name, subdir=subdir)
+        super().__init__(component=component, name=name, subdir=subdir)
 
         # setup files for JIGSAW
         self.opts = jigsawpy.jigsaw_jig_t()
@@ -184,15 +184,15 @@ class QuasiUniformSphericalMeshStep(SphericalBaseStep):
         The approximate cell width in km of the mesh if constant resolution
     """
 
-    def __init__(self, task, name='base_mesh', subdir=None,
+    def __init__(self, component, name='base_mesh', subdir=None,
                  cell_width=None):
         """
         Create a new step
 
         Parameters
         ----------
-        task : polaris.Task
-            The task this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         name : str, optional
             the name of the step
@@ -203,7 +203,7 @@ class QuasiUniformSphericalMeshStep(SphericalBaseStep):
         cell_width : float, optional
             The approximate cell width in km of the mesh if constant resolution
         """
-        super().__init__(task=task, name=name, subdir=subdir)
+        super().__init__(component=component, name=name, subdir=subdir)
         self.cell_width = cell_width
 
         # build mesh via JIGSAW!
@@ -324,15 +324,15 @@ class IcosahedralMeshStep(SphericalBaseStep):
         The number of subdivisions of the icosahedral mesh to perform
     """
 
-    def __init__(self, task, name='base_mesh', subdir=None,
+    def __init__(self, component, name='base_mesh', subdir=None,
                  cell_width=None, subdivisions=None):
         """
         Create a new step
 
         Parameters
         ----------
-        task : polaris.Task
-            The task this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         name : str, optional
             the name of the step
@@ -346,7 +346,7 @@ class IcosahedralMeshStep(SphericalBaseStep):
         subdivisions : int, optional
             The number of subdivisions of the icosahedral mesh to perform
         """
-        super().__init__(task=task, name=name, subdir=subdir)
+        super().__init__(component=component, name=name, subdir=subdir)
 
         # run as a subprocess so output goes to a log file
         self.run_as_subprocess = True

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -12,7 +12,7 @@ class OceanModelStep(ModelStep):
         ``min_tasks``) are computed dynamically from the number of cells
         in the mesh
     """
-    def __init__(self, task, name, subdir=None, ntasks=None,
+    def __init__(self, component, name, subdir=None, indir=None, ntasks=None,
                  min_tasks=None, openmp_threads=None, max_memory=None,
                  cached=False, yaml=None, update_pio=True, make_graph=False,
                  mesh_filename=None, partition_graph=True,
@@ -22,14 +22,18 @@ class OceanModelStep(ModelStep):
 
         Parameters
         ----------
-        task : polaris.Task
-            The task this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         name : str
             The name of the step
 
         subdir : str, optional
-            the subdirectory for the step.  The default is ``name``
+            the subdirectory for the step.  If neither this nor ``indir``
+             are provided, the directory is the ``name``
+
+        indir : str, optional
+            the directory the step is in, to which ``name`` will be appended
 
         ntasks : int, optional
             the target number of tasks the step would ideally use.  If too
@@ -75,8 +79,8 @@ class OceanModelStep(ModelStep):
             The name of the graph file to partition
         """
         super().__init__(
-            task=task, name=name, subdir=subdir, ntasks=ntasks,
-            min_tasks=min_tasks, openmp_threads=openmp_threads,
+            component=component, name=name, subdir=subdir, indir=indir,
+            ntasks=ntasks, min_tasks=min_tasks, openmp_threads=openmp_threads,
             max_memory=max_memory, cached=cached, yaml=yaml,
             update_pio=update_pio, make_graph=make_graph,
             mesh_filename=mesh_filename, partition_graph=partition_graph,

--- a/polaris/ocean/resolution.py
+++ b/polaris/ocean/resolution.py
@@ -15,6 +15,8 @@ def resolution_to_subdir(resolution):
     """
     if resolution >= 1.:
         res_str = f'{resolution:g}km'
+    elif resolution < 0.001:
+        res_str = f'{resolution * 1.e5:g}cm'
     else:
         res_str = f'{resolution * 1000.:g}m'
     return res_str

--- a/polaris/ocean/resolution.py
+++ b/polaris/ocean/resolution.py
@@ -1,0 +1,20 @@
+def resolution_to_subdir(resolution):
+    """
+    Convert a resolution to a subdirectory name
+
+    Parameters
+    ----------
+    resolution : float
+        The resolution in km
+
+    Returns
+    -------
+    res_str : str
+        The resolution as a string for use as a subdirectory
+
+    """
+    if resolution >= 1.:
+        res_str = f'{resolution:g}km'
+    else:
+        res_str = f'{resolution * 1000.:g}m'
+    return res_str

--- a/polaris/ocean/tasks/baroclinic_channel/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/__init__.py
@@ -1,3 +1,4 @@
+from polaris.ocean.resolution import resolution_to_subdir
 from polaris.ocean.tasks.baroclinic_channel.baroclinic_channel_test_case import (  # noqa: E501
     BaroclinicChannelTestCase,
 )
@@ -15,20 +16,27 @@ def add_baroclinic_channel_tasks(component):
     component : polaris.ocean.Ocean
         the ocean component that the tasks will be added to
     """
+    for resolution in [10., 4., 1.]:
+        resdir = resolution_to_subdir(resolution)
+        resdir = f'baroclinic_channel/{resdir}'
 
-    for resolution in [10.]:
-        component.add_task(
-            Default(component=component, resolution=resolution))
+        if resolution == 10.:
+            component.add_task(
+                Default(component=component, resolution=resolution,
+                        indir=resdir))
+
+            component.add_task(
+                Decomp(component=component, resolution=resolution,
+                       indir=resdir))
+
+            component.add_task(
+                Restart(component=component, resolution=resolution,
+                        indir=resdir))
+
+            component.add_task(
+                Threads(component=component, resolution=resolution,
+                        indir=resdir))
 
         component.add_task(
-            Decomp(component=component, resolution=resolution))
-
-        component.add_task(
-            Restart(component=component, resolution=resolution))
-
-        component.add_task(
-            Threads(component=component, resolution=resolution))
-
-    for resolution in [1., 4., 10.]:
-        component.add_task(
-            Rpe(component=component, resolution=resolution))
+            Rpe(component=component, resolution=resolution,
+                indir=resdir))

--- a/polaris/ocean/tasks/baroclinic_channel/baroclinic_channel_test_case.py
+++ b/polaris/ocean/tasks/baroclinic_channel/baroclinic_channel_test_case.py
@@ -1,5 +1,3 @@
-import os
-
 from polaris import Task
 from polaris.ocean.tasks.baroclinic_channel.init import Init
 
@@ -15,7 +13,7 @@ class BaroclinicChannelTestCase(Task):
         The resolution of the test case in km
     """
 
-    def __init__(self, component, resolution, name):
+    def __init__(self, component, resolution, name, indir):
         """
         Create the test case, including adding the ``init`` step
 
@@ -29,18 +27,17 @@ class BaroclinicChannelTestCase(Task):
 
         name : str
             The name of the test case
-        """
-        self.resolution = resolution
-        if resolution >= 1.:
-            res_str = f'{resolution:g}km'
-        else:
-            res_str = f'{resolution * 1000.:g}m'
-        subdir = os.path.join('baroclinic_channel', res_str, name)
-        super().__init__(component=component, name=name,
-                         subdir=subdir)
 
+        indir : str
+            the directory the task is in, to which ``name`` will be appended
+        """
+        super().__init__(component=component, name=name,
+                         indir=indir)
+
+        self.resolution = resolution
         self.add_step(
-            Init(task=self, resolution=resolution))
+            Init(component=component, resolution=resolution,
+                 indir=self.subdir))
 
     def configure(self):
         """

--- a/polaris/ocean/tasks/baroclinic_channel/decomp/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/decomp/__init__.py
@@ -9,7 +9,7 @@ class Decomp(BaroclinicChannelTestCase):
     produces identical results on 1 and 4 cores.
     """
 
-    def __init__(self, component, resolution):
+    def __init__(self, component, resolution, indir):
         """
         Create the task
 
@@ -20,18 +20,22 @@ class Decomp(BaroclinicChannelTestCase):
 
         resolution : float
             The resolution of the task in km
+
+        indir : str
+            the directory the task is in, to which ``name`` will be appended
         """
 
         super().__init__(component=component, resolution=resolution,
-                         name='decomp')
+                         name='decomp', indir=indir)
 
         subdirs = list()
         for procs in [4, 8]:
             name = f'{procs}proc'
 
             self.add_step(Forward(
-                task=self, name=name, subdir=name, ntasks=procs,
-                min_tasks=procs, openmp_threads=1,
+                component=component, name=name, indir=self.subdir,
+                ntasks=procs, min_tasks=procs, openmp_threads=1,
                 resolution=resolution, run_time_steps=3))
             subdirs.append(name)
-        self.add_step(Validate(task=self, step_subdirs=subdirs))
+        self.add_step(Validate(component=component, step_subdirs=subdirs,
+                               indir=self.subdir))

--- a/polaris/ocean/tasks/baroclinic_channel/default/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/default/__init__.py
@@ -1,7 +1,6 @@
 from polaris.ocean.tasks.baroclinic_channel import BaroclinicChannelTestCase
 from polaris.ocean.tasks.baroclinic_channel.forward import Forward
 from polaris.ocean.tasks.baroclinic_channel.viz import Viz
-from polaris.validate import compare_variables
 
 
 class Default(BaroclinicChannelTestCase):
@@ -10,7 +9,7 @@ class Default(BaroclinicChannelTestCase):
     initial condition, then performs a short forward run on 4 cores.
     """
 
-    def __init__(self, component, resolution):
+    def __init__(self, component, resolution, indir):
         """
         Create the test case
 
@@ -21,13 +20,17 @@ class Default(BaroclinicChannelTestCase):
 
         resolution : float
             The resolution of the test case in km
+
+        indir : str
+            the directory the task is in, to which ``name`` will be appended
         """
         super().__init__(component=component, resolution=resolution,
-                         name='default')
+                         name='default', indir=indir)
 
         self.add_step(
-            Forward(task=self, ntasks=4, min_tasks=4, openmp_threads=1,
-                    resolution=resolution, run_time_steps=3))
+            Forward(component=component, indir=self.subdir, ntasks=4,
+                    min_tasks=4, openmp_threads=1, resolution=resolution,
+                    run_time_steps=3))
 
         self.add_step(
-            Viz(task=self))
+            Viz(component=component, indir=self.subdir))

--- a/polaris/ocean/tasks/baroclinic_channel/forward.py
+++ b/polaris/ocean/tasks/baroclinic_channel/forward.py
@@ -27,16 +27,16 @@ class Forward(OceanModelStep):
     run_time_steps : int or None
         Number of time steps to run for
     """
-    def __init__(self, task, resolution, name='forward', subdir=None,
-                 ntasks=None, min_tasks=None, openmp_threads=1, nu=None,
-                 run_time_steps=None):
+    def __init__(self, component, resolution, name='forward', subdir=None,
+                 indir=None, ntasks=None, min_tasks=None, openmp_threads=1,
+                 nu=None, run_time_steps=None):
         """
         Create a new task
 
         Parameters
         ----------
-        task : polaris.Task
-            The task this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolution : km
             The resolution of the task in km
@@ -45,7 +45,11 @@ class Forward(OceanModelStep):
             the name of the task
 
         subdir : str, optional
-            the subdirectory for the step.  The default is ``name``
+            the subdirectory for the step.  If neither this nor ``indir``
+             are provided, the directory is the ``name``
+
+        indir : str, optional
+            the directory the step is in, to which ``name`` will be appended
 
         ntasks : int, optional
             the number of tasks the step would ideally use.  If fewer tasks
@@ -68,8 +72,8 @@ class Forward(OceanModelStep):
         """
         self.resolution = resolution
         self.run_time_steps = run_time_steps
-        super().__init__(task=task, name=name, subdir=subdir,
-                         ntasks=ntasks, min_tasks=min_tasks,
+        super().__init__(component=component, name=name, subdir=subdir,
+                         indir=indir, ntasks=ntasks, min_tasks=min_tasks,
                          openmp_threads=openmp_threads)
 
         if nu is not None:

--- a/polaris/ocean/tasks/baroclinic_channel/init.py
+++ b/polaris/ocean/tasks/baroclinic_channel/init.py
@@ -21,19 +21,22 @@ class Init(Step):
     resolution : float
         The resolution of the task in km
     """
-    def __init__(self, task, resolution):
+    def __init__(self, component, resolution, indir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The task this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolution : float
             The resolution of the task in km
+
+        indir : str
+            the directory the step is in, to which ``name`` will be appended
         """
-        super().__init__(task=task, name='init')
+        super().__init__(component=component, name='init', indir=indir)
         self.resolution = resolution
 
         for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info']:

--- a/polaris/ocean/tasks/baroclinic_channel/restart/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/restart/__init__.py
@@ -12,7 +12,7 @@ class Restart(BaroclinicChannelTestCase):
     restart in between.
     """
 
-    def __init__(self, component, resolution):
+    def __init__(self, component, resolution, indir):
         """
         Create the test case
 
@@ -23,18 +23,22 @@ class Restart(BaroclinicChannelTestCase):
 
         resolution : float
             The resolution of the test case in km
+
+        indir : str
+            the directory the task is in, to which ``name`` will be appended
         """
         super().__init__(component=component, resolution=resolution,
-                         name='restart')
+                         name='restart', indir=indir)
 
-        full = RestartStep(task=self, resolution=resolution,
-                           name='full_run')
+        full = RestartStep(component=component, resolution=resolution,
+                           name='full_run', indir=self.subdir)
         self.add_step(full)
 
-        restart = RestartStep(task=self, resolution=resolution,
-                              name='restart_run')
+        restart = RestartStep(component=component, resolution=resolution,
+                              name='restart_run', indir=self.subdir)
         restart.add_dependency(full, full.name)
         self.add_step(restart)
 
-        self.add_step(Validate(task=self,
-                               step_subdirs=['full_run', 'restart_run']))
+        self.add_step(Validate(component=component,
+                               step_subdirs=['full_run', 'restart_run'],
+                               indir=self.subdir))

--- a/polaris/ocean/tasks/baroclinic_channel/restart/restart_step.py
+++ b/polaris/ocean/tasks/baroclinic_channel/restart/restart_step.py
@@ -7,23 +7,26 @@ class RestartStep(Forward):
     """
     A forward model step in the restart test case
     """
-    def __init__(self, task, resolution, name):
+    def __init__(self, component, resolution, name, indir):
         """
         Create a new test case
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolution : km
             The resolution of the test case in km
 
         name : str
             the name of the test case
+
+        indir : str
+            the directory the step is in, to which ``name`` will be appended
         """
         self.resolution = resolution
-        super().__init__(task=task, name=name, subdir=name, ntasks=4,
+        super().__init__(component=component, name=name, indir=indir, ntasks=4,
                          min_tasks=4, openmp_threads=1,
                          resolution=resolution)
 

--- a/polaris/ocean/tasks/baroclinic_channel/rpe/analysis.py
+++ b/polaris/ocean/tasks/baroclinic_channel/rpe/analysis.py
@@ -16,14 +16,17 @@ class Analysis(Step):
     nus : list
         A list of viscosities
     """
-    def __init__(self, task, resolution, nus):
+    def __init__(self, component, indir, resolution, nus):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
+
+        indir : str
+            the directory the step is in, to which ``name`` will be appended
 
         resolution : float
             The resolution of the test case in km
@@ -31,7 +34,7 @@ class Analysis(Step):
         nus : list
             A list of viscosities
         """
-        super().__init__(task=task, name='analysis')
+        super().__init__(component=component, name='analysis', indir=indir)
         self.nus = nus
 
         self.add_input_file(

--- a/polaris/ocean/tasks/baroclinic_channel/threads/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/threads/__init__.py
@@ -9,7 +9,7 @@ class Threads(BaroclinicChannelTestCase):
     identical results with 1 and 2 threads.
     """
 
-    def __init__(self, component, resolution):
+    def __init__(self, component, resolution, indir):
         """
         Create the test case
 
@@ -20,17 +20,21 @@ class Threads(BaroclinicChannelTestCase):
 
         resolution : float
             The resolution of the test case in km
+
+        indir : str
+            the directory the task is in, to which ``name`` will be appended
         """
 
         super().__init__(component=component, resolution=resolution,
-                         name='threads')
+                         name='threads', indir=indir)
 
         subdirs = list()
         for openmp_threads in [1, 2]:
             name = f'{openmp_threads}thread'
             self.add_step(Forward(
-                task=self, name=name, subdir=name, ntasks=4,
+                component=component, name=name, indir=self.subdir, ntasks=4,
                 min_tasks=4, openmp_threads=openmp_threads,
                 resolution=resolution, run_time_steps=3))
             subdirs.append(name)
-        self.add_step(Validate(task=self, step_subdirs=subdirs))
+        self.add_step(Validate(component=component, step_subdirs=subdirs,
+                               indir=self.subdir))

--- a/polaris/ocean/tasks/baroclinic_channel/validate.py
+++ b/polaris/ocean/tasks/baroclinic_channel/validate.py
@@ -11,19 +11,22 @@ class Validate(Step):
     step_subdirs : list of str
         The number of processors used in each run
     """
-    def __init__(self, task, step_subdirs):
+    def __init__(self, component, step_subdirs, indir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The task this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         step_subdirs : list of str
             The number of processors used in each run
-        """
-        super().__init__(task=task, name='validate')
+
+        indir : str
+            the directory the step is in, to which ``name`` will be appended
+       """
+        super().__init__(component=component, name='validate', indir=indir)
 
         self.step_subdirs = step_subdirs
 

--- a/polaris/ocean/tasks/baroclinic_channel/viz.py
+++ b/polaris/ocean/tasks/baroclinic_channel/viz.py
@@ -10,16 +10,19 @@ class Viz(Step):
     """
     A step for plotting the results of a series of baroclinic channel RPE runs
     """
-    def __init__(self, task):
+    def __init__(self, component, indir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The task this step belongs to
+        component : polaris.Component
+            The component the step belongs to
+
+        indir : str
+            the directory the step is in, to which ``name`` will be appended
         """
-        super().__init__(task=task, name='viz')
+        super().__init__(component=component, name='viz', indir=indir)
         self.add_input_file(
             filename='mesh.nc',
             target='../init/culled_mesh.nc')

--- a/polaris/ocean/tasks/global_convergence/cosine_bell/analysis.py
+++ b/polaris/ocean/tasks/global_convergence/cosine_bell/analysis.py
@@ -20,14 +20,14 @@ class Analysis(Step):
         Whether to use icosahedral, as opposed to less regular, JIGSAW
         meshes
     """
-    def __init__(self, task, resolutions, icosahedral):
+    def __init__(self, component, resolutions, icosahedral, taskdir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.ocean.tasks.global_convergence.cosine_bell.CosineBell  # noqa: E501
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolutions : list of int
             The resolutions of the meshes that have been run
@@ -35,8 +35,12 @@ class Analysis(Step):
         icosahedral : bool
             Whether to use icosahedral, as opposed to less regular, JIGSAW
             meshes
+
+        taskdir : str
+            The subdirectory that of the task, onto which the name of this
+            step will be added
         """
-        super().__init__(task=task, name='analysis')
+        super().__init__(component=component, name='analysis', indir=taskdir)
         self.resolutions = resolutions
         self.icosahedral = icosahedral
 

--- a/polaris/ocean/tasks/global_convergence/cosine_bell/forward.py
+++ b/polaris/ocean/tasks/global_convergence/cosine_bell/forward.py
@@ -17,14 +17,20 @@ class Forward(OceanModelStep):
         The name of the mesh
     """
 
-    def __init__(self, task, resolution, mesh_name):
+    def __init__(self, component, name, subdir, resolution, mesh_name):
         """
         Create a new step
 
         Parameters
         ----------
-        task : polaris.ocean.tasks.global_convergence.cosine_bell.CosineBell  # noqa: E501
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
+
+        name : str
+            The name of the step
+
+        subdir : str
+            The subdirectory for the step
 
         resolution : int
             The resolution of the (uniform) mesh in km
@@ -32,9 +38,7 @@ class Forward(OceanModelStep):
         mesh_name : str
             The name of the mesh
         """
-        super().__init__(task=task,
-                         name=f'{mesh_name}_forward',
-                         subdir=f'{mesh_name}/forward',
+        super().__init__(component=component, name=name, subdir=subdir,
                          openmp_threads=1)
 
         self.resolution = resolution

--- a/polaris/ocean/tasks/global_convergence/cosine_bell/init.py
+++ b/polaris/ocean/tasks/global_convergence/cosine_bell/init.py
@@ -10,22 +10,22 @@ class Init(Step):
     """
     A step for an initial condition for for the cosine bell test case
     """
-    def __init__(self, task, mesh_name):
+    def __init__(self, component, name, subdir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.ocean.tasks.global_convergence.cosine_bell.CosineBell  # noqa: E501
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
-        mesh_name : str
-            The name of the mesh
+        name : str
+            The name of the step
+
+        subdir : str
+            The subdirectory for the step
         """
-
-        super().__init__(task=task,
-                         name=f'{mesh_name}_init',
-                         subdir=f'{mesh_name}/init')
+        super().__init__(component=component, name=name, subdir=subdir)
 
         self.add_input_file(filename='mesh.nc', target='../mesh/mesh.nc')
 

--- a/polaris/ocean/tasks/global_convergence/cosine_bell/viz.py
+++ b/polaris/ocean/tasks/global_convergence/cosine_bell/viz.py
@@ -15,25 +15,25 @@ class VizMap(MappingFileStep):
     mesh_name : str
         The name of the mesh
     """
-    def __init__(self, task, name, subdir, mesh_name):
+    def __init__(self, component, name, subdir, mesh_name):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         name : str
             The name of the step
 
         subdir : str
-            The subdirectory in the test case's work directory for the step
+            The subdirectory for the step
 
         mesh_name : str
             The name of the mesh
         """
-        super().__init__(task=task, name=name, subdir=subdir,
+        super().__init__(component=component, name=name, subdir=subdir,
                          ntasks=128, min_tasks=1)
         self.mesh_name = mesh_name
         self.add_input_file(filename='mesh.nc', target='../mesh/mesh.nc')
@@ -63,14 +63,14 @@ class Viz(Step):
     mesh_name : str
         The name of the mesh
     """
-    def __init__(self, task, name, subdir, viz_map, mesh_name):
+    def __init__(self, component, name, subdir, viz_map, mesh_name):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         name : str
             The name of the step
@@ -85,7 +85,7 @@ class Viz(Step):
         mesh_name : str
             The name of the mesh
         """
-        super().__init__(task=task, name=name, subdir=subdir)
+        super().__init__(component=component, name=name, subdir=subdir)
         self.add_input_file(
             filename='mesh.nc',
             target='../init/mesh.nc')

--- a/polaris/ocean/tasks/inertial_gravity_wave/analysis.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/analysis.py
@@ -21,19 +21,22 @@ class Analysis(Step):
     resolutions : list of int
         The resolutions of the meshes that have been run
     """
-    def __init__(self, task, resolutions):
+    def __init__(self, component, resolutions, taskdir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolutions : list of int
             The resolutions of the meshes that have been run
+
+        taskdir : str
+            The subdirectory that the task belongs to
         """
-        super().__init__(task=task, name='analysis')
+        super().__init__(component=component, name='analysis', indir=taskdir)
         self.resolutions = resolutions
 
         for resolution in resolutions:

--- a/polaris/ocean/tasks/inertial_gravity_wave/convergence/__init__.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/convergence/__init__.py
@@ -25,11 +25,16 @@ class Convergence(Task):
 
         self.resolutions = [200, 100, 50, 25]
         for res in self.resolutions:
-            self.add_step(Init(task=self, resolution=res))
-            self.add_step(Forward(task=self, resolution=res))
+            self.add_step(Init(component=component, resolution=res,
+                               taskdir=self.subdir))
+            self.add_step(Forward(component=component, resolution=res,
+                                  taskdir=self.subdir))
 
-        self.add_step(Analysis(task=self, resolutions=self.resolutions))
-        self.add_step(Viz(task=self, resolutions=self.resolutions),
+        self.add_step(Analysis(component=component,
+                               resolutions=self.resolutions,
+                               taskdir=self.subdir))
+        self.add_step(Viz(component=component, resolutions=self.resolutions,
+                          taskdir=self.subdir),
                       run_by_default=False)
 
     def configure(self):

--- a/polaris/ocean/tasks/inertial_gravity_wave/forward.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/forward.py
@@ -16,18 +16,21 @@ class Forward(OceanModelStep):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, task, resolution,
+    def __init__(self, component, resolution, taskdir,
                  ntasks=None, min_tasks=None, openmp_threads=1):
         """
         Create a new test case
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolution : km
             The resolution of the test case in km
+
+        taskdir : str
+            The subdirectory that the task belongs to
 
         ntasks : int, optional
             the number of tasks the step would ideally use.  If fewer tasks
@@ -42,9 +45,9 @@ class Forward(OceanModelStep):
             the number of OpenMP threads the step will use
         """
         self.resolution = resolution
-        super().__init__(task=task,
+        super().__init__(component=component,
                          name=f'forward_{resolution}km',
-                         subdir=f'{resolution}km/forward',
+                         subdir=f'{taskdir}/{resolution}km/forward',
                          ntasks=ntasks, min_tasks=min_tasks,
                          openmp_threads=openmp_threads)
 

--- a/polaris/ocean/tasks/inertial_gravity_wave/init.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/init.py
@@ -22,21 +22,24 @@ class Init(Step):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, task, resolution):
+    def __init__(self, component, resolution, taskdir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolution : float
             The resolution of the test case in km
+
+        taskdir : str
+            The subdirectory that the task belongs to
         """
-        super().__init__(task=task,
+        super().__init__(component=component,
                          name=f'init_{resolution}km',
-                         subdir=f'{resolution}km/init')
+                         subdir=f'{taskdir}/{resolution}km/init')
         self.resolution = float(resolution)
         for filename in ['culled_mesh.nc', 'initial_state.nc',
                          'culled_graph.info']:

--- a/polaris/ocean/tasks/inertial_gravity_wave/viz.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/viz.py
@@ -22,19 +22,22 @@ class Viz(Step):
     resolutions : list of int
         The resolutions of the meshes that have been run
     """
-    def __init__(self, task, resolutions):
+    def __init__(self, component, resolutions, taskdir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.ocean.tasks.inertial_gravity_wave.convergence.Convergence # noqa: E501
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolutions : list of int
             The resolutions of the meshes that have been run
+
+        taskdir : str
+            The subdirectory that the task belongs to
         """
-        super().__init__(task=task, name='viz')
+        super().__init__(component=component, name='viz', indir=taskdir)
         self.resolutions = resolutions
 
         for resolution in resolutions:

--- a/polaris/ocean/tasks/manufactured_solution/analysis.py
+++ b/polaris/ocean/tasks/manufactured_solution/analysis.py
@@ -21,19 +21,22 @@ class Analysis(Step):
     resolutions : list of int
         The resolutions of the meshes that have been run
     """
-    def __init__(self, task, resolutions):
+    def __init__(self, component, resolutions, taskdir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolutions : list of int
             The resolutions of the meshes that have been run
+
+        taskdir : str
+            The subdirectory that the task belongs to
         """
-        super().__init__(task=task, name='analysis')
+        super().__init__(component=component, name='analysis', indir=taskdir)
         self.resolutions = resolutions
 
         for resolution in resolutions:

--- a/polaris/ocean/tasks/manufactured_solution/convergence/__init__.py
+++ b/polaris/ocean/tasks/manufactured_solution/convergence/__init__.py
@@ -3,7 +3,6 @@ from polaris.ocean.tasks.manufactured_solution.analysis import Analysis
 from polaris.ocean.tasks.manufactured_solution.forward import Forward
 from polaris.ocean.tasks.manufactured_solution.init import Init
 from polaris.ocean.tasks.manufactured_solution.viz import Viz
-from polaris.validate import compare_variables
 
 
 class Convergence(Task):
@@ -30,11 +29,16 @@ class Convergence(Task):
 
         self.resolutions = [200, 100, 50, 25]
         for res in self.resolutions:
-            self.add_step(Init(task=self, resolution=res))
-            self.add_step(Forward(task=self, resolution=res))
+            self.add_step(Init(component=component, resolution=res,
+                               taskdir=self.subdir))
+            self.add_step(Forward(component=component, resolution=res,
+                                  taskdir=self.subdir))
 
-        self.add_step(Analysis(task=self, resolutions=self.resolutions))
-        self.add_step(Viz(task=self, resolutions=self.resolutions),
+        self.add_step(Analysis(component=component,
+                               resolutions=self.resolutions,
+                               taskdir=self.subdir))
+        self.add_step(Viz(component=component, resolutions=self.resolutions,
+                          taskdir=self.subdir),
                       run_by_default=False)
 
     def configure(self):

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -19,18 +19,21 @@ class Forward(OceanModelStep):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, task, resolution,
+    def __init__(self, component, resolution, taskdir,
                  ntasks=None, min_tasks=None, openmp_threads=1):
         """
         Create a new test case
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolution : km
             The resolution of the test case in km
+
+        taskdir : str
+            The subdirectory that the task belongs to
 
         ntasks : int, optional
             the number of tasks the step would ideally use.  If fewer tasks
@@ -45,9 +48,9 @@ class Forward(OceanModelStep):
             the number of OpenMP threads the step will use
         """
         self.resolution = resolution
-        super().__init__(task=task,
+        super().__init__(component=component,
                          name=f'forward_{resolution}km',
-                         subdir=f'{resolution}km/forward',
+                         subdir=f'{taskdir}/{resolution}km/forward',
                          ntasks=ntasks, min_tasks=min_tasks,
                          openmp_threads=openmp_threads)
 

--- a/polaris/ocean/tasks/manufactured_solution/init.py
+++ b/polaris/ocean/tasks/manufactured_solution/init.py
@@ -22,21 +22,24 @@ class Init(Step):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, task, resolution):
+    def __init__(self, component, resolution, taskdir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolution : float
             The resolution of the test case in km
+
+        taskdir : str
+            The subdirectory that the task belongs to
         """
-        super().__init__(task=task,
+        super().__init__(component=component,
                          name=f'init_{resolution}km',
-                         subdir=f'{resolution}km/init')
+                         subdir=f'{taskdir}/{resolution}km/init')
         self.resolution = float(resolution)
 
     def run(self):

--- a/polaris/ocean/tasks/manufactured_solution/viz.py
+++ b/polaris/ocean/tasks/manufactured_solution/viz.py
@@ -22,19 +22,22 @@ class Viz(Step):
     resolutions : list of int
         The resolutions of the meshes that have been run
     """
-    def __init__(self, task, resolutions):
+    def __init__(self, component, resolutions, taskdir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.ocean.tasks.manufactured_solution.convergence.Convergence # noqa: E501
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         resolutions : list of int
             The resolutions of the meshes that have been run
+
+        taskdir : str
+            The subdirectory that the task belongs to
         """
-        super().__init__(task=task, name='viz')
+        super().__init__(component=component, name='viz', indir=taskdir)
         self.resolutions = resolutions
 
         for resolution in resolutions:

--- a/polaris/ocean/tasks/single_column/cvmix/__init__.py
+++ b/polaris/ocean/tasks/single_column/cvmix/__init__.py
@@ -4,7 +4,6 @@ from polaris import Task
 from polaris.ocean.tasks.single_column.forward import Forward
 from polaris.ocean.tasks.single_column.init import Init
 from polaris.ocean.tasks.single_column.viz import Viz
-from polaris.validate import compare_variables
 
 
 class CVMix(Task):
@@ -30,16 +29,18 @@ class CVMix(Task):
         super().__init__(component=component, name=name,
                          subdir=subdir)
         self.add_step(
-            Init(task=self, resolution=resolution))
+            Init(component=component, resolution=resolution,
+                 indir=self.subdir))
 
         validate_vars = ['temperature', 'salinity', 'layerThickness',
                          'normalVelocity']
         self.add_step(
-            Forward(task=self, ntasks=1, min_tasks=1,
-                    openmp_threads=1, validate_vars=validate_vars))
+            Forward(component=component, indir=self.subdir, ntasks=1,
+                    min_tasks=1, openmp_threads=1,
+                    validate_vars=validate_vars))
 
         self.add_step(
-            Viz(task=self))
+            Viz(component=component, indir=self.subdir))
 
     def configure(self):
         """

--- a/polaris/ocean/tasks/single_column/forward.py
+++ b/polaris/ocean/tasks/single_column/forward.py
@@ -18,7 +18,7 @@ class Forward(OceanModelStep):
     btr_dt : float
         The model barotropic time step in seconds
     """
-    def __init__(self, task, name='forward', subdir=None,
+    def __init__(self, component, name='forward', subdir=None, indir=None,
                  ntasks=None, min_tasks=None, openmp_threads=1,
                  validate_vars=None):
         """
@@ -26,14 +26,18 @@ class Forward(OceanModelStep):
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         name : str
             the name of the test case
 
         subdir : str, optional
-            the subdirectory for the step.  The default is ``name``
+            the subdirectory for the step.  If neither this nor ``indir``
+             are provided, the directory is the ``name``
+
+        indir : str, optional
+            the directory the step is in, to which ``name`` will be appended
 
         ntasks : int, optional
             the number of tasks the step would ideally use.  If fewer tasks
@@ -51,8 +55,8 @@ class Forward(OceanModelStep):
             A list of variable names to compare with a baseline (if one is
             provided)
         """
-        super().__init__(task=task, name=name, subdir=subdir,
-                         ntasks=ntasks, min_tasks=min_tasks,
+        super().__init__(component=component, name=name, subdir=subdir,
+                         indir=indir, ntasks=ntasks, min_tasks=min_tasks,
                          openmp_threads=openmp_threads)
 
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')

--- a/polaris/ocean/tasks/single_column/ideal_age/__init__.py
+++ b/polaris/ocean/tasks/single_column/ideal_age/__init__.py
@@ -4,7 +4,6 @@ from polaris import Task
 from polaris.ocean.tasks.single_column.forward import Forward
 from polaris.ocean.tasks.single_column.init import Init
 from polaris.ocean.tasks.single_column.viz import Viz
-from polaris.validate import compare_variables
 
 
 class IdealAge(Task):
@@ -39,12 +38,13 @@ class IdealAge(Task):
         super().__init__(component=component, name=name,
                          subdir=subdir)
         self.add_step(
-            Init(task=self, resolution=resolution,
-                 ideal_age=ideal_age))
+            Init(component=component, resolution=resolution,
+                 indir=self.subdir, ideal_age=ideal_age))
 
         validate_vars = ['temperature', 'salinity', 'iAge']
-        step = Forward(task=self, ntasks=1, min_tasks=1,
-                       openmp_threads=1, validate_vars=validate_vars)
+        step = Forward(component=component, indir=self.subdir, ntasks=1,
+                       min_tasks=1, openmp_threads=1,
+                       validate_vars=validate_vars)
 
         step.add_yaml_file('polaris.ocean.tasks.single_column.ideal_age',
                            'forward.yaml')
@@ -52,7 +52,7 @@ class IdealAge(Task):
         self.add_step(step)
 
         self.add_step(
-            Viz(task=self, ideal_age=ideal_age))
+            Viz(component=component, indir=self.subdir, ideal_age=ideal_age))
 
     def configure(self):
         """

--- a/polaris/ocean/tasks/single_column/init.py
+++ b/polaris/ocean/tasks/single_column/init.py
@@ -17,17 +17,26 @@ class Init(Step):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, task, resolution, ideal_age=False):
+    def __init__(self, component, resolution, indir, ideal_age=False):
         """
         Create the step
+
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
+
         resolution : float
             The resolution of the test case in km
+
+        indir : str
+            The subdirectory that the task belongs to, that this step will
+            go into a subdirectory of
+
+        ideal_age : bool, optional
+            Whether the initial condition should include the ideal age tracer
         """
-        super().__init__(task=task, name='init')
+        super().__init__(component=component, name='init', indir=indir)
         self.resolution = resolution
         self.ideal_age = ideal_age
         for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info',

--- a/polaris/ocean/tasks/single_column/viz.py
+++ b/polaris/ocean/tasks/single_column/viz.py
@@ -18,16 +18,23 @@ class Viz(Step):
     """
     A step for plotting the results of a single-column test
     """
-    def __init__(self, task, ideal_age=False):
+    def __init__(self, component, indir, ideal_age=False):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
+
+        indir : str
+            The subdirectory that the task belongs to, that this step will
+            go into a subdirectory of
+
+        ideal_age : bool, optional
+            Whether the initial condition should include the ideal age tracer
         """
-        super().__init__(task=task, name='viz')
+        super().__init__(component=component, name='viz', indir=indir)
         self.ideal_age = ideal_age
         self.add_input_file(
             filename='initial_state.nc',
@@ -59,7 +66,6 @@ class Viz(Step):
         for field_name, field_units in fields.items():
             if field_name not in ds.keys():
                 raise ValueError(f'{field_name} not present in output.nc')
-                continue
             var = ds[field_name].mean(dim='nCells')
             var_init = var.isel(Time=0)
             var_final = var.isel(Time=t_index)

--- a/polaris/remap/mapping_file_step.py
+++ b/polaris/remap/mapping_file_step.py
@@ -35,21 +35,25 @@ class MappingFileStep(Step):
         The name of the output mapping file
     """
 
-    def __init__(self, task, name, subdir=None, ntasks=None,
+    def __init__(self, component, name, subdir=None, indir=None, ntasks=None,
                  min_tasks=None, map_filename=None, method='bilinear'):
         """
         Create a new step
 
         Parameters
         ----------
-        task : compass.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         name : str
             the name of the step
 
         subdir : str, optional
-            the subdirectory for the step.  The default is ``name``
+            the subdirectory for the step.  If neither this nor ``indir``
+             are provided, the directory is the ``name``
+
+        indir : str, optional
+            the directory the step is in, to which ``name`` will be appended
 
         ntasks : int, optional
             the target number of MPI tasks the step would ideally use
@@ -64,8 +68,8 @@ class MappingFileStep(Step):
         method : {'bilinear', 'neareststod', 'conserve'}, optional
             The method of interpolation used
         """
-        super().__init__(task, name=name, subdir=subdir,
-                         ntasks=ntasks, min_tasks=min_tasks)
+        super().__init__(component=component, name=name, subdir=subdir,
+                         indir=indir, ntasks=ntasks, min_tasks=min_tasks)
         self.src_grid_info = dict()
         self.dst_grid_info = dict()
         self.map_filename = map_filename

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 import mpas_tools.io
 from mpas_tools.logging import LoggingContext, check_call
 
+from polaris import Task
 from polaris.logging import log_function_call, log_method_call
 from polaris.parallel import (
     get_available_parallel_resources,
@@ -16,8 +17,8 @@ from polaris.parallel import (
     set_cores_per_node,
 )
 from polaris.run import (
+    complete_step_run,
     load_dependencies,
-    pickle_step_after_run,
     setup_config,
     unpickle_suite,
 )
@@ -125,8 +126,9 @@ def run_single_step(step_is_subprocess=False):
         Whether the step is being run as a subprocess of a task or suite
     """
     with open('step.pickle', 'rb') as handle:
-        task, step = pickle.load(handle)
-    task.steps_to_run = [step.name]
+        step = pickle.load(handle)
+    task = Task(component=step.component, name='dummy_task')
+    task.add_step(step)
     task.new_step_log_file = False
 
     # This prevents infinite loop of subprocesses
@@ -142,8 +144,8 @@ def run_single_step(step_is_subprocess=False):
     mpas_tools.io.default_engine = config.get('io', 'engine')
 
     # start logging to stdout/stderr
-    task_name = step.path.replace('/', '_')
-    with LoggingContext(name=task_name) as stdout_logger:
+    logger_name = step.path.replace('/', '_')
+    with LoggingContext(name=logger_name) as stdout_logger:
         task.logger = stdout_logger
         task.stdout_logger = None
         log_function_call(function=_run_task, logger=stdout_logger)
@@ -342,23 +344,30 @@ def _run_task(task, available_resources):
     cwd = os.getcwd()
     for step_name in task.steps_to_run:
         step = task.steps[step_name]
+        complete_filename = os.path.join(step.work_dir,
+                                         'polaris_step_complete.log')
+
+        _print_to_stdout(task, f'  * step: {step_name}')
+
+        if os.path.exists(complete_filename):
+            _print_to_stdout(task, '          already completed')
+            continue
+        if step.cached:
+            _print_to_stdout(task, '          cached')
+            continue
+
         step_start = time.time()
 
-        if step.cached:
-            logger.info(f'  * Cached step: {step_name}')
-            continue
         step.config = task.config
         if task.log_filename is not None:
             step_log_filename = task.log_filename
         else:
             step_log_filename = None
 
-        _print_to_stdout(task, f'  * step: {step_name}')
-
         try:
             if step.run_as_subprocess:
                 _run_step_as_subprocess(
-                    task, step, task.new_step_log_file)
+                    logger, step, task.new_step_log_file)
             else:
                 _run_step(task, step, task.new_step_log_file,
                           available_resources, step_log_filename)
@@ -403,10 +412,10 @@ def _run_step(task, step, new_log_file, available_resources,
 
     if len(missing_files) > 0:
         raise OSError(
-            f'input file(s) missing in step {step.name} of '
-            f'{step.component.name}/{step.task.subdir}: {missing_files}')
+            f'input file(s) missing in step {step.name} in '
+            f'{step.component.name}/{step.subdir}: {missing_files}')
 
-    load_dependencies(task, step)
+    load_dependencies(step)
 
     # each logger needs a unique name
     logger_name = step.path.replace('/', '_')
@@ -456,7 +465,7 @@ def _run_step(task, step, new_log_file, available_resources,
             step_logger.info('')
             step.run()
 
-    pickle_step_after_run(task, step)
+    complete_step_run(step)
 
     missing_files = list()
     for output_file in step.outputs:
@@ -470,15 +479,14 @@ def _run_step(task, step, new_log_file, available_resources,
         except FileNotFoundError:
             pass
         raise OSError(
-            f'output file(s) missing in step {step.name} of '
-            f'{step.component.name}/{step.task.subdir}: {missing_files}')
+            f'output file(s) missing in step {step.name} in '
+            f'{step.component.name}/{step.subdir}: {missing_files}')
 
 
-def _run_step_as_subprocess(task, step, new_log_file):
+def _run_step_as_subprocess(logger, step, new_log_file):
     """
     Run the requested step as a subprocess
     """
-    logger = task.logger
     cwd = os.getcwd()
     logger_name = step.path.replace('/', '_')
     if new_log_file:

--- a/polaris/seaice/tasks/single_column/exact_restart/__init__.py
+++ b/polaris/seaice/tasks/single_column/exact_restart/__init__.py
@@ -57,7 +57,7 @@ class ExactRestart(Task):
                          'freezingMeltingPotential',
                          'airOceanDragCoefficientRatio']
 
-        step = Forward(task=self, name='full_run')
+        step = Forward(component=component, name='full_run', indir=self.subdir)
         step.add_output_file(
             filename='restarts/restart.2000-01-01_12.00.00.nc',
             validate_vars=validate_vars)
@@ -73,7 +73,8 @@ class ExactRestart(Task):
             streams='streams.full')
         self.add_step(step)
 
-        step = Forward(task=self, name='restart_run')
+        step = Forward(component=component, name='restart_run',
+                       indir=self.subdir)
         step.add_input_file(
             filename='restarts/restart.2000-01-01_12.00.00.nc',
             target='../../full_run/restarts/restart.2000-01-01_12.00.00.nc')
@@ -91,6 +92,6 @@ class ExactRestart(Task):
 
         subdirs = ['full_run', 'restart_run']
         restart_filename = 'restarts/restart.2000-01-02_00.00.00.nc'
-        self.add_step(Validate(task=self, step_subdirs=subdirs,
-                               variables=validate_vars,
+        self.add_step(Validate(component=component, step_subdirs=subdirs,
+                               indir=self.subdir, variables=validate_vars,
                                restart_filename=restart_filename))

--- a/polaris/seaice/tasks/single_column/exact_restart/validate.py
+++ b/polaris/seaice/tasks/single_column/exact_restart/validate.py
@@ -14,17 +14,22 @@ class Validate(Step):
     variables : list of str
         The variables to validate
     """
-    def __init__(self, task, step_subdirs, variables, restart_filename):
+    def __init__(self, component, step_subdirs, indir, variables,
+                 restart_filename):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The task this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         step_subdirs : list of str
             The number of processors used in each run
+
+        indir : str
+            the directory the step is in, to which the name of the step will
+            be appended
 
         variables : list of str
             The variables to validate
@@ -32,7 +37,7 @@ class Validate(Step):
         restart_filename : str
             The relative path to the restart file to compare in the 2 subdirs
         """
-        super().__init__(task=task, name='validate')
+        super().__init__(component=component, name='validate', indir=indir)
 
         self.step_subdirs = step_subdirs
 

--- a/polaris/seaice/tasks/single_column/forward.py
+++ b/polaris/seaice/tasks/single_column/forward.py
@@ -5,19 +5,22 @@ class Forward(ModelStep):
     """
     A step for staging a mesh for “single column” test cases
     """
-    def __init__(self, task, name='forward'):
+    def __init__(self, component, name='forward', indir=None):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-          The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
 
         name : str, optional
           The name of the step
+
+        indir : str, optional
+            the directory the step is in, to which ``name`` will be appended
         """
-        super().__init__(task=task, name=name,
+        super().__init__(component=component, name=name, indir=indir,
                          ntasks=1, min_tasks=1, openmp_threads=1)
 
         self.add_input_file(filename='grid.nc',

--- a/polaris/seaice/tasks/single_column/standard_physics/__init__.py
+++ b/polaris/seaice/tasks/single_column/standard_physics/__init__.py
@@ -23,7 +23,7 @@ class StandardPhysics(Task):
         name = 'standard_physics'
         subdir = os.path.join('single_column', name)
         super().__init__(component=component, name=name, subdir=subdir)
-        step = Forward(task=self)
+        step = Forward(component=component, indir=self.subdir)
         step.add_namelist_file(
             package='polaris.seaice.tasks.single_column.standard_physics',
             namelist='namelist.seaice')
@@ -32,4 +32,4 @@ class StandardPhysics(Task):
         step.add_output_file(filename='output/output.2000.nc',
                              validate_vars=variables)
         self.add_step(step)
-        self.add_step(Viz(task=self))
+        self.add_step(Viz(component=component, indir=self.subdir))

--- a/polaris/seaice/tasks/single_column/standard_physics/viz.py
+++ b/polaris/seaice/tasks/single_column/standard_physics/viz.py
@@ -17,16 +17,20 @@ class Viz(Step):
     """
     A step for plotting the results of a single column test
     """
-    def __init__(self, task):
+    def __init__(self, component, indir):
         """
         Create the step
 
         Parameters
         ----------
-        task : polaris.Task
-            The test case this step belongs to
+        component : polaris.Component
+            The component the step belongs to
+
+        indir : str
+            the directory the step is in, to which the name of the step will
+            be appended
         """
-        super().__init__(task=task, name='viz')
+        super().__init__(component=component, name='viz', indir=indir)
         self.add_input_file(
             filename='output.2000.nc',
             target='../forward/output/output.2000.nc')
@@ -40,7 +44,6 @@ class Viz(Step):
         plt.style.use(style_filename)
         ds = xr.open_dataset('output.2000.nc', decode_times=False)
         daysSinceStartOfSim = ds.daysSinceStartOfSim.values
-        iceVolumeCell = ds.iceVolumeCell.values
         snowVolumeCell = ds.snowVolumeCell.values
         iceVolumeCell = ds.iceVolumeCell.values
         surfaceTemperatureCell = ds.surfaceTemperatureCell.values

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -238,11 +238,16 @@ def setup_task(path, task, config_file, machine, work_dir, baseline_dir,
 
     # iterate over steps
     for step in task.steps.values():
+        # make the step directory if it doesn't exist
+        step_dir = os.path.join(work_dir, step.path)
+
+        if step.name in task.step_symlinks:
+            symlink(step_dir,
+                    os.path.join(task_dir, task.step_symlinks[step.name]))
+
         if step.setup_complete:
             # this is a shared step that has already been set up
             continue
-        # make the step directory if it doesn't exist
-        step_dir = os.path.join(work_dir, step.path)
         try:
             os.makedirs(step_dir)
         except OSError:

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -78,17 +78,7 @@ def setup_tasks(work_dir, task_list=None, numbers=None, config_file=None,
         print('Warning: no base work directory was provided so setting up in '
               'the current directory.')
         work_dir = os.getcwd()
-        if clean:
-            print('Warning: Polaris refuses to clean the current directory---'
-                  'too dangerous!')
-            clean = False
     work_dir = os.path.abspath(work_dir)
-
-    if clean:
-        try:
-            shutil.rmtree(work_dir)
-        except FileNotFoundError:
-            pass
 
     components = get_components()
 
@@ -113,6 +103,12 @@ def setup_tasks(work_dir, task_list=None, numbers=None, config_file=None,
     provenance.write(work_dir, tasks, config=basic_config)
 
     _expand_and_mark_cached_steps(tasks, cached_steps)
+
+    if clean:
+        print('')
+        print('Cleaning task and step work directories:')
+        _clean_tasks_and_steps(tasks, work_dir)
+        print('')
 
     print('Setting up tasks:')
     for path, task in tasks.items():
@@ -383,6 +379,28 @@ def _expand_and_mark_cached_steps(tasks, cached_steps):
 
         for step_name in cached_steps[path]:
             task.steps[step_name].cached = True
+
+
+def _clean_tasks_and_steps(tasks, base_work_dir):
+    """
+    Remove contents of task and step work directories to start fresh
+    """
+    print(f'{base_work_dir}:')
+    for path, task in tasks.items():
+        task_work_dir = os.path.join(base_work_dir, path)
+        try:
+            shutil.rmtree(task_work_dir)
+            print(f' {path}')
+        except FileNotFoundError:
+            pass
+
+        for step in task.steps.values():
+            step_work_dir = os.path.join(base_work_dir, step.path)
+            try:
+                shutil.rmtree(step_work_dir)
+                print(f'  {step.path}')
+            except FileNotFoundError:
+                pass
 
 
 def _get_required_cores(tasks):

--- a/polaris/suite.py
+++ b/polaris/suite.py
@@ -8,7 +8,7 @@ from polaris.setup import setup_tasks
 
 def setup_suite(component, suite_name, work_dir, config_file=None,
                 machine=None, baseline_dir=None, component_path=None,
-                copy_executable=False):
+                copy_executable=False, clean=False):
     """
     Set up a suite of tasks
 
@@ -43,6 +43,10 @@ def setup_suite(component, suite_name, work_dir, config_file=None,
 
     copy_executable : bool, optional
         Whether to copy the MPAS executable to the work directory
+
+    clean : bool, optional
+        Whether to delete the contents of the base work directory before
+        setting up the suite
     """
 
     text = imp_res.files(f'polaris.{component}.suites').joinpath(
@@ -53,7 +57,7 @@ def setup_suite(component, suite_name, work_dir, config_file=None,
     setup_tasks(work_dir, tasks, config_file=config_file, machine=machine,
                 baseline_dir=baseline_dir, component_path=component_path,
                 suite_name=suite_name, cached=cached,
-                copy_executable=copy_executable)
+                copy_executable=copy_executable, clean=clean)
 
 
 def main():
@@ -86,13 +90,16 @@ def main():
                         action="store_true",
                         help="If the model executable should be copied to the "
                              "work directory.")
+    parser.add_argument("--clean", dest="clean", action="store_true",
+                        help="If the base work directory should be deleted "
+                             "before setting up the suite.")
     args = parser.parse_args(sys.argv[2:])
 
     setup_suite(component=args.component, suite_name=args.task_suite,
                 work_dir=args.work_dir, config_file=args.config_file,
                 machine=args.machine, baseline_dir=args.baseline_dir,
                 component_path=args.component_path,
-                copy_executable=args.copy_executable)
+                copy_executable=args.copy_executable, clean=args.clean)
 
 
 def _parse_suite(text):

--- a/polaris/task.py
+++ b/polaris/task.py
@@ -20,6 +20,10 @@ class Task:
     steps : dict
         A dictionary of steps in the task with step names as keys
 
+    step_symlinks : dict
+        A dictionary of symlink paths within the test case's work directory
+        to shared steps outside the test case
+
     steps_to_run : list
         A list of the steps to run when ``run()`` gets called.  This list
         includes all steps by default but can be replaced with a list of only
@@ -101,6 +105,7 @@ class Task:
 
         # steps will be added by calling add_step()
         self.steps = dict()
+        self.step_symlinks = dict()
         self.steps_to_run = list()
 
         # these will be set during setup, dummy values for now
@@ -128,7 +133,8 @@ class Task:
         """
         pass
 
-    def add_step(self, step=None, subdir=None, run_by_default=True):
+    def add_step(self, step=None, subdir=None, symlink=None,
+                 run_by_default=True):
         """
         Add a step to the task and component (if not already present)
 
@@ -140,6 +146,11 @@ class Task:
         subdir : str, optional
             The subdirectory of the step within the component if wish to add
             the step by path, and it has already been added to the component
+
+        symlink : str, optional
+            A location for a symlink to the step, relative to the test case's
+            work directory. This is typically used for a shared step that lives
+            outside of the test case
 
         run_by_default : bool, optional
             Whether to add this step to the list of steps to run when the
@@ -168,6 +179,8 @@ class Task:
         component.add_step(step)
 
         self.steps[step.name] = step
+        if symlink:
+            self.step_symlinks[step.name] = symlink
         if run_by_default:
             self.steps_to_run.append(step.name)
 
@@ -185,5 +198,7 @@ class Task:
 
         self.component.remove_step(step)
         self.steps.pop(step.name)
+        if step.name in self.step_symlinks:
+            self.step_symlinks.pop(step.name)
         if step.name in self.steps_to_run:
             self.steps_to_run.remove(step.name)

--- a/polaris/task.py
+++ b/polaris/task.py
@@ -52,10 +52,6 @@ class Task:
     base_work_dir : str
         The base work directory
 
-    baseline_dir : str
-        Location of the same task within the baseline work directory,
-        for use in comparing variables and timers
-
     stdout_logger : logging.Logger
         A logger for output from the task that goes to stdout regardless
         of whether ``logger`` is a log file or stdout
@@ -113,8 +109,6 @@ class Task:
         self.config_filename = ''
         self.work_dir = ''
         self.base_work_dir = ''
-        # may be set during setup if there is a baseline for comparison
-        self.baseline_dir = None
 
         # these will be set when running the task, dummy values for now
         self.new_step_log_file = True


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge adds support to the polaris framework for shared steps (steps that can belong to more than one task).  Existing tasks and steps are modified to accommodate the changes to the framework but tasks and steps are not yet reorganized to take advantage of shared steps so that bit-for-bit comparison with `main` can still be made with this branch.

Changes to `Step` include:
* switch the `subdir` attribute to be relative to the component work directory, not the task work directory
* add an `indir` parameter to the constructor to easily construct a `subdir` that joins `indir` and `name`.  If `indir` is the task work directory, this is the same as the old default behavior when `subdir` was not specified. 

Changes to `Component` include:
* adding a dictionary of steps (with work-directory paths relative to the component's work directory as keys)
* add `add_step()` and `remove_step()` methods

Changes to `Task` include:
* modify the `add_step()` method to perform error checking (e.g. make sure a different step with the same path hasn't already been added) and then add the step to the component and the task.  This method also includes a new `symlink` parameter that can be used to make a local symlink in the task's work directory to a shared step if it resides outside the task.
* add `remove_step()` methods

Other changes include:
* listing steps with full work-directory paths when `polaris list --verbose` is called
* removing tasks from step pickle files (since shared steps will not belong to a single task)
* add a `polaris_step_complete.log` file once a step has run to indicate that it is complete (and should not be run again)
* add `--clean` flags to `polaris setup` and `polaris suite` to remove the base work directory before setting up tasks.  (This is sometimes useful when debugging because steps that have already run will now be skipped, rather than running again, which may not be what the developer wants.)
* adding a `resolution_to_subdir()` function to the ocean framework for conveniently converting a float resolution to a string.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
