### PR TITLE
Tweak behavior of CI workflows

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -10,14 +10,14 @@ on:
   workflow_dispatch:
 
 env:
-  CANCEL_OTHERS: true
+  CANCEL_OTHERS: false
   PATHS_IGNORE: '["**/README.md", "**/docs/**"]'
 
 jobs:
   pre-commit-hooks:
     name: lint with pre-commit
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
@@ -80,7 +80,7 @@ jobs:
         with:
           activate-environment: "polaris_ci"
           miniforge-version: latest
-          channels: conda-forge,e3sm/label/polaris,defaults
+          channels: conda-forge,e3sm/label/polaris
           channel-priority: strict
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           activate-environment: "polaris_ci"
           miniforge-version: latest
-          channels: conda-forge,e3sm/label/polaris,defaults
+          channels: conda-forge,e3sm/label/polaris
           channel-priority: strict
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
In this PR I made a few tweaks to the behavior of the CI workflows. These changes are:
1. `cancel_others` is now set to false by default, which should make it easier to decipher if a bug is isolated to a specific version of python via CI
2. The `defaults` channel has been removed as we can now exclusively use `conda-forge`
3. The timeout for the `pre-commit` job has been upped to 5 minutes
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
