### PR TITLE
Cleanup `configure_polaris_envs.py` and `deploy/shared.py`

### DIFF
--- a/configure_polaris_envs.py
+++ b/configure_polaris_envs.py
@@ -49,8 +49,8 @@ def main():
 
     packages = '--file deploy/spec-bootstrap.txt'
     if not local_mache:
-        # we need to specify the mache version and all dependencies
-        # since we won't be installing from mache's spec file
+        # we need to add the mache package, specifying a version,
+        # since we won't be installing mache from a local clone of a branch
         mache_version = config.get('deploy', 'mache')
         packages = f'{packages} "mache={mache_version}"'
 

--- a/deploy/shared.py
+++ b/deploy/shared.py
@@ -156,9 +156,7 @@ def check_call(commands, env=None, logger=None):
 def install_miniforge(conda_base, activate_base, logger):
     if not os.path.exists(conda_base):
         print('Installing Miniforge3')
-        if platform.system() == 'Linux':
-            system = 'Linux'
-        elif platform.system() == 'Darwin':
+        if platform.system() == 'Darwin':
             system = 'MacOSX'
         else:
             system = 'Linux'
@@ -190,7 +188,7 @@ def get_logger(name, log_filename):
     print(f'Logging to: {log_filename}\n')
     try:
         os.remove(log_filename)
-    except OSError:
+    except FileNotFoundError:
         pass
     logger = logging.getLogger(name)
     handler = logging.FileHandler(log_filename)

--- a/deploy/spec-bootstrap.txt
+++ b/deploy/spec-bootstrap.txt
@@ -1,0 +1,3 @@
+jinja2
+packaging
+progressbar2


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR includes some general cleanup that I did in `configure_polaris_envs.py` and `deploy/bootstrap.py`, as well as a slight change to the commands which install mache. The cleanup I did consisted of the following:
* Privatized all applicable methods
* Re-ordered some methods
* Narrowed the scope of some try/catch blocks (such as catching a `FileNotFound` error instead of a more general `OSError`)
* Removed some unnecessary try/catch blocks (in the case of `makedirs()` which has a built-in `FileExistsError` check)

The installation of mache now calls upon a new file, `deploy/spec-bootstrap.txt` instead of listing mache's dependencies directly in the configure script. This change is both to make the script more modular and to make updating this list easier. 
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
