### PR TITLE
Set config.filepath after loading new config options

### DIFF
--- a/polaris/run/__init__.py
+++ b/polaris/run/__init__.py
@@ -31,22 +31,32 @@ def unpickle_suite(suite_name):
     return test_suite
 
 
-def setup_config(config_filename):
+def setup_config(base_work_dir, component_name, config_filepath):
     """
     Set up the config object from the config file
 
     Parameters
     ----------
-    config_filename : str
-        The config filename
+    base_work_dir : str
+        The base work directory where suites and tasks are being set up
+
+    component_name : str
+        The component the config belongs to
+
+
+    config_filepath : str
+        The path to the config file within the component's work directory
 
     Returns
     -------
     config : polaris.config.PolarisConfigParser
         The config object
     """
+    config_filename = os.path.join(base_work_dir, component_name,
+                                   config_filepath)
     config = PolarisConfigParser()
     config.add_from_file(config_filename)
+    config.filepath = config_filepath
     return config
 
 

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -66,9 +66,9 @@ def run_tasks(suite_name, quiet=False, is_task=False, steps_to_run=None,
     # get the config file for the first task in the suite
     task = next(iter(suite['tasks'].values()))
     component = task.component
-    config_filename = \
-        f'{task.base_work_dir}/{component.name}/{component.name}.cfg'
-    common_config = setup_config(config_filename)
+    common_config = setup_config(task.base_work_dir,
+                                 component.name,
+                                 f'{component.name}.cfg')
     available_resources = get_available_parallel_resources(common_config)
 
     # start logging to stdout/stderr
@@ -140,10 +140,9 @@ def run_single_step(step_is_subprocess=False, quiet=False):
     if step_is_subprocess:
         step.run_as_subprocess = False
 
-    config_filename = os.path.join(step.base_work_dir,
-                                   step.component.name,
-                                   step.config.filepath)
-    config = setup_config(config_filename)
+    config = setup_config(step.base_work_dir,
+                          step.component.name,
+                          step.config.filepath)
     task.config = config
     available_resources = get_available_parallel_resources(config)
     set_cores_per_node(task.config, available_resources['cores_per_node'])
@@ -302,10 +301,9 @@ def _log_and_run_task(task, stdout_logger, task_logger, quiet,
 
         os.chdir(task.work_dir)
 
-        config_filename = os.path.join(task.base_work_dir,
-                                       task.component.name,
-                                       task.config.filepath)
-        config = setup_config(config_filename)
+        config = setup_config(task.base_work_dir,
+                              task.component.name,
+                              task.config.filepath)
         task.config = config
         set_cores_per_node(task.config,
                            available_resources['cores_per_node'])
@@ -389,11 +387,9 @@ def _run_task(task, available_resources):
 
         step_start = time.time()
 
-        config_filename = os.path.join(step.base_work_dir,
-                                       step.component.name,
-                                       step.config.filepath)
-
-        step.config = setup_config(config_filename)
+        step.config = setup_config(step.base_work_dir,
+                                   step.component.name,
+                                   step.config.filepath)
         if task.log_filename is not None:
             step_log_filename = task.log_filename
         else:


### PR DESCRIPTION
Before this merge, we were not setting a config's `filepath` attribute after loading the config options from a file.  This causes the step to fail for cryptic reasons if it is rerun later as part of a test suite (because it failed the first time).

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
