### PR TITLE
Clean up `plot_horiz_field()`

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -219,7 +219,6 @@ seaice/api
 
    download
    symlink
-   imp_res
 ```
 
 ### job

--- a/polaris/ocean/tasks/manufactured_solution/viz.py
+++ b/polaris/ocean/tasks/manufactured_solution/viz.py
@@ -72,9 +72,10 @@ class Viz(Step):
         rmse = []
         error_range = None
         for i, res in enumerate(resolutions):
-            ds_mesh = xr.open_dataset(f'mesh_{res}km.nc')
-            ds_init = xr.open_dataset(f'init_{res}km.nc')
-            ds = xr.open_dataset(f'output_{res}km.nc')
+            mesh_name = resolution_to_subdir(res)
+            ds_mesh = xr.open_dataset(f'mesh_{mesh_name}.nc')
+            ds_init = xr.open_dataset(f'init_{mesh_name}.nc')
+            ds = xr.open_dataset(f'output_{mesh_name}.nc')
             ds['maxLevelCell'] = ds_init.maxLevelCell
             exact = ExactSolution(config, ds_init)
 

--- a/polaris/viz/planar.py
+++ b/polaris/viz/planar.py
@@ -14,7 +14,7 @@ def plot_horiz_field(ds, ds_mesh, field_name, out_file_name=None,  # noqa: C901
                      ax=None, title=None, t_index=None, z_index=None,
                      vmin=None, vmax=None, show_patch_edges=False,
                      cmap=None, cmap_set_under=None, cmap_set_over=None,
-                     cmap_scale='linear', cmap_title=None):
+                     cmap_scale='linear', cmap_title=None, figsize=None):
     """
     Plot a horizontal field from a planar domain using x,y coordinates at a
     single time and depth slice.
@@ -67,6 +67,10 @@ def plot_horiz_field(ds, ds_mesh, field_name, out_file_name=None,  # noqa: C901
 
     cmap_title : str
         Title for color bar
+
+    figsize : tuple
+        The width and height of the figure in inches. Default is determined
+        based on the aspect ratio of the domain.
     """
     use_mplstyle()
 
@@ -130,12 +134,13 @@ def plot_horiz_field(ds, ds_mesh, field_name, out_file_name=None,  # noqa: C901
         ocean_patches.set_norm(LogNorm(vmin=max(1e-10, vmin),
                                vmax=vmax, clip=False))
 
-    width = ds_mesh.xCell.max() - ds_mesh.xCell.min()
-    length = ds_mesh.yCell.max() - ds_mesh.yCell.min()
-    aspect_ratio = width.values / length.values
-    fig_width = 4
-    legend_width = fig_width / 5
-    figsize = (fig_width + legend_width, fig_width / aspect_ratio)
+    if figsize is None:
+        width = ds_mesh.xCell.max() - ds_mesh.xCell.min()
+        length = ds_mesh.yCell.max() - ds_mesh.yCell.min()
+        aspect_ratio = width.values / length.values
+        fig_width = 4
+        legend_width = fig_width / 5
+        figsize = (fig_width + legend_width, fig_width / aspect_ratio)
 
     if create_fig:
         plt.figure(figsize=figsize)

--- a/polaris/viz/planar.py
+++ b/polaris/viz/planar.py
@@ -36,15 +36,22 @@ def plot_horiz_field(ds, ds_mesh, field_name, out_file_name=None,  # noqa: C901
     title: str, optional
         The title of the plot
 
-    vmin, vmax : float, optional
-        The minimum and maximum values for the colorbar
+    vmin : float, optional
+        The minimum values for the colorbar
+
+    vmax : float, optional
+        The maximum values for the colorbar
 
     show_patch_edges : boolean, optional
         If true, patches will be plotted with visible edges
 
-    t_index, z_index: int, optional
-        The indices of 'Time' and 'nVertLevels' axes to select for plotting
-        The default time index is 0 (initial time)
+    t_index: int, optional
+        The indices of ``Time`` axes to select for plotting. The default is 0
+        (initial time)
+
+    z_index: int, optional
+        The indices of ``nVertLevels`` axes to select for plotting. The default
+        is 0 (top level)
 
     cmap : Colormap or str, optional
         A color map to plot

--- a/polaris/viz/planar.py
+++ b/polaris/viz/planar.py
@@ -155,8 +155,7 @@ def plot_horiz_field(ds, ds_mesh, field_name, out_file_name=None,  # noqa: C901
         cbar.set_label(cmap_title)
     if create_fig:
         plt.title(title)
-        plt.tight_layout(pad=0.5)
-        plt.savefig(out_file_name)
+        plt.savefig(out_file_name, bbox_inches='tight', pad_inches=0.2)
         plt.close()
 
 

--- a/polaris/viz/planar.py
+++ b/polaris/viz/planar.py
@@ -13,8 +13,8 @@ from polaris.viz.style import use_mplstyle
 def plot_horiz_field(ds, ds_mesh, field_name, out_file_name=None,  # noqa: C901
                      ax=None, title=None, t_index=None, z_index=None,
                      vmin=None, vmax=None, show_patch_edges=False,
-                     cmap=None, cmap_set_under=None, cmap_scale='linear',
-                     cmap_title=None):
+                     cmap=None, cmap_set_under=None, cmap_set_over=None,
+                     cmap_scale='linear', cmap_title=None):
     """
     Plot a horizontal field from a planar domain using x,y coordinates at a
     single time and depth slice.
@@ -51,6 +51,9 @@ def plot_horiz_field(ds, ds_mesh, field_name, out_file_name=None,  # noqa: C901
 
     cmap_set_under : str or None, optional
         A color for low out-of-range values
+
+    cmap_set_over : str or None, optional
+        A color for upper out-of-range values
 
     cmap_scale : {'log', 'linear'}, optional
         Whether the colormap is logarithmic or linear
@@ -106,6 +109,9 @@ def plot_horiz_field(ds, ds_mesh, field_name, out_file_name=None,  # noqa: C901
     if cmap_set_under is not None:
         current_cmap = ocean_patches.get_cmap()
         current_cmap.set_under(cmap_set_under)
+    if cmap_set_over is not None:
+        current_cmap = ocean_patches.get_cmap()
+        current_cmap.set_over(cmap_set_over)
 
     if show_patch_edges:
         ocean_patches.set_edgecolor('black')


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge includes a few pieces of clean-up for `plot_horiz_field()` that came up while porting the ISOMIP+ initial condition.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
