### PR TITLE
Fix deployment on unknown machines

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -90,16 +90,15 @@ jobs:
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           ./configure_polaris_envs.py \
-            --conda_env_only \
             --env_name polaris_test \
             --verbose \
             --python=${{ matrix.python-version }}
-          source load_polaris_test.sh
+          source load_polaris_test_mpich.sh
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs
         run: |
-          source load_polaris_test.sh
+          source load_polaris_test_mpich.sh
           # sphinx-multiversion expects at least a "main" branch
           git branch main || echo "branch main already exists."
           cd docs

--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -378,7 +378,7 @@ def build_jigsaw(activate_env, conda_base, source_path, env_path, logger):
         jigsaw_build_deps = f'{jigsaw_build_deps} sysroot_linux-64=2.17'
     elif platform.system() == 'Darwin':
         jigsaw_build_deps = \
-            f'{jigsaw_build_deps} macosx_deployment_target=10.13'
+            f'{jigsaw_build_deps} macosx_deployment_target_osx-64=10.13'
     netcdf_lib = f'{env_path}/lib/libnetcdf.so'
     cmake_args = f'-DCMAKE_BUILD_TYPE=Release -DNETCDF_LIBRARY={netcdf_lib}'
 

--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -373,13 +373,14 @@ def build_jigsaw(activate_env, conda_base, source_path, env_path, logger):
 
     print('Building JIGSAW\n')
     # add build tools to deployment env, not polaris env
-    jigsaw_build_deps = 'cxx-compiler cmake'
+    jigsaw_build_deps = 'cxx-compiler cmake make'
     if platform.system() == 'Linux':
         jigsaw_build_deps = f'{jigsaw_build_deps} sysroot_linux-64=2.17'
+        netcdf_lib = f'{env_path}/lib/libnetcdf.so'
     elif platform.system() == 'Darwin':
         jigsaw_build_deps = \
             f'{jigsaw_build_deps} macosx_deployment_target_osx-64=10.13'
-    netcdf_lib = f'{env_path}/lib/libnetcdf.so'
+        netcdf_lib = f'{env_path}/lib/libnetcdf.dylib'
     cmake_args = f'-DCMAKE_BUILD_TYPE=Release -DNETCDF_LIBRARY={netcdf_lib}'
 
     commands = \

--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -1192,12 +1192,13 @@ def main():  # noqa: C901
                     f'export PIO={conda_env_path}\n' \
                     f'export OPENMP_INCLUDE=-I"{conda_env_path}/include"\n'
 
-            if soft_spack_view is None:
+            if soft_spack_view is not None:
+                env_vars = f'{env_vars}' \
+                           f'export PATH="{soft_spack_view}/bin:$PATH"\n'
+            elif known_machine:
                 raise ValueError('A software compiler or a spack base was not '
                                  'defined so required software was not '
                                  'installed with spack.')
-            env_vars = f'{env_vars}' \
-                       f'export PATH="{soft_spack_view}/bin:$PATH"\n'
 
         else:
             env_vars = ''

--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -24,15 +24,15 @@ geometric_features = 1.2.0
 mache = 1.24.0
 mpas_tools = 0.34.1
 otps = 2021.10
-parallelio = 2.6.0
+parallelio = 2.6.2
 
 # versions of conda or spack packages (depending on machine type)
-esmf = 8.4.2
+esmf = 8.6.1
 metis = 5.1.0
 moab = 5.5.1
 netcdf_c = 4.9.2
 netcdf_fortran = 4.6.1
-pnetcdf = 1.12.3
+pnetcdf = 1.13.0
 
 # versions of spack packages
 albany = develop

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.4.0-alpha.1'
+__version__ = '0.4.0-alpha.2'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge updates versions of ESMF, ParallelIO and PNetCDF for conda environments.  These were needed for compatibility with the required version of MPAS-Tools.  (It won't affect spack deployments until we update to 1.5.0-alpha.1.)  As a result, the Polaris alpha version has been bumped to 2.

This merge also fixes a check for a software spack environment in the bootstrap stage of deployment.  The check is only performed if we are on a "known" machine.

GitHub Actions has been updated to deploy a full conda environment including compilers and MPI support.  This should catch incompatibilities like emerged between MPAS-Tools and other dependencies specified in `deploy/default.cfg`.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
fixes #213 