### PR TITLE
Clean up and add method to spherical convergence analysis

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -285,6 +285,18 @@ seaice/api
    make_graph_file
 ```
 
+### mpas
+
+```{eval-rst}
+.. currentmodule:: polaris.mpas
+
+.. autosummary::
+   :toctree: generated/
+   
+   area_for_field
+   time_index_from_xtime
+```
+
 ### namelist
 
 ```{eval-rst}

--- a/docs/developers_guide/framework/index.md
+++ b/docs/developers_guide/framework/index.md
@@ -19,6 +19,7 @@ config
 logging
 io
 mesh
+mpas
 model
 provenance
 remapping

--- a/docs/developers_guide/framework/mpas.md
+++ b/docs/developers_guide/framework/mpas.md
@@ -1,0 +1,58 @@
+(dev-mpas)=
+
+# MPAS
+
+The module `polaris.mpas` has some helper functions that are handy for
+working with output from MPAS components.
+
+## Area
+
+The function {py:func}`polaris.mpas.area_for_field()` is handy for getting
+the right area (on cells, edges or vertices) associated with a given field in 
+an MPAS output file.  This function determines from the dimensions of the
+given field which area is appropriate.  This is useful in computing
+integrals or other area-weighted statistics.
+
+Example usage in an error calculation:
+
+```python
+import numpy as np
+import xarray as xr
+from polaris.mpas import area_for_field
+
+
+def compute_error(field_exact, field_mpas, mesh_filename):
+    ds_mesh = xr.open_dataset(mesh_filename)
+    
+    diff = field_exact - field_mpas
+    area = area_for_field(ds_mesh, diff)
+    total_area = np.sum(area)
+    den_l2 = np.sum(field_exact**2 * area) / total_area
+    num_l2 = np.sum(diff**2 * area) / total_area
+    error = np.sqrt(num_l2) / np.sqrt(den_l2)
+    return error
+```
+
+## Time
+
+The function {py:func}`polaris.mpas.time_index_from_xtime()` can be used to
+find the time index closest to a requested time interval in seconds from a 
+given start time.  The default start time is the first time in the array of
+`xtime` values, but a different string can be supplied instead (e.g. if the
+start time isn't included in the output file).
+
+Example usage for extracting a field at a given time from an MPAS output file:
+
+```python
+import xarray as xr
+from polaris.mpas import time_index_from_xtime
+
+
+def get_output_field(field_name, time, output_filename):
+    ds_out = xr.open_dataset(output_filename)
+
+    time_index = time_index_from_xtime(ds_out.xtime.values, time)
+    ds_out = ds_out.isel(Time=time_index)
+    field_mpas = ds_out[field_name]
+    return field_mpas
+```

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -182,6 +182,7 @@
    SphericalConvergenceAnalysis.compute_error
    SphericalConvergenceAnalysis.convergence_parameters
    SphericalConvergenceAnalysis.exact_solution
+   SphericalConvergenceAnalysis.get_output_field
    SphericalConvergenceAnalysis.run
    SphericalConvergenceAnalysis.plot_convergence
 ```

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -368,10 +368,17 @@ class Analysis(SphericalConvergenceAnalysis):
                          convergence_vars=convergence_vars)
 ```
 
-Many tasks will also need to override the `exact_solution` method given in
-{py:class}`polaris.ocean.convergence.spherical.SphericalConvergenceAnalysis`.
-If not overridden, the analysis step will compute the difference of the output
-from the initial state.
+Many tasks will also need to override the 
+{py:meth}`polaris.ocean.convergence.spherical.SphericalConvergenceAnalysis.exact_solution()` 
+method. If not overridden, the analysis step will compute the difference of the 
+output from the initial state.
+
+In some cases, the child class will also need to override the 
+{py:meth}`polaris.ocean.convergence.spherical.SphericalConvergenceAnalysis.get_output_field()`
+method if the requested field is not available directly from the output put
+rather needs to be computed.  The default behavior is to read the requested
+variable (the value associate the `'name'` key) at the time index closest to
+the evaluation time specified by the `convergence_eval_time` config option.
 
 (dev-ocean-framework-vertical)=
 

--- a/polaris/mpas/__init__.py
+++ b/polaris/mpas/__init__.py
@@ -1,0 +1,2 @@
+from polaris.mpas.area import area_for_field
+from polaris.mpas.time import time_index_from_xtime

--- a/polaris/mpas/area.py
+++ b/polaris/mpas/area.py
@@ -1,0 +1,38 @@
+import xarray as xr
+
+
+def area_for_field(ds_mesh, field):
+    """
+    Get the appropriate area (on cells, vertices or edges) for the given
+    field
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        The MPAS mesh
+
+    field : xarray.DataArray
+        The field whose dimensions determine which area to return
+
+    Returns
+    -------
+    area : xarray.DataArray
+        The area on cells, vertices or edges
+    """
+    if 'nCells' in field.dims:
+        area = ds_mesh.areaCell
+    elif 'nEdges' in field.dims:
+        area = 0.25 * ds_mesh.dcEdge * ds_mesh.dvEdge
+    elif 'nVertices' in field.dims:
+        vertex_degree = ds_mesh.sizes['vertexDegree']
+        area = xr.zeros_like(ds_mesh.xVertex)
+        for ivert in range(vertex_degree):
+            cov = ds_mesh.cellsOnVertex.isel(vertexDegree=ivert) - 1
+            mask = cov >= 0
+            kite_area = ds_mesh.kiteAreasOnVertex.isel(vertexDegree=ivert)
+            area = area + kite_area.where(mask, other=0.)
+    else:
+        raise ValueError('The field does not have any of the expected '
+                         'horizontal dimensions for an MPAS mesh')
+
+    return area

--- a/polaris/mpas/time.py
+++ b/polaris/mpas/time.py
@@ -1,0 +1,36 @@
+import datetime
+
+import numpy as np
+
+
+def time_index_from_xtime(xtime, dt_target, start_xtime=None):
+    """
+    Determine the time index closest to the target time
+
+    Parameters
+    ----------
+    xtime : numpy.ndarray of numpy.char
+        Times in the dataset
+
+    dt_target : float
+        Time in seconds since the first time in the list of ``xtime`` values
+
+    start_xtime : str, optional
+        The start time, the first entry in ``xtime`` by default
+
+    Returns
+    -------
+    time_index : int
+        Index in xtime that is closest to dt_target
+    """
+    if start_xtime is None:
+        start_xtime = xtime[0].decode()
+
+    t0 = datetime.datetime.strptime(start_xtime, '%Y-%m-%d_%H:%M:%S')
+    dt = np.zeros((len(xtime),))
+    for idx, xt in enumerate(xtime):
+        t = datetime.datetime.strptime(xt.decode(),
+                                       '%Y-%m-%d_%H:%M:%S')
+        dt[idx] = (t - t0).total_seconds()
+    time_index = np.argmin(np.abs(np.subtract(dt, dt_target)))
+    return time_index

--- a/polaris/ocean/convergence/spherical/analysis.py
+++ b/polaris/ocean/convergence/spherical/analysis.py
@@ -6,7 +6,7 @@ import pandas as pd
 import xarray as xr
 
 from polaris import Step
-from polaris.mpas import time_index_from_xtime
+from polaris.mpas import area_for_field, time_index_from_xtime
 from polaris.ocean.resolution import resolution_to_subdir
 from polaris.viz import use_mplstyle
 
@@ -305,10 +305,10 @@ class SphericalConvergenceAnalysis(Step):
         diff = field_exact - field_mpas
 
         if error_type == 'l2':
-            area_cell = ds_mesh.areaCell.values
-            total_area = np.sum(area_cell)
-            den_l2 = np.sum(field_exact**2 * area_cell) / total_area
-            num_l2 = np.sum(diff**2 * area_cell) / total_area
+            area = area_for_field(ds_mesh, diff)
+            total_area = np.sum(area)
+            den_l2 = np.sum(field_exact**2 * area) / total_area
+            num_l2 = np.sum(diff**2 * area) / total_area
             error = np.sqrt(num_l2) / np.sqrt(den_l2)
         elif error_type == 'inf':
             error = np.amax(diff) / np.amax(np.abs(field_exact))

--- a/polaris/ocean/convergence/spherical/analysis.py
+++ b/polaris/ocean/convergence/spherical/analysis.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 
 import matplotlib.pyplot as plt
@@ -7,6 +6,7 @@ import pandas as pd
 import xarray as xr
 
 from polaris import Step
+from polaris.mpas import time_index_from_xtime
 from polaris.ocean.resolution import resolution_to_subdir
 from polaris.viz import use_mplstyle
 
@@ -292,8 +292,8 @@ class SphericalConvergenceAnalysis(Step):
         section = config['spherical_convergence']
         eval_time = section.getfloat('convergence_eval_time')
         s_per_day = 86400.0
-        tidx = _time_index_from_xtime(ds_out.xtime.values,
-                                      eval_time * s_per_day)
+        tidx = time_index_from_xtime(ds_out.xtime.values,
+                                     eval_time * s_per_day)
         ds_out = ds_out.isel(Time=tidx)
 
         if zidx is not None:
@@ -376,30 +376,3 @@ class SphericalConvergenceAnalysis(Step):
         conv_thresh = section.getfloat('convergence_thresh')
         error_type = section.get('error_type')
         return conv_thresh, error_type
-
-
-def _time_index_from_xtime(xtime, dt_target):
-    """
-    Determine the time index at which to evaluate convergence
-
-    Parameters
-    ----------
-    xtime : list of str
-        Times in the dataset
-
-    dt_target : float
-        Time in seconds at which to evaluate convergence
-
-    Returns
-    -------
-    tidx : int
-        Index in xtime that is closest to dt_target
-    """
-    t0 = datetime.datetime.strptime(xtime[0].decode(),
-                                    '%Y-%m-%d_%H:%M:%S')
-    dt = np.zeros((len(xtime)))
-    for idx, xt in enumerate(xtime):
-        t = datetime.datetime.strptime(xt.decode(),
-                                       '%Y-%m-%d_%H:%M:%S')
-        dt[idx] = (t - t0).total_seconds()
-    return np.argmin(np.abs(np.subtract(dt, dt_target)))


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge adds a `polaris.mpas` module that has:
* an `area` module that currently has a function `area_for_field()` for computing the area associated with a given data array from and MPAS output file.  This is useful for getting different areas for fields on cells, edges and vertices.
* a `time` module where I have moved `time_index_from_xtime()`.  I also added an optional `start_xtime` argument in case the start time isn't written to the output file.
`SphericalConvergenceAnalysis` has been updated to use these.

This merge also adds a `get_output_field()` method to `SphericalConvergenceAnalysis` that can be overridden to compute fields based on MPAS output. This is useful, for example, in #120, where I need to compute the water column thickness (not an output variable from MPAS-Ocean) based on the `ssh` and `bottomDepth` variables.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
