### PR TITLE
Set default `time_integrator` for Omega

### DIFF
--- a/polaris/ocean/convergence/convergence.cfg
+++ b/polaris/ocean/convergence/convergence.cfg
@@ -12,7 +12,9 @@ error_type = l2
 # config options for convergence forward steps
 [convergence_forward]
 
-# time integrator: {'split_explicit', 'RK4'}
+# time integrator
+#  mpas-ocean: {'split_explicit', 'RK4'}
+#  omega: {'Forward-Backward', 'RungeKutta4', 'RungeKutta2'}
 time_integrator = RK4
 
 # RK4 time step per resolution (s/km), since dt is proportional to resolution

--- a/polaris/ocean/tasks/manufactured_solution/__init__.py
+++ b/polaris/ocean/tasks/manufactured_solution/__init__.py
@@ -71,3 +71,13 @@ class ManufacturedSolution(Task):
         self.config.add_from_package(
             'polaris.ocean.tasks.manufactured_solution',
             'manufactured_solution.cfg')
+
+    def configure(self):
+        """
+        Set omega default config options
+        """
+        super().configure()
+        config = self.config
+        model = config.get('ocean', 'model')
+        if model == 'omega':
+            config.set('convergence_forward', 'time_integrator', 'RungeKutta4')

--- a/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
+++ b/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
@@ -69,7 +69,9 @@ error_type = l2
 # config options for spherical convergence tests
 [convergence_forward]
 
-# time integrator: {'split_explicit', 'RK4'}
+# time integrator
+#  mpas-ocean: {'split_explicit', 'RK4'}
+#  omega: {'Forward-Backward', 'RungeKutta4', 'RungeKutta2'}
 time_integrator = RK4
 
 # RK4 time step per resolution (s/km), since dt is proportional to resolution


### PR DESCRIPTION
In the `manufactured_solution` test, this needs to be `RungeKutte4`.  (I'm not worrying about other tests yet.)

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
