### PR TITLE
Fix conversion to absolute paths in config files

### DIFF
--- a/polaris/config.py
+++ b/polaris/config.py
@@ -71,5 +71,8 @@ class PolarisConfigParser(MpasConfigParser):
             if not config.has_section(section):
                 continue
             for option, value in config.items(section):
-                value = os.path.abspath(value)
-                config.set(section, option, value)
+                # not safe to make paths that start with other config options
+                # into absolute paths
+                if not value.startswith('$'):
+                    value = os.path.abspath(value)
+                    config.set(section, option, value)


### PR DESCRIPTION
We don't want to do this for config options that start with other config options.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
