### PR TITLE
Drop python 3.8

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master

--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -2,7 +2,7 @@
 # $ conda create --name <env> --file <this file>
 
 # Base
-python>=3.8
+python>=3.9,<3.12
 cartopy
 cartopy_offlinedata
 cmocean

--- a/polaris/cache.py
+++ b/polaris/cache.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib.resources as imp_res
 import json
 import os
 import pickle
@@ -9,7 +10,6 @@ from typing import Dict, List
 
 from polaris import Step
 from polaris.config import PolarisConfigParser
-from polaris.io import imp_res
 
 
 def update_cache(step_paths, date_string=None, dry_run=False):

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -1,6 +1,5 @@
+import importlib.resources as imp_res
 import json
-
-from polaris.io import imp_res
 
 
 class Component:

--- a/polaris/io.py
+++ b/polaris/io.py
@@ -1,14 +1,6 @@
 import os
-import sys
 import tempfile
-from typing import TYPE_CHECKING  # noqa: F401
 from urllib.parse import urlparse
-
-if TYPE_CHECKING or sys.version_info >= (3, 9, 0):
-    import importlib.resources as imp_res  # noqa: F401
-else:
-    # python <= 3.8
-    import importlib_resources as imp_res  # noqa: F401
 
 import progressbar
 import requests

--- a/polaris/job/__init__.py
+++ b/polaris/job/__init__.py
@@ -1,9 +1,8 @@
+import importlib.resources as imp_res
 import os
 
 import numpy as np
 from jinja2 import Template
-
-from polaris.io import imp_res
 
 
 def write_job_script(config, machine, target_cores, min_cores, work_dir,

--- a/polaris/list.py
+++ b/polaris/list.py
@@ -1,10 +1,10 @@
 import argparse
+import importlib.resources as imp_res
 import os
 import re
 import sys
 
 from polaris.components import get_components
-from polaris.io import imp_res
 
 
 def list_cases(task_expr=None, number=None, verbose=False):

--- a/polaris/machines/__init__.py
+++ b/polaris/machines/__init__.py
@@ -1,13 +1,7 @@
+import importlib.resources as imp_res
 import os
 import socket
 import sys
-from typing import TYPE_CHECKING  # noqa: F401
-
-if TYPE_CHECKING or sys.version_info >= (3, 9, 0):
-    import importlib.resources as imp_res  # noqa: F401
-else:
-    # python <= 3.8
-    import importlib_resources as imp_res  # noqa: F401
 
 from mache import discover_machine as mache_discover_machine
 

--- a/polaris/namelist.py
+++ b/polaris/namelist.py
@@ -1,6 +1,5 @@
+import importlib.resources as imp_res
 from typing import Dict
-
-from polaris.io import imp_res
 
 
 def parse_replacements(package, namelist):

--- a/polaris/ocean/vertical/grid_1d.py
+++ b/polaris/ocean/vertical/grid_1d.py
@@ -1,11 +1,10 @@
+import importlib.resources as imp_res
 import json
 
 import numpy
 import numpy as np
 from netCDF4 import Dataset
 from scipy.optimize import root_scalar
-
-from polaris.io import imp_res
 
 
 def generate_1d_grid(config):

--- a/polaris/seaice/tasks/single_column/standard_physics/viz.py
+++ b/polaris/seaice/tasks/single_column/standard_physics/viz.py
@@ -1,11 +1,4 @@
-import sys
-from typing import TYPE_CHECKING  # noqa: F401
-
-if TYPE_CHECKING or sys.version_info >= (3, 9, 0):
-    import importlib.resources as imp_res  # noqa: F401
-else:
-    # python <= 3.8
-    import importlib_resources as imp_res  # noqa: F401
+import importlib.resources as imp_res
 
 import matplotlib.pyplot as plt
 import xarray as xr

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -1,4 +1,5 @@
 import grp
+import importlib.resources as imp_res
 import logging
 import os
 import shutil
@@ -8,7 +9,7 @@ import progressbar
 from mache import MachineInfo
 
 from polaris.config import PolarisConfigParser
-from polaris.io import download, imp_res, symlink
+from polaris.io import download, symlink
 from polaris.validate import compare_variables
 
 

--- a/polaris/streams.py
+++ b/polaris/streams.py
@@ -1,9 +1,8 @@
+import importlib.resources as imp_res
 from copy import deepcopy
 
 from jinja2 import Template
 from lxml import etree
-
-from polaris.io import imp_res
 
 
 def read(package, streams_filename, tree=None, replacements=None):

--- a/polaris/suite.py
+++ b/polaris/suite.py
@@ -1,8 +1,8 @@
 import argparse
+import importlib.resources as imp_res
 import sys
 from typing import List
 
-from polaris.io import imp_res
 from polaris.setup import setup_tasks
 
 

--- a/polaris/viz/style.py
+++ b/polaris/viz/style.py
@@ -1,11 +1,4 @@
-import sys
-from typing import TYPE_CHECKING  # noqa: F401
-
-if TYPE_CHECKING or sys.version_info >= (3, 9, 0):
-    import importlib.resources as imp_res  # noqa: F401
-else:
-    # python <= 3.8
-    import importlib_resources as imp_res  # noqa: F401
+import importlib.resources as imp_res
 
 import matplotlib.pyplot as plt
 

--- a/polaris/yaml.py
+++ b/polaris/yaml.py
@@ -1,12 +1,11 @@
 import argparse
+import importlib.resources as imp_res
 from collections import OrderedDict
 from typing import Dict
 
 from jinja2 import Template
 from lxml import etree
 from ruamel.yaml import YAML
-
-from polaris.io import imp_res
 
 
 class PolarisYaml:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ project_urls =
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -22,7 +21,7 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.8,<3.12
+python_requires = >=3.9,<3.12
 install_requires =
     cartopy
     cmocean


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge drop support for python 3.8 in deployment and CI, since it is nearing end of life and is giving us a headache.

This allows us to drop a bunch of `importlib.resources` special cases that were for handling python 3.8.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
