### PR TITLE
Extend manufactured solution to del2 and del4

### DIFF
--- a/docs/users_guide/ocean/tasks/manufactured_solution.md
+++ b/docs/users_guide/ocean/tasks/manufactured_solution.md
@@ -16,9 +16,9 @@ Currently, the there is only one task, the convergence test from
 
 These tasks support both MPAS-Ocean and Omega.
 
-(ocean-manufactured-solution-convergence)=
+(ocean-manufactured-solution-default)=
 
-## convergence
+## default
 
 ### description
 
@@ -127,3 +127,22 @@ conv_thresh = 1.8
 
 The number of cores is determined according to the config options
 ``max_cells_per_core`` and ``goal_cells_per_core``.
+
+(ocean-manufactured-solution-del2)=
+
+## del2
+
+### description
+
+All settings are the same as the {ref}`ocean-manufactured-solution-default` case
+except laplacian viscosity is turned on.
+
+(ocean-manufactured-solution-del4)=
+
+## del4
+
+### description
+
+All settings are the same as the {ref}`ocean-manufactured-solution-default` case
+except hyperviscosity is turned on. The expected convergence should not be
+significantly different from the {ref}`ocean-manufactured-solution-default` case.

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -218,7 +218,7 @@ class ConvergenceAnalysis(OceanIOStep):
         convergence_failed = False
         poly = np.polyfit(np.log10(refinement_array), np.log10(error_array), 1)
         convergence = poly[0]
-        conv_round = np.round(convergence, 3)
+        conv_round = convergence
 
         fit = refinement_array ** poly[0] * 10 ** poly[1]
 
@@ -239,7 +239,7 @@ class ConvergenceAnalysis(OceanIOStep):
         ax.loglog(resolutions, order2, 'k', label='second order',
                   alpha=0.3)
         ax.loglog(refinement_array, fit, 'k',
-                  label=f'linear fit (order={conv_round})')
+                  label=f'linear fit (order={convergence:1.3f})')
         ax.loglog(refinement_array, error_array, 'o', label='numerical')
 
         if self.baseline_dir is not None:
@@ -255,14 +255,14 @@ class ConvergenceAnalysis(OceanIOStep):
                     poly = np.polyfit(
                         np.log10(refinement_array), np.log10(error_array), 1)
                     base_convergence = poly[0]
-                    conv_round = np.round(base_convergence, 3)
+                    conv_round = base_convergence
 
                     fit = refinement_array ** poly[0] * 10 ** poly[1]
                     ax.loglog(refinement_array, error_array, 'o',
                               color='#ff7f0e', label='baseline')
                     ax.loglog(refinement_array, fit, color='#ff7f0e',
                               label=f'linear fit, baseline '
-                                    f'(order={conv_round})')
+                                    f'(order={base_convergence:1.3f})')
         ax.set_xlabel(x_label)
         ax.set_ylabel(f'{error_title}')
         ax.set_title(f'Error Convergence of {title}')
@@ -273,11 +273,11 @@ class ConvergenceAnalysis(OceanIOStep):
         plt.close()
 
         logger.info(f'Order of convergence for {title}: '
-                    f'{conv_round}')
+                    f'{conv_round:1.3f}')
 
         if conv_round < conv_thresh:
             logger.error(f'Error: order of convergence for {title}\n'
-                         f'  {conv_round} < min tolerance '
+                         f'  {conv_round:1.3f} < min tolerance '
                          f'{conv_thresh}')
             convergence_failed = True
 

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -410,7 +410,7 @@ class ConvergenceAnalysis(OceanIOStep):
 
         ds_out = ds_out.isel(Time=tidx)
         field_mpas = ds_out[field_name]
-        if zidx is not None:
+        if zidx is not None and 'nVertLevels' in field_mpas.dims:
             field_mpas = field_mpas.isel(nVertLevels=zidx)
         return field_mpas
 

--- a/polaris/ocean/suites/convergence.txt
+++ b/polaris/ocean/suites/convergence.txt
@@ -1,5 +1,7 @@
 ocean/planar/inertial_gravity_wave/convergence_both
-ocean/planar/manufactured_solution/convergence_both
+ocean/planar/manufactured_solution/convergence_both/default
+ocean/planar/manufactured_solution/convergence_both/del2
+ocean/planar/manufactured_solution/convergence_both/del4
 ocean/spherical/icos/correlated_tracers_2d
   cached: icos_base_mesh_60km icos_base_mesh_120km icos_base_mesh_240km icos_base_mesh_480km
 ocean/spherical/qu/correlated_tracers_2d

