### PR TITLE
Clean up RPE analysis step and framework

### DIFF
--- a/polaris/ocean/tasks/baroclinic_channel/baroclinic_channel.cfg
+++ b/polaris/ocean/tasks/baroclinic_channel/baroclinic_channel.cfg
@@ -37,9 +37,6 @@ btr_dt_per_km = 1.5
 # or fractions. False means fractions.
 use_distances = False
 
-# Viscosity values to test for rpe test case
-viscosities = 1, 5, 10, 20, 200
-
 # Temperature of the surface in the northern half of the domain.
 surface_temperature = 13.1
 
@@ -63,3 +60,17 @@ salinity = 35.0
 
 # Coriolis parameter for entire domain.
 coriolis_parameter = -1.2e-4
+
+
+# config options for the baroclinic channel RPE tasks
+[baroclinic_channel_rpe]
+
+# Viscosity values to test for rpe test case
+viscosities = 1.0, 5.0, 10.0, 20.0, 200.0
+
+# plot time (days)
+plot_time = 20.0
+
+# min and max temperature range
+min_temp = 11.8
+max_temp = 13.0

--- a/polaris/ocean/tasks/baroclinic_channel/forward.py
+++ b/polaris/ocean/tasks/baroclinic_channel/forward.py
@@ -72,10 +72,6 @@ class Forward(OceanModelStep):
                          indir=indir, ntasks=ntasks, min_tasks=min_tasks,
                          openmp_threads=openmp_threads)
 
-        if nu is not None:
-            # update the viscosity to the requested value
-            self.add_model_config_options(options=dict(config_mom_del2=nu))
-
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
@@ -86,6 +82,11 @@ class Forward(OceanModelStep):
 
         self.add_yaml_file('polaris.ocean.tasks.baroclinic_channel',
                            'forward.yaml')
