### PR TITLE
Use Separate geostrophic thresholds for h and norm. vel.

### DIFF
--- a/docs/users_guide/ocean/tasks/geostrophic.md
+++ b/docs/users_guide/ocean/tasks/geostrophic.md
@@ -166,18 +166,23 @@ These are the basic constants used to initialize the test case according to
 the Williams et al. (1992) paper.  The temperature and salinity are arbitrary,
 since they do not vary in space and should not affect the evolution.
 
-Two additional config options relate to detecting when the convergence rate of 
-the test (using the L2 norm to compute the error) is unexpectedly low, which 
-raises an error:
+Three additional config options relate to detecting when the convergence rate
+for the water-column thickness (h) and normal velocity (using the L2 norm to 
+compute the error).  If either convergence rate is unexpectedly low an error is
+raised:
 ```cfg
 # config options for convergence tests
 [convergence]
 
-# Convergence threshold below which a test fails
-convergence_thresh = 0.4
-
 # Type of error to compute
 error_type = l2
+
+# options for geostrophic convergence test case
+[geostrophic]
+
+# convergence threshold below which the test fails
+convergence_thresh_h = 0.4
+convergence_thresh_normalVelocity = 1.3
 ```
 
 The convergence rate of the water-column thickness for this test case is very

--- a/polaris/ocean/tasks/geostrophic/analysis.py
+++ b/polaris/ocean/tasks/geostrophic/analysis.py
@@ -128,3 +128,27 @@ class Analysis(ConvergenceAnalysis):
                                            time=time, zidx=None)
             h = ssh + bottom_depth
             return h
+
+    def convergence_parameters(self, field_name=None):
+        """
+        Get convergence parameters
+
+        Parameters
+        ----------
+        field_name : str
+            The name of the variable of which we evaluate convergence
+            For cosine_bell, we use the same convergence rate for all fields
+        Returns
+        -------
+        conv_thresh: float
+            The minimum convergence rate
+
+        conv_thresh: float
+            The maximum convergence rate
+        """
+        config = self.config
+        conv_thresh = config.getfloat('geostrophic',
+                                      f'convergence_thresh_{field_name}')
+        error_type = config.get('convergence', 'error_type')
+
+        return conv_thresh, error_type

--- a/polaris/ocean/tasks/geostrophic/geostrophic.cfg
+++ b/polaris/ocean/tasks/geostrophic/geostrophic.cfg
@@ -19,9 +19,6 @@ coord_type = z-star
 # Evaluation time for convergence analysis (in hours)
 convergence_eval_time = 120.0
 
-# Convergence threshold below which a test fails
-convergence_thresh = 0.4
-
 # Type of error to compute
 error_type = l2
 
@@ -53,6 +50,10 @@ temperature = 15.0
 
 # the constant salinity of the domain
 salinity = 35.0
+
+# convergence threshold below which the test fails
+convergence_thresh_h = 0.4
+convergence_thresh_normalVelocity = 1.3
 
 
 # options for visualization for the geostrophic convergence test case


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

We want to have a higher threshold on velocity convergence since it is better behaved than water-column thickness.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
