### PR TITLE
Allow patches to be reused in `plot_horiz_field()`

### DIFF
--- a/docs/developers_guide/framework/visualization.md
+++ b/docs/developers_guide/framework/visualization.md
@@ -46,11 +46,42 @@ polygons characterized by the field values, accordingly.
 An example function call that uses the default vertical level (top) is:
 
 ```python
+cell_mask = ds_init.maxLevelCell >= 1
 plot_horiz_field(config, ds, ds_mesh, 'normalVelocity',
                  'final_normalVelocity.png',
                  t_index=t_index,
                  vmin=-max_velocity, vmax=max_velocity,
-                 cmap='cmo.balance', show_patch_edges=True)
+                 cmap='cmo.balance', show_patch_edges=True,
+                 cell_mask=cell_mask)
+```
+
+The `cell_mask` argument can be any field indicating which horizontal cells
+are valid and which are not.  A typical value for ocean plots is as shown 
+above: whether there are any active cells in the water column.
+
+For increased efficiency, you can store the `patches` and `patch_mask` from
+one call to `plot_horiz_field()` and reuse them in subsequent calls.  The
+`patches` and `patch_mask` are specific to the dimension (`nCell` or `nEdges`) 
+of the field to plot and the `cell_mask`.  So separate `patches` and 
+`patch_mask` variables should be stored for as needed:
+
+```python
+cell_mask = ds_init.maxLevelCell >= 1
+cell_patches, cell_patch_mask = plot_horiz_field(
+    ds=ds, ds_mesh=ds_mesh, field_name='ssh', out_file_name='plots/ssh.png',
+    vmin=-720, vmax=0, figsize=figsize, cell_mask=cell_mask)
+
+plot_horiz_field(ds=ds, ds_mesh=ds_mesh, field_name='bottomDepth', 
+                 out_file_name='plots/bottomDepth.png', vmin=0, vmax=720,
+                 figsize=figsize, patches=cell_patches, 
+                 patch_mask=cell_patch_mask)
+
+edge_patches, edge_patch_mask = plot_horiz_field(
+    ds=ds, ds_mesh=ds_mesh, field_name='normalVelocity', 
+    out_file_name='plots/normalVelocity.png', t_index=t_index, 
+    vmin=-0.1, vmax=0.1, cmap='cmo.balance', cell_mask=cell_mask)
+
+...
 ```
 
 (dev-visualization-global)=

--- a/polaris/ocean/tasks/baroclinic_channel/init.py
+++ b/polaris/ocean/tasks/baroclinic_channel/init.py
@@ -161,8 +161,9 @@ class Init(Step):
 
         write_netcdf(ds, 'initial_state.nc')
 
+        cell_mask = ds.maxLevelCell >= 1
         plot_horiz_field(ds, ds_mesh, 'temperature',
-                         'initial_temperature.png')
+                         'initial_temperature.png', cell_mask=cell_mask)
         plot_horiz_field(ds, ds_mesh, 'normalVelocity',
                          'initial_normal_velocity.png', cmap='cmo.balance',
-                         show_patch_edges=True)
+                         show_patch_edges=True, cell_mask=cell_mask)

--- a/polaris/ocean/tasks/baroclinic_channel/rpe/analysis.py
+++ b/polaris/ocean/tasks/baroclinic_channel/rpe/analysis.py
@@ -100,14 +100,14 @@ class Analysis(Step):
             ax = axes[row_index]
             ds = xr.open_dataset(f'output_nu_{nu:g}.nc', decode_times=False)
             ds = ds.isel(nVertLevels=0)
-            ds['maxLevelCell'] = ds_init.maxLevelCell
             times = ds.daysSinceStartOfSim.values
             time_index = np.argmin(np.abs(times - time))
 
+            cell_mask = ds_init.maxLevelCell >= 1
             plot_horiz_field(ds, ds_mesh, 'temperature', ax=ax,
                              cmap='cmo.thermal', t_index=time_index,
                              vmin=min_temp, vmax=max_temp,
-                             cmap_title='SST (C)')
+                             cmap_title='SST (C)', cell_mask=cell_mask)
             ax.set_title(f'day {times[time_index]:g}, $\\nu_h=${nu:g}')
 
         plt.savefig(output_filename)

--- a/polaris/ocean/tasks/baroclinic_channel/viz.py
+++ b/polaris/ocean/tasks/baroclinic_channel/viz.py
@@ -40,13 +40,15 @@ class Viz(Step):
         ds_mesh = xr.load_dataset('mesh.nc')
         ds_init = xr.load_dataset('init.nc')
         ds = xr.load_dataset('output.nc')
-        ds['maxLevelCell'] = ds_init.maxLevelCell
         t_index = ds.sizes['Time'] - 1
+        cell_mask = ds_init.maxLevelCell >= 1
         plot_horiz_field(ds, ds_mesh, 'temperature',
-                         'final_temperature.png', t_index=t_index)
+                         'final_temperature.png', t_index=t_index,
+                         cell_mask=cell_mask)
         max_velocity = np.max(np.abs(ds.normalVelocity.values))
         plot_horiz_field(ds, ds_mesh, 'normalVelocity',
                          'final_normalVelocity.png',
                          t_index=t_index,
                          vmin=-max_velocity, vmax=max_velocity,
-                         cmap='cmo.balance', show_patch_edges=True)
+                         cmap='cmo.balance', show_patch_edges=True,
+                         cell_mask=cell_mask)

