### PR TITLE
Add shared ocean framework for spherical convergence tests

### DIFF
--- a/docs/developers_guide/framework/config.md
+++ b/docs/developers_guide/framework/config.md
@@ -33,18 +33,16 @@ the file is in the path `polaris/ocean/tasks/baroclinic_channel`
 that the config file should always exist, so we would like the code to raise
 an exception (`exception=True`) if the file is not found.  This is the
 default behavior.  In some cases, you would like the code to add the config
-options if the config file exists and do nothing if it does not.  This can
-be useful if a common configure function is being used for all test
-cases in a configuration, as in this example from
-{py:func}`setup.setup_task()`:
+options if the config file exists and do nothing if it does not.  In this 
+example from {py:func}`polaris.setup.setup_task()`, there may not be a config 
+file for the particular machine we're on, and that's fine:
 
 ```python
-# add the config options for the task (if defined)
-config.add_from_package(task.__module__,
-                        f'{task.name}.cfg', exception=False)
+if machine is not None:
+    config.add_from_package('mache.machines', f'{machine}.cfg',
+                            exception=False)
 ```
-
-If a task doesn't have any config options, nothing will happen.
+If there isn't a config file for this machine, nothing will happen.
 
 The `MpasConfigParser` class also includes methods for adding a user
 config file and other config files by file name, but these are largely intended

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -169,7 +169,18 @@
 
 ## Ocean Framework
 
-### OceanModelStep
+### Spherical Convergence Tests
+
+```{eval-rst}
+.. currentmodule:: polaris.ocean.convergence.spherical
+
+.. autosummary::
+   :toctree: generated/
+
+   SphericalConvergenceForward
+```
+
+### Ocean Model
 
 ```{eval-rst}
 .. currentmodule:: polaris.ocean.model
@@ -182,6 +193,8 @@
    OceanModelStep.constrain_resources
    OceanModelStep.compute_cell_count
    OceanModelStep.map_yaml_to_namelist
+   
+   get_time_interval_string
 ```
 
 ### Spherical Base Mesh Step

--- a/docs/developers_guide/ocean/tasks/cosine_bell.md
+++ b/docs/developers_guide/ocean/tasks/cosine_bell.md
@@ -16,7 +16,9 @@ The config options for the `cosine_bell` tests are described in
 Additionally, the test uses a `forward.yaml` file with a few common
 model config options related to drag and default horizontal and
 vertical momentum and tracer diffusion, as well as defining `mesh`, `input`,
-`restart`, and `output` streams.
+`restart`, and `output` streams.  This file has Jinja templating that is
+used to update model config options based on Polaris config options, see
+{ref}`dev-ocean-spherical-convergence`.
 
 ### base_mesh
 
@@ -32,10 +34,12 @@ tracer distributed in a cosine-bell shape.
 ### forward
 
 The class {py:class}`polaris.ocean.tasks.cosine_bell.forward.Forward`
-defines a step for running MPAS-Ocean from an initial condition produced in
-an `init` step.  The time step is determined from the resolution
-based on the `dt_per_km` config option.  Other namelist options are taken
-from the task's `forward.yaml`.
+descends from {py:class}`polaris.ocean.convergence.spherical.SphericalConvergenceForward`,
+and defines a step for running MPAS-Ocean from an initial condition produced in
+an `init` step. See {ref}`dev-ocean-spherical-convergence` for some relevant
+discussion of the parent class. The time step is determined from the resolution
+based on the `dt_per_km` config option in the `[spherical_convergences]` 
+section.  Other model config options are taken from `forward.yaml`.
 
 ### analysis
 

--- a/docs/developers_guide/organization/tasks.md
+++ b/docs/developers_guide/organization/tasks.md
@@ -459,10 +459,21 @@ config files within the task or its shared framework. The `self.config`
 attribute that is modified in this function will be written to a config file
 for the task (see {ref}`config-files`).
 
-If you override this method in a task, you should assume that the
-`<task.name>.cfg` file in its package has already been added to the
-config options prior to calling `configure()`.  This happens automatically
-before running the task.
+If you define a `<task.name>.cfg` file, you will want to override this method 
+to add those config options, e.g.:
+
+```python
+from polaris import Task
+
+class InertialGravityWave(Task):
+    def configure(self):
+        """
+        Add the config file common to inertial gravity wave tests
+        """
+        self.config.add_from_package(
+            'polaris.ocean.tasks.inertial_gravity_wave',
+            'inertial_gravity_wave.cfg')
+```
 
 Since many tasks may need similar behavior in their `configure()` methods, it 
 is sometimes useful to define a parent class that overrides the 
