### PR TITLE
Change references from `compass` to `polaris`

### DIFF
--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -1,4 +1,4 @@
-# Options related to deploying a compass conda environment on supported
+# Options related to deploying a polaris conda environment on supported
 # machines
 [deploy]
 

--- a/deploy/shared.py
+++ b/deploy/shared.py
@@ -9,7 +9,7 @@ from urllib.request import Request, urlopen
 
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
-        description='Deploy a compass conda environment')
+        description='Deploy a polaris conda environment')
     parser.add_argument("-m", "--machine", dest="machine",
                         help="The name of the machine for loading machine-"
                              "related config options.")

--- a/docs/developers_guide/ocean/index.md
+++ b/docs/developers_guide/ocean/index.md
@@ -28,12 +28,12 @@ MPAS-Ocean tasks also have these config options:
 ```cfg
 # This config file has default config options for MPAS-Ocean
 
-# The paths section points compass to external paths
+# The paths section points polaris to external paths
 [paths]
 
 # the relative or absolute path to the root of a branch where MPAS-Ocean
 # or Omega has been built
-component_path = ${paths:compass_branch}/e3sm_submodules/E3SM-Project/components/mpas-ocean
+component_path = ${paths:polaris_branch}/e3sm_submodules/E3SM-Project/components/mpas-ocean
 
 # The namelists section defines paths to example_compact namelists that will
 # be used to generate specific namelists. By default, these point to the
@@ -56,7 +56,7 @@ init    = ${paths:component_path}/default_inputs/streams.ocean.init
 
 # The executables section defines paths to required executables. These
 # executables are provided for use by specific tasks.  Most tools that
-# compass needs should be in the conda environment, so this is only the path
+# polaris needs should be in the conda environment, so this is only the path
 # to the MPAS-Ocean or Omega executable by default.
 [executables]
 component = ${paths:component_path}/ocean_model

--- a/docs/developers_guide/ocean/tasks/ice_shelf_2d.md
+++ b/docs/developers_guide/ocean/tasks/ice_shelf_2d.md
@@ -43,7 +43,7 @@ uniform temperature and zero initial velocity.
 
 ### forward
 
-The class {py:class}`compass.ocean.tests.ice_shelf_2d.forward.Forward`
+The class {py:class}`polaris.ocean.tests.ice_shelf_2d.forward.Forward`
 defines a step for running MPAS-Ocean from the initial condition produced in
 the `init` step. For MPAS-Ocean, PIO namelist options are modified and a
 graph partition is generated as part of `runtime_setup()`.  Next, the ocean 

--- a/docs/developers_guide/organization/tasks.md
+++ b/docs/developers_guide/organization/tasks.md
@@ -535,7 +535,7 @@ def configure(self):
     """
     Modify the configuration options for this task
     """
-    package = 'compass.ocean.tests.global_ocean.files_for_e3sm'
+    package = 'polaris.ocean.tests.global_ocean.files_for_e3sm'
     target = imp_res.files(package).joinpath('README')
     symlink(str(target), f'{self.work_dir}/README')
 ```

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -332,8 +332,8 @@ you have worked with (or if you aren't sure), it is safest to not just reinstall
 the `polaris` package but also to check the dependencies by re-running:
 `./configure_polaris_envs.py`  with the same arguments as above.
 This will also reinstall the `polaris` package from the current directory.
-The activation script includes a check to see if the version of compass used
-to produce the load script is the same as the version of compass in the
+The activation script includes a check to see if the version of polaris used
+to produce the load script is the same as the version of polaris in the
 current branch.  If the two don't match, an error like the following results
 and the environment is not activated:
 

--- a/polaris/ocean/tasks/internal_wave/viz.py
+++ b/polaris/ocean/tasks/internal_wave/viz.py
@@ -16,7 +16,7 @@ class Viz(Step):
 
         Parameters
         ----------
-        test_case : compass.TestCase
+        test_case : polaris.TestCase
             The test case this step belongs to
         """
         super().__init__(component=component, name='viz', indir=indir)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
I noticed these compass references needed to be updated.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
