### PR TITLE
Fix `cores_per_node` calculation on Compy and Anvil

### DIFF
--- a/polaris/parallel.py
+++ b/polaris/parallel.py
@@ -36,6 +36,11 @@ def get_available_parallel_resources(config):
 
         # we can only use the allocated cores
         cores_per_node = int(aiot[0])
+
+        if cores_per_node == 0:
+            # hmm, no allocated cores so I guess we'll go with total cores
+            cores_per_node = int(aiot[3])
+
         args = ['sinfo', '--noheader', '--node', node, '-o', '%Z']
         slurm_threads_per_core = _get_subprocess_int(args)
 


### PR DESCRIPTION
Compy and Anvil don't think their nodes have any allocated cores (all idle) so we will use the total number of cores per node instead.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
