### PR TITLE
Better support for Omega in Polaris

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -175,6 +175,8 @@ seaice/api
    ModelStep.set_model_resources
    ModelStep.add_model_config_options
    ModelStep.add_yaml_file
+   ModelStep.map_yaml_options
+   ModelStep.map_yaml_configs
    ModelStep.map_yaml_to_namelist
    ModelStep.add_namelist_file
    ModelStep.add_streams_file

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -31,7 +31,7 @@
 
    validate.Validate
    validate.Validate.run
-   
+
    viz.Viz
    viz.Viz.run
 
@@ -128,12 +128,12 @@
 
    validate.Validate
    validate.Validate.run
-   
+
    viz.Viz
    viz.Viz.run
 ```
 
-### inertial_gravity_wave 
+### inertial_gravity_wave
 
 ```{eval-rst}
 .. currentmodule:: polaris.ocean.tasks.inertial_gravity_wave
@@ -142,7 +142,7 @@
    :toctree: generated/
 
    add_inertial_gravity_wave_tasks
-   
+
    InertialGravityWave
 
    analysis.Analysis
@@ -200,7 +200,7 @@
    :toctree: generated/
 
    add_manufactured_solution_tasks
-   
+
    ManufacturedSolution
 
    analysis.Analysis
@@ -340,8 +340,9 @@
    OceanModelStep.setup
    OceanModelStep.constrain_resources
    OceanModelStep.compute_cell_count
-   OceanModelStep.map_yaml_to_namelist
-   
+   OceanModelStep.map_yaml_options
+   OceanModelStep.map_yaml_configs
+
    get_time_interval_string
 ```
 

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -62,14 +62,14 @@ mpas-ocean:
   debug:
     config_disable_vel_hmix: true
 
-omega:
+Omega:
   Tendencies:
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false
 ```
 
 When model config options are set in code, it is also important to specify
-which `config_model` they apply to (`ocean`, `mpas-ocean` or `omega`):
+which `config_model` they apply to (`ocean`, `mpas-ocean` or `Omega`):
 ```python
 self.add_model_config_options(options=dict(config_mom_del2=nu),
                               config_model='ocean')
@@ -81,7 +81,8 @@ names for the `ocean` config options in the methods
 {py:meth}`polaris.ocean.model.OceanModelStep.map_yaml_configs()`.
 As new config options are added to Omega, they should be added to the
 map in the [mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml)
-file.
+file. Note that `config_model='Omega'` must be capitalized since this is the
+convention on the model name in Omega's own YAML files.
 
 #### Setting MPI resources
 

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -27,19 +27,65 @@ get set up.
 As a result, the `add_namelist_file()` and `add_streams_file()` methods should
 not be used for ocean model steps (they will raise errors).
 
-#### Mapping from Omega to MPAS-Ocean config options
+#### Mapping from MPAS-Ocean to Omega config options
 
-As the Omega component is in very early stages of development, we don't yet
-know whether Omega's config options will always have the same names as the
-corresponding namelist options in MPAS-Ocean.  To support the possibility
-that they are different, the 
-{py:meth}`polaris.ocean.model.OceanModelStep.map_yaml_to_namelist()` method
-can be used to translate names of Omega config options to their MPAS-Ocean
-counterparts.
+As the Omega component is in very early stages of development, it has far
+fewer config options than MPAS-Ocean at present.  To complicate things further,
+it is already clear that there will be config options in Omega without a
+corresponding option in MPAS-Ocean (just as there are clearly many MPAS-Ocean
+config options that don't exist in Omega).  As a result, we need a way to
+support three categories of config options:
+
+1. `ocean` config options available in both models (we use the MPAS-Ocean names
+   for these and map to the Omega names),
+2. `mpas-ocean` config options that only exist in MPAS-Ocean,
+3. `omega` config options that only exist in Omega.
+
+YAML files can have root-level sections with 1, 2 or all 3 of these
+so-called `config_models`, as in the following example:
+
+```
+ocean:
+  time_management:
+    config_run_duration: {{ run_duration }}
+  time_integration:
+    config_dt: {{ dt }}
+    config_time_integrator: {{ time_integrator }}
+
+mpas-ocean:
+  bottom_drag:
+    config_bottom_drag_mode: implicit
+    config_implicit_bottom_drag_type: constant
+    config_implicit_constant_bottom_drag_coeff: 0.0
+  manufactured_solution:
+     config_use_manufactured_solution: true
+  debug:
+    config_disable_vel_hmix: true
+
+omega:
+  Tendencies:
+    VelDiffTendencyEnable: false
+    VelHyperDiffTendencyEnable: false
+```
+
+When model config options are set in code, it is also important to specify
+which `config_model` they apply to (`ocean`, `mpas-ocean` or `omega`):
+```python
+self.add_model_config_options(options=dict(config_mom_del2=nu),
+                              config_model='ocean')
+```
+
+We implement a mapping from the MPAS-Ocean names to the corresponding Omega
+names for the `ocean` config options in the methods
+{py:meth}`polaris.ocean.model.OceanModelStep.map_yaml_options()` and
+{py:meth}`polaris.ocean.model.OceanModelStep.map_yaml_configs()`.
+As new config options are added to Omega, they should be added to the
+map in the [mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml)
+file.
 
 #### Setting MPI resources
 
-The target and minimum number of MPI tasks (`ntasks` and `min_tasks`, 
+The target and minimum number of MPI tasks (`ntasks` and `min_tasks`,
 respectively) are set automatically if `ntasks` and `min_tasks` have not
 already been set explicitly.  In such cases, a subclass of `OceanModelStep`
 must override the
@@ -56,9 +102,9 @@ self.min_tasks = max(1, round(cell_count / max_cells_per_core + 0.5))
 ```
 
 The config options `goal_cells_per_core` and `max_cells_per_core` in the
-`[ocean]` seciton can be used to control how resources scale with the size of 
-the planar mesh.  By default,  the number of MPI tasks tries to apportion 200 
-cells to each core, but it will allow as many as 2000. 
+`[ocean]` seciton can be used to control how resources scale with the size of
+the planar mesh.  By default,  the number of MPI tasks tries to apportion 200
+cells to each core, but it will allow as many as 2000.
 
 ### Setting time intervals in model config options
 
