### PR TITLE
Fix the `bisect` utility

### DIFF
--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -465,12 +465,12 @@ class ModelStep(Step):
         copy_executable = config.getboolean('setup', 'copy_executable')
         if copy_executable:
             # make a copy of the model executable, then link to that
-            mpas_subdir = os.path.basename(
-                config.get('paths', 'mpas_model'))
-            mpas_workdir = os.path.join(base_work_dir, mpas_subdir)
-            target = os.path.join(mpas_workdir, filename)
+            component_subdir = os.path.basename(
+                config.get('paths', 'component_path'))
+            component_workdir = os.path.join(base_work_dir, component_subdir)
+            target = os.path.join(component_workdir, filename)
             try:
-                os.makedirs(mpas_workdir)
+                os.makedirs(component_workdir)
             except FileExistsError:
                 pass
 

--- a/utils/bisect/example.cfg
+++ b/utils/bisect/example.cfg
@@ -27,4 +27,4 @@ setup_command = polaris setup --copy_executable -n 39 -b /lcrc/group/e3sm/ac.xyl
 # polaris environment
 load_script = load_polaris_bisect_anvil_intel_impi.sh
 # the command to run polaris within the work directory
-run_command = polaris run
+run_command = polaris serial


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge fixes the `--copy_exectable` flag to `polaris setup`, which referred to nonexistent config options.

It also fixes the way E3SM submodules are checked out at the beginning of each bisection step.  The submodule is cleaned, hard-reset to the `HEAD` and then submodules are recursively checked out to ensure that every step is starting from a clean state.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
