### PR TITLE
Only print task baseline status if basline compared

### DIFF
--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -335,16 +335,21 @@ def _log_and_run_task(task, stdout_logger, task_logger, quiet,
         status = f'  task execution:   {run_status}'
         if task_pass:
             stdout_logger.info(status)
-            if baselines_passed:
-                baseline_str = pass_str
+            if baselines_passed is None:
                 result_str = pass_str
                 success = True
             else:
-                baseline_str = fail_str
-                result_str = fail_str
-                success = False
-            status = f'  baseline comp.:   {baseline_str}'
-            stdout_logger.info(status)
+                if baselines_passed:
+                    baseline_str = pass_str
+                    result_str = pass_str
+                    success = True
+                else:
+                    baseline_str = fail_str
+                    result_str = fail_str
+                    success = False
+                status = f'  baseline comp.:   {baseline_str}'
+                stdout_logger.info(status)
+
         else:
             stdout_logger.error(status)
             if not is_task:
@@ -367,7 +372,7 @@ def _run_task(task, available_resources):
     """
     logger = task.logger
     cwd = os.getcwd()
-    baselines_passed = True
+    baselines_passed = None
     for step_name in task.steps_to_run:
         step = task.steps[step_name]
         complete_filename = os.path.join(step.work_dir,
@@ -419,7 +424,9 @@ def _run_task(task, available_resources):
                 baseline_str = fail_str
             _print_to_stdout(task,
                              f'          baseline comp.:   {baseline_str}')
-            if not status:
+            if baselines_passed is None:
+                baselines_passed = status
+            elif not status:
                 baselines_passed = False
 
         _print_to_stdout(task,


### PR DESCRIPTION
Before this merge, we were incorrectly printing a message that baselines passed when no baseline comparison was made.  With this fix, a message about baselines is only printed if baseline comparisons were performed.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
closes #132 