--- a/polaris/ocean/suites/manufactured_solution.txt
+++ b/polaris/ocean/suites/manufactured_solution.txt
@@ -1,0 +1,5 @@
+ocean/planar/manufactured_solution/convergence_space/default
+# ocean/planar/manufactured_solution/convergence_time/default
+ocean/planar/manufactured_solution/convergence_both/default
+ocean/planar/manufactured_solution/convergence_both/del2
+ocean/planar/manufactured_solution/convergence_both/del4

--- a/polaris/ocean/tasks/manufactured_solution/__init__.py
+++ b/polaris/ocean/tasks/manufactured_solution/__init__.py
@@ -136,7 +136,7 @@ class ManufacturedSolution(Task):
                     component=component,
                     refinement=refinement,
                     refinement_factor=refinement_factor,
-                    name=f'forward_{mesh_name}_{timestep}s',
+                    name=f'{forward_name}_{timestep}s',
                     subdir=subdir,
                     init=init_step,
                     del2=del2, del4=del4)

--- a/polaris/ocean/tasks/manufactured_solution/__init__.py
+++ b/polaris/ocean/tasks/manufactured_solution/__init__.py
@@ -37,11 +37,11 @@ def add_manufactured_solution_tasks(component):
                                                 refinement=refinement))
     component.add_task(ManufacturedSolution(component=component,
                                             config=config,
-                                            refinement='space',
+                                            refinement='both',
                                             del2=True))
     component.add_task(ManufacturedSolution(component=component,
                                             config=config,
-                                            refinement='space',
+                                            refinement='both',
                                             del4=True))
 
 
@@ -116,7 +116,7 @@ class ManufacturedSolution(Task):
                 init_step = component.steps[subdir]
             else:
                 init_step = Init(component=component, resolution=resolution,
-                                 subdir=subdir)
+                                 name=f'init_{mesh_name}', subdir=subdir)
                 init_step.set_shared_config(self.config, link=config_filename)
             if resolution not in resolutions:
                 self.add_step(init_step, symlink=symlink)
@@ -136,7 +136,7 @@ class ManufacturedSolution(Task):
                     component=component,
                     refinement=refinement,
                     refinement_factor=refinement_factor,
-                    name=f'{forward_name}_{timestep}s',
+                    name=f'forward_{mesh_name}_{timestep}s',
                     subdir=subdir,
                     init=init_step,
                     del2=del2, del4=del4)

--- a/polaris/ocean/tasks/manufactured_solution/__init__.py
+++ b/polaris/ocean/tasks/manufactured_solution/__init__.py
@@ -75,19 +75,20 @@ class ManufacturedSolution(Task):
         basedir = 'planar/manufactured_solution'
         subdir = f'{basedir}/convergence_{refinement}'
         name = f'manufactured_solution_convergence_{refinement}'
+
         if del2:
-            name = f'{name}_del2'
-            subdir = f'{subdir}/del2'
+            test_name = 'del2'
             if del4:
                 del4 = False
                 print('Manufactured solution test does not currently support'
                       'both del2 and del4 convergence; testing del2 alone.')
         elif del4:
-            name = f'{name}_del4'
-            subdir = f'{subdir}/del4'
+            test_name = 'del4'
         else:
-            name = f'{name}_default'
-            subdir = f'{subdir}/default'
+            test_name = 'default'
+
+        name = f'{name}_{test_name}'
+        subdir = f'{subdir}/{test_name}'
 
         config_filename = 'manufactured_solution.cfg'
 
@@ -127,7 +128,7 @@ class ManufacturedSolution(Task):
             timestep = ceil(timestep)
             timesteps.append(timestep)
 
-            subdir = f'{basedir}/forward/{mesh_name}_{timestep}s'
+            subdir = f'{basedir}/{test_name}/forward/{mesh_name}_{timestep}s'
             symlink = f'forward/{mesh_name}_{timestep}s'
             if subdir in component.steps:
                 forward_step = component.steps[subdir]

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -21,9 +21,18 @@ class Forward(ConvergenceForward):
     refinement : str
         Refinement type. One of 'space', 'time' or 'both' indicating both
         space and time
+
+    resolution : float
+        The resolution of the test case in km
+
+    del2 : bool
+        Whether to evaluate the momentum del2 operator
+
+    del4 : bool
+        Whether to evaluate the momentum del4 operator
     """
     def __init__(self, component, name, refinement_factor, subdir,
-                 init, refinement='both'):
+                 init, refinement='both', del2=False, del4=False):
         """
         Create a new test case
 
@@ -47,6 +56,12 @@ class Forward(ConvergenceForward):
         refinement : str, optional
             Refinement type. One of 'space', 'time' or 'both' indicating both
             space and time
