### PR TITLE
Add a version check to load script

### DIFF
--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -540,7 +540,8 @@ def set_ld_library_path(spack_branch_base, spack_env, logger):
 
 def write_load_polaris(template_path, activ_path, conda_base, env_type,
                        activ_suffix, prefix, env_name, spack_script, machine,
-                       env_vars, conda_env_only, source_path, without_openmp):
+                       env_vars, conda_env_only, source_path, without_openmp,
+                       polaris_version):
 
     try:
         os.makedirs(activ_path)
@@ -571,10 +572,6 @@ def write_load_polaris(template_path, activ_path, conda_base, env_type,
         env_vars = f'{env_vars}\n' \
                    f'export POLARIS_MACHINE={machine}'
 
-    if env_type == 'dev':
-        env_vars = f'{env_vars}\n' \
-                   f'export POLARIS_BRANCH={source_path}'
-
     filename = f'{template_path}/load_polaris.template'
     with open(filename, 'r') as f:
         template = Template(f.read())
@@ -599,7 +596,10 @@ def write_load_polaris(template_path, activ_path, conda_base, env_type,
     script = template.render(conda_base=conda_base, polaris_env=env_name,
                              env_vars=env_vars,
                              spack=spack_script,
-                             update_polaris=update_polaris)
+                             update_polaris=update_polaris,
+                             env_type=env_type,
+                             polaris_source_path=source_path,
+                             polaris_version=polaris_version)
 
     # strip out redundant blank lines
     lines = list()
@@ -1037,7 +1037,8 @@ def main():  # noqa: C901
         script_filename = write_load_polaris(
             conda_template_path, activ_path, conda_base, env_type,
             activ_suffix, prefix, conda_env_name, spack_script, machine,
-            env_vars, args.conda_env_only, source_path, args.without_openmp)
+            env_vars, args.conda_env_only, source_path, args.without_openmp,
+            polaris_version)
 
         if args.check:
             check_env(script_filename, conda_env_name, logger)

--- a/deploy/load_polaris.template
+++ b/deploy/load_polaris.template
@@ -1,3 +1,24 @@
+{% if env_type == 'dev' -%}
+export POLARIS_BRANCH="{{ polaris_source_path }}"
+export POLARIS_VERSION="{{ polaris_version }}"
+
+version_file="${POLARIS_BRANCH}/polaris/version.py"
+code_version=$(cat $version_file)
+if [[ "$code_version" != *"$POLARIS_VERSION"* ]]; then
+
+echo "This load script is for a different version of polaris:"
+echo "__version__ = '$POLARIS_VERSION'"
+echo ""
+echo "Your code is version:"
+echo "$code_version"
+echo ""
+echo "You need to run ./configure_polaris_envs.py to update your conda "
+echo "environment and load script."
+
+else
+# the right polaris version
+{%- endif %}
+
 echo Loading conda environment
 source {{ conda_base }}/etc/profile.d/conda.sh
 source {{ conda_base }}/etc/profile.d/mamba.sh
@@ -10,3 +31,8 @@ echo
 {{ spack }}
 
 {{ env_vars }}
+
+{% if env_type == 'dev' -%}
+# the right polaris version
+fi
+{%- endif %}

--- a/docs/developers_guide/command_line.md
+++ b/docs/developers_guide/command_line.md
@@ -91,7 +91,7 @@ The command-line options are:
 
 ```none
 $ polaris setup --help
-usage: polaris setup [-h] [-t PATH] [-n NUM [NUM ...]] [-f FILE] [-m MACH] -w
+usage: polaris setup [-h] [-t PATH [PATH ...]] [-n NUM [NUM ...]] [-f FILE] [-m MACH] -w
                      PATH [-b PATH] [-p PATH] [--suite_name SUITE]
                      [--cached STEP [STEP ...]] [--copy_executable] [--clean]
 
@@ -103,12 +103,12 @@ command-line options.
 The tasks to set up can be specified either by relative path or by number.
 The `-t` or `--task` flag is used to pass the relative path of the task
 within the resulting work directory.  The is the path given by
-{ref}`dev-polaris-list`.  Only one task at a time can be supplied to
-`polaris setup` this way.
+{ref}`dev-polaris-list`.  You can specify several tasks at once, separated by 
+spaces, this way.
 
 Alternatively, you can supply the task numbers of any number of tasks to
 the `-n` or `--task_number` flag.  Multiple test numbers are separated by
-spaces.  These are the test numbers  given by {ref}`dev-polaris-list`.
+spaces.  These are the test numbers given by {ref}`dev-polaris-list`.
 
 `polaris setup` requires a few basic pieces of information to be able to set
 up a task.  These include places to download and cache some data files

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -323,6 +323,22 @@ you have worked with (or if you aren't sure), it is safest to not just reinstall
 the `polaris` package but also to check the dependencies by re-running:
 `./configure_polaris_envs.py`  with the same arguments as above.
 This will also reinstall the `polaris` package from the current directory.
+The activation script includes a check to see if the version of compass used
+to produce the load script is the same as the version of compass in the
+current branch.  If the two don't match, an error like the following results
+and the environment is not activated:
+
+```
+$ source load_polaris_test_morpheus_gnu_openmpi.sh 
+This load script is for a different version of polaris:
+__version__ = '0.2.0'
+
+Your code is version:
+__version__ = '0.3.0-alpha.1'
+
+You need to run ./configure_polaris_envs.py to update your conda 
+environment and load script.
+```
 
 If you need more than one conda environment (e.g. because you are testing
 multiple branches at the same time), you can choose your own name
@@ -358,10 +374,13 @@ python -m pip install -e .
 ```
 
 The activation script will do this automatically when you source it in
-the root directory of your polaris branch.  This is substantially faster
-than rerunning `./configure_polaris_envs.py ...` but risks
-dependencies being out of date.  Since dependencies change fairly rarely,
-this will usually be safe.
+the root directory of your polaris branch.  The activation script will also
+check if the current polaris version matches the one used to create the
+activation script, thus catching situations where the dependencies are out
+of date and the configure script needs to be rerun.  Since sourcing the
+activation script is substantially faster than rerunning the configure script, 
+it is best to try the activation script first and run the configure script only
+if you have to.
 :::
 
 ### Troubleshooting


### PR DESCRIPTION
If the load script is for a different polaris version, a developer is told to rerun the configure script.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #155 
closes #154 