### PR TITLE
Enhance spherical tracer transport test viz

### DIFF
--- a/docs/developers_guide/framework/visualization.md
+++ b/docs/developers_guide/framework/visualization.md
@@ -154,7 +154,13 @@ colormap).
 
 The `colorbar_limits` are the lower and upper bound of the colorbar range.
 
+There are also two optional config options used to set the colors on either end of the colormap:
 
+```cfg
+# [optional] colormap set_under and set_over options
+under_color = k
+over_color = orange
+```
 ### plotting from lat/lon grids
 
 You can use {py:func}`polaris.viz.plot_global_lat_lon_field()` to plot a field 

--- a/docs/developers_guide/ocean/tasks/correlated_tracers_2d.md
+++ b/docs/developers_guide/ocean/tasks/correlated_tracers_2d.md
@@ -77,6 +77,10 @@ each resolution.  The colormap is controlled by these options:
 # colormap
 colormap_name = viridis
 
+# [optional] colormap set_under and set_over options
+under_color = k
+over_color = orange
+
 # the type of norm used in the colormap
 norm_type = linear
 

--- a/docs/developers_guide/ocean/tasks/divergent_2d.md
+++ b/docs/developers_guide/ocean/tasks/divergent_2d.md
@@ -71,6 +71,10 @@ each resolution.  The colormap is controlled by these options:
 # colormap
 colormap_name = viridis
 
+# [optional] colormap set_under and set_over options
+under_color = k
+over_color = orange
+
 # the type of norm used in the colormap
 norm_type = linear
 

--- a/docs/developers_guide/ocean/tasks/nondivergent_2d.md
+++ b/docs/developers_guide/ocean/tasks/nondivergent_2d.md
@@ -77,6 +77,10 @@ each resolution.  The colormap is controlled by these options:
 # colormap
 colormap_name = viridis
 
+# [optional] colormap set_under and set_over options
+under_color = k
+over_color = orange
+
 # the type of norm used in the colormap
 norm_type = linear
 

--- a/docs/developers_guide/ocean/tasks/rotation_2d.md
+++ b/docs/developers_guide/ocean/tasks/rotation_2d.md
@@ -71,6 +71,10 @@ each resolution.  The colormap is controlled by these options:
 # colormap
 colormap_name = viridis
 
+# [optional] colormap set_under and set_over options
+under_color = k
+over_color = orange
+
 # the type of norm used in the colormap
 norm_type = linear
 

--- a/polaris/ocean/tasks/sphere_transport/sphere_transport.cfg
+++ b/polaris/ocean/tasks/sphere_transport/sphere_transport.cfg
@@ -84,6 +84,7 @@ slotted_cylinders_amplitude = 1.0
 # colormap
 colormap_name = viridis
 
+# [optional] colormap set_under and set_over options
 under_color = k
 over_color = orange
 

--- a/polaris/ocean/tasks/sphere_transport/sphere_transport.cfg
+++ b/polaris/ocean/tasks/sphere_transport/sphere_transport.cfg
@@ -84,6 +84,9 @@ slotted_cylinders_amplitude = 1.0
 # colormap
 colormap_name = viridis
 
+under_color = k
+over_color = orange
+
 # the type of norm used in the colormap
 norm_type = linear
 

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -9,6 +9,7 @@ import matplotlib
 import matplotlib.colors as cols
 import matplotlib.pyplot as plt
 import uxarray as ux
+from matplotlib import cm
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from pyremap.descriptor.utility import interp_extrap_corner
 
@@ -81,6 +82,13 @@ def plot_global_mpas_field(mesh_filename, da, out_filename, config,
     projection = cartopy.crs.PlateCarree(central_longitude=central_longitude)
 
     colormap = config.get(colormap_section, 'colormap_name')
+    cmap = cm.get_cmap(colormap)
+    if config.has_option(colormap_section, 'under_color'):
+        under_color = config.get(colormap_section, 'under_color')
+        cmap.set_under(under_color)
+    if config.has_option(colormap_section, 'over_color'):
+        over_color = config.get(colormap_section, 'over_color')
+        cmap.set_over(over_color)
 
     norm_type = config.get(colormap_section, 'norm_type')
     if norm_type == 'linear':
@@ -94,7 +102,7 @@ def plot_global_mpas_field(mesh_filename, da, out_filename, config,
                                      dtype=float)
 
     plot = gdf_data.hvplot.polygons(
-        c=da.name, cmap=colormap, logz=logz,
+        c=da.name, cmap=cmap, logz=logz,
         clim=tuple(colorbar_limits),
         clabel=colorbar_label,
         width=1600, height=800, title=title,


### PR DESCRIPTION
Add options for over/under colors for the colormap used in spherical mpas visualization. These were added to be able to more conveniently visualize over and undershoots in the tracer advection scheme tested in the `sphere_transport` tests.

* [X] `Testing` comment in the PR documents testing used to verify the changes