### PR TITLE
Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+￼
+￼updates:
+￼
+￼  - package-ecosystem: "github-actions"
+￼    directory: "/"
+￼    schedule:
+￼      interval: "weekly"
+￼    assignees:
+￼      - "xylar"
+￼    reviewers:
+￼      - "xylar"


### PR DESCRIPTION
With this merge, dependabot will perform dependency checks on the dependencies of our GitHub Actions on a weekly basis.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Following the example of https://github.com/E3SM-Project/E3SM/pull/6163 (Thanks @mahf708!).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
