### PR TITLE
Update docs link to newer URL style

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supported models include:
 
 The latest Polaris documentation can be found here:
 
-[http://e3sm-project.github.io/polaris/main/](http://e3sm-project.github.io/polaris/main/)
+[https://docs.e3sm.org/polaris/](https://docs.e3sm.org/polaris/)
 
 Documentation on its predecessor, Compass, can be found here:
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR simply updates the link to the Polaris documentation in the README to the newer style of URL that's being adopted for other E3SM projects.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