@@ -472,24 +483,19 @@ the `configure()` method with their own additional changes.
 
 A `configure()` method can also be used to perform other operations at the
 task level when a task is being set up. An example of this would be
-creating a symlink to a README file that is shared across the whole task,
-as in {py:meth}`polaris.ocean.tasks.global_ocean.files_for_e3sm.FilesForE3SM.configure()`:
+creating a symlink to a README file that is shared across the whole task:
 
 ```python
-from importlib.resources import path
-
-from polaris.ocean.tasks.global_ocean.configure import configure_global_ocean
-from polaris.io import symlink
+from polaris.io import imp_res, symlink
 
 
 def configure(self):
     """
     Modify the configuration options for this task
     """
-    configure_global_ocean(task=self, mesh=self.mesh, init=self.init)
-    with path('polaris.ocean.tasks.global_ocean.files_for_e3sm',
-              'README') as target:
-        symlink(str(target), '{}/README'.format(self.work_dir))
+    package = 'compass.ocean.tests.global_ocean.files_for_e3sm'
+    target = imp_res.files(package).joinpath('README')
+    symlink(str(target), f'{self.work_dir}/README')
 ```
 
 The `configure()` method is not the right place for adding or modifying steps

--- a/docs/users_guide/ocean/tasks/cosine_bell.md
+++ b/docs/users_guide/ocean/tasks/cosine_bell.md
@@ -41,24 +41,33 @@ The default resolutions used in the task depends on the mesh type.
 For the `icos` mesh type, the defaults are:
 
 ```cfg
-resolutions = 60, 120, 240, 480
+# config options for spherical convergence tests
+[spherical_convergence]
+
+# a list of icosahedral mesh resolutions (km) to test
+icos_resolutions = 60, 120, 240, 480
 ```
 
 for the `qu` mesh type, they are:
 
 ```cfg
-resolutions = 60, 90, 120, 150, 180, 210, 240
+# config options for spherical convergence tests
+[spherical_convergence]
+
+# a list of quasi-uniform mesh resolutions (km) to test
+qu_resolutions = 60, 90, 120, 150, 180, 210, 240
 ```
 
 To alter the resolutions used in this task, you will need to create your own
