### PR TITLE
Fix cores_per_node for Frontier

### DIFF
--- a/polaris/machines/frontier.cfg
+++ b/polaris/machines/frontier.cfg
@@ -43,7 +43,7 @@ use_e3sm_hdf5_netcdf = True
 [parallel]
 
 # cores per node on the machine
-cores_per_node = 64
+cores_per_node = 56
 
 # threads per core (set to 1 because hyperthreading requires extra sbatch
 # flag --threads-per-core that polaris doesn't yet support)


### PR DESCRIPTION
Should apparently be 56 rather than 64 (though that's hard to find in the docs).

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