@@ -93,7 +139,7 @@ self.add_yaml_file(package, yaml_filename,
 ```
 where the YAML file might include:
 ```
-omega:
+ocean:
   time_management:
     config_run_duration: {{ run_duration }}
   time_integration:
@@ -117,7 +163,7 @@ omega:
 
 The module `polaris.ocean.config` contains yaml files for setting model
 config options and configuring streams.  These include things like setting
-output to double precision, adjusting sea surface height in ice-shelf cavities, 
+output to double precision, adjusting sea surface height in ice-shelf cavities,
 and outputting variables related to frazil ice and land-ice fluxes.
 
 
@@ -125,15 +171,15 @@ and outputting variables related to frazil ice and land-ice fluxes.
 
 ## Quasi-uniform and Icosahedral Spherical Meshes
 
-Many ocean tasks support two types of meshes: `qu` meshes created with the 
-{py:class}`polaris.mesh.QuasiUniformSphericalMeshStep` step and `icos` meshes 
-created with {py:class}`polaris.mesh.IcosahedralMeshStep`.  In general, the 
-`icos` meshes are more uniform but the `qu` meshes are more flexible.  The 
+Many ocean tasks support two types of meshes: `qu` meshes created with the
+{py:class}`polaris.mesh.QuasiUniformSphericalMeshStep` step and `icos` meshes
+created with {py:class}`polaris.mesh.IcosahedralMeshStep`.  In general, the
+`icos` meshes are more uniform but the `qu` meshes are more flexible.  The
 `icos` meshes only support a fixed set of resolutions described in
 {ref}`dev-spherical-meshes`.
 
 The function {py:func}`polaris.ocean.mesh.spherical.add_spherical_base_mesh_step()`
-returns a step for for a spherical `qu` or `icos` mesh of a given resolution 
+returns a step for for a spherical `qu` or `icos` mesh of a given resolution
 (in km).  The step can be shared between tasks.
 
 (dev-ocean-convergence)=
@@ -206,10 +252,10 @@ mesh resolution (proportional to the cell size). For split time integrators,
 way.  The `run_duration` and `output_interval` are typically the same, and
 they are given in hours.
 
-Each convergence test can override these defaults with its own defaults by 
+Each convergence test can override these defaults with its own defaults by
 defining them in its own config file.  Convergence tests should bring in this
 config file in their constructor or by adding them to a shared `config`.  The
-options from the shared infrastructure should be added first, then those from 
+options from the shared infrastructure should be added first, then those from
 its own config file to make sure they take precedence, e.g.:
 
 ```python
@@ -288,7 +334,7 @@ Each convergence test must define a YAML file with model config options, called
 `forward.yaml` by default.  The `package` parameter is the location of this
 file within the Polaris code (using python package syntax).  Although it is
 not used here, the `options` parameter can be used to pass model config options
-as a python dictionary so that they are added to with 
+as a python dictionary so that they are added to with
 {py:meth}`polaris.ModelStep.add_model_config_options()`. The
 `output_filename` is an output file that will have fields to validate and
 analyze.  The `validate_vars` are a list of variables to compare against a
@@ -299,10 +345,10 @@ The `mesh` step should be created with the function described in
 {ref}`dev-ocean-spherical-meshes`, and the `init` step should produce a file
 `init.nc` that will be the initial condition for the forward run.
 
-The `forward.yaml` file should be a YAML file with Jinja templating for the 
+The `forward.yaml` file should be a YAML file with Jinja templating for the
 time integrator, time step, run duration and output interval, e.g.:
 ```
-omega:
+ocean:
   time_management:
     config_run_duration: {{ run_duration }}
   time_integration:
@@ -310,6 +356,7 @@ omega:
     config_time_integrator: {{ time_integrator }}
   split_explicit_ts:
     config_btr_dt: {{ btr_dt }}
+mpas-ocean:
   streams:
     mesh:
       filename_template: init.nc
@@ -371,12 +418,12 @@ class Analysis(ConvergenceAnalysis):
                          convergence_vars=convergence_vars)
 ```
 
-Many tasks will also need to override the 
-{py:meth}`polaris.ocean.convergence.ConvergenceAnalysis.exact_solution()` 
-method. If not overridden, the analysis step will compute the difference of the 
+Many tasks will also need to override the
+{py:meth}`polaris.ocean.convergence.ConvergenceAnalysis.exact_solution()`
+method. If not overridden, the analysis step will compute the difference of the
 output from the initial state.
 
-In some cases, the child class will also need to override the 
+In some cases, the child class will also need to override the
 {py:meth}`polaris.ocean.convergence.ConvergenceAnalysis.get_output_field()`
 method if the requested field is not available directly from the output put
 rather needs to be computed.  The default behavior is to read the requested
@@ -430,7 +477,7 @@ changed.
 
 ## reference (resting) potential energy (RPE)
 
-The module `polaris.ocean.rpe` is used to compute the reference (or 
+The module `polaris.ocean.rpe` is used to compute the reference (or
 resting) potential energy for an entire model domain.  The RPE as given in
 [Petersen et al. 2015](https://doi.org/10.1016/j.ocemod.2014.12.004) is:
 

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -507,6 +507,7 @@ git submodule update --init --recursive externals/YAKL externals/ekat \
     externals/scorpio cime
 cd components/omega
 mkdir build
+cd build
 cmake \
    -DOMEGA_BUILD_TYPE=Release \
    -DOMEGA_CIME_COMPILER=${POLARIS_COMPILER} \

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -530,6 +530,10 @@ location you like.  If you build in a location other than
 relative or absolute path using the `-p` flag when you call `polaris setup` or
 `polaris suite`.
 
+To set up tasks and suites to use Omega, you need to supply `--model=omega`
+to `polaris setup` or `polaris suite`.  Otherwise, it will default to
+MPAS-Ocean.
+
 (dev-working-with-polaris)=
 
 ## Running polaris from the repo

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -458,13 +458,23 @@ be safe.
 ## Building E3SM components
 
 There are 3 E3SM repositories that are submodules within the polaris
-repository.  To build MPAS-Ocean, you would typically run:
+repository.
+
+For MPAS-Ocean and MALI both, see the last column of the table in
+{ref}`dev-supported-machines` for the right `<mpas_make_target>` command for
+each machine and compiler.
+
+### MPAS-Ocean
+
+To build MPAS-Ocean, you would typically run:
 
 ```bash
 source ./load_<env_name>_<machine>_<compiler>_<mpi>.sh
 cd e3sm_submodules/E3SM-Project/components/mpas-ocean/
 make <mpas_make_target>
 ```
+
+### MALI
 
 MALI should typically be compiled with the Albany library that contains the
 first-order velocity solver.  The Albany first-order velocity solver is the
@@ -483,13 +493,42 @@ cd e3sm_submodules/MALI-Dev/components/mpas-albany-landice
 make ALBANY=true <mpas_make_target>
 ```
 
-For MPAS-Ocean and MALI both, see the last column of the table in
-{ref}`dev-supported-machines` for the right `<mpas_make_target>` command for
-each machine and compiler.
+### Omega
 
