### PR TITLE
Add link to Omega CTest in Quick Start

### DIFF
--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -487,7 +487,9 @@ For MPAS-Ocean and MALI both, see the last column of the table in
 {ref}`dev-supported-machines` for the right `<mpas_make_target>` command for
 each machine and compiler.
 
-Instructions for building Omega will be added as development proceeds.
+Instructions for building Omega will be added as development proceeds. For now,
+you can run 
+[Omega CTest Utility](https://github.com/E3SM-Project/polaris/blob/main/utils/omega/ctest/README.md). 
 
 (dev-working-with-polaris)=
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
In this PR I just added a link inside of the quick start documentation for the Omega CTest utility. I built the documentation locally and it looks correct to me.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
