### PR TITLE
Set METIS to build with 64-bit int and real

### DIFF
--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -588,12 +588,12 @@ def build_spack_libs_env(config, update_spack, machine, compiler,  # noqa: C901
     else:
         include_e3sm_lapack = True
     if metis != 'None':
-        specs.append(f'"metis@{metis}~shared"')
+        specs.append(f'"metis@{metis}+int64+real64~shared"')
     if moab != 'None':
         specs.append(
             f'"moab@{moab}+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest"')
     if parmetis != 'None':
-        specs.append(f'"parmetis@{parmetis}~shared"')
+        specs.append(f'"parmetis@{parmetis}+int64~shared"')
     if petsc != 'None':
         specs.append(f'"petsc@{petsc}+mpi+batch"')
 


### PR DESCRIPTION
This is necessary for larger meshes and partition sizes (such at the RRS meshe used in E3SM HR simulations).

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