-Instructions for building Omega will be added as development proceeds. For now,
-you can run 
-[Omega CTest Utility](https://github.com/E3SM-Project/polaris/blob/main/utils/omega/ctest/README.md). 
+If you simply wish to run the CTests from Omega, you likely want to use the
+[Omega CTest Utility](https://github.com/E3SM-Project/polaris/blob/main/utils/omega/ctest/README.md).
+
+Otherwise, to build Omega,
+```bash
+source ./load_<env_name>_<machine>_<compiler>_<mpi>.sh
+git submodule update --init e3sm_submodules/Omega
+cd e3sm_submodules/Omega
+git submodule update --init --recursive externals/YAKL externals/ekat \
+    externals/scorpio cime
+cd components/omega
+mkdir build
+cmake \
+   -DOMEGA_BUILD_TYPE=Release \
+   -DOMEGA_CIME_COMPILER=${POLARIS_COMPILER} \
+   -DOMEGA_CIME_MACHINE=${POLARIS_MACHINE} \
+   -DOMEGA_METIS_ROOT=${METIS_ROOT} \
+   -DOMEGA_PARMETIS_ROOT=${PARMETIS_ROOT} \
+   -DOMEGA_BUILD_TEST=ON \
+   -Wno-dev \
+   -S .. \
+   -B .
+
+./omega_build.sh
+```
+You can remove `-DOMEGA_BUILD_TEST=ON` to skip building CTests.  You can change
+`-DOMEGA_BUILD_TYPE=Release` to `-DOMEGA_BUILD_TYPE=Debug` to build in debug
+mode.
+
+You can alter the example above to build whichever Omega branch and in whatever
+location you like.  If you build in a location other than
+`e3sm_submodules/Omega/components/omega/build`, you will need to point to the
+relative or absolute path using the `-p` flag when you call `polaris setup` or
+`polaris suite`.
 
 (dev-working-with-polaris)=
 

--- a/docs/tutorials/dev_add_test_group.md
+++ b/docs/tutorials/dev_add_test_group.md
@@ -1325,7 +1325,7 @@ $ cp ${POLARIS_HEAD}/polaris/ocean/tasks/baroclinic_channel/forward.yaml \
 $ vi ${POLARIS_HEAD}/polaris/ocean/tasks/yet_another_channel/forward.yaml
 ```
 ```yaml
-omega:
+mpas-ocean:
   time_management:
     config_run_duration: 00:15:00
   time_integration:
@@ -1414,7 +1414,7 @@ we get double-precision output (the default is single precision, which saves a
 lot of space but isn't great for regression testing):
 
 ```yaml
-omega:
+mpas-ocean:
   streams:
     output:
       type: output
@@ -1463,7 +1463,7 @@ files added to it.  If you want the default definition of a stream, referring
 to it is enough:
 
 ```yaml
-omega:
+mpas-ocean:
   streams:
     restart: {}
 ```
@@ -1471,7 +1471,7 @@ omega:
 If you want to change one of its attributes but not its contents, you can do
 that:
 ```yaml
-omega:
+mpas-ocean:
   streams:
     input:
       filename_template: initial_state.nc
@@ -1485,7 +1485,7 @@ contents:
 $ vi ${POLARIS_HEAD}/polaris/ocean/tasks/yet_another_channel/forward.yaml
 ```
 ```yaml
-omega:
+mpas-ocean:
   ...
   streams:
     output:
@@ -2530,9 +2530,10 @@ The names of the steps and the number of steps are determined by `nus`.
 We also add another file with model config options and streams specific to
 this task, `rpe/forward.yaml`:
 ```yaml
-omega:
+ocean:
   time_management:
     config_run_duration: 20_00:00:00
+mpas-ocean:
   streams:
     output:
       type: output

--- a/docs/users_guide/ocean/tasks/baroclinic_channel.md
+++ b/docs/users_guide/ocean/tasks/baroclinic_channel.md
@@ -9,9 +9,13 @@ from [Ilicak et al. (2012)](https://doi.org/10.1016/j.ocemod.2011.10.003).
 
 Polaris includes includes 5 baroclinic channel test cases.  All test cases have
 at least 2 steps, `init`, which defines the mesh and initial conditions for the
-model, and some variation on `forward` (given another name in many test cases 
-to distinguish multiple forward runs), which performs time integration of the 
+model, and some variation on `forward` (given another name in many test cases
+to distinguish multiple forward runs), which performs time integration of the
 model.
+
+## suppported models
+
+These tasks support only MPAS-Ocean.
 
 ## mesh
 
@@ -23,7 +27,7 @@ resolution.
 
 ## vertical grid
 
-By default, all tests have 20 vertical layers of 50-m uniform thickness. The 
+By default, all tests have 20 vertical layers of 50-m uniform thickness. The
 domain bottom is flat.
 
 ```cfg
@@ -86,7 +90,7 @@ $$
 T_0(y) = \begin{cases}
     T_0(z) - \Delta T \: f(y) + \Delta T_{crest} \:
     (1-(y - (y_{mid} - y_{crest}(x))/\frac{1}{2} \Delta y_{perturb}) &
-    \text{ if } y_{min}(x) \le y \le y_{max}(x); 
+    \text{ if } y_{min}(x) \le y \le y_{max}(x);
     \frac{4}{6} l_x \le x \le \frac{5}{6} l_x \\
     T_0(z) - \Delta T \: f(y) & \text{otherwise}
 \end{cases}
@@ -170,7 +174,7 @@ coriolis_parameter = -1.2e-4
 ```
 
 The default domain size (`lx` and `ly`) is designed to be consistent with the
-literature, but can be modified by users to suit their needs.  
+literature, but can be modified by users to suit their needs.
 
 The config options `dt_per_km` and `btr_dt_per_km` are used to determine a
 time steps that is consistent with a given resolution.  Changing these config
@@ -187,7 +191,7 @@ All units are mks, with temperature in degrees Celsius and salinity in PSU.
 
 `ocean/baroclinic_channel/10km/default` is the default version of the
 baroclinic eddies test case for a short (15 min) test run and validation of
-prognostic variables for regression testing.  
+prognostic variables for regression testing.
 
 ### mesh
 
@@ -227,7 +231,7 @@ The number of processors is hard-coded to be 4 for this case.
 of the model forward in time on 4 (`4proc` step) and then on 8 processors
 (`8proc` step) to make sure the resulting prognostic variables are
 bit-for-bit identical between the two runs.
- 
+
 ### mesh
 
 See {ref}`ocean-baroclinic-channel`. Currently, only 10-km horizontal

--- a/docs/users_guide/ocean/tasks/correlated_tracers_2d.md
+++ b/docs/users_guide/ocean/tasks/correlated_tracers_2d.md
@@ -6,8 +6,8 @@
 
 The `correlated_tracers_2d` and `correlated_tracers_2d/with_viz` tasks implement the
 non-divergent flow field test of (1) numerical order of convergence and (2)
-mixing as described in 
-[Lauritzen et al. 2012](<https://gmd.copernicus.org/articles/5/887/2012/>). 
+mixing as described in
+[Lauritzen et al. 2012](<https://gmd.copernicus.org/articles/5/887/2012/>).
 
 The numerical order of convergence is analyzed in the `analysis` step and
 produces a figure similar to the following showing L2 error norm as a function
@@ -27,6 +27,10 @@ the end of the simulation:
 :align: center
 :width: 500 px
 ```
+
+## suppported models
+
+These tasks support only MPAS-Ocean.
 
 ## mesh
 
@@ -61,14 +65,14 @@ qu_resolutions = 60, 90, 120, 150, 180, 210, 240
 ```
 
 To alter the resolutions used in this task, you will need to create your own
-config file (or add a `spherical_convergence` section to a config file if 
+config file (or add a `spherical_convergence` section to a config file if
 you're already using one).  The resolutions are a comma-separated list of the
 resolution of the mesh in km.  If you specify a different list
 before setting up `correlated_tracers_2d`, steps will be generated with the requested
-resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the 
-task's config file in the work directory, nothing will happen.)  For `icos` 
-meshes, make sure you use a resolution close to those listed in 
-{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest 
+resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the
+task's config file in the work directory, nothing will happen.)  For `icos`
+meshes, make sure you use a resolution close to those listed in
+{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest
 allowed icosahedral resolution.
 
 The `base_mesh` steps are shared with other tasks so they are not housed in
@@ -169,11 +173,11 @@ This case is forced to follow $u(t)$ and $v(t)$ given above.
 
 ## time step and run duration
 
-This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step 
+This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step
 for forward integration is determined by multiplying the resolution by a config
 option, `rk4_dt_per_km`, so that coarser meshes have longer time steps. You can
-alter this before setup (in a user config file) or before running the task (in 
-the config file in the work directory). 
+alter this before setup (in a user config file) or before running the task (in
+the config file in the work directory).
 
 ```cfg
 # config options for spherical convergence tests
@@ -200,7 +204,7 @@ run_duration = ${sphere_transport:vel_pd}
 output_interval = ${sphere_transport:vel_pd}
 ```
 
-Here, `${sphere_transport:vel_pd}` means that the same value is used as in the 
+Here, `${sphere_transport:vel_pd}` means that the same value is used as in the
 option `vel_pd` in section `[sphere_transport]`, see below.
 
 ## config options
@@ -317,7 +321,7 @@ only, the convergence rate threshold, and the time at which to evaluate mixing
 diagnostics.
 
 The options in sections `sphere_transport_viz*` control properties of the `viz`
-step of the test case. 
+step of the test case.
 
 The default options for the convergence analysis step can be changed here:
 

--- a/docs/users_guide/ocean/tasks/cosine_bell.md
+++ b/docs/users_guide/ocean/tasks/cosine_bell.md
@@ -4,8 +4,8 @@
 
 ## description
 
-The `cosine_bell` and `cosine_bell/with_viz` tasks implement the Cosine 
-Bell test case as first described in 
+The `cosine_bell` and `cosine_bell/with_viz` tasks implement the Cosine
+Bell test case as first described in
 [Williamson et al. 1992](<https://doi.org/10.1016/S0021-9991(05)80016-6>)
 but using the variant from Sec. 3a of
 [Skamarock and Gassmann](https://doi.org/10.1175/MWR-D-10-05056.1).  A flow
@@ -25,6 +25,10 @@ The `cosine_bell/with_viz` variant also includes visualization of the initial
 and final state on a lat-lon grid for each resolution.  The visualization is
 not included in the `cosine_bell` version of the task in order to not slow down
 regression testing.
+
+## suppported models
+
+These tasks support only MPAS-Ocean.
 
 (ocean-cosine-bell-mesh)=
 ## mesh
@@ -60,14 +64,14 @@ qu_resolutions = 60, 90, 120, 150, 180, 210, 240
 ```
 
 To alter the resolutions used in this task, you will need to create your own
-config file (or add a `spherical_convergence` section to a config file if 
+config file (or add a `spherical_convergence` section to a config file if
 you're already using one).  The resolutions are a comma-separated list of the
 resolution of the mesh in km.  If you specify a different list
 before setting up `cosine_bell`, steps will be generated with the requested
-resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the 
-task's config file in the work directory, nothing will happen.)  For `icos` 
-meshes, make sure you use a resolution close to those listed in 
-{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest 
+resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the
+task's config file in the work directory, nothing will happen.)  For `icos`
+meshes, make sure you use a resolution close to those listed in
+{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest
 allowed icosahedral resolution.
 
 The `base_mesh` steps are shared with other tasks so they are not housed in
@@ -163,11 +167,11 @@ field remains at the initial velocity $u_0$.
 (ocean-cosine-bell-time-step)=
 ## time step and run duration
 
-This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step 
+This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step
 for forward integration is determined by multiplying the resolution by a config
 option, `rk4_dt_per_km`, so that coarser meshes have longer time steps. You can
-alter this before setup (in a user config file) or before running the task (in 
-the config file in the work directory). 
+alter this before setup (in a user config file) or before running the task (in
+the config file in the work directory).
 
 ```cfg
 # config options for convergence tests
@@ -194,7 +198,7 @@ run_duration = ${cosine_bell:vel_pd}
 output_interval = ${cosine_bell:vel_pd}
 ```
 
-Here, `${cosine_bell:vel_pd}` means that the same value is used as in the 
+Here, `${cosine_bell:vel_pd}` means that the same value is used as in the
 option `vel_pd` in section `[cosine_bell]`, see below.
 
 ## config options

--- a/docs/users_guide/ocean/tasks/divergent_2d.md
+++ b/docs/users_guide/ocean/tasks/divergent_2d.md
@@ -5,7 +5,7 @@
 ## description
 
 The `divergent_2d` and `divergent_2d/with_viz` tasks implement the
-divergent flow field test of numerical order of convergence as described in 
+divergent flow field test of numerical order of convergence as described in
 [Lauritzen et al. 2012](<https://gmd.copernicus.org/articles/5/887/2012/>).
 
 The numerical order of convergence is analyzed in the `analysis` step and
@@ -16,6 +16,10 @@ of horizontal resolution:
 :align: center
 :width: 500 px
 ```
+
+## suppported models
+
+These tasks support only MPAS-Ocean.
 
 ## mesh
 
@@ -50,14 +54,14 @@ qu_resolutions = 60, 90, 120, 150, 180, 210, 240
 ```
 
 To alter the resolutions used in this task, you will need to create your own
-config file (or add a `spherical_convergence` section to a config file if 
+config file (or add a `spherical_convergence` section to a config file if
 you're already using one).  The resolutions are a comma-separated list of the
 resolution of the mesh in km.  If you specify a different list
 before setting up `divergent_2d`, steps will be generated with the requested
-resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the 
-task's config file in the work directory, nothing will happen.)  For `icos` 
-meshes, make sure you use a resolution close to those listed in 
-{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest 
+resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the
+task's config file in the work directory, nothing will happen.)  For `icos`
+meshes, make sure you use a resolution close to those listed in
+{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest
 allowed icosahedral resolution.
 
 The `base_mesh` steps are shared with other tasks so they are not housed in
@@ -158,11 +162,11 @@ This case is forced to follow $u(t)$ and $v(t)$ given above.
 
 ## time step and run duration
 
-This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step 
+This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step
 for forward integration is determined by multiplying the resolution by a config
 option, `rk4_dt_per_km`, so that coarser meshes have longer time steps. You can
-alter this before setup (in a user config file) or before running the task (in 
-the config file in the work directory). 
+alter this before setup (in a user config file) or before running the task (in
+the config file in the work directory).
 
 ```cfg
 # config options for spherical convergence tests
@@ -189,7 +193,7 @@ run_duration = ${sphere_transport:vel_pd}
 output_interval = ${sphere_transport:vel_pd}
 ```
 
-Here, `${sphere_transport:vel_pd}` means that the same value is used as in the 
+Here, `${sphere_transport:vel_pd}` means that the same value is used as in the
 option `vel_pd` in section `[sphere_transport]`, see below.
 
 ## config options
@@ -301,7 +305,7 @@ section `divergent_2d` control the initial condition of that case
 only and the convergence rate threshold.
 
 The options in sections `sphere_transport_viz*` control properties of the `viz`
-step of the test case. 
+step of the test case.
 
 The default options for the convergence analysis step can be changed here:
 

--- a/docs/users_guide/ocean/tasks/geostrophic.md
+++ b/docs/users_guide/ocean/tasks/geostrophic.md
@@ -10,7 +10,7 @@ State Nonlinear Zonal Geostrophic Flow" test case described in
 
 The task is a convergence test with time step varying proportionately to grid
 size. The result of the `analysis` step of the task are plots like the
-following showing convergence of water-column thickness and normal velocity as 
+following showing convergence of water-column thickness and normal velocity as
 functions of the mesh resolution:
 
 ```{image} images/geostrophic_convergence.png
@@ -18,11 +18,15 @@ functions of the mesh resolution:
 :width: 500 px
 ```
 
+## suppported models
+
+These tasks support only MPAS-Ocean.
+
 ## mesh
 
 The mesh is global and can be constructed either as quasi-uniform or
 icosahedral. At least three resolutions must be chosen for the mesh
-convergence study. The base meshes are the same as used in 
+convergence study. The base meshes are the same as used in
 {ref}`ocean-cosine-bell`.  See cosine bell's {ref}`ocean-cosine-bell-mesh`
 section for more details.
 
@@ -30,7 +34,7 @@ section for more details.
 
 This test case only exercises the shallow water dynamics. As such, the minimum
 number of vertical levels may be used. The bottom depth is constant and the
-results should be insensitive to the choice of `bottom_depth`.  See cosine 
+results should be insensitive to the choice of `bottom_depth`.  See cosine
 bell's {ref}`ocean-cosine-bell-vertical` section for the config options.
 
 (ocean-geostrophic-init)=
@@ -82,16 +86,16 @@ $$
 
 ## forcing
 
-Probably N/A but see Williamson's text about the possibility of prescribing a 
+Probably N/A but see Williamson's text about the possibility of prescribing a
 wind field.
 
 ## time step and run duration
 
-This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step 
+This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step
 for forward integration is determined by multiplying the resolution by a config
 option, `rk4_dt_per_km`, so that coarser meshes have longer time steps. You can
-alter this before setup (in a user config file) or before running the task (in 
-the config file in the work directory). 
+alter this before setup (in a user config file) or before running the task (in
+the config file in the work directory).
 
 ```cfg
 # config options for convergence tests
@@ -125,7 +129,7 @@ run_duration = ${convergence:convergence_eval_time}
 output_interval = ${run_duration}
 ```
 
-Here, `${convergence:convergence_eval_time}` means that the same value is used 
+Here, `${convergence:convergence_eval_time}` means that the same value is used
 as in the option `convergence_eval_time` in section `[convergence]`.
 
 ## analysis
@@ -167,7 +171,7 @@ the Williams et al. (1992) paper.  The temperature and salinity are arbitrary,
 since they do not vary in space and should not affect the evolution.
 
 Three additional config options relate to detecting when the convergence rate
-for the water-column thickness (h) and normal velocity (using the L2 norm to 
+for the water-column thickness (h) and normal velocity (using the L2 norm to
 compute the error).  If either convergence rate is unexpectedly low an error is
 raised:
 ```cfg
@@ -186,7 +190,7 @@ convergence_thresh_normalVelocity = 1.3
 ```
 
 The convergence rate of the water-column thickness for this test case is very
-low for the QU meshes in MPAS-Ocean, about 0.5, which necessitates the very 
+low for the QU meshes in MPAS-Ocean, about 0.5, which necessitates the very
 generous  convergence threshold used here.
 
 Config options related to visualization are as follows.  The options in

--- a/docs/users_guide/ocean/tasks/ice_shelf_2d.md
+++ b/docs/users_guide/ocean/tasks/ice_shelf_2d.md
@@ -60,6 +60,10 @@ freshwater and heat fluxes under ice shelves.
 Frazil-ice formation is not included in the `ssh_adjustment` steps but is
 included in the `forward` step of this test case.
 
+## suppported models
+
+These tasks support only MPAS-Ocean.
+
 ## mesh
 
 The test case currently supports only 5-km horizontal resolution. The x
@@ -130,7 +134,7 @@ The initial temperature for the whole domain is constant (1 degree Celsius),
 while salinity varies linearly with depth from 34.5 PSU at the sea surface
 to 34.7 PSU at the sea floor, which is at a constant at 2000 m depth. These
 initial conditions can be modified with config options `temperature`,
-`surface_salinity`, and `bottom_salinity` 
+`surface_salinity`, and `bottom_salinity`
 
 ## forcing
 
@@ -197,7 +201,7 @@ temperature and salinity of the test case by altering these options.
 
 `ocean/planar/ice_shelf_2d/${RES}/default` is the default version of the
 ice shelf 2-d test case for a short (10 min) test run and validation of
-prognostic variables for regression testing.  
+prognostic variables for regression testing.
 
 ### mesh
 
@@ -301,7 +305,7 @@ See {ref}`ocean-ice-shelf-2d-default`.
 
 `ocean/planar/ice_shelf_2d/5km/default` is the default version of the
 ice shelf 2-d test case for a short (10 min) test run and validation of
-prognostic variables for regression testing.  
+prognostic variables for regression testing.
 
 ### mesh
 

--- a/docs/users_guide/ocean/tasks/inertial_gravity_wave.md
+++ b/docs/users_guide/ocean/tasks/inertial_gravity_wave.md
@@ -38,6 +38,10 @@ SSH fields.
 :width: 500 px
 ```
 
+## suppported models
+
+These tasks support only MPAS-Ocean.
+
 ## mesh
 
 For each resolution, the `init` step generates and planar hexagonal
@@ -55,7 +59,7 @@ single layer configuration.
 grid_type = uniform
 
 # Number of vertical levels
-vert_levels = 1 
+vert_levels = 1
 
 # Depth of the bottom of the ocean
 bottom_depth = 1000.0

--- a/docs/users_guide/ocean/tasks/internal_wave.md
+++ b/docs/users_guide/ocean/tasks/internal_wave.md
@@ -5,6 +5,10 @@
 The ``ocean/internal_wave`` test group induces internal wave propagation and is documented in
 `Ilicak et al. (2012) <https://doi.org/10.1016/j.ocemod.2011.10.003>`_.
 
+## suppported models
+
+These tasks support only MPAS-Ocean.
+
 (ocean-internal-wave-default)=
 
 ## default task

--- a/docs/users_guide/ocean/tasks/manufactured_solution.md
+++ b/docs/users_guide/ocean/tasks/manufactured_solution.md
@@ -7,10 +7,14 @@ propagation with the rotating, nonlinear shallow water equations on a doubly
 periodic domain. These tasks are intended to utilize tendency terms embedded
 in the forward ocean model in order to produce the manufactured solution. This
 solution can be then used to assess the numerical accuracy and convergence of
-the discretized nonlinear momentum equation. 
+the discretized nonlinear momentum equation.
 
 Currently, the there is only one task, the convergence test from
 [Bishnu et al.(2023)](https://doi.org/10.22541/essoar.167100170.03833124/v1)
+
+## suppported models
+
+These tasks support both MPAS-Ocean and Omega.
 
 (ocean-manufactured-solution-convergence)=
 
@@ -20,7 +24,7 @@ Currently, the there is only one task, the convergence test from
 
 The `convergence` test case runs the manufactured solution simulation for 4
 different resolutions: 200, 100, 50, and 25 km.
- 
+
 The forward step for each resolution runs the simulation for 10 hours. The
 model is configured without vertical advection and mixing. No tracers are enabled
 and the pressure gradient used is the gradient of the sea surface height.
@@ -51,7 +55,7 @@ single layer configuration.
 grid_type = uniform
 
 # Number of vertical levels
-vert_levels = 1 
+vert_levels = 1
 
 # Depth of the bottom of the ocean
 bottom_depth = 1000.0

--- a/docs/users_guide/ocean/tasks/nondivergent_2d.md
+++ b/docs/users_guide/ocean/tasks/nondivergent_2d.md
@@ -6,7 +6,7 @@
 
 The `nondivergent_2d` and `nondivergent_2d/with_viz` tasks implement the
 non-divergent flow field test of (1) numerical order of convergence, (2)
-filament preservation and (3) rough distribution as described in 
+filament preservation and (3) rough distribution as described in
 [Lauritzen et al. 2012](<https://gmd.copernicus.org/articles/5/887/2012/>).
 The reversing deformational flow in this test case explores large-scale to small-scale transport.
 
@@ -35,6 +35,10 @@ is addressed in the `viz` steps for each resolution of the
 debug tracers at initial time, thhe mid-point and final time. The rough
 distributions are represented as slotted cylinders in the `tracer3`
 field.
+
+## suppported models
+
+These tasks support only MPAS-Ocean.
 
 ## mesh
 
@@ -69,14 +73,14 @@ qu_resolutions = 60, 90, 120, 150, 180, 210, 240
 ```
 
 To alter the resolutions used in this task, you will need to create your own
-config file (or add a `spherical_convergence` section to a config file if 
+config file (or add a `spherical_convergence` section to a config file if
 you're already using one).  The resolutions are a comma-separated list of the
 resolution of the mesh in km.  If you specify a different list
 before setting up `nondivergent_2d`, steps will be generated with the requested
-resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the 
-task's config file in the work directory, nothing will happen.)  For `icos` 
-meshes, make sure you use a resolution close to those listed in 
-{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest 
+resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the
+task's config file in the work directory, nothing will happen.)  For `icos`
+meshes, make sure you use a resolution close to those listed in
+{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest
 allowed icosahedral resolution.
 
 The `base_mesh` steps are shared with other tasks so they are not housed in
@@ -177,11 +181,11 @@ This case is forced to follow $u(t)$ and $v(t)$ given above.
 
 ## time step and run duration
 
-This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step 
+This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step
 for forward integration is determined by multiplying the resolution by a config
 option, `rk4_dt_per_km`, so that coarser meshes have longer time steps. You can
-alter this before setup (in a user config file) or before running the task (in 
-the config file in the work directory). 
+alter this before setup (in a user config file) or before running the task (in
+the config file in the work directory).
 
 ```cfg
 # config options for spherical convergence tests
@@ -208,7 +212,7 @@ run_duration = ${sphere_transport:vel_pd}
 output_interval = ${sphere_transport:vel_pd}
 ```
 
-Here, `${sphere_transport:vel_pd}` means that the same value is used as in the 
+Here, `${sphere_transport:vel_pd}` means that the same value is used as in the
 option `vel_pd` in section `[sphere_transport]`, see below.
 
 ## config options
@@ -325,7 +329,7 @@ only, the convergence rate threshold, and the time at which to evaluate
 filament preservation.
 
 The options in sections `sphere_transport_viz*` control properties of the `viz`
-step of the test case. 
+step of the test case.
 
 The default options for the convergence analysis step can be changed here:
 

--- a/docs/users_guide/ocean/tasks/rotation_2d.md
+++ b/docs/users_guide/ocean/tasks/rotation_2d.md
@@ -18,6 +18,10 @@ of horizontal resolution:
 :width: 500 px
 ```
 
+## suppported models
+
+These tasks support only MPAS-Ocean.
+
 ## mesh
 
 Two global mesh variants are tested, quasi-uniform (QU) and icosohydral. Thus,
@@ -51,14 +55,14 @@ qu_resolutions = 60, 90, 120, 150, 180, 210, 240
 ```
 
 To alter the resolutions used in this task, you will need to create your own
-config file (or add a `spherical_convergence` section to a config file if 
+config file (or add a `spherical_convergence` section to a config file if
 you're already using one).  The resolutions are a comma-separated list of the
 resolution of the mesh in km.  If you specify a different list
 before setting up `rotation_2d`, steps will be generated with the requested
-resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the 
-task's config file in the work directory, nothing will happen.)  For `icos` 
-meshes, make sure you use a resolution close to those listed in 
-{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest 
+resolutions.  (If you alter `icos_resolutions` or `qu_resolutions`) in the
+task's config file in the work directory, nothing will happen.)  For `icos`
+meshes, make sure you use a resolution close to those listed in
+{ref}`dev-spherical-meshes`.  Each resolution will be rounded to the nearest
 allowed icosahedral resolution.
 
 The `base_mesh` steps are shared with other tasks so they are not housed in
@@ -148,11 +152,11 @@ in the config options.
 
 ## time step and run duration
 
-This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step 
+This task uses the Runge-Kutta 4th-order (RK4) time integrator. The time step
 for forward integration is determined by multiplying the resolution by a config
 option, `rk4_dt_per_km`, so that coarser meshes have longer time steps. You can
-alter this before setup (in a user config file) or before running the task (in 
-the config file in the work directory). 
+alter this before setup (in a user config file) or before running the task (in
+the config file in the work directory).
 
 ```cfg
 # config options for spherical convergence tests
@@ -179,7 +183,7 @@ run_duration = ${sphere_transport:vel_pd}
 output_interval = ${sphere_transport:vel_pd}
 ```
 
-Here, `${sphere_transport:vel_pd}` means that the same value is used as in the 
+Here, `${sphere_transport:vel_pd}` means that the same value is used as in the
 option `vel_pd` in section `[sphere_transport]`, see below.
 
 ## config options
@@ -291,7 +295,7 @@ on Lauritzen et al. (2012) and control the initial condition. The options in
 section `rotation_2d` control the convergence rate threshold.
 
 The options in sections `sphere_transport_viz*` control properties of the `viz`
-step of the test case. 
+step of the test case.
 
 The default options for the convergence analysis step can be changed here:
 

--- a/docs/users_guide/ocean/tasks/single_column.md
+++ b/docs/users_guide/ocean/tasks/single_column.md
@@ -4,8 +4,12 @@
 
 ## description
 
-The `single_column` tasks include any ocean tests of the vertical ocean 
+The `single_column` tasks include any ocean tests of the vertical ocean
 dynamics.
+
+## suppported models
+
+These tasks support only MPAS-Ocean.
 
 ## mesh
 
@@ -129,7 +133,7 @@ See mesh section for a description of `lx` and `ly` and initial conditions secti
 ### description
 
 The `cvmix` test exercises the [CVMix](https://github.com/CVMix/CVMix-src)
-schemes for vertical mixing. 
+schemes for vertical mixing.
 
 The temperature and salinity profiles only evolve a small amount over the 1-
 day duration of the test, so the 10-day profiles are shown here:
@@ -234,8 +238,8 @@ The `ideal age` test exercises the ideal age tracers.
 
 ### description
 
-Temperature and salinity profiles evolve in the same way as in the 
-{ref}`ocean-single-column-cvmix` test case. 10-day profiles for the ideal age 
+Temperature and salinity profiles evolve in the same way as in the
+{ref}`ocean-single-column-cvmix` test case. 10-day profiles for the ideal age
 tracer are as follows:
 
 ```{image} images/single_column_ideal_age_tracer_10day.png

--- a/docs/users_guide/ocean/tasks/template.md
+++ b/docs/users_guide/ocean/tasks/template.md
@@ -6,12 +6,24 @@ Description of common characteristics of the tasks.
 
 (ocean-category-of-task-task-name)=
 
+## suppported models
+
+This section should have one of the following lines, as appropriate, or if
+individual tasks support different models, each task should have a similar
+section:
+
+These tasks support both MPAS-Ocean and Omega.
+
+These tasks support only MPAS-Ocean.
+
+These tasks support only Omega.
+
 ## task_name
 
 In cases where the test cases within a category share many characteristics,
 it may be more appropriate to move the certain sections up one level to the
-common subdirectory. In that case, the respective section should still be 
-included for each test case, specifying any or no differences from the section 
+common subdirectory. In that case, the respective section should still be
+included for each test case, specifying any or no differences from the section
 in the shared framework level.
 
 ### description

--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -177,8 +177,12 @@ class ModelStep(Step):
         config = self.config
         component_path = config.get('executables', 'component')
         model_basename = os.path.basename(component_path)
-        self.args = [[f'./{model_basename}', '-n', self.namelist,
-                      '-s', self.streams]]
+        if self.make_yaml:
+            self.args = [[f'./{model_basename}']]
+        else:
+            self.args = [[f'./{model_basename}',
+                          '-n', self.namelist,
+                          '-s', self.streams]]
 
     def set_model_resources(self, ntasks=None, min_tasks=None,
                             openmp_threads=None, max_memory=None):

--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -252,6 +252,50 @@ class ModelStep(Step):
         self.streams_data.append(dict(package=package, yaml=yaml,
                                       replacements=template_replacements))
 
+    def map_yaml_options(self, options):
+        """
+        A mapping between model config options between different models.  This
+        method should be overridden for situations in which yaml config
+        options have diverged in name or structure from their counterparts in
+        another model (e.g. when translating from MPAS-Ocean namelist options
+        to Omega config options)
+
+        Parameters
+        ----------
+        options : dict
+            A dictionary of yaml options and value to use as replacements for
+            existing values
+
+        Returns
+        -------
+        options : dict
+            A revised dictionary of yaml options and value to use as
+            replacements for existing values
+        """
+        return options
+
+    def map_yaml_configs(self, configs):
+        """
+        A mapping between model config options between different models.  This
+        method should be overridden for situations in which yaml config
+        options have diverged in name or structure from their counterparts in
+        another model (e.g. when translating from MPAS-Ocean namelist options
+        to Omega config options)
+
+        Parameters
+        ----------
+        configs : dict
+            A nested dictionary of yaml sections, options and value to use as
+            replacements for existing values
+
+        Returns
+        -------
+        configs : dict
+            A revised nested dictionary of yaml sections, options and value to
+            use as replacements for existing values
+        """
+        return configs
+
     def map_yaml_to_namelist(self, options):
         """
         A mapping from yaml model config options to namelist options.  This
@@ -673,13 +717,15 @@ class ModelStep(Step):
             if 'options' in entry:
                 # this is a dictionary of replacement model config options
                 options = entry['options']
+                options = self.map_yaml_options(options=entry['options'])
                 self._yaml.update(options=options, quiet=quiet)
             else:
                 yaml = PolarisYaml.read(filename=entry['yaml'],
                                         package=entry['package'],
                                         replacements=entry['replacements'])
 
-                self._yaml.update(configs=yaml.configs, quiet=quiet)
+                configs = self.map_yaml_configs(configs=yaml.configs)
+                self._yaml.update(configs=configs, quiet=quiet)
 
 
 def make_graph_file(mesh_filename, graph_filename='graph.info',

--- a/polaris/ocean/config/output.yaml
+++ b/polaris/ocean/config/output.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   streams:
     output:
       type: output

--- a/polaris/ocean/config/single_layer.yaml
+++ b/polaris/ocean/config/single_layer.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   cvmix:
     config_use_cvmix: false
   ALE_vertical_grid:

--- a/polaris/ocean/convergence/forward.py
+++ b/polaris/ocean/convergence/forward.py
@@ -47,8 +47,8 @@ class ConvergenceForward(OceanModelStep):
             A YAML file that is a Jinja2 template with model config options
 
         options : dict, optional
-            A dictionary of options and value to replace model config options
-            with new values
+            A nested dictionary of options and value for each ``config_model``
+            to replace model config options with new values
 
         output_filename : str, optional
             The output file that will be written out at the end of the forward
@@ -68,7 +68,9 @@ class ConvergenceForward(OceanModelStep):
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
         if options is not None:
-            self.add_model_config_options(options=options)
+            for config_model in options:
+                self.add_model_config_options(options=options[config_model],
+                                              config_model=config_model)
 
         self.add_input_file(
             filename='init.nc',

--- a/polaris/ocean/ice_shelf/ssh_forward.yaml
+++ b/polaris/ocean/ice_shelf/ssh_forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   io:
     config_write_output_on_startup: true
   time_management:

--- a/polaris/ocean/ice_shelf/ssh_forward.yaml
+++ b/polaris/ocean/ice_shelf/ssh_forward.yaml
@@ -3,6 +3,7 @@ mpas-ocean:
     config_write_output_on_startup: true
   time_management:
     config_do_restart: false
+    config_stop_time: none
     config_run_duration: {{ run_duration }}
   time_integration:
     config_dt: {{ dt }}

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -1,0 +1,41 @@
+map:
+- section:
+    time_management: TimeManagement
+  options:
+    config_start_time: StartTime
+    config_stop_time: StopTime
+    config_run_duration: RunDuration
+    config_calendar_type: CalendarType
+
+- section:
+    time_integration: TimeIntegration
+  options:
+    config_time_integrator: TimeStepper
+    config_dt: TimeStep
+
+- section:
+    time_integration: State
+  options:
+    config_number_of_time_levels: NTimeLevels
+
+- section:
+    decomposition: Decomp
+  options:
+    config_num_halos: HaloWidth
+
+- section:
+    advection: Advection
+  options:
+    config_thickness_flux_type: FluxThicknessType
+
+- section:
+    hmix_del2: Tendencies
+  options:
+    config_use_mom_del2: VelDiffTendencyEnable
+    config_mom_del2: ViscDel2
+
+- section:
+    hmix_del4: Tendencies
+  options:
+    config_use_mom_del4: VelHyperDiffTendencyEnable
+    config_mom_del4: ViscDel4

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -348,31 +348,26 @@ class OceanModelStep(ModelStep):
 
         assert self.map is not None
 
-        section_found = False
         option_found = False
-
         # traverse the map
         for entry in self.map:
-            section_found = False
             section_dict = entry['section']
-            for mpaso_section, omega_section in section_dict.items():
-                if section == mpaso_section:
-                    section_found = True
-                    break
-
-            if not section_found:
+            try:
+                omega_section = section_dict[section]
+            except KeyError:
                 continue
-
-            options_dict = entry['options']
-            for mpaso_option, omega_option in options_dict.items():
-                if option == mpaso_option:
+            else:
+                options_dict = entry['options']
+                option_found = False
+                try:
+                    omega_option = options_dict[option]
+                except KeyError:
+                    continue
+                else:
                     option_found = True
+                    out_section = omega_section
+                    out_option = omega_option
                     break
-
-            if option_found:
-                out_section = omega_section
-                out_option = omega_option
-                break
 
         if not option_found:
             raise ValueError(f'No mapping found for {section}/{option}')

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -109,7 +109,7 @@ class OceanModelStep(ModelStep):
         model = config.get('ocean', 'model')
         if model == 'omega':
             self.make_yaml = True
-            self.config_models = ['ocean', 'omega']
+            self.config_models = ['ocean', 'Omega']
             self.yaml = 'omega.yml'
             self._read_map()
         elif model == 'mpas-ocean':

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -109,6 +109,7 @@ class OceanModelStep(ModelStep):
         model = config.get('ocean', 'model')
         if model == 'omega':
             self.make_yaml = True
+            self.yaml = 'omega.yml'
             self._read_map()
         elif model == 'mpas-ocean':
             self.make_yaml = False

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -355,7 +355,7 @@ class OceanModelStep(ModelStep):
         for entry in self.map:
             section_found = False
             section_dict = entry['section']
-            for mpaso_section, omega_seciton in section_dict.items():
+            for mpaso_section, omega_section in section_dict.items():
                 if section == mpaso_section:
                     section_found = True
                     break
@@ -370,7 +370,7 @@ class OceanModelStep(ModelStep):
                     break
 
             if option_found:
-                out_section = omega_seciton
+                out_section = omega_section
                 out_option = omega_option
                 break
 

--- a/polaris/ocean/mpas_ocean.cfg
+++ b/polaris/ocean/mpas_ocean.cfg
@@ -4,20 +4,20 @@
 [paths]
 
 # the relative or absolute path to the root of a branch where MPAS-Ocean
-# or Omega has been built
+# has been built
 component_path = ${paths:polaris_branch}/e3sm_submodules/E3SM-Project/components/mpas-ocean
 
-# The namelists section defines paths to example_compact namelists that will
+# The namelists section defines paths to default namelists that will
 # be used to generate specific namelists. By default, these point to the
-# forward and init namelists in the default_inputs directory after a successful
+# forward namelists in the default_inputs directory after a successful
 # build of the ocean model.  Change these in a custom config file if you need
 # a different location.
 [namelists]
 forward = ${paths:component_path}/default_inputs/namelist.ocean.forward
 
-# The streams section defines paths to example_compact streams files that will
+# The streams section defines paths to default streams files that will
 # be used to generate specific streams files. By default, these point to the
-# forward and init streams files in the default_inputs directory after a
+# forward streams files in the default_inputs directory after a
 # successful build of the ocean model. Change these in a custom config file if
 # you need a different location.
 [streams]
@@ -32,6 +32,6 @@ processed = ${paths:component_path}/src/Registry_processed.xml
 # The executables section defines paths to required executables. These
 # executables are provided for use by specific test cases.  Most tools that
 # polaris needs should be in the conda environment, so this is only the path
-# to the MPAS-Ocean or Omega executable by default.
+# to the MPAS-Ocean executable by default.
 [executables]
 component = ${paths:component_path}/ocean_model

--- a/polaris/ocean/omega.cfg
+++ b/polaris/ocean/omega.cfg
@@ -4,17 +4,14 @@
 [paths]
 
 
-# the relative or absolute path to the Omega component source code
-source_path = ${paths:polaris_branch}/e3sm_submodules/Omega/components/omega
-
 # the relative or absolute path to the root of a branch where Omega
 # has been built
-component_path = ${paths:source_path}/build
+component_path = ${paths:polaris_branch}/e3sm_submodules/Omega/components/omega/build
 
 # The model_config section defines paths to yaml file with default model config
 # options that will be used to generate specific yaml config files for Omega.
 [model_config]
-defaults = ${paths:source_path}/configs/Default.yml
+defaults = ${paths:component_path}/configs/Default.yml
 
 # The executables section defines paths to required executables. These
 # executables are provided for use by specific test cases.  Most tools that

--- a/polaris/ocean/omega.cfg
+++ b/polaris/ocean/omega.cfg
@@ -3,14 +3,18 @@
 # The paths section points polaris to external paths
 [paths]
 
+
+# the relative or absolute path to the Omega component source code
+source_path = ${paths:polaris_branch}/e3sm_submodules/Omega/components/omega
+
 # the relative or absolute path to the root of a branch where Omega
 # has been built
-component_path = ${paths:polaris_branch}/e3sm_submodules/Omega/components/omega/build
+component_path = ${paths:source_path}/build
 
 # The model_config section defines paths to yaml file with default model config
 # options that will be used to generate specific yaml config files for Omega.
 [model_config]
-defaults = ${paths:component_path}/src/omega.yml
+defaults = ${paths:source_path}/configs/Default.yml
 
 # The executables section defines paths to required executables. These
 # executables are provided for use by specific test cases.  Most tools that

--- a/polaris/ocean/omega.cfg
+++ b/polaris/ocean/omega.cfg
@@ -1,0 +1,20 @@
+# This config file has default config options for Omega
+
+# The paths section points polaris to external paths
+[paths]
+
+# the relative or absolute path to the root of a branch where Omega
+# has been built
+component_path = ${paths:polaris_branch}/e3sm_submodules/Omega/components/omega/build
+
+# The model_config section defines paths to yaml file with default model config
+# options that will be used to generate specific yaml config files for Omega.
+[model_config]
+defaults = ${paths:component_path}/src/omega.yml
+
+# The executables section defines paths to required executables. These
+# executables are provided for use by specific test cases.  Most tools that
+# polaris needs should be in the conda environment, so this is only the path
+# to the Omega executable by default.
+[executables]
+component = ${paths:component_path}/src/omega.exe

--- a/polaris/ocean/tasks/baroclinic_channel/forward.py
+++ b/polaris/ocean/tasks/baroclinic_channel/forward.py
@@ -86,7 +86,8 @@ class Forward(OceanModelStep):
         if nu is not None:
             # update the viscosity to the requested value *after* loading
             # forward.yaml
-            self.add_model_config_options(options=dict(config_mom_del2=nu))
+            self.add_model_config_options(options=dict(config_mom_del2=nu),
+                                          config_model='mpas-ocean')
 
         self.add_output_file(
             filename='output.nc',
@@ -153,4 +154,5 @@ class Forward(OceanModelStep):
         self.dt = dt
         self.btr_dt = btr_dt
 
-        self.add_model_config_options(options=options)
+        self.add_model_config_options(options=options,
+                                      config_model='mpas-ocean')

--- a/polaris/ocean/tasks/baroclinic_channel/forward.py
+++ b/polaris/ocean/tasks/baroclinic_channel/forward.py
@@ -144,6 +144,7 @@ class Forward(OceanModelStep):
             run_seconds = self.run_time_steps * dt
             options['config_run_duration'] = \
                 time.strftime('%H:%M:%S', time.gmtime(run_seconds))
+            options['config_stop_time'] = 'none'
 
         # btr_dt is also proportional to resolution: default 1.5 seconds per km
         btr_dt_per_km = config.getfloat('baroclinic_channel', 'btr_dt_per_km')

--- a/polaris/ocean/tasks/baroclinic_channel/forward.yaml
+++ b/polaris/ocean/tasks/baroclinic_channel/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   io:
     config_write_output_on_startup: false
   hmix_del2:

--- a/polaris/ocean/tasks/baroclinic_channel/restart/forward.yaml
+++ b/polaris/ocean/tasks/baroclinic_channel/restart/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   time_management:
     config_start_time: {{ start_time }}
     config_run_duration: {{ run_duration }}

--- a/polaris/ocean/tasks/baroclinic_channel/restart/forward.yaml
+++ b/polaris/ocean/tasks/baroclinic_channel/restart/forward.yaml
@@ -1,6 +1,7 @@
 mpas-ocean:
   time_management:
     config_start_time: {{ start_time }}
+    config_stop_time: none
     config_run_duration: {{ run_duration }}
     config_do_restart: {{ do_restart }}
   io:

--- a/polaris/ocean/tasks/baroclinic_channel/rpe/forward.yaml
+++ b/polaris/ocean/tasks/baroclinic_channel/rpe/forward.yaml
@@ -1,5 +1,6 @@
 mpas-ocean:
   time_management:
+    config_stop_time: none
     config_run_duration: 20_00:00:00
   streams:
     output:

--- a/polaris/ocean/tasks/baroclinic_channel/rpe/forward.yaml
+++ b/polaris/ocean/tasks/baroclinic_channel/rpe/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   time_management:
     config_run_duration: 20_00:00:00
   streams:

--- a/polaris/ocean/tasks/cosine_bell/forward.yaml
+++ b/polaris/ocean/tasks/cosine_bell/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   run_modes:
     config_ocean_run_mode: forward
   time_management:

--- a/polaris/ocean/tasks/cosine_bell/forward.yaml
+++ b/polaris/ocean/tasks/cosine_bell/forward.yaml
@@ -2,6 +2,7 @@ mpas-ocean:
   run_modes:
     config_ocean_run_mode: forward
   time_management:
+    config_stop_time: none
     config_run_duration: {{ run_duration }}
   decomposition:
     config_block_decomp_file_prefix: graph.info.part.

--- a/polaris/ocean/tasks/geostrophic/forward.yaml
+++ b/polaris/ocean/tasks/geostrophic/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   time_management:
     config_run_duration: {{ run_duration }}
   time_integration:

--- a/polaris/ocean/tasks/geostrophic/forward.yaml
+++ b/polaris/ocean/tasks/geostrophic/forward.yaml
@@ -1,5 +1,6 @@
 mpas-ocean:
   time_management:
+    config_stop_time: none
     config_run_duration: {{ run_duration }}
   time_integration:
     config_dt: {{ dt }}

--- a/polaris/ocean/tasks/ice_shelf_2d/forward.yaml
+++ b/polaris/ocean/tasks/ice_shelf_2d/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   io:
     config_write_output_on_startup: false
   hmix_del2:

--- a/polaris/ocean/tasks/ice_shelf_2d/forward.yaml
+++ b/polaris/ocean/tasks/ice_shelf_2d/forward.yaml
@@ -13,6 +13,7 @@ mpas-ocean:
     config_do_restart: {{ do_restart }}
     config_run_duration: {{ run_duration }}
     config_start_time: {{ start_time }}
+    config_stop_time: none
   time_integration:
     config_dt: {{ dt }}
     config_time_integrator: {{ time_integrator }}

--- a/polaris/ocean/tasks/ice_shelf_2d/global_stats.yaml
+++ b/polaris/ocean/tasks/ice_shelf_2d/global_stats.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   AM_globalStats:
     config_AM_globalStats_enable: true
     config_AM_globalStats_compute_on_startup: true

--- a/polaris/ocean/tasks/ice_shelf_2d/ssh_forward.yaml
+++ b/polaris/ocean/tasks/ice_shelf_2d/ssh_forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   hmix_del2:
     config_use_mom_del2: true
     config_mom_del2: 10.0

--- a/polaris/ocean/tasks/ice_shelf_2d/tidal_forcing.yaml
+++ b/polaris/ocean/tasks/ice_shelf_2d/tidal_forcing.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   tidal_forcing:
     config_use_tidal_forcing: true
     config_use_tidal_forcing_tau: 10000

--- a/polaris/ocean/tasks/inertial_gravity_wave/forward.yaml
+++ b/polaris/ocean/tasks/inertial_gravity_wave/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   time_management:
     config_run_duration: {{ run_duration }}
   time_integration:

--- a/polaris/ocean/tasks/inertial_gravity_wave/forward.yaml
+++ b/polaris/ocean/tasks/inertial_gravity_wave/forward.yaml
@@ -1,5 +1,6 @@
 mpas-ocean:
   time_management:
+    config_stop_time: none
     config_run_duration: {{ run_duration }}
   time_integration:
     config_dt: {{ dt }}

--- a/polaris/ocean/tasks/internal_wave/forward.py
+++ b/polaris/ocean/tasks/internal_wave/forward.py
@@ -138,5 +138,6 @@ class Forward(OceanModelStep):
             run_seconds = self.run_time_steps * dt
             options['config_run_duration'] = \
                 time.strftime('%H:%M:%S', time.gmtime(run_seconds))
+            options['config_stop_time'] = 'none'
         self.add_model_config_options(options=options,
                                       config_model='mpas-ocean')

--- a/polaris/ocean/tasks/internal_wave/forward.py
+++ b/polaris/ocean/tasks/internal_wave/forward.py
@@ -76,12 +76,14 @@ class Forward(OceanModelStep):
         if nu is not None:
             # update the viscosity to the requested value *after* loading
             # forward.yaml
-            self.add_model_config_options(options=dict(config_mom_del2=nu))
+            self.add_model_config_options(options=dict(config_mom_del2=nu),
+                                          config_model='mpas-ocean')
 
         vadv_dict = {'standard': 'flux-form',
                      'vlr': 'remap'}
         self.add_model_config_options({
-            'config_vert_advection_method': f"{vadv_dict[vadv_method]}"})
+            'config_vert_advection_method': f"{vadv_dict[vadv_method]}"},
+            config_model='mpas-ocean')
 
         self.add_output_file(
             filename='output.nc',
@@ -136,4 +138,5 @@ class Forward(OceanModelStep):
             run_seconds = self.run_time_steps * dt
             options['config_run_duration'] = \
                 time.strftime('%H:%M:%S', time.gmtime(run_seconds))
-        self.add_model_config_options(options=options)
+        self.add_model_config_options(options=options,
+                                      config_model='mpas-ocean')

--- a/polaris/ocean/tasks/internal_wave/forward.yaml
+++ b/polaris/ocean/tasks/internal_wave/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   time_management:
     config_run_duration: 0000_00:15:00
   time_integration:

--- a/polaris/ocean/tasks/internal_wave/forward.yaml
+++ b/polaris/ocean/tasks/internal_wave/forward.yaml
@@ -1,5 +1,6 @@
 mpas-ocean:
   time_management:
+    config_stop_time: none
     config_run_duration: 0000_00:15:00
   time_integration:
     config_time_integrator: split_explicit

--- a/polaris/ocean/tasks/internal_wave/rpe/forward.yaml
+++ b/polaris/ocean/tasks/internal_wave/rpe/forward.yaml
@@ -1,5 +1,6 @@
 mpas-ocean:
   time_management:
+    config_stop_time: none
     config_run_duration: 20_00:00:00
   streams:
     output:

--- a/polaris/ocean/tasks/internal_wave/rpe/forward.yaml
+++ b/polaris/ocean/tasks/internal_wave/rpe/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   time_management:
     config_run_duration: 20_00:00:00
   streams:

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -44,6 +44,17 @@ class Forward(ConvergenceForward):
                          output_filename='output.nc',
                          validate_vars=['layerThickness', 'normalVelocity'])
 
+    def setup(self):
+        """
+        TEMP: symlink initial condition to name hard-coded in Omega
+        """
+        super().setup()
+        config = self.config
+        model = config.get('ocean', 'model')
+        # TODO: remove as soon as Omega supports I/O streams
+        if model == 'omega':
+            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
+
     def compute_cell_count(self):
         """
         Compute the approximate number of cells in the mesh, used to constrain

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -81,4 +81,4 @@ class Forward(ConvergenceForward):
                    float(exact_solution.lambda_x),
                    'config_manufactured_solution_wavelength_y':
                    float(exact_solution.lambda_y)}
-        self.add_model_config_options(options)
+        self.add_model_config_options(options, config_model='mpas-ocean')

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -31,7 +31,7 @@ mpas-ocean:
   debug:
     config_disable_vel_hmix: true
 
-omega:
+Omega:
   Tendencies:
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -1,17 +1,9 @@
-omega:
+ocean:
   time_management:
     config_run_duration: {{ run_duration }}
   time_integration:
     config_dt: {{ dt }}
     config_time_integrator: {{ time_integrator }}
-  bottom_drag:
-    config_bottom_drag_mode: implicit
-    config_implicit_bottom_drag_type: constant
-    config_implicit_constant_bottom_drag_coeff: 0.0
-  manufactured_solution:
-     config_use_manufactured_solution: true
-  debug:
-    config_disable_vel_hmix: true
   streams:
     mesh:
       filename_template: init.nc
@@ -28,3 +20,18 @@ omega:
       - normalVelocity
       - layerThickness
       - ssh
+
+mpas-ocean:
+  bottom_drag:
+    config_bottom_drag_mode: implicit
+    config_implicit_bottom_drag_type: constant
+    config_implicit_constant_bottom_drag_coeff: 0.0
+  manufactured_solution:
+     config_use_manufactured_solution: true
+  debug:
+    config_disable_vel_hmix: true
+
+omega:
+  Tendencies:
+    VelDiffTendencyEnable: false
+    VelHyperDiffTendencyEnable: false

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -36,3 +36,5 @@ Omega:
   Tendencies:
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false
+  Dimension:
+    NVertLevels: 1

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -1,5 +1,6 @@
 ocean:
   time_management:
+    config_stop_time: none
     config_run_duration: {{ run_duration }}
   time_integration:
     config_dt: {{ dt }}

--- a/polaris/ocean/tasks/single_column/forward.yaml
+++ b/polaris/ocean/tasks/single_column/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   run_modes:
     config_ocean_run_mode: forward
   time_management:

--- a/polaris/ocean/tasks/single_column/forward.yaml
+++ b/polaris/ocean/tasks/single_column/forward.yaml
@@ -2,6 +2,7 @@ mpas-ocean:
   run_modes:
     config_ocean_run_mode: forward
   time_management:
+    config_stop_time: none
     config_run_duration: 0001_00:00:00
   time_integration:
     config_dt: 00:10:00

--- a/polaris/ocean/tasks/single_column/ideal_age/forward.yaml
+++ b/polaris/ocean/tasks/single_column/ideal_age/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   tracer_forcing_idealAgeTracers:
     config_use_idealAgeTracers: true
     config_use_idealAgeTracers_idealAge_forcing: true

--- a/polaris/ocean/tasks/sphere_transport/forward.py
+++ b/polaris/ocean/tasks/sphere_transport/forward.py
@@ -40,8 +40,11 @@ class Forward(SphericalConvergenceForward):
                    'nondivergent_2d': 2,
                    'divergent_2d': 3,
                    'correlated_tracers_2d': 4}
-        namelist_options = dict(
-            config_transport_tests_flow_id=flow_id[case_name])
+        namelist_options = {
+            'mpas-ocean': {
+                'config_transport_tests_flow_id': flow_id[case_name]
+            }
+        }
         validate_vars = ['normalVelocity', 'tracer1', 'tracer2', 'tracer3']
         super().__init__(component=component, name=name, subdir=subdir,
                          resolution=resolution, mesh=base_mesh,

--- a/polaris/ocean/tasks/sphere_transport/forward.yaml
+++ b/polaris/ocean/tasks/sphere_transport/forward.yaml
@@ -1,4 +1,4 @@
-omega:
+mpas-ocean:
   run_modes:
     config_ocean_run_mode: forward
   time_management:

--- a/polaris/ocean/tasks/sphere_transport/forward.yaml
+++ b/polaris/ocean/tasks/sphere_transport/forward.yaml
@@ -2,6 +2,7 @@ mpas-ocean:
   run_modes:
     config_ocean_run_mode: forward
   time_management:
+    config_stop_time: none
     config_run_duration: {{ run_duration }}
   decomposition:
     config_block_decomp_file_prefix: graph.info.part.

--- a/polaris/suite.py
+++ b/polaris/suite.py
@@ -8,7 +8,7 @@ from polaris.setup import setup_tasks
 
 def setup_suite(component, suite_name, work_dir, config_file=None,
                 machine=None, baseline_dir=None, component_path=None,
-                copy_executable=False, clean=False):
+                copy_executable=False, clean=False, model=None):
     """
     Set up a suite of tasks
 
@@ -47,6 +47,9 @@ def setup_suite(component, suite_name, work_dir, config_file=None,
     clean : bool, optional
         Whether to delete the contents of the base work directory before
         setting up the suite
+
+    model : str, optional
+        The model to run
     """
 
     text = imp_res.files(f'polaris.{component}.suites').joinpath(
@@ -57,7 +60,7 @@ def setup_suite(component, suite_name, work_dir, config_file=None,
     setup_tasks(work_dir, tasks, config_file=config_file, machine=machine,
                 baseline_dir=baseline_dir, component_path=component_path,
                 suite_name=suite_name, cached=cached,
-                copy_executable=copy_executable, clean=clean)
+                copy_executable=copy_executable, clean=clean, model=model)
 
 
 def main():
@@ -93,13 +96,17 @@ def main():
     parser.add_argument("--clean", dest="clean", action="store_true",
                         help="If the base work directory should be deleted "
                              "before setting up the suite.")
+    parser.add_argument("--model", dest="model",
+                        help="The model to run (one of 'mpas-ocean', 'omega', "
+                             "or 'mpas-seaice')")
     args = parser.parse_args(sys.argv[2:])
 
     setup_suite(component=args.component, suite_name=args.task_suite,
                 work_dir=args.work_dir, config_file=args.config_file,
                 machine=args.machine, baseline_dir=args.baseline_dir,
                 component_path=args.component_path,
-                copy_executable=args.copy_executable, clean=args.clean)
+                copy_executable=args.copy_executable, clean=args.clean,
+                model=args.model)
 
 
 def _parse_suite(text):

--- a/polaris/yaml.py
+++ b/polaris/yaml.py
@@ -34,7 +34,7 @@ class PolarisYaml:
         self.model = None
 
     @classmethod
-    def read(cls, filename, package=None, replacements=None):
+    def read(cls, filename, package=None, replacements=None, model=None):
         """
         Add config options from a yaml file
 
@@ -50,6 +50,10 @@ class PolarisYaml:
             A dictionary of replacements, which, if provided, is used to
             replace Jinja variables and the yaml file is assumed do be a Jinja
             template
+
+        model : str, optional
+            The name of the model to parse if the yaml file might have multiple
+            models
 
         Returns
         -------
@@ -73,18 +77,24 @@ class PolarisYaml:
         yaml_data = YAML(typ='rt')
         configs = yaml_data.load(text)
 
-        keys = list(configs)
-        if len(keys) > 1:
-            raise ValueError(
-                f'Config yaml file contains unexpected sections:\n '
-                f'{keys[1:]}')
-        yaml.model = keys[0]
-        yaml.streams = dict()
-        configs = configs[yaml.model]
-        if 'streams' in configs:
-            yaml.streams = configs['streams']
-            configs = dict(configs)
-            configs.pop('streams')
+        if model is None:
+            keys = list(configs)
+            if len(keys) > 1:
+                raise ValueError(
+                    f'Config yaml file contains unexpected sections:\n '
+                    f'{keys[1:]}')
+            model = keys[0]
+
+        yaml.model = model
+        yaml.streams = {}
+        if model in configs:
+            configs = configs[model]
+            if 'streams' in configs:
+                yaml.streams = configs['streams']
+                configs = dict(configs)
+                configs.pop('streams')
+        else:
+            configs = {}
 
         yaml.configs = configs
         return yaml


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Most of the work in this PR is focused on support for mapping from MPAS-Ocean namelist options (in YAML format) to their Omega equivalents.  This support has required changes to the `polaris.yaml` and `polaris.model_step` framework as well as extensive changes to the Ocean framework and tasks.

The proposed solution would allow for:
1. shared model config options (using MPAS-Ocean names) in an `ocean:` section in a yaml file or with `config_model='ocean'` when added in code.
2. model config options specific to MPAS-Ocean (using MPAS-Ocean names and ignored by Omega) with an `mpas-ocean:` section in a yaml file or with `config_model='mpas-ocean'` when added in code.
2. model config options specific to Omega (using Omega names and ignored by MPAS-Ocean) with an `omega:` section in a yaml file or with `config_model='omega'` when added in code.

Here is an example:
```yaml
ocean:
  time_management:
    config_run_duration: {{ run_duration }}
  time_integration:
    config_dt: {{ dt }}
    config_time_integrator: {{ time_integrator }}

mpas-ocean:
  bottom_drag:
    config_bottom_drag_mode: implicit
    config_implicit_bottom_drag_type: constant
    config_implicit_constant_bottom_drag_coeff: 0.0
  manufactured_solution:
     config_use_manufactured_solution: true
  debug:
    config_disable_vel_hmix: true

omega:
  Tendencies:
    VelDiffTendencyEnable: false
    VelHyperDiffTendencyEnable: false
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
