### PR TITLE
Updates related to Omega IOStreams

### DIFF
--- a/polaris/ocean/convergence/forward.py
+++ b/polaris/ocean/convergence/forward.py
@@ -141,6 +141,9 @@ class ConvergenceForward(OceanModelStep):
         output_interval_str = get_time_interval_string(
             seconds=output_interval * s_per_hour)
 
+        # For Omega, we want the output interval as a number of seconds
+        output_freq = int(output_interval * s_per_hour)
+
         time_integrator = section.get('time_integrator')
         time_integrator_map = dict([('RK4', 'RungeKutta4')])
         model = config.get('ocean', 'model')
@@ -158,6 +161,7 @@ class ConvergenceForward(OceanModelStep):
             btr_dt=btr_dt_str,
             run_duration=run_duration_str,
             output_interval=output_interval_str,
+            output_freq=f'{output_freq}'
         )
 
         self.add_yaml_file(self.package, self.yaml_filename,

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -23,7 +23,7 @@ variables:
   normalVelocity: NormalVelocity
 
   # auxiliary state
-  ssh: SshCell
+  ssh: SshCellDefault
 
 config:
 - section:

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -1,14 +1,33 @@
+dimensions:
+  Time: time
+  nCells: NCells
+  nEdges: NEdges
+  nVertices: NVertices
+  maxEdges: MaxEdges
+  maxEdges2: MaxEdges2
+  TWO: MaxCellsOnEdge
+  vertexDegree: VertexDegree
+  nVertLevels: NVertLevels
+  nVertLevelsP1: NVertLevelsP1
+
 variables:
-  temperature: Temp
-  salinity: Salt
+  # tracers
+  temperature: Temperature
+  salinity: Salinity
   tracer1: Debug1
   tracer2: Debug2
   tracer3: Debug3
+
+  # state
+  layerThickness: LayerThickness
+  normalVelocity: NormalVelocity
+
+  # auxiliary state
   ssh: SshCell
 
 config:
 - section:
-    time_management: TimeManagement
+    time_management: TimeIntegration
   options:
     config_start_time: StartTime
     config_stop_time: StopTime

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -66,3 +66,10 @@ config:
   options:
     config_use_mom_del4: VelHyperDiffTendencyEnable
     config_mom_del4: ViscDel4
+
+- section:
+    manufactured_solution: ManufacturedSolution
+  options:
+    config_manufactured_solution_wavelength_x: WavelengthX
+    config_manufactured_solution_wavelength_y: WavelengthY
+    config_manufactured_solution_amplitude: Amplitude

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -119,6 +119,7 @@ class OceanModelStep(ModelStep):
             self.make_yaml = True
             self.config_models = ['ocean', 'Omega']
             self.yaml = 'omega.yml'
+            self.streams_section = 'IOStreams'
             self._read_config_map()
             self.partition_graph = False
         elif model == 'mpas-ocean':
@@ -127,7 +128,7 @@ class OceanModelStep(ModelStep):
             self.add_input_file(
                 filename='graph.info',
                 work_dir_target=self.graph_target)
-
+            self.streams_section = 'streams'
         else:
             raise ValueError(f'Unexpected ocean model: {model}')
 

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -58,6 +58,17 @@ class Forward(ConvergenceForward):
                          output_filename='output.nc',
                          validate_vars=['layerThickness', 'normalVelocity'])
 
+    def setup(self):
+        """
+        TEMP: symlink initial condition to name hard-coded in Omega
+        """
+        super().setup()
+        config = self.config
+        model = config.get('ocean', 'model')
+        # TODO: remove as soon as Omega no longer hard-codes this file
+        if model == 'omega':
+            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
+
     def compute_cell_count(self):
         """
         Compute the approximate number of cells in the mesh, used to constrain

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -58,17 +58,6 @@ class Forward(ConvergenceForward):
                          output_filename='output.nc',
                          validate_vars=['layerThickness', 'normalVelocity'])
 
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        config = self.config
-        model = config.get('ocean', 'model')
-        # TODO: remove as soon as Omega supports I/O streams
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
-
     def compute_cell_count(self):
         """
         Compute the approximate number of cells in the mesh, used to constrain

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -5,6 +5,16 @@ ocean:
   time_integration:
     config_dt: {{ dt }}
     config_time_integrator: {{ time_integrator }}
+
+mpas-ocean:
+  bottom_drag:
+    config_bottom_drag_mode: implicit
+    config_implicit_bottom_drag_type: constant
+    config_implicit_constant_bottom_drag_coeff: 0.0
+  manufactured_solution:
+     config_use_manufactured_solution: true
+  debug:
+    config_disable_vel_hmix: true
   streams:
     mesh:
       filename_template: init.nc
@@ -22,19 +32,31 @@ ocean:
       - layerThickness
       - ssh
 
-mpas-ocean:
-  bottom_drag:
-    config_bottom_drag_mode: implicit
-    config_implicit_bottom_drag_type: constant
-    config_implicit_constant_bottom_drag_coeff: 0.0
-  manufactured_solution:
-     config_use_manufactured_solution: true
-  debug:
-    config_disable_vel_hmix: true
-
 Omega:
   Tendencies:
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false
   Dimension:
     NVertLevels: 1
