### PR TITLE
Fix slurm handling of allocatable cores

### DIFF
--- a/polaris/parallel.py
+++ b/polaris/parallel.py
@@ -30,16 +30,22 @@ def get_available_parallel_resources(config):
     if parallel_system == 'slurm':
         job_id = os.environ['SLURM_JOB_ID']
         node = os.environ['SLURMD_NODENAME']
-        args = ['sinfo', '--noheader', '--node', node, '-o', '%X']
-        sockets_per_node = _get_subprocess_int(args)
-        args = ['sinfo', '--noheader', '--node', node, '-o', '%Y']
-        cores_per_socket = _get_subprocess_int(args)
+        args = ['sinfo', '--noheader', '--node', node, '-o', '%C']
+        # get allocated, idle, other and total cores
+        aiot = _get_subprocess_str(args).split('/')
+
+        # we can only use the allocated cores
+        cores_per_node = int(aiot[0])
+        args = ['sinfo', '--noheader', '--node', node, '-o', '%Z']
+        slurm_threads_per_core = _get_subprocess_int(args)
+
         if config.has_option('parallel', 'threads_per_core'):
             threads_per_core = config.getint('parallel', 'threads_per_core')
+            # correct for this in allocated_cores, which might not match
+            cores_per_node = ((cores_per_node * threads_per_core) //
+                              slurm_threads_per_core)
         else:
-            args = ['sinfo', '--noheader', '--node', node, '-o', '%Z']
-            threads_per_core = _get_subprocess_int(args)
-        cores_per_node = sockets_per_node * cores_per_socket * threads_per_core
+            threads_per_core = slurm_threads_per_core
         args = ['squeue', '--noheader', '-j', job_id, '-o', '%D']
         nodes = _get_subprocess_int(args)
         cores = cores_per_node * nodes
@@ -182,7 +188,12 @@ def get_parallel_command(args, cpus_per_task, ntasks, config):
     return command_line_args
 
 
-def _get_subprocess_int(args):
+def _get_subprocess_str(args):
     value = subprocess.check_output(args)
-    value_int = int(value.decode('utf-8').strip('\n'))
+    value_str = value.decode('utf-8').strip('\n')
+    return value_str
+
+
+def _get_subprocess_int(args):
+    value_int = int(_get_subprocess_str(args))
     return value_int


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Some systems like Frontier have cores that aren't allocatable. These need to be excluded from the core count that Polaris determines from slurm.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
