### PR TITLE
Set permissions for Omega CTest downloads 

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -169,7 +169,7 @@ seaice/api
 
 .. autosummary::
    :toctree: generated/
-   
+
    ModelStep
    ModelStep.setup
    ModelStep.set_model_resources
@@ -219,6 +219,7 @@ seaice/api
 
    download
    symlink
+   update_permissions
 ```
 
 ### job
@@ -250,7 +251,7 @@ seaice/api
 
 .. autosummary::
    :toctree: generated/
-   
+
    planar.compute_planar_hex_nx_ny
 
    spherical.SphericalBaseStep
@@ -280,7 +281,7 @@ seaice/api
 
 .. autosummary::
    :toctree: generated/
-   
+
    make_graph_file
 ```
 
@@ -291,7 +292,7 @@ seaice/api
 
 .. autosummary::
    :toctree: generated/
-   
+
    area_for_field
    time_index_from_xtime
 ```
@@ -409,7 +410,7 @@ seaice/api
    PolarisYaml.read
    PolarisYaml.update
    PolarisYaml.write
-   
+
    mpas_namelist_and_streams_to_yaml
    yaml_to_mpas_streams
 

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -1,15 +1,12 @@
-import grp
 import importlib.resources as imp_res
 import logging
 import os
 import shutil
-import stat
 
-import progressbar
 from mache import MachineInfo
 
 from polaris.config import PolarisConfigParser
-from polaris.io import download, symlink
+from polaris.io import download, symlink, update_permissions
 from polaris.validate import compare_variables
 
 
@@ -585,8 +582,10 @@ class Step:
             inputs.append(input_file)
         self.inputs = inputs
 
-        if len(databases_with_downloads) > 0:
-            self._fix_permissions(databases_with_downloads)
+        if len(databases_with_downloads) > 0 and \
+                config.has_option('e3sm_unified', 'group'):
+            group = config.get('e3sm_unified', 'group')
+            update_permissions(databases_with_downloads, group)
 
         # inputs are already absolute paths, convert outputs to absolute paths
         self.outputs = [os.path.abspath(os.path.join(step_dir, filename)) for
@@ -694,120 +693,3 @@ class Step:
         input_file = os.path.abspath(input_file)
 
         return input_file, database_subdirs
-
-    def _fix_permissions(self, databases):  # noqa: C901
-        """
-        Fix permissions on the databases where files were downloaded so
-        everyone in the group can read/write to them
-        """
-        config = self.config
-
-        if not config.has_option('e3sm_unified', 'group'):
-            return
-
-        group = config.get('e3sm_unified', 'group')
-
-        new_uid = os.getuid()
-        new_gid = grp.getgrnam(group).gr_gid
-
-        write_perm = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP |
-                      stat.S_IWGRP | stat.S_IROTH)
-        exec_perm = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
-                     stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |
-                     stat.S_IROTH | stat.S_IXOTH)
-
-        mask = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
-
-        print('changing permissions on downloaded files')
-
-        # first the base directories that don't seem to be included in
-        # os.walk()
-        for directory in databases:
-            dir_stat = os.stat(directory)
-
-            perm = dir_stat.st_mode & mask
-
-            if dir_stat.st_uid != new_uid:
-                # current user doesn't own this dir so let's move on
-                continue
-
-            if perm == exec_perm and dir_stat.st_gid == new_gid:
-                continue
-
-            try:
-                os.chown(directory, new_uid, new_gid)
-                os.chmod(directory, exec_perm)
-            except OSError:
-                continue
-
-        files_and_dirs = []
-        for base in databases:
-            for root, dirs, files in os.walk(base):
-                files_and_dirs.extend(dirs)
-                files_and_dirs.extend(files)
-
-        widgets = [progressbar.Percentage(), ' ', progressbar.Bar(),
-                   ' ', progressbar.ETA()]
-        bar = progressbar.ProgressBar(widgets=widgets,
-                                      maxval=len(files_and_dirs)).start()
-        progress = 0
-        for base in databases:
-            for root, dirs, files in os.walk(base):
-                for directory in dirs:
-                    progress += 1
-                    bar.update(progress)
-
-                    directory = os.path.join(root, directory)
-
-                    try:
-                        dir_stat = os.stat(directory)
-                    except OSError:
-                        continue
-
-                    if dir_stat.st_uid != new_uid:
-                        # current user doesn't own this dir so let's move on
-                        continue
-
-                    perm = dir_stat.st_mode & mask
-
-                    if perm == exec_perm and dir_stat.st_gid == new_gid:
-                        continue
-
-                    try:
-                        os.chown(directory, new_uid, new_gid)
-                        os.chmod(directory, exec_perm)
-                    except OSError:
-                        continue
-
-                for file_name in files:
-                    progress += 1
-                    bar.update(progress)
-                    file_name = os.path.join(root, file_name)
-                    try:
-                        file_stat = os.stat(file_name)
-                    except OSError:
-                        continue
-
-                    if file_stat.st_uid != new_uid:
-                        # current user doesn't own this file so let's move on
-                        continue
-
-                    perm = file_stat.st_mode & mask
-
-                    if perm & stat.S_IXUSR:
-                        # executable, so make sure others can execute it
-                        new_perm = exec_perm
-                    else:
-                        new_perm = write_perm
-
-                    if perm == new_perm and file_stat.st_gid == new_gid:
-                        continue
-
-                    try:
-                        os.chown(file_name, new_uid, new_gid)
-                        os.chmod(file_name, new_perm)
-                    except OSError:
-                        continue
-
-        bar.finish()
-        print('  done.')

--- a/utils/omega/ctest/omega_ctest.py
+++ b/utils/omega/ctest/omega_ctest.py
@@ -7,7 +7,7 @@ import subprocess
 from jinja2 import Template
 
 from polaris.config import PolarisConfigParser
-from polaris.io import download
+from polaris.io import download, update_permissions
 from polaris.job import _clean_up_whitespace, get_slurm_options
 
 
@@ -99,6 +99,12 @@ def download_meshes(config):
         url = f'{base_url}/{database_path}/{filename}'
         download_target = download(url, download_path, config)
         download_targets.append(download_target)
+
+    if config.has_option('e3sm_unified', 'group'):
+        database_path = os.path.join(database_root, database_path)
+        group = config.get('e3sm_unified', 'group')
+        update_permissions([database_path], group)
+
     return download_targets
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Without this, the files are being left with permissions such that only the person downloading the file can read them.

To support this, we move code for updating permissions to the shared `io` module 


<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

fixes #198 
