### PR TITLE
Add support for creating mapping files with `mbtempest`

### DIFF
--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -291,7 +291,7 @@ def build_conda_env(config, env_type, recreate, mpi, conda_mpi, version,
                             mpi_prefix=mpi_prefix,
                             include_mache=not local_mache)
 
-        for package in ['esmf', 'geometric_features', 'mache', 'metis',
+        for package in ['esmf', 'geometric_features', 'mache', 'metis', 'moab',
                         'mpas_tools', 'netcdf_c', 'netcdf_fortran', 'otps',
                         'parallelio', 'pnetcdf']:
             replacements[package] = config.get('deploy', package)

--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -23,6 +23,7 @@ mache={{ mache }}
 {% endif %}
 matplotlib-base>=3.9.0
 metis={{ metis }}
+moab={{ moab }}=*_tempest_*
 mpas_tools={{ mpas_tools }}
 nco
 netcdf4=*=nompi_*

--- a/docs/developers_guide/framework/remapping.md
+++ b/docs/developers_guide/framework/remapping.md
@@ -6,17 +6,18 @@ It is frequently useful when working with observational datasets or
 visualizing MPAS data to remap between different global or regional grids and
 meshes.  The [pyremap](https://mpas-dev.github.io/pyremap/stable/) provides
 capabilities for making mapping files (which contain the weights needed to
-interpolate between meshes) and using them to remap files or 
+interpolate between meshes) and using them to remap files or
 {py:class}`xarray.Dataset` objects.  Polaris provides a step for producing
 such a mapping file.  Under the hood, `pyremap` uses the
 [ESMF_RegridWeightGen](https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node3.html#SECTION03020000000000000000)
-tool, which uses MPI parallelism.  To better support task parallelism, it is
+or [mbtempest](https://sigma.mcs.anl.gov/moab/offline-remapping-workflow-with-mbtempest/)
+tools, which use MPI parallelism.  To better support task parallelism, it is
 best to have each MPI task be a separate polaris step.  For this reason, we
 provide {py:class}`polaris.remap.MappingFileStep` to perform remapping.
 
 A remapping step can be added to a task either by creating a
 {py:class}`polaris.remap.MappingFileStep` object directly or by creating a
-step that descends from the class.  Here is an example of using 
+step that descends from the class.  Here is an example of using
 `MappingFileStep` directly to remap data from a WOA 2023 lon-lat grid to an
 MPAS mesh. This could happen in the task's `__init__()` or `configure()`
 method:
@@ -24,12 +25,18 @@ method:
 ```python
 
 from polaris import Task
+from polaris.config import PolarisConfigParser
 from polaris.remap import MappingFileStep
 
 class MyTestCase(Task):
     def __int__(self, component):
-        step = MappingFileStep(component=component, name='make_map', ntasks=64, 
+        step = MappingFileStep(component=component, name='make_map', ntasks=64,
                                min_tasks=1, method='bilinear')
+        # add required config options related to mapping
+        config = PolarisConfigParser(filepath=filepath)
+        config.add_from_package('polaris.remap', 'mapping.cfg')
+        step.set_shared_config(config, link='my_test_case.cfg')
+
         # indicate the the mesh from another step is an input to this step
         # note: the target is relative to the step, not the task.
         step.add_input_file(filename='woa.nc',
@@ -38,7 +45,7 @@ class MyTestCase(Task):
 
         step.add_input_file(filename='mesh.nc',
                             target='../mesh/mesh.nc')
-        
+
         # you need to specify what type of source and destination mesh you
         # will use
         step.src_from_lon_lat(filename='woa.nc', lon_var='lon', lat_var='lat')
@@ -62,7 +69,7 @@ from polaris.remap import MappingFileStep
 
 
 class VizMap(MappingFileStep):
-    def __init__(self, component, name, subdir, mesh_name):
+    def __init__(self, component, name, subdir, mesh_name, config):
         super().__init__(component=component, name=name, subdir=subdir,
                          ntasks=128, min_tasks=1)
         self.mesh_name = mesh_name
@@ -81,11 +88,26 @@ class VizMap(MappingFileStep):
         super().runtime_setup()
 ```
 
-With either approach, you will need to call one of the `src_*()` methods to
-set up the source mesh or grid and one of the `dst_*()` to configure the 
-destination.  Expect for lon-lat grids, you will need to provide a name for
-the mesh or grid, typically describing its resolution and perhaps its extent
-and the region covered.
+It is important that the task that the step belongs to includes the required
+config options related to mapping.  This could be accomplished either by
+calling:
+```python
+config.add_from_package('polaris.remap', 'mapping.cfg')
+```
+or by including the corresponding config options in the task's config file:
+```cfg
+# config options related to creating mapping files
+[mapping]
+
+# The tool to use for creating mapping files: esmf or moab
+map_tool = moab
+```
+
+Whether you create a `MappingFileStep` object directly or create a subclass,
+you will need to call one of the `src_*()` methods to set up the source mesh or
+grid and one of the `dst_*()` to configure the destination.  Expect for lon-lat
+grids, you will need to provide a name for the mesh or grid, typically
+describing its resolution and perhaps its extent and the region covered.
 
 In nearly all situations, creating the mapping file is only one step in the
 workflow. After that, the mapping file will be used to remap data between

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -182,7 +182,8 @@ this script will also:
   build several libraries with system compilers and MPI library, including:
   [SCORPIO](https://github.com/E3SM-Project/scorpio) (parallel i/o for E3SM
   components) [ESMF](https://earthsystemmodeling.org/) (making mapping files
-  in parallel), [Trilinos](https://trilinos.github.io/),
+  in parallel), [MOAB](https://sigma.mcs.anl.gov/moab-library/),
+  [Trilinos](https://trilinos.github.io/),
   [Albany](https://github.com/sandialabs/Albany),
   [Netlib-LAPACK](http://www.netlib.org/lapack/) and
   [PETSc](https://petsc.org/). **Please uses these flags with caution, as

--- a/docs/developers_guide/troubleshooting.md
+++ b/docs/developers_guide/troubleshooting.md
@@ -117,5 +117,5 @@ of your user config file:
 parallel_executable = mpirun -host localhost
 ```
 
-The [example config file](https://github.com/E3SM-Project/polaris/blob/main/exmaple.cfg)
+The [example config file](https://github.com/E3SM-Project/polaris/blob/main/example.cfg)
 has been updated to include this flag.

--- a/docs/users_guide/quick_start.md
+++ b/docs/users_guide/quick_start.md
@@ -17,7 +17,8 @@ documentation as soon as there is one.  Until then please refer to the
 For each polaris release, we maintain a
 [conda environment](https://docs.conda.io/en/latest/). that includes the
 `polaris` package as well as all of its dependencies and some libraries
-(currently [ESMF](https://earthsystemmodeling.org/) and
+(currently [ESMF](https://earthsystemmodeling.org/),
+[MOAB](https://sigma.mcs.anl.gov/moab-library/) and
 [SCORPIO](https://e3sm.org/scorpio-parallel-io-library/)) built with system
 MPI using [spack](https://spack.io/) on our standard machines (Anvil, Chicoma,
 Chrysalis, Compy, and  Perlmutter).  Once there is a polaris release,

--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -177,8 +177,8 @@ class ModelStep(Step):
         config = self.config
         component_path = config.get('executables', 'component')
         model_basename = os.path.basename(component_path)
-        self.args = [f'./{model_basename}', '-n', self.namelist,
-                     '-s', self.streams]
+        self.args = [[f'./{model_basename}', '-n', self.namelist,
+                      '-s', self.streams]]
 
     def set_model_resources(self, ntasks=None, min_tasks=None,
                             openmp_threads=None, max_memory=None):

--- a/polaris/ocean/tasks/isomip_plus/__init__.py
+++ b/polaris/ocean/tasks/isomip_plus/__init__.py
@@ -34,6 +34,8 @@ def add_isomip_plus_tasks(component, mesh_type):
             config.set('spherical_mesh', 'mpas_mesh_filename',
                        'base_mesh_without_xy.nc')
 
+        config.add_from_package('polaris.remap', 'mapping.cfg')
+
         config.add_from_package('polaris.ocean.tasks.isomip_plus',
                                 'isomip_plus.cfg')
 

--- a/polaris/remap/mapping.cfg
+++ b/polaris/remap/mapping.cfg
@@ -1,0 +1,5 @@
+# config options related to creating mapping files
+[mapping]
+
+# The tool to use for creating mapping files: esmf or moab
+map_tool = moab

--- a/polaris/remap/remap.cfg
+++ b/polaris/remap/remap.cfg
@@ -1,5 +1,0 @@
-# config options related to creating mapping files and remapping data
-[remap]
-
-# The tool to use for remapping: esmf or moab
-remap_tool = esmf

--- a/polaris/remap/remap.cfg
+++ b/polaris/remap/remap.cfg
@@ -1,0 +1,5 @@
+# config options related to creating mapping files and remapping data
+[remap]
+
+# The tool to use for remapping: esmf or moab
+remap_tool = esmf

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -490,10 +490,11 @@ def _run_step(task, step, new_log_file, available_resources,
         if step.args is not None:
             step_logger.info('\nBypassing step\'s run() method and running '
                              'with command line args\n')
-            log_function_call(function=run_command, logger=step_logger)
-            step_logger.info('')
-            run_command(step.args, step.cpus_per_task, step.ntasks,
-                        step.openmp_threads, step.config, step.logger)
+            for args in step.args:
+                log_function_call(function=run_command, logger=step_logger)
+                step_logger.info('')
+                run_command(args, step.cpus_per_task, step.ntasks,
+                            step.openmp_threads, step.config, step.logger)
         else:
             step_logger.info('')
             log_method_call(method=step.run, logger=step_logger)

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -142,8 +142,10 @@ class Step:
         file (e.g. if the step calls external code that, in turn, calls
         additional subprocesses).
 
-    args : {list of str, None}
-        A list of command-line arguments to call in parallel
+    args : {list of list of str, None}
+        A list of lists of command-line arguments to call in parallel.  Each
+        inner list represents a single command.  All commands must use the
+        same parallel resources.
     """
 
     def __init__(self, component, name, subdir=None, indir=None,


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge adds support for creating mapping files with `mbtempest` in addition to `ESMF_RegridWeightGen`.  I have added `moab` with `tempest-remap` as a conda dependency.

Because `mbtempest` creates mapping files in 2 steps (first creating intersections and then creating the mapping file), I have modified the `args` attribute of `Step` to be a list of lists, allowing multiple commands.  Each command is required to take the same parallel resources, which is fine for `mbtempest`.

I have added a new config file `mapping.cfg` with a `[mapping]` section and a `map_tool` config option (either `esmf` or `moab`).  I have made `moab` the default.

Finally, I have updated the `isomip_plus` tests include the new mapping config.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