--- a/polaris/ocean/tasks/inertial_gravity_wave/viz.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/viz.py
@@ -76,7 +76,6 @@ class Viz(Step):
             ds_mesh = xr.open_dataset(f'mesh_{mesh_name}.nc')
             ds_init = xr.open_dataset(f'init_{mesh_name}.nc')
             ds = xr.open_dataset(f'output_{mesh_name}.nc')
-            ds['maxLevelCell'] = ds_init.maxLevelCell
             exact = ExactSolution(ds_init, config)
 
             t0 = datetime.datetime.strptime(ds.xtime.values[0].decode(),
@@ -93,16 +92,20 @@ class Viz(Step):
             if error_range is None:
                 error_range = np.max(np.abs(ds.ssh_error.values))
 
-            plot_horiz_field(ds, ds_mesh, 'ssh', ax=axes[i, 0],
-                             cmap='cmo.balance', t_index=ds.sizes["Time"] - 1,
-                             vmin=-eta0, vmax=eta0, cmap_title="SSH (m)")
+            cell_mask = ds_init.maxLevelCell >= 1
+            patches, patch_mask = plot_horiz_field(
+                ds, ds_mesh, 'ssh', ax=axes[i, 0], cmap='cmo.balance',
+                t_index=ds.sizes["Time"] - 1, vmin=-eta0, vmax=eta0,
+                cmap_title="SSH (m)", cell_mask=cell_mask)
             plot_horiz_field(ds, ds_mesh, 'ssh_exact', ax=axes[i, 1],
                              cmap='cmo.balance',
-                             vmin=-eta0, vmax=eta0, cmap_title="SSH (m)")
+                             vmin=-eta0, vmax=eta0, cmap_title="SSH (m)",
+                             patches=patches, patch_mask=patch_mask)
             plot_horiz_field(ds, ds_mesh, 'ssh_error', ax=axes[i, 2],
                              cmap='cmo.balance',
                              cmap_title=r"$\Delta$ SSH (m)",
-                             vmin=-error_range, vmax=error_range)
+                             vmin=-error_range, vmax=error_range,
+                             patches=patches, patch_mask=patch_mask)
 
         axes[0, 0].set_title('Numerical solution')
         axes[0, 1].set_title('Analytical solution')

--- a/polaris/ocean/tasks/manufactured_solution/viz.py
+++ b/polaris/ocean/tasks/manufactured_solution/viz.py
@@ -76,7 +76,6 @@ class Viz(Step):
             ds_mesh = xr.open_dataset(f'mesh_{mesh_name}.nc')
             ds_init = xr.open_dataset(f'init_{mesh_name}.nc')
             ds = xr.open_dataset(f'output_{mesh_name}.nc')
-            ds['maxLevelCell'] = ds_init.maxLevelCell
             exact = ExactSolution(config, ds_init)
 
             t0 = datetime.datetime.strptime(ds.xtime.values[0].decode(),
@@ -93,15 +92,19 @@ class Viz(Step):
             if error_range is None:
                 error_range = np.max(np.abs(ds.ssh_error.values))
 
-            plot_horiz_field(ds, ds_mesh, 'ssh', ax=axes[i, 0],
-                             cmap='cmo.balance', t_index=ds.sizes["Time"] - 1,
-                             vmin=-eta0, vmax=eta0, cmap_title="SSH")
+            cell_mask = ds_init.maxLevelCell >= 1
+            patches, patch_mask = plot_horiz_field(
+                ds, ds_mesh, 'ssh', ax=axes[i, 0], cmap='cmo.balance',
+                t_index=ds.sizes["Time"] - 1, vmin=-eta0, vmax=eta0,
+                cmap_title="SSH", cell_mask=cell_mask)
             plot_horiz_field(ds, ds_mesh, 'ssh_exact', ax=axes[i, 1],
                              cmap='cmo.balance',
-                             vmin=-eta0, vmax=eta0, cmap_title="SSH")
+                             vmin=-eta0, vmax=eta0, cmap_title="SSH",
+                             patches=patches, patch_mask=patch_mask)
             plot_horiz_field(ds, ds_mesh, 'ssh_error', ax=axes[i, 2],
                              cmap='cmo.balance', cmap_title="dSSH",
-                             vmin=-error_range, vmax=error_range)
+                             vmin=-error_range, vmax=error_range,
+                             patches=patches, patch_mask=patch_mask)
 
         axes[0, 0].set_title('Numerical solution')
         axes[0, 1].set_title('Analytical solution')


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge returns `patches` and `patch_mask` variables from `plot_horiz_field()` so they can be reused in subsequent calls.  This should save a lot of time in tests that plot many fields.  Corresponding input arguments have been added to take  `patches` and `patch_mask`  from previous plots on the same mesh. 

**Note:** you need need to keep patches for cells and edges separate.

This merge also removes some ocean-specific variable and dimension names.  This because the function lives in the top-level framework so it should work for any component.  Instead of providing `maxLevelCell` in `ds`, the function needs to be called with a `cell_mask` argument that should typcially be `cell_mask = ds_init.maxLevelCell >= 1` (though it could be another field such as `landIceFloatingMaks` if appropriate).

All steps that call `plot_horiz_field()` have been updated to supply the `cell_mask` argument or to use `patches` and `patch_mask` from a previous call.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
