### PR TITLE
Fixup graph paths for cached inputs

### DIFF
--- a/polaris/ocean/tasks/cosine_bell/forward.py
+++ b/polaris/ocean/tasks/cosine_bell/forward.py
@@ -39,4 +39,4 @@ class Forward(SphericalConvergenceForward):
                          yaml_filename='forward.yaml',
                          output_filename='output.nc',
                          validate_vars=validate_vars,
-                         graph_target=f'{init.path}/graph.info')
+                         graph_target=f'{mesh.path}/graph.info')

--- a/polaris/ocean/tasks/geostrophic/forward.py
+++ b/polaris/ocean/tasks/geostrophic/forward.py
@@ -42,4 +42,4 @@ class Forward(SphericalConvergenceForward):
                          yaml_filename='forward.yaml',
                          output_filename='output.nc',
                          validate_vars=validate_vars,
-                         graph_target=f'{init.path}/graph.info')
+                         graph_target=f'{mesh.path}/graph.info')

--- a/polaris/ocean/tasks/sphere_transport/forward.py
+++ b/polaris/ocean/tasks/sphere_transport/forward.py
@@ -53,4 +53,4 @@ class Forward(SphericalConvergenceForward):
                          output_filename='output.nc',
                          validate_vars=validate_vars,
                          options=namelist_options,
-                         graph_target=f'{init.path}/graph.info')
+                         graph_target=f'{base_mesh.path}/graph.info')


### PR DESCRIPTION
This PR corrects a small bug introduced by https://github.com/E3SM-Project/polaris/pull/225. When inputs are cached, we need to point to the mesh step rather than the init step for the graph files. Doesn't hurt to point to the mesh step when inputs are not cached either.