### PR TITLE
Remove `polaris clean` from check polaris commands

### DIFF
--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -796,8 +796,7 @@ def check_env(script_filename, env_name, logger):
                 ['ffmpeg', '--help'],
                 ['polaris', 'list'],
                 ['polaris', 'setup', '--help'],
-                ['polaris', 'suite', '--help'],
-                ['polaris', 'clean', '--help']]
+                ['polaris', 'suite', '--help']]
 
     for import_name in imports:
         command = f'{activate} && python -c "import {import_name}"'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
`check_env()` fails when trying to run `polaris clean` because it's a deprecated command. I just removed this call from the check.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
