### PR TITLE
Fix how yaml model config options are update 

### DIFF
--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -658,7 +658,12 @@ class ModelStep(Step):
         if not self.model_config_data:
             return
 
-        replacements = dict()
+        if self._yaml is None:
+            raise ValueError('Trying to update a yaml object but it was '
+                             'never created.')
+
+        if not quiet:
+            print(f'Warning: replacing yaml options in {self.yaml}')
 
         for entry in self.model_config_data:
             if 'namelist' in entry:
@@ -666,22 +671,15 @@ class ModelStep(Step):
                                  'namelist file.')
 
             if 'options' in entry:
-                # this is a dictionary of replacement namelist options
+                # this is a dictionary of replacement model config options
                 options = entry['options']
+                self._yaml.update(options=options, quiet=quiet)
             else:
                 yaml = PolarisYaml.read(filename=entry['yaml'],
                                         package=entry['package'],
                                         replacements=entry['replacements'])
-                options = yaml.configs
-            replacements.update(options)
 
-        if not quiet:
-            print(f'Warning: replacing yaml options in {self.yaml}')
-
-        if self._yaml is None:
-            raise ValueError('Trying to update a yaml object but it was '
-                             'never created.')
-        self._yaml = self._yaml.update(replacements, quiet=quiet)
+                self._yaml.update(configs=yaml.configs, quiet=quiet)
 
 
 def make_graph_file(mesh_filename, graph_filename='graph.info',

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -76,9 +76,9 @@ class Forward(ConvergenceForward):
 
         exact_solution = ExactSolution(self.config)
         options = {'config_manufactured_solution_amplitude':
-                   exact_solution.eta0,
+                   float(exact_solution.eta0),
                    'config_manufactured_solution_wavelength_x':
-                   exact_solution.lambda_x,
+                   float(exact_solution.lambda_x),
                    'config_manufactured_solution_wavelength_y':
-                   exact_solution.lambda_y}
+                   float(exact_solution.lambda_y)}
         self.add_model_config_options(options)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

With this update, we treat config options from files (with sections) differently from replacement options provided in a dictionary in code.

This merge also explicitly converts some model config options to floats.  This seems to be necessary because the yaml parser doesn't understand numpy scalars.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
