### PR TITLE
Workaround for z-star minimum number of vertical levels

### DIFF
--- a/docs/users_guide/ocean/framework/vertical.md
+++ b/docs/users_guide/ocean/framework/vertical.md
@@ -36,6 +36,12 @@ partial_cell_type = full
 
 # The minimum fraction of a layer for partial cells
 min_pc_fraction = 0.1
+
+# The minimum number of vertical levels for z-star coordinate
+min_vert_levels = 1
+
+# Minimum thickness of each layer for z-star coordinate
+min_layer_thickness = 0
 ```
 
 The vertical coordinate is typically defined based on a 1D reference grid.

--- a/polaris/ocean/ocean.cfg
+++ b/polaris/ocean/ocean.cfg
@@ -24,8 +24,8 @@ iterations = 10
 # Options related to the vertical grid
 [vertical_grid]
 
-# The minimum number of vertical levels for multi-layer cases
+# The minimum number of vertical levels for z-star coordinate
 min_vert_levels = 1
 
-# Minimum thickness of each layer
+# Minimum thickness of each layer for z-star coordinate
 min_layer_thickness = 0

--- a/polaris/ocean/ocean.cfg
+++ b/polaris/ocean/ocean.cfg
@@ -20,3 +20,12 @@ max_cells_per_core = 2000
 
 # the number of iterations of ssh adjustment to perform
 iterations = 10
+
+# Options related to the vertical grid
+[vertical_grid]
+
+# The minimum number of vertical levels for multi-layer cases
+min_vert_levels = 1
+
+# Minimum thickness of each layer
+min_layer_thickness = 0

--- a/polaris/ocean/vertical/zstar.py
+++ b/polaris/ocean/vertical/zstar.py
@@ -65,9 +65,14 @@ def init_z_star_vertical_coord(config, ds):
     ds['vertCoordMovementWeights'] = xarray.ones_like(ds.refBottomDepth)
 
     restingSSH = xarray.zeros_like(ds.bottomDepth)
+    min_vert_levels = config.getint('vertical_grid', 'min_vert_levels')
+    min_layer_thickness = config.getfloat('vertical_grid',
+                                          'min_layer_thickness')
     ds['minLevelCell'], ds['maxLevelCell'], ds['cellMask'] = \
         compute_min_max_level_cell(ds.refTopDepth, ds.refBottomDepth,
-                                   restingSSH, ds.bottomDepth)
+                                   restingSSH, ds.bottomDepth,
+                                   min_vert_levels=min_vert_levels,
+                                   min_layer_thickness=min_layer_thickness)
 
     ds['bottomDepth'], ds['maxLevelCell'] = alter_bottom_depth(
         config, ds.bottomDepth, ds.refBottomDepth, ds.maxLevelCell)
@@ -113,7 +118,8 @@ def _compute_z_star_layer_thickness(restingThickness, ssh, bottomDepth,
     nVertLevels = restingThickness.sizes['nVertLevels']
     layerThickness = []
 
-    layerStretch = (ssh + bottomDepth) / bottomDepth
+    layerStretch = (ssh + bottomDepth) / \
+        restingThickness.sum(dim='nVertLevels')
     for zIndex in range(nVertLevels):
         mask = numpy.logical_and(zIndex >= minLevelCell,
                                  zIndex <= maxLevelCell)


### PR DESCRIPTION
For MPAS-O configurations where tracers are active, we want a minimum of 3 vertical levels. This was not easy to enforce for z-star (or z-level) coordinates. This is one possible work-around for z-star coordinates which relies on new `min_vert_levels` and `min_layer_thickness` config options AND requires that the config option `bottom_depth` be set to less than or equal to `min(bottomDepth + ssh)` (but if less than this value, it may be that `min(maxLevelCell - minLevelCell + 1) > min_vert_levels`).

Checklist
* [X] User's Guide has been updated
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes