### PR TITLE
Updates for pyremap >= 1.1.0

### DIFF
--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -31,7 +31,7 @@ otps={{ otps }}
 progressbar2
 pyamg>=4.2.2
 pyproj
-pyremap>=1.0.0,<2.0.0
+pyremap>=1.1.0,<2.0.0
 ruamel.yaml
 requests
 scipy>=1.8.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

We need to make a few changes to remapping to take advantage of pyremap 1.1.0 and later.  This merge switches to only using SCRIP, not ESMF, format in anticipation of adding `mbtempest` support.  It uses the new mesh descriptors for cell and vertex meshes.

Some bugs in projection and point descriptor support have also been fixed.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
