### PR TITLE
Removing tracers in variable list that have been turned off by default

### DIFF
--- a/polaris/seaice/tasks/single_column/exact_restart/__init__.py
+++ b/polaris/seaice/tasks/single_column/exact_restart/__init__.py
@@ -32,8 +32,6 @@ class ExactRestart(Task):
                          'iceEnthalpy',
                          'iceSalinity',
                          'snowEnthalpy',
-                         'iceAge',
-                         'firstYearIceArea',
                          'levelIceArea',
                          'levelIceVolume',
                          'pondArea',


### PR DESCRIPTION
Removes two variables, `iceAge` and `firstYearIceArea`, from the list of validated variables in the seaice exact restart test. These tracers have recently been turned off by default in E3SM for v3 (https://github.com/E3SM-Project/E3SM/pull/6090).


Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

With this branch:
```
Test Runtimes:
00:09 PASS seaice/single_column/standard_physics
00:02 PASS seaice/single_column/exact_restart
Total runtime 00:11
PASS: All passed successfully!
```

Addresses https://github.com/E3SM-Project/polaris/issues/159 (already closed).
