### PR TITLE
Update to `mpas_tools` v0.23.0

### DIFF
--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -24,7 +24,7 @@ geometric_features = 1.2.0
 jigsaw = 0.9.14
 jigsawpy = 0.3.3
 mache = 1.16.0
-mpas_tools = 0.21.0
+mpas_tools = 0.23.0
 otps = 2021.10
 parallelio = 2.6.0
 

--- a/polaris/mesh/spherical.py
+++ b/polaris/mesh/spherical.py
@@ -7,9 +7,7 @@ import xarray
 import xarray.plot
 from jigsawpy.savejig import savejig
 from mpas_tools.cime.constants import constants
-from mpas_tools.io import write_netcdf
 from mpas_tools.logging import check_call
-from mpas_tools.mesh.conversion import convert
 from mpas_tools.mesh.creation.jigsaw_to_netcdf import jigsaw_to_netcdf
 from mpas_tools.ocean.inject_meshDensity import inject_spherical_meshDensity
 from mpas_tools.viz.colormaps import register_sci_viz_colormaps
@@ -103,9 +101,11 @@ class SphericalBaseStep(Step):
                          sphere_radius=earth_radius)
 
         logger.info('Convert from triangles to MPAS mesh')
-        write_netcdf(convert(xarray.open_dataset('mesh_triangles.nc'),
-                             dir='.', logger=logger),
-                     mpas_mesh_filename)
+
+        args = ['MpasMeshConverter.x',
+                'mesh_triangles.nc',
+                mpas_mesh_filename]
+        check_call(args=args, logger=logger)
 
         if section.getboolean('add_mesh_density'):
             logger.info('Add meshDensity into the mesh file')

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -209,7 +209,7 @@ def _compute_cell_patches(ds, mask):
         if dx * dy / 10 > area_cell[cell_index]:
             mask[cell_index] = False
         else:
-            polygon = Polygon(vertices, True)
+            polygon = Polygon(vertices, closed=True)
             patches.append(polygon)
 
     p = PatchCollection(patches, alpha=1.)
@@ -240,7 +240,7 @@ def _compute_edge_patches(ds, mask):
         vertices[3, 0] = 1e-3 * x_cell[cell_indices[1]]
         vertices[3, 1] = 1e-3 * y_cell[cell_indices[1]]
 
-        polygon = Polygon(vertices, True)
+        polygon = Polygon(vertices, closed=True)
         patches.append(polygon)
 
     p = PatchCollection(patches, alpha=1.)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

The newer MPAS-Tools brings in the new, faster version of the MPAS mesh converter and cell culler, as well as tools for sorting mesh indices for improved MPAS-Ocean parallel and memory performance.

This merge also ports over a small change from https://github.com/MPAS-Dev/compass/pull/659 to better support large spherical meshes.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
