### PR TITLE
Fix libnetcdf in jigsaw build

### DIFF
--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -337,42 +337,7 @@ def build_conda_env(config, env_type, recreate, mpi, conda_mpi, version,
 
     if env_type == 'dev':
         if recreate or update_jigsaw:
-            # remove conda jigsaw and jigsaw-python
-            t0 = time.time()
-            commands = \
-                f'{activate_env} && ' \
-                f'conda remove -y --force-remove jigsaw jigsawpy'
-            check_call(commands, logger=logger)
-
-            commands = \
-                f'{activate_env} && ' \
-                f'cd {source_path} && ' \
-                f'git submodule update --init jigsaw-python'
-            check_call(commands, logger=logger)
-
-            print('Building JIGSAW\n')
-            # add build tools to deployment env, not compass env
-            commands = \
-                f'conda install -y cxx-compiler cmake && ' \
-                f'cd {source_path}/jigsaw-python && ' \
-                f'python setup.py build_external'
-            check_call(commands, logger=logger)
-
-            print('Installing JIGSAW and JIGSAW-Python\n')
-            commands = \
-                f'{activate_env} && ' \
-                f'cd {source_path}/jigsaw-python && ' \
-                f'python -m pip install --no-deps -e . && ' \
-                f'cp jigsawpy/_bin/* ${{CONDA_PREFIX}}/bin'
-            check_call(commands, logger=logger)
-
-            t1 = time.time()
-            total = int(t1 - t0 + 0.5)
-            message = f'JIGSAW install took {total:.1f} s.'
-            if logger is None:
-                print(message)
-            else:
-                logger.info(message)
+            build_jigsaw(activate_env, source_path, env_path, logger)
 
         # install (or reinstall) polaris in edit mode
         print('Installing polaris\n')
@@ -389,6 +354,57 @@ def build_conda_env(config, env_type, recreate, mpi, conda_mpi, version,
             f'cd {source_path} && ' \
             f'pre-commit install'
         check_call(commands, logger=logger)
+
+
+def build_jigsaw(activate_env, source_path, env_path, logger):
+    # remove conda jigsaw and jigsaw-python
+    t0 = time.time()
+    commands = \
+        f'{activate_env} && ' \
+        f'conda remove -y --force-remove jigsaw jigsawpy'
+    check_call(commands, logger=logger)
+
+    commands = \
+        f'{activate_env} && ' \
+        f'cd {source_path} && ' \
+        f'git submodule update --init jigsaw-python'
+    check_call(commands, logger=logger)
+
+    print('Building JIGSAW\n')
+    # add build tools to deployment env, not polaris env
+    jigsaw_build_deps = 'cxx-compiler cmake'
+    netcdf_lib = f'{env_path}/lib/libnetcdf.so'
+    cmake_args = f'-DCMAKE_BUILD_TYPE=Release -DNETCDF_LIBRARY={netcdf_lib}'
+
+    commands = \
+        f'conda install -y {jigsaw_build_deps} && ' \
+        f'cd {source_path}/jigsaw-python/external/jigsaw && ' \
+        f'rm -rf tmp && ' \
+        f'mkdir tmp && ' \
+        f'cd tmp && ' \
+        f'cmake .. {cmake_args} && ' \
+        f'cmake --build . --config Release --target install --parallel 4 && ' \
+        f'cd {source_path}/jigsaw-python && ' \
+        f'rm -rf jigsawpy/_bin jigsawpy/_lib && ' \
+        f'cp -r external/jigsaw/bin/ jigsawpy/_bin && ' \
+        f'cp -r external/jigsaw/lib/ jigsawpy/_lib'
+    check_call(commands, logger=logger)
+
+    print('Installing JIGSAW and JIGSAW-Python\n')
+    commands = \
+        f'{activate_env} && ' \
+        f'cd {source_path}/jigsaw-python && ' \
+        f'python -m pip install --no-deps -e . && ' \
+        f'cp jigsawpy/_bin/* ${{CONDA_PREFIX}}/bin'
+    check_call(commands, logger=logger)
+
+    t1 = time.time()
+    total = int(t1 - t0 + 0.5)
+    message = f'JIGSAW install took {total:.1f} s.'
+    if logger is None:
+        print(message)
+    else:
+        logger.info(message)
 
 
 def get_env_vars(machine, compiler, mpilib):


### PR DESCRIPTION
This merge explicitly points to the libnetcdf that should be used in the Jigsaw build.  It also breaks the jigsaw build into its own function.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
