### PR TITLE
Fix issues with shared config files

### DIFF
--- a/polaris/config.py
+++ b/polaris/config.py
@@ -21,11 +21,7 @@ class PolarisConfigParser(MpasConfigParser):
         A filepath within the component's work directory where this config
         will be written out
 
-    symlinks : list of str
-        A list of filepaths within the component's work directory where
-        symlinks to ``filepath`` will be created
-
-    symlinks : set of polaris.Task
+    tasks : set of polaris.Task
         A list of tasks that use this config
     """
 
@@ -41,7 +37,6 @@ class PolarisConfigParser(MpasConfigParser):
         """
         super().__init__()
         self.filepath: Union[str, None] = filepath
-        self.symlinks = list()
         self.tasks = set()
 
     def setup(self):

--- a/polaris/ocean/mesh/spherical.py
+++ b/polaris/ocean/mesh/spherical.py
@@ -1,5 +1,6 @@
 import os
 
+from polaris.config import PolarisConfigParser
 from polaris.mesh.spherical import (
     IcosahedralMeshStep,
     QuasiUniformSphericalMeshStep,
@@ -55,10 +56,11 @@ def add_spherical_base_mesh_step(component, resolution, icosahedral):
                 cell_width=resolution)
 
         # add default config options for spherical meshes
-        base_mesh.config_filename = f'{base_mesh.name}.cfg'
-        base_mesh.config.filepath = os.path.join(base_mesh.subdir,
-                                                 base_mesh.config_filename)
-        base_mesh.config.add_from_package('polaris.mesh', 'spherical.cfg')
+        config_filename = f'{base_mesh.name}.cfg'
+        filepath = os.path.join(base_mesh.subdir, config_filename)
+        config = PolarisConfigParser(filepath=filepath)
+        config.add_from_package('polaris.mesh', 'spherical.cfg')
+        base_mesh.set_shared_config(config)
 
         component.add_step(base_mesh)
 

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -345,14 +345,8 @@ def _add_task_configs(component, tasks, common_config):
 
     # get a list of shared steps and add config files for tasks to the
     # component
-    shared_steps = dict()
     configs = dict()
     for task in tasks.values():
-        for step in task.steps.values():
-            is_shared = len(step.tasks) > 1
-            if is_shared:
-                shared_steps[step.subdir] = step
-
         if task.config.filepath is None:
             task.config_filename = f'{task.name}.cfg'
             task.config.filepath = os.path.join(task.subdir,
@@ -391,8 +385,7 @@ def _configure_tasks_and_add_step_configs(tasks, component, initial_configs,
     for task in tasks.values():
         configs[task.config.filepath] = task.config
         for step in task.steps.values():
-            is_shared = len(step.tasks) > 1
-            if is_shared:
+            if step.has_shared_config:
                 configs[step.config.filepath] = step.config
                 if step.config.filepath is None:
                     step.config_filename = f'{step.name}.cfg'
@@ -402,8 +395,7 @@ def _configure_tasks_and_add_step_configs(tasks, component, initial_configs,
                     new_configs[step.config.filepath] = step.config
                     component.add_config(step.config)
             else:
-                step.set_shared_config(task.config,
-                                       link=task.config_filename)
+                step._set_config(task.config, link=task.config_filename)
 
     for config in new_configs.values():
         config.prepend(common_config)

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -337,6 +337,8 @@ def _setup_configs(component, tasks, work_dir, config_file, machine,
 
     _write_configs(common_config, configs, component.name, work_dir)
 
+    _symlink_configs(tasks, component.name, work_dir)
+
 
 def _add_task_configs(component, tasks, common_config):
     """
@@ -372,11 +374,11 @@ def _configure_tasks_and_add_step_configs(tasks, component, initial_configs,
     for config in initial_configs.values():
         for task in config.tasks:
             task.configure()
-            task.config.set(section=f'{task.name}',
-                            option='steps_to_run',
-                            value=' '.join(task.steps_to_run),
-                            comment=f'A list of steps to include when running '
-                                    f'the {task.name} task')
+            config.set(section=f'{task.name}',
+                       option='steps_to_run',
+                       value=' '.join(task.steps_to_run),
+                       comment=f'A list of steps to include when running the '
+                               f'{task.name} task')
 
     # add configs to steps after calling task.configure() on all tasks in case
     # new steps were added
@@ -405,13 +407,13 @@ def _configure_tasks_and_add_step_configs(tasks, component, initial_configs,
 
 
 def _write_configs(common_config, configs, component_name, work_dir):
-    """ Write out and symlink all the config files """
+    """ Write out all the config files """
 
     # add the common config at the component level
     common_config.filepath = f'{component_name}.cfg'
     configs[common_config.filepath] = common_config
 
-    # finally, write out the config files and make the symlinks
+    # finally, write out the config files
     component_work_dir = os.path.join(work_dir, component_name)
     for config in configs.values():
         config_filepath = os.path.join(component_work_dir, config.filepath)
@@ -422,14 +424,37 @@ def _write_configs(common_config, configs, component_name, work_dir):
             pass
         with open(config_filepath, 'w') as f:
             config.write(f)
-        for link in config.symlinks:
-            link_filepath = os.path.join(component_work_dir, link)
-            link_dir = os.path.dirname(link_filepath)
+
+
+def _symlink_configs(tasks, component_name, work_dir):
+    """ Symlink config files for requested tasks and steps """
+
+    component_work_dir = os.path.join(work_dir, component_name)
+
+    symlinks = dict()
+    for task in tasks.values():
+        config = task.config
+        config_filepath = os.path.join(component_work_dir, config.filepath)
+        link_path = os.path.join(component_work_dir, task.subdir,
+                                 task.config_filename)
+        if not os.path.exists(link_path) and link_path not in symlinks:
+            symlinks[link_path] = config_filepath
+
+        for step in task.steps.values():
+            config = step.config
+            config_filepath = os.path.join(component_work_dir, config.filepath)
+            link_path = os.path.join(component_work_dir, step.subdir,
+                                     step.config_filename)
+            if not os.path.exists(link_path) and link_path not in symlinks:
+                symlinks[link_path] = config_filepath
+
+        for link_path, config_filepath in symlinks.items():
+            link_dir = os.path.dirname(link_path)
             try:
                 os.makedirs(link_dir)
             except FileExistsError:
                 pass
-            symlink(config_filepath, link_filepath)
+            symlink(config_filepath, link_path)
 
 
 def _clean_tasks_and_steps(tasks, base_work_dir):

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -619,8 +619,6 @@ class Step:
             self.config_filename = basename
         else:
             self.config_filename = link
-            config_link = os.path.join(self.subdir, link)
-            config.symlinks.append(config_link)
 
     @staticmethod
     def _process_input(entry, config, base_work_dir, component, step_dir):

--- a/polaris/task.py
+++ b/polaris/task.py
@@ -230,5 +230,3 @@ class Task:
             self.config_filename = basename
         else:
             self.config_filename = link
-            config_link = os.path.join(self.subdir, link)
-            config.symlinks.append(config_link)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge fixes two main issues with shared config files:
1. The main one is adding an explicit attribute of steps to indicate whether they have a shared config (the alternative being that they use the config for the task they belong to). Previously, a step was assumed to have a shared config if it belonged to multiple tasks but that causes trouble when a conceptually shared step happens to belong to only one task (e.g. because other tasks may use it in the future).
2. The minor fix is that only the tasks and steps requested during setup have their config files linked.  Previously, symlinks to the shared config were being created for all tasks and steps that used the config, even if they were not requested at setup.  This created confusing directories for unrequested tasks that just had a symlink to the config file.


<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