+
+        del2 : bool
+            Whether to evaluate the momentum del2 operator
+
+        del4 : bool
+            Whether to evaluate the momentum del4 operator
         """
         super().__init__(component=component,
                          name=name, subdir=subdir,
@@ -68,6 +83,8 @@ class Forward(ConvergenceForward):
         # TODO: remove as soon as Omega no longer hard-codes this file
         if model == 'omega':
             self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
+        self.del2 = del2
+        self.del4 = del4
 
     def compute_cell_count(self):
         """
@@ -107,5 +124,15 @@ class Forward(ConvergenceForward):
                    'config_manufactured_solution_wavelength_x':
                    float(exact_solution.lambda_x),
                    'config_manufactured_solution_wavelength_y':
-                   float(exact_solution.lambda_y)}
+                   float(exact_solution.lambda_y),
+                   'config_disable_vel_hmix':
+                   True}
+
+        if self.del2:
+            options['config_disable_vel_hmix'] = False
+            options['config_use_mom_del2'] = True
+        if self.del4:
+            options['config_disable_vel_hmix'] = False
+            options['config_use_mom_del4'] = True
+
         self.add_model_config_options(options, config_model='mpas-ocean')

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -12,13 +12,15 @@ mpas-ocean:
     config_implicit_bottom_drag_type: constant
     config_implicit_constant_bottom_drag_coeff: 0.0
   hmix_del2:
-    config_mom_del2: 1000.
+    config_mom_del2: 1.5e6
   hmix_del4:
-    config_mom_del4: 1.e10
+    config_mom_del4: 5.e13
   manufactured_solution:
      config_use_manufactured_solution: true
   debug:
-    config_disable_vel_hmix: true
+    config_compute_active_tracer_budgets: false
+    config_disable_vel_vmix: true
+    config_disable_tr_all_tend: true
   streams:
     mesh:
       filename_template: init.nc

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -11,6 +11,10 @@ mpas-ocean:
     config_bottom_drag_mode: implicit
     config_implicit_bottom_drag_type: constant
     config_implicit_constant_bottom_drag_coeff: 0.0
+  hmix_del2:
+    config_mom_del2: 1000.
+  hmix_del4:
+    config_mom_del4: 1.e10
   manufactured_solution:
      config_use_manufactured_solution: true
   debug:

--- a/polaris/ocean/tasks/manufactured_solution/init.py
+++ b/polaris/ocean/tasks/manufactured_solution/init.py
@@ -22,7 +22,7 @@ class Init(OceanIOStep):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, component, resolution, subdir):
+    def __init__(self, component, resolution, subdir, name):
         """
         Create the step
 
@@ -37,9 +37,8 @@ class Init(OceanIOStep):
         taskdir : str
             The subdirectory that the task belongs to
         """
-        mesh_name = resolution_to_subdir(resolution)
         super().__init__(component=component,
-                         name=f'init_{mesh_name}',
+                         name=name,
                          subdir=subdir)
         self.resolution = resolution
 

--- a/polaris/ocean/tasks/manufactured_solution/init.py
+++ b/polaris/ocean/tasks/manufactured_solution/init.py
@@ -5,7 +5,6 @@ from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
 from polaris.ocean.model import OceanIOStep
-from polaris.ocean.resolution import resolution_to_subdir
 from polaris.ocean.tasks.manufactured_solution.exact_solution import (
     ExactSolution,
 )

--- a/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
+++ b/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
@@ -25,7 +25,7 @@ n_wavelengths_x = 2
 n_wavelengths_y = 2
 
 # Time step per resolution (s/km), since dt is proportional to resolution
-dt_per_km = 3.0
+dt_per_km = 1.5
 
 # Convergence threshold below which the test fails
 conv_thresh = 1.8

--- a/polaris/ocean/tasks/manufactured_solution/viz.py
+++ b/polaris/ocean/tasks/manufactured_solution/viz.py
@@ -109,7 +109,7 @@ class Viz(OceanIOStep):
             forward = dependencies['forward'][refinement_factor]
             self.add_input_file(
                 filename=f'mesh_r{refinement_factor:02g}.nc',
-                work_dir_target=f'{base_mesh.path}/base_mesh.nc')
+                work_dir_target=f'{base_mesh.path}/culled_mesh.nc')
             self.add_input_file(
                 filename=f'init_r{refinement_factor:02g}.nc',
                 work_dir_target=f'{init.path}/initial_state.nc')


### PR DESCRIPTION
This PR adds manufactured solution tests for del2 and del4 and renames the existing case to `default`. Both del2 and del4 tests depend on the corresponding source terms being added to the model. These terms are added to MPAS-Ocean here https://github.com/E3SM-Ocean-Discussion/E3SM/pull/110. All tests depend on https://github.com/E3SM-Ocean-Discussion/E3SM/pull/55 to achieve expected convergence. 

Checklist
* [X] User's Guide has been updated
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes
* [X] New tests have been added to a test suite
