### PR TITLE
Switch the mesh used for Omega CTests 

### DIFF
--- a/utils/omega/ctest/omega_ctest.py
+++ b/utils/omega/ctest/omega_ctest.py
@@ -80,13 +80,12 @@ def download_mesh(config):
     """
     Download and symlink a mesh to use for testing.
     """
-    base_url = config.get('download', 'server_base_url')
     database_root = config.get('paths', 'database_root')
 
-    filepath = 'ocean/polaris_cache/global_convergence/icos/cosine_bell/' \
-               'Icos480/mesh/mesh.230220.nc'
+    filepath = 'ocean/omega_ctest/ocean.QU.240km.151209.nc'
 
-    url = f'{base_url}/{filepath}'
+    url = 'https://web.lcrc.anl.gov/public/e3sm/inputdata/ocn/mpas-o/oQU240/' \
+          'ocean.QU.240km.151209.nc'
     download_path = os.path.join(database_root, filepath)
     download_target = download(url, download_path, config)
     return download_target


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge updates the mesh used in Omega's CTests to an oQU240 initial condition taken from `inputdata` on the E3SM server. This is necessary for the `HORZMESH_TEST` to pass, since that test assumes realistic total ocean area and coriolis parameter.

This merge also updates the `Omega` submodule to the latest `develop` (hash: ca19fa9)

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