+  IOStreams:
+    InitialState:
+      UsePointerFile: false
+      Filename: init.nc
+      Mode: read
+      Precision: double
+      Freq: 1
+      FreqUnits: OnStartup
+      UseStartEnd: false
+      Contents:
+        - Restart
+    History:
+      UsePointerFile: false
+      Filename: output.nc
+      Mode: write
+      IfExists: replace
+      Precision: double
+      Freq: {{ output_freq }}
+      FreqUnits: Seconds
+      UseStartEnd: false
+      Contents:
+        - Tracers

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -42,21 +42,15 @@ Omega:
     InitialState:
       UsePointerFile: false
       Filename: init.nc
-      Mode: read
-      Precision: double
-      Freq: 1
-      FreqUnits: OnStartup
-      UseStartEnd: false
       Contents:
-        - Restart
+      - NormalVelocity
+      - LayerThickness
     History:
-      UsePointerFile: false
       Filename: output.nc
-      Mode: write
-      IfExists: replace
-      Precision: double
       Freq: {{ output_freq }}
       FreqUnits: Seconds
-      UseStartEnd: false
       Contents:
-        - Tracers
+      - NormalVelocity
+      - LayerThickness
+      - SshCellDefault
+    RestartRead: {}

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -36,6 +36,8 @@ Omega:
   Tendencies:
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false
+    UseCustomTendency: true
+    ManufacturedSolutionTendency: true
   Dimension:
     NVertLevels: 1
   IOStreams:

--- a/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
+++ b/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
@@ -77,8 +77,9 @@ refinement_factors_time = 1., 0.5, 0.25
 [convergence_forward]
 
 # time integrator
-#  mpas-ocean: {'split_explicit', 'RK4'}
-#  omega: {'Forward-Backward', 'RungeKutta4', 'RungeKutta2'}
+#  either: {'RK4'}
+#  mpas-ocean: {'split_explicit'}
+#  omega: {'Forward-Backward', 'RungeKutta2'}
 time_integrator = RK4
 
 # RK4 time step per resolution (s/km), since dt is proportional to resolution

--- a/polaris/yaml.py
+++ b/polaris/yaml.py
@@ -21,6 +21,9 @@ class PolarisYaml:
     streams : dict
         Nested dictionaries containing data about streams
 
+    streams_section : str
+        The name of the streams section
+
     model : str
         The name of the E3SM component
     """
@@ -30,11 +33,13 @@ class PolarisYaml:
         Create a yaml config object
         """
         self.configs = dict()
+        self.streams_section = 'streams'
         self.streams = dict()
         self.model = None
 
     @classmethod
-    def read(cls, filename, package=None, replacements=None, model=None):
+    def read(cls, filename, package=None, replacements=None, model=None,
+             streams_section='streams'):
         """
         Add config options from a yaml file
 
@@ -55,6 +60,9 @@ class PolarisYaml:
             The name of the model to parse if the yaml file might have multiple
             models
 
+        streams_section : str, optional
+            The name of the streams section
+
         Returns
         -------
         yaml : polaris.yaml.PolarisYaml
@@ -74,6 +82,7 @@ class PolarisYaml:
             text = template.render(**replacements)
 
         yaml = cls()
+        yaml.streams_section = streams_section
         yaml_data = YAML(typ='rt')
         configs = yaml_data.load(text)
 
@@ -89,10 +98,10 @@ class PolarisYaml:
         yaml.streams = {}
         if model in configs:
             configs = configs[model]
-            if 'streams' in configs:
-                yaml.streams = configs['streams']
+            if streams_section in configs:
+                yaml.streams = configs[streams_section]
                 configs = dict(configs)
-                configs.pop('streams')
+                configs.pop(streams_section)
         else:
             configs = {}
 
@@ -136,7 +145,7 @@ class PolarisYaml:
         yaml = YAML(typ='rt')
         configs = dict(self.configs)
         if self.streams:
-            configs['streams'] = self.streams
+            configs[self.streams_section] = self.streams
 
         model_configs = dict()
         model_configs[self.model] = configs

--- a/polaris/yaml.py
+++ b/polaris/yaml.py
@@ -153,12 +153,6 @@ class PolarisYaml:
         with open(filename, 'w') as outfile:
             yaml.dump(model_configs, outfile)
 
-    def _add_stream(self, stream_name, stream):
-        """
-        Add stream from a dictionary
-        """
-        self.streams[stream_name] = stream
-
 
 def mpas_namelist_and_streams_to_yaml(model, namelist_template=None,
                                       namelist=None,


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge adds the capability to only copy streams from the Omega `Default.yml` file if they are explicitly requested by a given test case.

Here, we also update the map of variables between MPAS-Ocean and Omega, and add placeholders for mapping dimension names once the new Omega names are fully supported.  (See https://github.com/E3SM-Project/Omega/issues/172).

This merge updates the manufactured solution test case to support Omega in all steps but `analysis` (which requires further development of the time variable, see https://github.com/E3SM-Project/Omega/pull/169).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
