### PR TITLE
Add support for python 3.12

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master

--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -2,7 +2,7 @@
 # $ conda create --name <env> --file <this file>
 
 # Base
-python>=3.9,<3.12
+python>=3.9,<=3.12
 antimeridian
 cartopy
 cartopy_offlinedata

--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -14,7 +14,7 @@ recreate = False
 suffix =
 
 # the python version
-python = 3.11
+python = 3.12
 
 # the MPI version (nompi, mpich or openmpi)
 mpi = nompi

--- a/docs/users_guide/quick_start.md
+++ b/docs/users_guide/quick_start.md
@@ -73,7 +73,7 @@ if you don't already have it.  Then, create a new conda environment (called
 `polaris` in this example) as follows:
 
 ```bash
-conda create -n polaris -c conda-forge -c e3sm/label/polaris python=3.11 \
+conda create -n polaris -c conda-forge -c e3sm/label/polaris python=3.12 \
     "polaris=*=mpi_mpich*"
 ```
 
@@ -85,7 +85,7 @@ system with its own MPI), use `"polaris=*=nompi*"`
 To get a specific version of polaris, you can instead run:
 
 ```bash
-conda create -n polaris -c conda-forge -c e3sm/label/polaris python=3.11 \
+conda create -n polaris -c conda-forge -c e3sm/label/polaris python=3.12 \
     "polaris=1.0.0=mpi_mpich*"
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,13 +15,14 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
 
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.9,<3.12
+python_requires = >=3.9,<=3.12
 install_requires =
     cartopy
     cmocean


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
Python 3.12 is now supported by `conda-forge`, and thus I've added it to polaris in this PR.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