+
+        if nu is not None:
+            # update the viscosity to the requested value *after* loading
+            # forward.yaml
+            self.add_model_config_options(options=dict(config_mom_del2=nu))
 
         self.add_output_file(
             filename='output.nc',

--- a/polaris/ocean/tasks/baroclinic_channel/rpe/__init__.py
+++ b/polaris/ocean/tasks/baroclinic_channel/rpe/__init__.py
@@ -68,7 +68,8 @@ class Rpe(Task):
         component = self.component
         resolution = self.resolution
 
-        nus = config.getlist('baroclinic_channel', 'viscosities', dtype=float)
+        nus = config.getlist('baroclinic_channel_rpe', 'viscosities',
+                             dtype=float)
         for nu in nus:
             name = f'nu_{nu:g}'
             step = Forward(

--- a/polaris/ocean/tasks/baroclinic_channel/rpe/analysis.py
+++ b/polaris/ocean/tasks/baroclinic_channel/rpe/analysis.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 from polaris import Step
 from polaris.ocean.rpe import compute_rpe
+from polaris.viz import plot_horiz_field
 
 
 class Analysis(Step):
@@ -38,7 +39,11 @@ class Analysis(Step):
         self.nus = nus
 
         self.add_input_file(
-            filename='initial_state.nc',
+            filename='mesh.nc',
+            target='../../init/culled_mesh.nc')
+
+        self.add_input_file(
+            filename='init.nc',
             target='../../init/initial_state.nc')
 
         for nu in nus:
@@ -55,100 +60,53 @@ class Analysis(Step):
         """
         Run this step of the test case
         """
-        section = self.config['baroclinic_channel']
-        lx = section.getfloat('lx')
-        ly = section.getfloat('ly')
-        init_filename = self.inputs[0]
-        rpe = compute_rpe(initial_state_file_name=init_filename,
-                          output_files=self.inputs[1:])
-        with xr.open_dataset(init_filename) as ds_init:
-            nx = ds_init.attrs['nx']
-            ny = ds_init.attrs['ny']
-        _plot(nx, ny, lx, ly, self.outputs[0], self.nus, rpe)
+        mesh_filename = 'mesh.nc'
+        init_filename = 'init.nc'
+        output_filename = self.outputs[0]
+        nus = self.nus
+        section = self.config['baroclinic_channel_rpe']
 
+        rpe = compute_rpe(mesh_filename=mesh_filename,
+                          initial_state_filename=init_filename,
+                          output_filenames=self.inputs[2:])
 
-def _plot(nx, ny, lx, ly, filename, nus, rpe):
-    """
-    Plot section of the baroclinic channel at different viscosities
+        plt.switch_backend('Agg')
+        sim_count = len(nus)
+        time = section.getfloat('plot_time')
+        min_temp = section.getfloat('min_temp')
+        max_temp = section.getfloat('max_temp')
 
-    Parameters
-    ----------
-    nx : int
-        The number of cells in the x direction
-
-    ny : int
-        The number of cells in the y direction (before culling)
-
-    lx : float
-        The size of the domain in km in the x direction
-
-    ly : int
-        The size of the domain in km in the y direction
-
-    filename : str
-        The output file name
-
-    nus : list
-        The viscosity values
-
-    rpe : numpy.ndarray
-        The reference potential energy with size len(nu) x len(time)
-    """
-
-    plt.switch_backend('Agg')
-    num_files = len(nus)
-    time = 20
-
-    ds = xr.open_dataset(f'output_nu_{nus[0]:g}.nc', decode_times=False)
-    times = ds.daysSinceStartOfSim.values
-
-    fig = plt.figure()
-    for i in range(num_files):
-        rpe_norm = np.divide((rpe[i, :] - rpe[i, 0]), rpe[i, 0])
-        plt.plot(times, rpe_norm,
-                 label=f"$\\nu_h=${nus[i]}")
-    plt.xlabel('Time, days')
-    plt.ylabel('RPE-RPE(0)/RPE(0)')
-    plt.legend()
-    plt.savefig('rpe_t.png')
-    plt.close(fig)
-
-    fig, axs = plt.subplots(1, num_files, figsize=(
-        2.1 * num_files, 5.0), constrained_layout=True)
-
-    # ***NOTE***: This is a quick-and-dirty plotting technique for regular
-    # planar hex meshes that we do not recommend adopting in other tasks
-    for iCol, nu in enumerate(nus):
-        ds = xr.open_dataset(f'output_nu_{nu:g}.nc', decode_times=False)
+        ds = xr.open_dataset(f'output_nu_{nus[0]:g}.nc', decode_times=False)
         times = ds.daysSinceStartOfSim.values
-        time_index = np.argmin(np.abs(times - time))
-        var = ds.temperature.values
-        var1 = np.reshape(var[time_index, :, 0], [ny, nx])
-        # flip in y-dir
-        var = np.flipud(var1)
 
-        # Every other row in y needs to average two neighbors in x on
-        # planar hex mesh
-        var_avg = var
-        for j in range(0, ny, 2):
-            for i in range(1, nx - 2):
-                var_avg[j, i] = (var[j, i + 1] + var[j, i]) / 2.0
+        fig = plt.figure()
+        for i in range(sim_count):
+            rpe_norm = np.divide((rpe[i, :] - rpe[i, 0]), rpe[i, 0])
+            plt.plot(times, rpe_norm, label=f'$\\nu_h=${nus[i]}')
+        plt.xlabel('Time, days')
+        plt.ylabel('RPE-RPE(0)/RPE(0)')
+        plt.legend()
+        plt.savefig('rpe_t.png')
+        plt.close(fig)
 
-        ax = axs[iCol]
-        dis = ax.imshow(
-            var_avg,
-            extent=[0, lx, 0, ly],
-            cmap='cmo.thermal',
-            vmin=11.8,
-            vmax=13.0)
-        ax.set_title(f'day {times[time_index]}, '
-                     f'$\\nu_h=${nus[iCol]}')
-        ax.set_xticks(np.linspace(0, lx, 5))
-        ax.set_yticks(np.arange(0, ly, 11))
+        ds_mesh = xr.open_dataset(mesh_filename)
+        ds_init = xr.open_dataset(init_filename)
 
-        ax.set_xlabel('x, km')
-        if iCol == 0:
-            ax.set_ylabel('y, km')
-        if iCol == num_files - 1:
-            fig.colorbar(dis, ax=axs[num_files - 1], aspect=40)
-    plt.savefig(filename)
+        fig, axes = plt.subplots(1, sim_count, figsize=(
+            3 * sim_count, 5.0), constrained_layout=True)
+
+        for row_index, nu in enumerate(nus):
+            ax = axes[row_index]
+            ds = xr.open_dataset(f'output_nu_{nu:g}.nc', decode_times=False)
+            ds = ds.isel(nVertLevels=0)
+            ds['maxLevelCell'] = ds_init.maxLevelCell
+            times = ds.daysSinceStartOfSim.values
+            time_index = np.argmin(np.abs(times - time))
+
+            plot_horiz_field(ds, ds_mesh, 'temperature', ax=ax,
+                             cmap='cmo.thermal', t_index=time_index,
+                             vmin=min_temp, vmax=max_temp,
+                             cmap_title='SST (C)')
+            ax.set_title(f'day {times[time_index]:g}, $\\nu_h=${nu:g}')
+
+        plt.savefig(output_filename)

--- a/polaris/ocean/tasks/cosine_bell/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/__init__.py
@@ -78,6 +78,8 @@ class CosineBell(Task):
         super().configure()
         config = self.config
         config.add_from_package('polaris.mesh', 'mesh.cfg')
+        config.add_from_package('polaris.ocean.tasks.cosine_bell',
+                                'cosine_bell.cfg')
 
         # set up the steps again in case a user has provided new resolutions
         self._setup_steps(config)

--- a/polaris/ocean/tasks/cosine_bell/analysis.py
+++ b/polaris/ocean/tasks/cosine_bell/analysis.py
@@ -9,7 +9,7 @@ from polaris import Step
 
 class Analysis(Step):
     """
-    A step for visualizing the output from the cosine bell test case
+    A step for analyzing the output from the cosine bell test case
 
     Attributes
     ----------


### PR DESCRIPTION
Rather than using some iffy custom plotting techniques, this uses the framework `plot_horiz_field()` function.

This merge also fix a bug in the placement of `nu` being added to model config options.  Before this fix, the `forward.yaml` options were overwriting the `nu` value so all RPE runs used the same viscosity.  This problem was introduced in the initial port of baroclinic channel (https://github.com/E3SM-Project/polaris/commit/875e7fe6b6e3a34939adeacb4594ab9e07ec5f17) but apparently after initial testing showed that it worked as expected.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