-config file (or add a `cosine_bell` section to a config file if you're
-already using one).  The resolutions are a comma-separated list of the
+config file (or add a `spherical_convergence` section to a config file if 
+you're already using one).  The resolutions are a comma-separated list of the
 resolution of the mesh in km.  If you specify a different list
 before setting up `cosine_bell`, steps will be generated with the requested
-resolutions.  (If you alter `resolutions` in the task's config file in
-the work directory, nothing will happen.)  For `icos` meshes, make sure you
-use a resolution close to those listed in {ref}`dev-spherical-meshes`.  Each
-resolution will be rounded to the nearest allowed icosahedral resolution.
+resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the 
+task's config file in the work directory, nothing will happen.)  For `icos` 
+meshes, make sure you use a resolution close to those listed in 
+{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest 
+allowed icosahedral resolution.
 
 The `base_mesh` steps are shared with other tasks so they are not housed in
 the `cosine_bell` work directory.  Instead, they are in work directories like:
@@ -146,11 +155,45 @@ field remains at the initial velocity $u_0$.
 
 ## time step and run duration
 
-The time step for forward integration is determined by multiplying the
-resolution by `dt_per_km`, so that coarser meshes have longer time steps.
-You can alter this before setup (in a user config file) or before running the
-task (in the config file in the work directory). The run duration is 24
-days.
+This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step 
+for forward integration is determined by multiplying the resolution by a config
+option, `rk4_dt_per_km`, so that coarser meshes have longer time steps. You can
+alter this before setup (in a user config file) or before running the task (in 
+the config file in the work directory). 
+
+```cfg
+# config options for spherical convergence tests
+[spherical_convergence_forward]
+
+# time integrator: {'split_explicit', 'RK4'}
+time_integrator = RK4
+
+# RK4 time step per resolution (s/km), since dt is proportional to resolution
+rk4_dt_per_km = 3.0
+```
+
+The convergence_eval_time, run duration and output interval are the period for 
+advection to make a full rotation around the globe, 24 days:
+
+```cfg
+# config options for spherical convergence tests
+[spherical_convergence]
+
+# Evaluation time for convergence analysis (in days)
+convergence_eval_time = ${cosine_bell:vel_pd}
+
+# config options for spherical convergence tests
+[spherical_convergence_forward]
+
+# Run duration in days
+run_duration = ${cosine_bell:vel_pd}
+
+# Output interval in days
+output_interval = ${cosine_bell:vel_pd}
+```
+
+Her, `${cosine_bell:vel_pd}` means that the same value is used as in the 
+option `vel_pd` in section `[cosine_bell]`, see below.
 
 ## config options
 
@@ -159,9 +202,6 @@ The `cosine_bell` config options include:
 ```cfg
 # options for cosine bell convergence test case
 [cosine_bell]
-
-# time step per resolution (s/km), since dt is proportional to resolution
-dt_per_km = 30
 
 # the constant temperature of the domain
 temperature = 15.0
@@ -220,9 +260,6 @@ norm_args = {'vmin': 0., 'vmax': 1.}
 # We could provide colorbar tick marks but we'll leave the defaults
 # colorbar_ticks = np.linspace(0., 1., 9)
 ```
-
-The `dt_per_km` option `[cosine_bell]` is used to control the time step, as
-discussed above in more detail.
 
 The 7 options from `temperature` to `vel_pd` are used to control properties of
 the cosine bell and the rest of the sphere, as well as the advection.

--- a/polaris/ocean/convergence/spherical/__init__.py
+++ b/polaris/ocean/convergence/spherical/__init__.py
@@ -1,0 +1,3 @@
+from polaris.ocean.convergence.spherical.forward import (
+    SphericalConvergenceForward,
+)

--- a/polaris/ocean/convergence/spherical/forward.py
+++ b/polaris/ocean/convergence/spherical/forward.py
@@ -1,0 +1,145 @@
+from polaris.ocean.model import OceanModelStep, get_time_interval_string
+
+
+class SphericalConvergenceForward(OceanModelStep):
+    """
+    A step for performing forward ocean component runs as part of a spherical
+    convergence test
+
+    Attributes
+    ----------
+    resolution : float
+        The resolution of the (uniform) mesh in km
+
+    package : Package
+        The package name or module object that contains the YAML file
+
+    yaml_filename : str
+        A YAML file that is a Jinja2 template with model config options
+
+    """
+
+    def __init__(self, component, name, subdir, resolution, base_mesh, init,
+                 package, yaml_filename='forward.yaml', options=None,
+                 output_filename='output.nc', validate_vars=None):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        name : str
+            The name of the step
+
+        subdir : str
+            The subdirectory for the step
+
+        resolution : float
+            The resolution of the (uniform) mesh in km
+
+        package : Package
+            The package name or module object that contains the YAML file
+
+        yaml_filename : str, optional
+            A YAML file that is a Jinja2 template with model config options
+
+        options : dict, optional
+            A dictionary of options and value to replace model config options
+            with new values
+
+        output_filename : str, optional
+            The output file that will be written out at the end of the forward
+            run
+
+        validate_vars : list of str, optional
+            A list of variables to validate against a baseline if requested
+        """
+        super().__init__(component=component, name=name, subdir=subdir,
+                         openmp_threads=1)
+
+        self.resolution = resolution
+        self.package = package
+        self.yaml_filename = yaml_filename
+
+        # make sure output is double precision
+        self.add_yaml_file('polaris.ocean.config', 'output.yaml')
+
+        if options is not None:
+            self.add_model_config_options(options=options)
+
+        self.add_input_file(
+            filename='init.nc',
+            work_dir_target=f'{init.path}/initial_state.nc')
+        self.add_input_file(
+            filename='graph.info',
+            work_dir_target=f'{base_mesh.path}/graph.info')
+
+        self.add_output_file(filename=output_filename,
+                             validate_vars=validate_vars)
+
+    def compute_cell_count(self):
+        """
+        Compute the approximate number of cells in the mesh, used to constrain
+        resources
+
+        Returns
+        -------
+        cell_count : int or None
+            The approximate number of cells in the mesh
+        """
+        # use a heuristic based on QU30 (65275 cells) and QU240 (10383 cells)
+        cell_count = 6e8 / self.resolution**2
+        return cell_count
+
+    def dynamic_model_config(self, at_setup):
+        """
+        Set the model time step from config options at setup and runtime
+
+        Parameters
+        ----------
+        at_setup : bool
+            Whether this method is being run during setup of the step, as
+            opposed to at runtime
+        """
+        super().dynamic_model_config(at_setup=at_setup)
+
+        config = self.config
+
+        vert_levels = config.getfloat('vertical_grid', 'vert_levels')
+        if not at_setup and vert_levels == 1:
+            self.add_yaml_file('polaris.ocean.config', 'single_layer.yaml')
+
+        section = config['spherical_convergence_forward']
+
+        time_integrator = section.get('time_integrator')
+
+        # dt is proportional to resolution: default 30 seconds per km
+        if time_integrator == 'RK4':
+            dt_per_km = section.getfloat('rk4_dt_per_km')
+        else:
+            dt_per_km = section.getfloat('split_dt_per_km')
+        dt_str = get_time_interval_string(seconds=dt_per_km * self.resolution)
+
+        # btr_dt is also proportional to resolution: default 1.5 seconds per km
+        btr_dt_per_km = section.getfloat('btr_dt_per_km')
+        btr_dt_str = get_time_interval_string(
+            seconds=btr_dt_per_km * self.resolution)
+
+        run_duration = section.getfloat('run_duration')
+        run_duration_str = get_time_interval_string(days=run_duration)
+
+        output_interval = section.getfloat('output_interval')
+        output_interval_str = get_time_interval_string(days=output_interval)
+
+        replacements = dict(
+            time_integrator=time_integrator,
+            dt=dt_str,
+            btr_dt=btr_dt_str,
+            run_duration=run_duration_str,
+            output_interval=output_interval_str,
+        )
+
+        self.add_yaml_file(self.package, self.yaml_filename,
+                           template_replacements=replacements)

--- a/polaris/ocean/convergence/spherical/spherical.cfg
+++ b/polaris/ocean/convergence/spherical/spherical.cfg
@@ -1,0 +1,34 @@
+# config options for spherical convergence tests
+[spherical_convergence]
+
+# a list of icosahedral mesh resolutions (km) to test
+icos_resolutions = 60, 120, 240, 480
+
+# a list of quasi-uniform mesh resolutions (km) to test
+qu_resolutions = 60, 90, 120, 150, 180, 210, 240
+
+# Evaluation time for convergence analysis (in days)
+convergence_eval_time = 1.0
+
+
+# config options for spherical convergence forward steps
+[spherical_convergence_forward]
+
+# time integrator: {'split_explicit', 'RK4'}
+time_integrator = RK4
+
+# RK4 time step per resolution (s/km), since dt is proportional to resolution
+rk4_dt_per_km = 3.0
+
+# split time step per resolution (s/km), since dt is proportional to resolution
+split_dt_per_km = 30.0
+
+# the barotropic time step (s/km) for simulations using split time stepping,
+# since btr_dt is proportional to resolution
+btr_dt_per_km = 1.5
+
+# Run duration in days
+run_duration = ${spherical_convergence:convergence_eval_time}
+
+# Output interval in days
+output_interval = ${run_duration}

--- a/polaris/ocean/model/__init__.py
+++ b/polaris/ocean/model/__init__.py
@@ -1,1 +1,2 @@
 from polaris.ocean.model.ocean_model_step import OceanModelStep
+from polaris.ocean.model.time import get_time_interval_string

--- a/polaris/ocean/model/time.py
+++ b/polaris/ocean/model/time.py
@@ -1,0 +1,36 @@
+import time
+
+
+def get_time_interval_string(days=None, seconds=None):
+    """
+    Convert a time interval in days and/or seconds to a string for use in a
+    model config option.  If both are provided, they will be added
+
+    Parameters
+    ----------
+    days : float, optional
+        A time interval in days
+
+    seconds : float, optional
+        A time interval in seconds
+
+    Returns
+    -------
+    time_str : str
+        The time as a string in the format "DDDD_HH:MM:SS.SS"
+
+    """
+    sec_per_day = 86400
+    total = 0.
+    if seconds is not None:
+        total += seconds
+    if days is not None:
+        total += sec_per_day * days
+
+    day_part = int(total / sec_per_day)
+    sec_part = total - day_part * sec_per_day
+
+    # https://stackoverflow.com/a/1384565/7728169
+    seconds_str = time.strftime('%H:%M:%S', time.gmtime(sec_part))
+    time_str = f'{day_part:04d}_{seconds_str}'
+    return time_str

--- a/polaris/ocean/tasks/cosine_bell/cosine_bell.cfg
+++ b/polaris/ocean/tasks/cosine_bell/cosine_bell.cfg
@@ -19,11 +19,32 @@ partial_cell_type = None
 # The minimum fraction of a layer for partial cells
 min_pc_fraction = 0.1
 
+
+# config options for spherical convergence tests
+[spherical_convergence]
+
+# Evaluation time for convergence analysis (in days)
+convergence_eval_time = ${cosine_bell:vel_pd}
+
+
+# config options for spherical convergence tests
+[spherical_convergence_forward]
+
+# time integrator: {'split_explicit', 'RK4'}
+time_integrator = RK4
+
+# RK4 time step per resolution (s/km), since dt is proportional to resolution
+rk4_dt_per_km = 3.0
+
+# Run duration in days
+run_duration = ${cosine_bell:vel_pd}
+
+# Output interval in days
+output_interval = ${cosine_bell:vel_pd}
+
+
 # options for cosine bell convergence test case
 [cosine_bell]
-
-# time step per resolution (s/km), since dt is proportional to resolution
-dt_per_km = 30
 
 # the constant temperature of the domain
 temperature = 15.0

--- a/polaris/ocean/tasks/cosine_bell/forward.py
+++ b/polaris/ocean/tasks/cosine_bell/forward.py
@@ -1,23 +1,13 @@
-import time
-
-from polaris.ocean.model import OceanModelStep
+from polaris.ocean.convergence.spherical import SphericalConvergenceForward
 
 
-class Forward(OceanModelStep):
+class Forward(SphericalConvergenceForward):
     """
     A step for performing forward ocean component runs as part of the cosine
     bell test case
-
-    Attributes
-    ----------
-    resolution : int
-        The resolution of the (uniform) mesh in km
-
-    mesh_name : str
-        The name of the mesh
     """
 
-    def __init__(self, component, name, subdir, resolution, mesh_name):
+    def __init__(self, component, name, subdir, resolution, base_mesh, init):
         """
         Create a new step
 
@@ -32,75 +22,20 @@ class Forward(OceanModelStep):
         subdir : str
             The subdirectory for the step
 
-        resolution : int
+        resolution : float
             The resolution of the (uniform) mesh in km
 
-        mesh_name : str
-            The name of the mesh
+        base_mesh : polaris.Step
+            The base mesh step
+
+        init : polaris.Step
+            The init step
         """
+        package = 'polaris.ocean.tasks.cosine_bell'
+        validate_vars = ['normalVelocity', 'tracer1']
         super().__init__(component=component, name=name, subdir=subdir,
-                         openmp_threads=1)
-
-        self.resolution = resolution
-        self.mesh_name = mesh_name
-
-        # make sure output is double precision
-        self.add_yaml_file('polaris.ocean.config', 'output.yaml')
-        self.add_yaml_file(
-            'polaris.ocean.tasks.cosine_bell',
-            'forward.yaml')
-
-        self.add_input_file(
-            filename='init.nc',
-            target=f'../../init/{mesh_name}/initial_state.nc')
-        self.add_input_file(
-            filename='graph.info',
-            target=f'../../../base_mesh/{mesh_name}/graph.info')
-
-        self.add_output_file(filename='output.nc',
-                             validate_vars=['normalVelocity', 'tracer1'])
-
-    def compute_cell_count(self):
-        """
-        Compute the approximate number of cells in the mesh, used to constrain
-        resources
-
-        Returns
-        -------
-        cell_count : int or None
-            The approximate number of cells in the mesh
-        """
-        # use a heuristic based on QU30 (65275 cells) and QU240 (10383 cells)
-        cell_count = 6e8 / self.resolution**2
-        return cell_count
-
-    def dynamic_model_config(self, at_setup):
-        """
-        Set the model time step from config options at setup and runtime
-
-        Parameters
-        ----------
-        at_setup : bool
-            Whether this method is being run during setup of the step, as
-            opposed to at runtime
-        """
-        super().dynamic_model_config(at_setup=at_setup)
-
-        config = self.config
-
-        vert_levels = config.getfloat('vertical_grid', 'vert_levels')
-        if not at_setup and vert_levels == 1:
-            self.add_yaml_file('polaris.ocean.config', 'single_layer.yaml')
-            self.add_yaml_file(
-                'polaris.ocean.tasks.cosine_bell',
-                'forward.yaml')
-
-        # dt is proportional to resolution: default 30 seconds per km
-        dt_per_km = config.getfloat('cosine_bell', 'dt_per_km')
-
-        dt = dt_per_km * self.resolution
-        # https://stackoverflow.com/a/1384565/7728169
-        dt_str = time.strftime('%H:%M:%S', time.gmtime(dt))
-
-        options = dict(config_dt=dt_str)
-        self.add_model_config_options(options)
+                         resolution=resolution, base_mesh=base_mesh,
+                         init=init, package=package,
+                         yaml_filename='forward.yaml',
+                         output_filename='output.nc',
+                         validate_vars=validate_vars)

--- a/polaris/ocean/tasks/cosine_bell/forward.yaml
+++ b/polaris/ocean/tasks/cosine_bell/forward.yaml
@@ -2,11 +2,12 @@ omega:
   run_modes:
     config_ocean_run_mode: forward
   time_management:
-    config_run_duration: 0024_00:00:00
+    config_run_duration: {{ run_duration }}
   decomposition:
     config_block_decomp_file_prefix: graph.info.part.
   time_integration:
-    config_time_integrator: RK4
+    config_dt: {{ dt }}
+    config_time_integrator: {{ time_integrator }}
   debug:
     config_disable_thick_all_tend: true
     config_disable_thick_hadv: true
@@ -50,7 +51,7 @@ omega:
     output:
       type: output
       filename_template: output.nc
-      output_interval: 0024_00:00:00
+      output_interval: {{ output_interval }}
       clobber_mode: truncate
       reference_time: 0001-01-01_00:00:00
       contents:

--- a/polaris/ocean/tasks/cosine_bell/init.py
+++ b/polaris/ocean/tasks/cosine_bell/init.py
@@ -10,7 +10,7 @@ class Init(Step):
     """
     A step for an initial condition for for the cosine bell test case
     """
-    def __init__(self, component, name, subdir, mesh_name):
+    def __init__(self, component, name, subdir, base_mesh):
         """
         Create the step
 
@@ -25,18 +25,18 @@ class Init(Step):
         subdir : str
             The subdirectory for the step
 
-        mesh_name : str
-            The name of the mesh
+        base_mesh : polaris.Step
+            The base mesh step
         """
         super().__init__(component=component, name=name, subdir=subdir)
 
         self.add_input_file(
             filename='mesh.nc',
-            target=f'../../../base_mesh/{mesh_name}/base_mesh.nc')
+            work_dir_target=f'{base_mesh.path}/base_mesh.nc')
 
         self.add_input_file(
             filename='graph.info',
-            target=f'../../../base_mesh/{mesh_name}/graph.info')
+            work_dir_target=f'{base_mesh.path}/graph.info')
 
         self.add_output_file(filename='initial_state.nc')
 

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -189,10 +189,6 @@ def setup_task(path, task, config_file, machine, work_dir, baseline_dir,
     if copy_executable:
         config.set('setup', 'copy_executable', 'True')
 
-    # add the config options for the task (if defined)
-    config.add_from_package(task.__module__,
-                            f'{task.name}.cfg', exception=False)
-
     if 'POLARIS_BRANCH' in os.environ:
         polaris_branch = os.environ['POLARIS_BRANCH']
         config.set('paths', 'polaris_branch', polaris_branch)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge adds some shared framework for spherical convergence tests with constant resolution meshes like `cosine_bell` and soon `geostrophic` and the various `sphere_transport` tests.

A new `SphericalConvergenceForward` parent class does most of the work involved in forward runs for convergence tests, including determining the approximate number of cells in the mesh (for constraining required resources), computing a time step based on the mesh resolution, and setting the run duration and output interval based on a config option.

A set of common (standardized) config options in the `spherical_convergence` section helps support this approach.

The cosine bell tests have been updated to use the shared framework, and the documentation as also been updated.

We no longer automatically add a task's config options to the `config` object -- this has to be done in `configure()`.  Cosine bell was the only test so far that relied on this functionality and it did not work quite as expected.  It is better to do it manually and control the order in which config options are added from different sources.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
