### PR TITLE
Add convergence tasks for space and time only

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -313,18 +313,21 @@
 .. autosummary::
    :toctree: generated/
 
-   ConvergenceForward
-   ConvergenceForward.compute_cell_count
-   ConvergenceForward.dynamic_model_config
+   get_resolution_for_tasks
+   get_timestep_for_tasks
 
-   ConvergenceAnalysis
-   ConvergenceAnalysis.compute_error
-   ConvergenceAnalysis.convergence_parameters
-   ConvergenceAnalysis.exact_solution
-   ConvergenceAnalysis.get_output_field
-   ConvergenceAnalysis.plot_convergence
-   ConvergenceAnalysis.run
-   ConvergenceAnalysis.setup
+   forward.ConvergenceForward
+   forward.ConvergenceForward.compute_cell_count
+   forward.ConvergenceForward.dynamic_model_config
+
+   analysis.ConvergenceAnalysis
+   analysis.ConvergenceAnalysis.compute_error
+   analysis.ConvergenceAnalysis.convergence_parameters
+   analysis.ConvergenceAnalysis.exact_solution
+   analysis.ConvergenceAnalysis.get_output_field
+   analysis.ConvergenceAnalysis.plot_convergence
+   analysis.ConvergenceAnalysis.run
+   analysis.ConvergenceAnalysis.setup
 ```
 ### Spherical Convergence Tests
 

--- a/docs/users_guide/ocean/tasks/cosine_bell.md
+++ b/docs/users_guide/ocean/tasks/cosine_bell.md
@@ -33,34 +33,56 @@ These tasks support only MPAS-Ocean.
 (ocean-cosine-bell-mesh)=
 ## mesh
 
-Two global mesh variants are tested, quasi-uniform (QU) and icosohydral. Thus,
-there are 4 variants of the task:
+Two global mesh variants are tested, quasi-uniform (QU) and icosohydral. There
+are also variants to test convergence in space, time, or both space and time.
+In addition, the tests can be set up with or without the viz step. Thus, there
+are 12 variants of the task:
 ```
-ocean/spherical/icos/cosine_bell
-ocean/spherical/icos/cosine_bell/with_viz
-ocean/spherical/qu/cosine_bell
-ocean/spherical/qu/cosine_bell/with_viz
+ocean/spherical/icos/cosine_bell/convergence_both/
+ocean/spherical/icos/cosine_bell/convergence_both/with_viz
+ocean/spherical/qu/cosine_bell/convergence_both/
+ocean/spherical/qu/cosine_bell/convergence_both/with_viz
+ocean/spherical/icos/cosine_bell/convergence_space/
+ocean/spherical/icos/cosine_bell/convergence_space/with_viz
+ocean/spherical/qu/cosine_bell/convergence_space/
+ocean/spherical/qu/cosine_bell/convergence_space/with_viz
+ocean/spherical/icos/cosine_bell/convergence_time/
+ocean/spherical/icos/cosine_bell/convergence_time/with_viz
+ocean/spherical/qu/cosine_bell/convergence_time/
+ocean/spherical/qu/cosine_bell/convergence_time/with_viz
 ```
 The default resolutions used in the task depends on the mesh type.
 
-For the `icos` mesh type, the defaults are:
+For the `icos` mesh type, the defaults are 60, 120, 240, 480 km, as determined
+by the following config options. See {ref}`dev-ocean-convergence` for more
+details.
 
 ```cfg
 # config options for spherical convergence tests
 [spherical_convergence]
+
+# The base resolution for the icosahedral mesh to which the refinement
+# factors are applied
+icos_base_resolution = 60.
 
 # a list of icosahedral mesh resolutions (km) to test
-icos_resolutions = 60, 120, 240, 480
+icos_refinement_factors = 8., 4., 2., 1.
+# a list of icosahedral mesh resolutions (km) to test
 ```
 
-for the `qu` mesh type, they are:
+For the `qu` mesh type, they are 60, 90, 120, 150, 180, 210, 240 km as
+determined by the following config options:
 
 ```cfg
 # config options for spherical convergence tests
 [spherical_convergence]
 
+# The base resolution for the quasi-uniform mesh to which the refinement
+# factors are applied
+qu_base_resolution = 120.
+
 # a list of quasi-uniform mesh resolutions (km) to test
-qu_resolutions = 60, 90, 120, 150, 180, 210, 240
+qu_refinement_factors = 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2.
 ```
 
 To alter the resolutions used in this task, you will need to create your own

--- a/docs/users_guide/ocean/tasks/geostrophic.md
+++ b/docs/users_guide/ocean/tasks/geostrophic.md
@@ -4,19 +4,24 @@
 
 ## description
 
-The `geostrophic` and `geostrophic/with_viz` tasks implement the "Global Steady
+The `geostrophic` tasks implement the "Global Steady
 State Nonlinear Zonal Geostrophic Flow" test case described in
 [Williamson et al. 1992](<https://doi.org/10.1016/S0021-9991(05)80016-6>)
 
-The task is a convergence test with time step varying proportionately to grid
-size. The result of the `analysis` step of the task are plots like the
-following showing convergence of water-column thickness and normal velocity as
-functions of the mesh resolution:
+The task `geostrophic/convergence_both` is a space-and-time convergence test
+with time step varying proportionately to grid size. Convergence tests in
+either space or time are also available as `convergence_space` or 
+`convergence_time`. The result of the `analysis` step of the task are plots
+like the following showing convergence of water-column thickness and normal
+velocity as functions of the mesh resolution:
 
 ```{image} images/geostrophic_convergence.png
 :align: center
 :width: 500 px
 ```
+
+Visualizations of the fields themselves can be added in viz steps by appending
+`with_viz` to the task name at setup.
 
 ## suppported models
 

--- a/docs/users_guide/ocean/tasks/inertial_gravity_wave.md
+++ b/docs/users_guide/ocean/tasks/inertial_gravity_wave.md
@@ -11,6 +11,14 @@ The implementation is from
 
 ## description
 
+There are 3 versions of the convergence test case, `convergence_space`,
+`convergence_time`, and `convergence_both` corresponding to space, time, and
+space and time convergence tests. Tests involving spatial convergence run the
+inertial gravity wave simulation for 4 different resolutions: 200, 100, 50,
+and 25 km. Tests involving temporal convergence use the parameter `dt_per_km`
+at the `base_resolution` multiplied by `refinement_factors` (see
+{ref}`dev-ocean-convergence` for more details on how to change resolutions or
+time steps tested).
 The `inertial_gravity_wave` task runs the inertial gravity wave simulation for 4
 different resolutions: 200, 100, 50, and 25 km.
 

--- a/docs/users_guide/ocean/tasks/manufactured_solution.md
+++ b/docs/users_guide/ocean/tasks/manufactured_solution.md
@@ -22,8 +22,14 @@ These tasks support both MPAS-Ocean and Omega.
 
 ### description
 
-The `convergence` test case runs the manufactured solution simulation for 4
-different resolutions: 200, 100, 50, and 25 km.
+There are 3 versions of the convergence test case, `convergence_space`,
+`convergence_time`, and `convergence_both` corresponding to space, time, and
+space and time convergence tests. Tests involving spatial convergence run the
+manufactured solution simulation for 4 different resolutions: 200, 100, 50,
+and 25 km. Tests involving temporal convergence use the parameter `dt_per_km`
+at the `base_resolution` multiplied by `refinement_factors` (see
+{ref}`dev-ocean-convergence` for more details on how to change resolutions or
+time steps tested).
 
 The forward step for each resolution runs the simulation for 10 hours. The
 model is configured without vertical advection and mixing. No tracers are enabled

--- a/polaris/ocean/convergence/__init__.py
+++ b/polaris/ocean/convergence/__init__.py
@@ -3,7 +3,26 @@ import numpy as np
 
 def get_resolution_for_task(config, refinement_factor,
                             refinement='both'):
+    """
+    Get the resolution for a step in a convergence task
 
+    Parameters
+    ----------
+    config : polaris.Config
+        The config options for this task
+
+    refinement_factor : float
+        The factor by which either resolution or time is refined for this step
+
+    refinement : str, optional
+        Whether to refine in space, time or both
+
+    Returns
+    -------
+    resolution : float
+        The resolution corresponding to the refinement_factor and convergence
+        test type
+    """
     base_resolution = config.getfloat('convergence', 'base_resolution')
     refinement_factors = config.getlist('convergence',
                                         'refinement_factors',
@@ -23,6 +42,26 @@ def get_resolution_for_task(config, refinement_factor,
 
 def get_timestep_for_task(config, refinement_factor,
                           refinement='both'):
+    """
+    Get the time step for a forward step in a convergence task
+
+    Parameters
+    ----------
+    config : polaris.Config
+        The config options for this task
+
+    refinement_factor : float
+        The factor by which either resolution or time is refined for this step
+
+    refinement : str, optional
+        Whether to refine in space, time or both
+
+    Returns
+    -------
+    resolution : float
+        The resolution corresponding to the refinement_factor and convergence
+        test type
+    """
 
     base_resolution = config.getfloat('convergence', 'base_resolution')
     refinement_factors = config.getlist('convergence',

--- a/polaris/ocean/convergence/__init__.py
+++ b/polaris/ocean/convergence/__init__.py
@@ -1,2 +1,63 @@
-from polaris.ocean.convergence.analysis import ConvergenceAnalysis
-from polaris.ocean.convergence.forward import ConvergenceForward
+import numpy as np
+
+
+def get_resolution_for_task(config, refinement_factor,
+                            refinement='both'):
+
+    base_resolution = config.getfloat('convergence', 'base_resolution')
+    refinement_factors = config.getlist('convergence',
+                                        'refinement_factors',
+                                        dtype=float)
+
+    if refinement_factor not in refinement_factors:
+        raise ValueError(
+            'refinement_factor not found in config option refinement_factors')
+
+    if refinement == 'time':
+        resolution = base_resolution
+    else:
+        resolution = refinement_factor * base_resolution
+
+    return resolution
+
+
+def get_timestep_for_task(config, refinement_factor,
+                          refinement='both'):
+
+    base_resolution = config.getfloat('convergence', 'base_resolution')
+    refinement_factors = config.getlist('convergence',
+                                        'refinement_factors',
+                                        dtype=float)
+
+    if refinement_factor not in refinement_factors:
+        raise ValueError(
+            'refinement_factor not found in config option refinement_factors')
+
+    resolution = get_resolution_for_task(
+        config, refinement_factor, refinement=refinement)
+
+    section = config['convergence_forward']
+    time_integrator = section.get('time_integrator')
+    # dt is proportional to resolution: default 30 seconds per km
+    if time_integrator == 'RK4':
+        dt_per_km = section.getfloat('rk4_dt_per_km')
+        btr_timestep = 0.
+    else:
+        dt_per_km = section.getfloat('split_dt_per_km')
+        btr_dt_per_km = section.getfloat('btr_dt_per_km')
+        for idx, refinement_factor in enumerate(refinement_factors):
+            if refinement == 'time':
+                btr_timestep = btr_dt_per_km * base_resolution * \
+                    refinement_factor
+            elif refinement == 'space':
+                btr_timestep = btr_dt_per_km * base_resolution
+            else:
+                btr_timestep = btr_dt_per_km * resolution
+    if refinement == 'time':
+        timestep = dt_per_km * refinement_factor * base_resolution
+    elif refinement == 'space':
+        timestep = dt_per_km * base_resolution
+    else:
+        timestep = dt_per_km * resolution
+
+    return timestep, btr_timestep

--- a/polaris/ocean/convergence/__init__.py
+++ b/polaris/ocean/convergence/__init__.py
@@ -23,10 +23,12 @@ def get_resolution_for_task(config, refinement_factor,
         The resolution corresponding to the refinement_factor and convergence
         test type
     """
+    if refinement == 'both':
+        option = 'refinement_factors_space'
+    else:
+        option = f'refinement_factors_{refinement}'
     base_resolution = config.getfloat('convergence', 'base_resolution')
-    refinement_factors = config.getlist('convergence',
-                                        'refinement_factors',
-                                        dtype=float)
+    refinement_factors = config.getlist('convergence', option, dtype=float)
 
     if refinement_factor not in refinement_factors:
         raise ValueError(
@@ -63,10 +65,12 @@ def get_timestep_for_task(config, refinement_factor,
         test type
     """
 
+    if refinement == 'both':
+        option = 'refinement_factors_space'
+    else:
+        option = f'refinement_factors_{refinement}'
     base_resolution = config.getfloat('convergence', 'base_resolution')
-    refinement_factors = config.getlist('convergence',
-                                        'refinement_factors',
-                                        dtype=float)
+    refinement_factors = config.getlist('convergence', option, dtype=float)
 
     if refinement_factor not in refinement_factors:
         raise ValueError(
@@ -93,7 +97,7 @@ def get_timestep_for_task(config, refinement_factor,
             else:
                 btr_timestep = btr_dt_per_km * resolution
     if refinement == 'time':
-        timestep = dt_per_km * refinement_factor * base_resolution
+        timestep = dt_per_km * refinement_factor * resolution
     elif refinement == 'space':
         timestep = dt_per_km * base_resolution
     else:

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -19,9 +19,6 @@ class ConvergenceAnalysis(OceanIOStep):
 
     Attributes
     ----------
-    resolutions : list of float
-        The resolutions of the meshes that have been run
-
     dependencies_dict : dict of dict of polaris.Steps
         The dependencies of this step must be given as separate keys in the
         dict:
@@ -55,6 +52,10 @@ class ConvergenceAnalysis(OceanIOStep):
             zidx : int
                 The z-index to use for variables that have an nVertLevels
                 dimension, which should be None for variables that don't
+
+    refinement : str
+        Refinement type. One of 'space', 'time' or 'both' indicating both
+        space and time
     """
     def __init__(self, component, subdir, dependencies, convergence_vars,
                  refinement='both'):
@@ -74,17 +75,17 @@ class ConvergenceAnalysis(OceanIOStep):
             dict:
 
                 mesh : dict of polaris.Steps
-                    Keys of the dict correspond to `resolutions`
+                    Keys of the dict correspond to `refinement_factors`
                     Values of the dict are polaris.Steps, which must have the
                     attribute `path`, the path to `base_mesh.nc` of that
                     resolution
                 init : dict of polaris.Steps
-                    Keys of the dict correspond to `resolutions`
+                    Keys of the dict correspond to `refinement_factors`
                     Values of the dict are polaris.Steps, which must have the
                     attribute `path`, the path to `initial_state.nc` of that
                     resolution
                 forward : dict of polaris.Steps
-                    Keys of the dict correspond to `resolutions`
+                    Keys of the dict correspond to `refinement_factors`
                     Values of the dict are polaris.Steps, which must have the
                     attribute `path`, the path to `forward.nc` of that
                     resolution

--- a/polaris/ocean/convergence/convergence.cfg
+++ b/polaris/ocean/convergence/convergence.cfg
@@ -4,19 +4,23 @@
 convergence_eval_time = 24.0
 
 # Convergence threshold below which a test fails
-convergence_thresh = 1.0
+convergence_thresh_space = 1.0
+convergence_thresh_time = 1.0
 
 # Type of error to compute
 error_type = l2
 
-# the base mesh resolution (km) to which refinement_factors
-# are applied if refinement is 'space' or 'both' on a planar mesh
+# the base mesh resolution (km) to which refinement_factors are applied
 # base resolutions for spherical meshes are given in section spherical_convergence
 base_resolution = 120
 
-# refinement factors for a planar mesh applied to either space or time
+# refinement factors for a planar mesh applied to either space or both space and time
 # refinement factors for a spherical mesh given in section spherical_convergence
-refinement_factors = 4., 2., 1., 0.5
+refinement_factors_space = 4., 2., 1., 0.5
+
+# refinement factors for a planar mesh applied to time with the base timestep
+# determined by base_resolution * dt_per_km
+refinement_factors_time = 1., 0.5, 0.25
 
 # config options for convergence forward steps
 [convergence_forward]

--- a/polaris/ocean/convergence/convergence.cfg
+++ b/polaris/ocean/convergence/convergence.cfg
@@ -9,6 +9,15 @@ convergence_thresh = 1.0
 # Type of error to compute
 error_type = l2
 
+# the base mesh resolution (km) to which refinement_factors
+# are applied if refinement is 'space' or 'both' on a planar mesh
+# base resolutions for spherical meshes are given in section spherical_convergence
+base_resolution = 120
+
+# refinement factors for a planar mesh applied to either space or time
+# refinement factors for a spherical mesh given in section spherical_convergence
+refinement_factors = 4., 2., 1., 0.5
+
 # config options for convergence forward steps
 [convergence_forward]
 
@@ -18,9 +27,11 @@ error_type = l2
 time_integrator = RK4
 
 # RK4 time step per resolution (s/km), since dt is proportional to resolution
+# if using convergence in time only, this is used for the largest resolution
 rk4_dt_per_km = 3.0
 
 # split time step per resolution (s/km), since dt is proportional to resolution
+# if using convergence in time only, this is used for the largest resolution
 split_dt_per_km = 30.0
 
 # the barotropic time step (s/km) for simulations using split time stepping,

--- a/polaris/ocean/convergence/forward.py
+++ b/polaris/ocean/convergence/forward.py
@@ -15,6 +15,13 @@ class ConvergenceForward(OceanModelStep):
     yaml_filename : str
         A YAML file that is a Jinja2 template with model config options
 
+    refinement : str
+        Refinement type. One of 'space', 'time' or 'both' indicating both
+        space and time
+
+    refinement_factor : float
+        Refinement factor use to scale space, time or both depending on
+        refinement option
     """
 
     def __init__(self, component, name, subdir, refinement_factor, mesh, init,
@@ -34,6 +41,10 @@ class ConvergenceForward(OceanModelStep):
 
         subdir : str
             The subdirectory for the step
+
+        refinement_factor : float
+            Refinement factor use to scale space, time or both depending on
+            refinement option
 
         package : Package
             The package name or module object that contains the YAML file
@@ -55,6 +66,10 @@ class ConvergenceForward(OceanModelStep):
 
         validate_vars : list of str, optional
             A list of variables to validate against a baseline if requested
+
+        refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         super().__init__(component=component, name=name, subdir=subdir,
                          openmp_threads=1, graph_target=graph_target)

--- a/polaris/ocean/convergence/forward.py
+++ b/polaris/ocean/convergence/forward.py
@@ -132,6 +132,7 @@ class ConvergenceForward(OceanModelStep):
         btr_dt_str = get_time_interval_string(seconds=btr_timestep)
 
         s_per_hour = 3600.
+        section = config['convergence_forward']
         run_duration = section.getfloat('run_duration')
         run_duration_str = get_time_interval_string(
             seconds=run_duration * s_per_hour)
@@ -140,6 +141,7 @@ class ConvergenceForward(OceanModelStep):
         output_interval_str = get_time_interval_string(
             seconds=output_interval * s_per_hour)
 
+        time_integrator = section.get('time_integrator')
         time_integrator_map = dict([('RK4', 'RungeKutta4')])
         model = config.get('ocean', 'model')
         if model == 'omega':

--- a/polaris/ocean/convergence/spherical/forward.py
+++ b/polaris/ocean/convergence/spherical/forward.py
@@ -1,4 +1,5 @@
-from polaris.ocean.convergence import ConvergenceForward
+from polaris.ocean.convergence import get_resolution_for_task
+from polaris.ocean.convergence.forward import ConvergenceForward
 
 
 class SphericalConvergenceForward(ConvergenceForward):
@@ -30,5 +31,8 @@ class SphericalConvergenceForward(ConvergenceForward):
             The approximate number of cells in the mesh
         """
         # use a heuristic based on QU30 (65275 cells) and QU240 (10383 cells)
-        cell_count = 6e8 / self.resolution**2
+        resolution = get_resolution_for_task(
+            self.config, self.refinement_factor,
+            refinement=self.refinement)
+        cell_count = 6e8 / resolution**2
         return cell_count

--- a/polaris/ocean/convergence/spherical/spherical.cfg
+++ b/polaris/ocean/convergence/spherical/spherical.cfg
@@ -6,11 +6,13 @@
 icos_base_resolution = 60.
 
 # The factors by which to scale space or time based on icos_base_resolution
-icos_refinement_factors = 8., 4., 2., 1.
+icos_refinement_factors_space = 8., 4., 2., 1.
+icos_refinement_factors_time = 1., 0.5, 0.25
 
 # The base resolution for the quasi-uniform mesh to which the refinement
 # factors are applied
 qu_base_resolution = 120.
 
 # The factors by which to scale space or time based on qu_base_resolution
-qu_refinement_factors = 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2.
+qu_refinement_factors_space = 2., 1.75, 1.5, 1.25, 1., 0.75, 0.5
+qu_refinement_factors_time = 1., 0.5, 0.25

--- a/polaris/ocean/convergence/spherical/spherical.cfg
+++ b/polaris/ocean/convergence/spherical/spherical.cfg
@@ -1,8 +1,16 @@
 # config options for spherical convergence tests
 [spherical_convergence]
 
+# The base resolution for the icosahedral mesh to which the refinement
+# factors are applied
+icos_base_resolution = 60.
+
 # a list of icosahedral mesh resolutions (km) to test
-icos_resolutions = 60, 120, 240, 480
+icos_refinement_factors = 8., 4., 2., 1.
+
+# The base resolution for the quasi-uniform mesh to which the refinement
+# factors are applied
+qu_base_resolution = 120.
 
 # a list of quasi-uniform mesh resolutions (km) to test
-qu_resolutions = 60, 90, 120, 150, 180, 210, 240
+qu_refinement_factors = 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2.

--- a/polaris/ocean/convergence/spherical/spherical.cfg
+++ b/polaris/ocean/convergence/spherical/spherical.cfg
@@ -5,12 +5,12 @@
 # factors are applied
 icos_base_resolution = 60.
 
-# a list of icosahedral mesh resolutions (km) to test
+# The factors by which to scale space or time based on icos_base_resolution
 icos_refinement_factors = 8., 4., 2., 1.
 
 # The base resolution for the quasi-uniform mesh to which the refinement
 # factors are applied
 qu_base_resolution = 120.
 
-# a list of quasi-uniform mesh resolutions (km) to test
+# The factors by which to scale space or time based on qu_base_resolution
 qu_refinement_factors = 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2.

--- a/polaris/ocean/suites/convergence.txt
+++ b/polaris/ocean/suites/convergence.txt
@@ -1,22 +1,22 @@
-ocean/planar/inertial_gravity_wave
-ocean/planar/manufactured_solution
+ocean/planar/inertial_gravity_wave/convergence_both
+ocean/planar/manufactured_solution/convergence_both
 ocean/spherical/icos/correlated_tracers_2d
   cached: icos_base_mesh_60km icos_base_mesh_120km icos_base_mesh_240km icos_base_mesh_480km
 ocean/spherical/qu/correlated_tracers_2d
   cached: qu_base_mesh_60km qu_base_mesh_90km qu_base_mesh_120km qu_base_mesh_150km
   cached: qu_base_mesh_180km qu_base_mesh_210km qu_base_mesh_240km
-ocean/spherical/icos/cosine_bell
+ocean/spherical/icos/cosine_bell/convergence_both
   cached: icos_base_mesh_60km icos_init_60km icos_base_mesh_120km icos_init_120km
   cached: icos_base_mesh_240km icos_init_240km icos_base_mesh_480km icos_init_480km
-ocean/spherical/qu/cosine_bell
+ocean/spherical/qu/cosine_bell/convergence_both
   cached: qu_base_mesh_60km qu_init_60km qu_base_mesh_90km qu_init_90km
   cached: qu_base_mesh_120km qu_init_120km qu_base_mesh_150km qu_init_150km
   cached: qu_base_mesh_180km qu_init_180km qu_base_mesh_210km qu_init_210km
   cached: qu_base_mesh_240km qu_init_240km
-ocean/spherical/icos/geostrophic
+ocean/spherical/icos/geostrophic/convergence_both
   cached: icos_base_mesh_60km icos_init_60km icos_base_mesh_120km icos_init_120km
   cached: icos_base_mesh_240km icos_init_240km icos_base_mesh_480km icos_init_480km
-ocean/spherical/qu/geostrophic
+ocean/spherical/qu/geostrophic/convergence_both
   cached: qu_base_mesh_60km qu_init_60km qu_base_mesh_90km qu_init_90km
   cached: qu_base_mesh_120km qu_init_120km qu_base_mesh_150km qu_init_150km
   cached: qu_base_mesh_180km qu_init_180km qu_base_mesh_210km qu_init_210km

--- a/polaris/ocean/suites/geostrophic.txt
+++ b/polaris/ocean/suites/geostrophic.txt
@@ -1,2 +1,2 @@
-ocean/spherical/icos/geostrophic
-ocean/spherical/qu/geostrophic
+ocean/spherical/icos/geostrophic/convergence_both
+ocean/spherical/qu/geostrophic/convergence_both

--- a/polaris/ocean/suites/nightly.txt
+++ b/polaris/ocean/suites/nightly.txt
@@ -3,5 +3,5 @@ ocean/planar/baroclinic_channel/10km/decomp
 ocean/planar/baroclinic_channel/10km/restart
 ocean/planar/ice_shelf_2d/5km/z-star/default/with_restart
 ocean/planar/ice_shelf_2d/5km/z-level/default/with_restart
-ocean/planar/inertial_gravity_wave
+ocean/planar/inertial_gravity_wave/convergence_both
 # ocean/planar/manufactured_solution

--- a/polaris/ocean/suites/pr.txt
+++ b/polaris/ocean/suites/pr.txt
@@ -3,7 +3,7 @@ ocean/planar/baroclinic_channel/10km/decomp
 ocean/planar/baroclinic_channel/10km/restart
 ocean/planar/ice_shelf_2d/5km/z-star/default/with_restart
 ocean/planar/ice_shelf_2d/5km/z-level/default/with_restart
-ocean/planar/inertial_gravity_wave
+ocean/planar/inertial_gravity_wave/convergence_both
 ocean/planar/internal_wave/standard/default
 ocean/planar/internal_wave/vlr/default
 # ocean/planar/manufactured_solution

--- a/polaris/ocean/tasks/cosine_bell/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/__init__.py
@@ -33,8 +33,8 @@ def add_cosine_bell_tasks(component):
         config.add_from_package('polaris.ocean.tasks.cosine_bell',
                                 'cosine_bell.cfg')
 
-        for include_viz in [False, True]:
-            for refinement in ['space', 'time', 'both']:
+        for refinement in ['space', 'time', 'both']:
+            for include_viz in [False, True]:
                 component.add_task(CosineBell(component=component,
                                               config=config,
                                               icosahedral=icosahedral,

--- a/polaris/ocean/tasks/cosine_bell/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/__init__.py
@@ -8,7 +8,6 @@ from polaris.ocean.convergence import (
     get_timestep_for_task,
 )
 from polaris.ocean.mesh.spherical import add_spherical_base_mesh_step
-from polaris.ocean.resolution import resolution_to_subdir
 from polaris.ocean.tasks.cosine_bell.analysis import Analysis
 from polaris.ocean.tasks.cosine_bell.forward import Forward
 from polaris.ocean.tasks.cosine_bell.init import Init

--- a/polaris/ocean/tasks/cosine_bell/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/__init__.py
@@ -49,8 +49,9 @@ class CosineBell(Task):
 
     Attributes
     ----------
-    resolutions : list of float
-        A list of mesh resolutions
+    refinement : str
+        Refinement type. One of 'space', 'time' or 'both' indicating both
+        space and time
 
     icosahedral : bool
         Whether to use icosahedral, as opposed to less regular, JIGSAW meshes
@@ -79,6 +80,8 @@ class CosineBell(Task):
             Include VizMap and Viz steps for each resolution
 
         refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         if icosahedral:
             prefix = 'icos'
@@ -92,7 +95,6 @@ class CosineBell(Task):
             name = f'{name}_with_viz'
         link = 'cosine_bell.cfg'
         super().__init__(component=component, name=name, subdir=subdir)
-        self.resolutions = list()
         self.refinement = refinement
         self.icosahedral = icosahedral
         self.include_viz = include_viz

--- a/polaris/ocean/tasks/cosine_bell/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/__init__.py
@@ -129,15 +129,16 @@ class CosineBell(Task):
         else:
             prefix = 'qu'
 
+        if refinement == 'time':
+            option = 'refinement_factors_time'
+        else:
+            option = 'refinement_factors_space'
         refinement_factors = config.getlist('spherical_convergence',
-                                            f'{prefix}_refinement_factors',
-                                            dtype=str)
+                                            f'{prefix}_{option}', dtype=str)
         refinement_factors = ', '.join(refinement_factors)
-        config.set('convergence', 'refinement_factors',
-                   value=refinement_factors)
+        config.set('convergence', option, value=refinement_factors)
         refinement_factors = config.getlist('convergence',
-                                            'refinement_factors',
-                                            dtype=float)
+                                            option, dtype=float)
 
         base_resolution = config.getfloat('spherical_convergence',
                                           f'{prefix}_base_resolution')

--- a/polaris/ocean/tasks/cosine_bell/analysis.py
+++ b/polaris/ocean/tasks/cosine_bell/analysis.py
@@ -25,6 +25,9 @@ class Analysis(ConvergenceAnalysis):
 
         dependencies : dict of dict of polaris.Steps
             The dependencies of this step
+
+        refinement : str, optional
+            Whether to refine in space, time or both space and time
         """
         convergence_vars = [{'name': 'tracer1',
                              'title': 'tracer1',
@@ -40,8 +43,8 @@ class Analysis(ConvergenceAnalysis):
 
         Parameters
         ----------
-        mesh_name : str
-            The mesh name which is the prefix for the initial condition file
+        refinement_factor : float
+            The factor by which to scale space, time or both
 
         field_name : str
             The name of the variable of which we evaluate convergence
@@ -58,7 +61,7 @@ class Analysis(ConvergenceAnalysis):
 
         Returns
         -------
-        solution: xarray.DataArray
+        solution : xarray.DataArray
             The exact solution with dimension nCells
         """
 

--- a/polaris/ocean/tasks/cosine_bell/analysis.py
+++ b/polaris/ocean/tasks/cosine_bell/analysis.py
@@ -3,7 +3,7 @@ import xarray as xr
 from mpas_tools.transects import lon_lat_to_cartesian
 from mpas_tools.vector import Vector
 
-from polaris.ocean.convergence import ConvergenceAnalysis
+from polaris.ocean.convergence.analysis import ConvergenceAnalysis
 from polaris.ocean.tasks.cosine_bell.init import cosine_bell
 
 
@@ -11,7 +11,7 @@ class Analysis(ConvergenceAnalysis):
     """
     A step for analyzing the output from the cosine bell test case
     """
-    def __init__(self, component, resolutions, subdir, dependencies):
+    def __init__(self, component, subdir, dependencies, refinement='both'):
         """
         Create the step
 
@@ -19,9 +19,6 @@ class Analysis(ConvergenceAnalysis):
         ----------
         component : polaris.Component
             The component the step belongs to
-
-        resolutions : list of float
-            The resolutions of the meshes that have been run
 
         subdir : str
             The subdirectory that the step resides in
@@ -33,11 +30,11 @@ class Analysis(ConvergenceAnalysis):
                              'title': 'tracer1',
                              'zidx': 0}]
         super().__init__(component=component, subdir=subdir,
-                         resolutions=resolutions,
                          dependencies=dependencies,
-                         convergence_vars=convergence_vars)
+                         convergence_vars=convergence_vars,
+                         refinement=refinement)
 
-    def exact_solution(self, mesh_name, field_name, time, zidx=None):
+    def exact_solution(self, refinement_factor, field_name, time, zidx=None):
         """
         Get the exact solution
 
@@ -76,10 +73,10 @@ class Analysis(ConvergenceAnalysis):
         psi0 = config.getfloat('cosine_bell', 'psi0')
         vel_pd = config.getfloat('cosine_bell', 'vel_pd')
 
-        ds_mesh = xr.open_dataset(f'{mesh_name}_mesh.nc')
+        ds_mesh = xr.open_dataset(f'mesh_r{refinement_factor:02g}.nc')
         sphere_radius = ds_mesh.sphere_radius
 
-        ds_init = xr.open_dataset(f'{mesh_name}_init.nc')
+        ds_init = xr.open_dataset(f'init_r{refinement_factor:02g}.nc')
         latCell = ds_init.latCell.values
         lonCell = ds_init.lonCell.values
 

--- a/polaris/ocean/tasks/cosine_bell/forward.py
+++ b/polaris/ocean/tasks/cosine_bell/forward.py
@@ -7,7 +7,8 @@ class Forward(SphericalConvergenceForward):
     bell test case
     """
 
-    def __init__(self, component, name, subdir, resolution, mesh, init):
+    def __init__(self, component, name, subdir, mesh, init,
+                 refinement_factor, refinement='both'):
         """
         Create a new step
 
@@ -30,13 +31,17 @@ class Forward(SphericalConvergenceForward):
 
         init : polaris.Step
             The init step
+
+        time_refinement_factor : float
+            The amount by which to scale dt_per_km and btr_dt_per_km
         """
         package = 'polaris.ocean.tasks.cosine_bell'
         validate_vars = ['normalVelocity', 'tracer1']
         super().__init__(component=component, name=name, subdir=subdir,
-                         resolution=resolution, mesh=mesh,
-                         init=init, package=package,
+                         mesh=mesh, init=init, package=package,
                          yaml_filename='forward.yaml',
                          output_filename='output.nc',
                          validate_vars=validate_vars,
-                         graph_target=f'{mesh.path}/graph.info')
+                         graph_target=f'{mesh.path}/graph.info',
+                         refinement_factor=refinement_factor,
+                         refinement=refinement)

--- a/polaris/ocean/tasks/cosine_bell/forward.py
+++ b/polaris/ocean/tasks/cosine_bell/forward.py
@@ -23,17 +23,18 @@ class Forward(SphericalConvergenceForward):
         subdir : str
             The subdirectory for the step
 
-        resolution : float
-            The resolution of the (uniform) mesh in km
-
         mesh : polaris.Step
             The base mesh step
 
         init : polaris.Step
             The init step
 
-        time_refinement_factor : float
-            The amount by which to scale dt_per_km and btr_dt_per_km
+        refinement_factor : float
+            The factor by which to scale space, time or both
+
+        refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         package = 'polaris.ocean.tasks.cosine_bell'
         validate_vars = ['normalVelocity', 'tracer1']

--- a/polaris/ocean/tasks/geostrophic/__init__.py
+++ b/polaris/ocean/tasks/geostrophic/__init__.py
@@ -1,7 +1,12 @@
+from math import ceil
 from typing import Dict
 
 from polaris import Step, Task
 from polaris.config import PolarisConfigParser
+from polaris.ocean.convergence import (
+    get_resolution_for_task,
+    get_timestep_for_task,
+)
 from polaris.ocean.mesh.spherical import add_spherical_base_mesh_step
 from polaris.ocean.tasks.geostrophic.analysis import Analysis
 from polaris.ocean.tasks.geostrophic.forward import Forward
@@ -29,10 +34,12 @@ def add_geostrophic_tasks(component):
                                 'geostrophic.cfg')
 
         for include_viz in [False, True]:
-            component.add_task(Geostrophic(component=component,
-                                           config=config,
-                                           icosahedral=icosahedral,
-                                           include_viz=include_viz))
+            for refinement in ['space', 'time', 'both']:
+                component.add_task(Geostrophic(component=component,
+                                               config=config,
+                                               icosahedral=icosahedral,
+                                               include_viz=include_viz,
+                                               refinement=refinement))
 
 
 class Geostrophic(Task):
@@ -50,7 +57,8 @@ class Geostrophic(Task):
     include_viz : bool
         Include VizMap and Viz steps for each resolution
     """
-    def __init__(self, component, config, icosahedral, include_viz):
+    def __init__(self, component, config, icosahedral, include_viz,
+                 refinement='both'):
         """
         Create the convergence test
 
@@ -74,23 +82,22 @@ class Geostrophic(Task):
         else:
             prefix = 'qu'
 
-        subdir = f'spherical/{prefix}/geostrophic'
-        name = f'{prefix}_geostrophic'
+        subdir = f'spherical/{prefix}/geostrophic/convergence_{refinement}'
+        name = f'{prefix}_geostrophic_convergence_{refinement}'
         if include_viz:
             subdir = f'{subdir}/with_viz'
             name = f'{name}_with_viz'
-            link = 'geostrophic.cfg'
-        else:
-            # config options live in the task already so no need for a symlink
-            link = None
+        link = 'geostrophic.cfg'
+
         super().__init__(component=component, name=name, subdir=subdir)
         self.resolutions = list()
+        self.refinement = refinement
         self.icosahedral = icosahedral
         self.include_viz = include_viz
 
         self.set_shared_config(config, link=link)
 
-        self._setup_steps()
+        self._setup_steps(refinement=refinement)
 
     def configure(self):
         """
@@ -99,96 +106,126 @@ class Geostrophic(Task):
         super().configure()
 
         # set up the steps again in case a user has provided new resolutions
-        self._setup_steps()
+        self._setup_steps(self.refinement)
 
-    def _setup_steps(self):
-        """ setup steps given resolutions """
+    def _setup_steps(self, refinement):
+        """
+        setup steps given resolutions
+
+        Parameters
+        ----------
+        refinement : str
+           refinement type. One of 'space', 'time' or 'both'
+        """
         icosahedral = self.icosahedral
         config = self.config
         config_filename = self.config_filename
+
         if icosahedral:
             prefix = 'icos'
         else:
             prefix = 'qu'
 
-        resolutions = config.getlist('spherical_convergence',
-                                     f'{prefix}_resolutions', dtype=float)
+        refinement_factors = config.getlist('spherical_convergence',
+                                            f'{prefix}_refinement_factors',
+                                            dtype=str)
+        refinement_factors = ', '.join(refinement_factors)
+        config.set('convergence', 'refinement_factors',
+                   value=refinement_factors)
+        refinement_factors = config.getlist('convergence',
+                                            'refinement_factors',
+                                            dtype=float)
 
-        if self.resolutions == resolutions:
-            return
+        base_resolution = config.getfloat('spherical_convergence',
+                                          f'{prefix}_base_resolution')
+        config.set('convergence', 'base_resolution',
+                   value=f'{base_resolution:03g}')
 
         # start fresh with no steps
         for step in list(self.steps.values()):
             self.remove_step(step)
 
-        self.resolutions = resolutions
-
         component = self.component
+
+        resolutions = list()
+        timesteps = list()
 
         case_dir = f'spherical/{prefix}/geostrophic'
 
         analysis_dependencies: Dict[str, Dict[float, Step]] = (
             dict(mesh=dict(), init=dict(), forward=dict()))
-        for resolution in resolutions:
+
+        for refinement_factor in refinement_factors:
+            resolution = get_resolution_for_task(
+                config, refinement_factor, refinement=refinement)
+
             base_mesh_step, mesh_name = add_spherical_base_mesh_step(
                 component, resolution, icosahedral)
-            self.add_step(base_mesh_step, symlink=f'base_mesh/{mesh_name}')
-            analysis_dependencies['mesh'][resolution] = base_mesh_step
+            analysis_dependencies['mesh'][refinement_factor] = base_mesh_step
 
             name = f'{prefix}_init_{mesh_name}'
             subdir = f'{case_dir}/init/{mesh_name}'
-            if self.include_viz:
-                symlink = f'init/{mesh_name}'
-            else:
-                symlink = None
             if subdir in component.steps:
                 init_step = component.steps[subdir]
             else:
-                init_step = Init(component=component, name=name, subdir=subdir,
-                                 base_mesh=base_mesh_step)
+                init_step = Init(component=component, name=name,
+                                 subdir=subdir, base_mesh=base_mesh_step)
                 init_step.set_shared_config(config, link=config_filename)
-            self.add_step(init_step, symlink=symlink)
-            analysis_dependencies['init'][resolution] = init_step
+            analysis_dependencies['init'][refinement_factor] = init_step
 
-            name = f'{prefix}_forward_{mesh_name}'
-            subdir = f'{case_dir}/forward/{mesh_name}'
-            if self.include_viz:
-                symlink = f'forward/{mesh_name}'
-            else:
-                symlink = None
+            if resolution not in resolutions:
+                self.add_step(base_mesh_step, symlink=f'base_mesh/{mesh_name}')
+                self.add_step(init_step, symlink=f'init/{mesh_name}')
+                resolutions.append(resolution)
+
+            timestep, _ = get_timestep_for_task(
+                config, refinement_factor, refinement=refinement)
+            timestep = ceil(timestep)
+            timesteps.append(timestep)
+
+            subdir = f'{case_dir}/forward/{mesh_name}_{timestep}s'
+            symlink = f'forward/{mesh_name}_{timestep}s'
             if subdir in component.steps:
                 forward_step = component.steps[subdir]
             else:
-                forward_step = Forward(component=component, name=name,
-                                       subdir=subdir, resolution=resolution,
-                                       mesh=base_mesh_step,
-                                       init=init_step)
-                forward_step.set_shared_config(config, link=config_filename)
+                name = f'{prefix}_forward_{mesh_name}_{timestep}s'
+                forward_step = Forward(
+                    component=component, name=name,
+                    subdir=subdir,
+                    refinement_factor=refinement_factor,
+                    mesh=base_mesh_step,
+                    init=init_step, refinement=refinement)
+                forward_step.set_shared_config(
+                    config, link=config_filename)
             self.add_step(forward_step, symlink=symlink)
-            analysis_dependencies['forward'][resolution] = forward_step
+            analysis_dependencies['forward'][refinement_factor] = forward_step
 
             if self.include_viz:
-                with_viz_dir = f'{case_dir}/with_viz'
-                name = f'{prefix}_viz_{mesh_name}'
-                subdir = f'{with_viz_dir}/viz/{mesh_name}'
-                step = Viz(component=component, name=name,
-                           subdir=subdir, base_mesh=base_mesh_step,
-                           init=init_step, forward=forward_step,
-                           mesh_name=mesh_name)
-                step.set_shared_config(config, link=config_filename)
-                self.add_step(step)
+                name = f'{prefix}_viz_{mesh_name}_{timestep}s'
+                subdir = f'{case_dir}/viz/{mesh_name}_{timestep}s'
+                if subdir in component.steps:
+                    viz_step = component.steps[subdir]
+                else:
+                    viz_step = Viz(component=component, name=name,
+                                   subdir=subdir, base_mesh=base_mesh_step,
+                                   init=init_step, forward=forward_step,
+                                   mesh_name=mesh_name)
+                    viz_step.set_shared_config(config, link=config_filename)
+                self.add_step(viz_step)
 
-        subdir = f'{case_dir}/analysis'
-        if self.include_viz:
-            symlink = 'analysis'
-        else:
-            symlink = None
+        subdir = f'{case_dir}/convergence_{refinement}/analysis'
         if subdir in component.steps:
             step = component.steps[subdir]
             step.resolutions = resolutions
             step.dependencies_dict = analysis_dependencies
         else:
-            step = Analysis(component=component, resolutions=resolutions,
-                            subdir=subdir, dependencies=analysis_dependencies)
+            step = Analysis(component=component,
+                            subdir=subdir,
+                            dependencies=analysis_dependencies,
+                            refinement=refinement)
             step.set_shared_config(config, link=config_filename)
-        self.add_step(step, symlink=symlink)
+        if self.include_viz:
+            symlink = f'analysis_{refinement}'
+            self.add_step(step, symlink=symlink)
+        else:
+            self.add_step(step)

--- a/polaris/ocean/tasks/geostrophic/__init__.py
+++ b/polaris/ocean/tasks/geostrophic/__init__.py
@@ -130,15 +130,16 @@ class Geostrophic(Task):
         else:
             prefix = 'qu'
 
+        if refinement == 'time':
+            option = 'refinement_factors_time'
+        else:
+            option = 'refinement_factors_space'
         refinement_factors = config.getlist('spherical_convergence',
-                                            f'{prefix}_refinement_factors',
-                                            dtype=str)
+                                            f'{prefix}_{option}', dtype=str)
         refinement_factors = ', '.join(refinement_factors)
-        config.set('convergence', 'refinement_factors',
-                   value=refinement_factors)
+        config.set('convergence', option, value=refinement_factors)
         refinement_factors = config.getlist('convergence',
-                                            'refinement_factors',
-                                            dtype=float)
+                                            option, dtype=float)
 
         base_resolution = config.getfloat('spherical_convergence',
                                           f'{prefix}_base_resolution')

--- a/polaris/ocean/tasks/geostrophic/__init__.py
+++ b/polaris/ocean/tasks/geostrophic/__init__.py
@@ -33,8 +33,8 @@ def add_geostrophic_tasks(component):
         config.add_from_package('polaris.ocean.tasks.geostrophic',
                                 'geostrophic.cfg')
 
-        for include_viz in [False, True]:
-            for refinement in ['space', 'time', 'both']:
+        for refinement in ['space', 'time', 'both']:
+            for include_viz in [False, True]:
                 component.add_task(Geostrophic(component=component,
                                                config=config,
                                                icosahedral=icosahedral,

--- a/polaris/ocean/tasks/geostrophic/__init__.py
+++ b/polaris/ocean/tasks/geostrophic/__init__.py
@@ -48,8 +48,9 @@ class Geostrophic(Task):
 
     Attributes
     ----------
-    resolutions : list of float
-        A list of mesh resolutions
+    refinement : str
+        Refinement type. One of 'space', 'time' or 'both' indicating both
+        space and time
 
     icosahedral : bool
         Whether to use icosahedral, as opposed to less regular, JIGSAW meshes
@@ -76,6 +77,10 @@ class Geostrophic(Task):
 
         include_viz : bool
             Include VizMap and Viz steps for each resolution
+
+        refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         if icosahedral:
             prefix = 'icos'
@@ -90,7 +95,6 @@ class Geostrophic(Task):
         link = 'geostrophic.cfg'
 
         super().__init__(component=component, name=name, subdir=subdir)
-        self.resolutions = list()
         self.refinement = refinement
         self.icosahedral = icosahedral
         self.include_viz = include_viz

--- a/polaris/ocean/tasks/geostrophic/analysis.py
+++ b/polaris/ocean/tasks/geostrophic/analysis.py
@@ -24,6 +24,9 @@ class Analysis(ConvergenceAnalysis):
 
         dependencies : dict of dict of polaris.Steps
             The dependencies of this step
+
+        refinement : str, optional
+            Whether to refine in space, time or both space and time
         """
         convergence_vars = [{'name': 'h',
                              'title': 'water-column thickness',
@@ -36,14 +39,14 @@ class Analysis(ConvergenceAnalysis):
                          convergence_vars=convergence_vars,
                          refinement=refinement)
 
-    def exact_solution(self, mesh_name, field_name, time, zidx=None):
+    def exact_solution(self, refinement_factor, field_name, time, zidx=None):
         """
         Get the exact solution
 
         Parameters
         ----------
-        mesh_name : str
-            The mesh name which is the prefix for the initial condition file
+        refinement_factor : float
+            The factor by which to scale space, time or both
 
         field_name : str
             The name of the variable of which we evaluate convergence
@@ -75,7 +78,7 @@ class Analysis(ConvergenceAnalysis):
         vel_period = section.getfloat('vel_period')
         gh_0 = section.getfloat('gh_0')
 
-        mesh_filename = f'{mesh_name}_mesh.nc'
+        mesh_filename = f'mesh_r{refinement_factor:02g}.nc'
 
         h, _, _, normalVelocity = compute_exact_solution(
             alpha, vel_period, gh_0, mesh_filename)

--- a/polaris/ocean/tasks/geostrophic/forward.py
+++ b/polaris/ocean/tasks/geostrophic/forward.py
@@ -7,7 +7,8 @@ class Forward(SphericalConvergenceForward):
     bell test case
     """
 
-    def __init__(self, component, name, subdir, resolution, mesh, init):
+    def __init__(self, component, name, subdir, mesh, init,
+                 refinement_factor, refinement='both'):
         """
         Create a new step
 
@@ -22,9 +23,6 @@ class Forward(SphericalConvergenceForward):
         subdir : str
             The subdirectory for the step
 
-        resolution : float
-            The resolution of the (uniform) mesh in km
-
         mesh : polaris.Step
             The base mesh step
 
@@ -37,9 +35,10 @@ class Forward(SphericalConvergenceForward):
                          'layerThickness',
                          'normalVelocity']
         super().__init__(component=component, name=name, subdir=subdir,
-                         resolution=resolution, mesh=mesh,
-                         init=init, package=package,
+                         mesh=mesh, init=init, package=package,
                          yaml_filename='forward.yaml',
                          output_filename='output.nc',
                          validate_vars=validate_vars,
-                         graph_target=f'{mesh.path}/graph.info')
+                         graph_target=f'{mesh.path}/graph.info',
+                         refinement_factor=refinement_factor,
+                         refinement=refinement)

--- a/polaris/ocean/tasks/geostrophic/forward.py
+++ b/polaris/ocean/tasks/geostrophic/forward.py
@@ -28,6 +28,13 @@ class Forward(SphericalConvergenceForward):
 
         init : polaris.Step
             The init step
+
+        refinement_factor : float
+            The factor by which to scale space, time or both
+
+        refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         package = 'polaris.ocean.tasks.geostrophic'
         validate_vars = ['temperature',

--- a/polaris/ocean/tasks/inertial_gravity_wave/__init__.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/__init__.py
@@ -1,6 +1,12 @@
+from math import ceil
 from typing import Dict
 
 from polaris import Step, Task
+from polaris.config import PolarisConfigParser
+from polaris.ocean.convergence import (
+    get_resolution_for_task,
+    get_timestep_for_task,
+)
 from polaris.ocean.resolution import resolution_to_subdir
 from polaris.ocean.tasks.inertial_gravity_wave.analysis import Analysis
 from polaris.ocean.tasks.inertial_gravity_wave.forward import Forward
@@ -15,7 +21,19 @@ def add_inertial_gravity_wave_tasks(component):
     component : polaris.ocean.Ocean
         the ocean component that the task will be added to
     """
-    component.add_task(InertialGravityWave(component=component))
+    basedir = 'planar/inertial_gravity_wave'
+    config_filename = 'inertial_gravity_wave.cfg'
+    filepath = f'{basedir}/{config_filename}'
+    config = PolarisConfigParser(filepath=filepath)
+    config.add_from_package('polaris.ocean.convergence',
+                            'convergence.cfg')
+    config.add_from_package(
+        'polaris.ocean.tasks.inertial_gravity_wave',
+        config_filename)
+    for refinement in ['space', 'time', 'both']:
+        component.add_task(InertialGravityWave(component=component,
+                                               config=config,
+                                               refinement=refinement))
 
 
 class InertialGravityWave(Task):
@@ -23,7 +41,7 @@ class InertialGravityWave(Task):
     The convergence test case for inertial gravity waves
     """
 
-    def __init__(self, component):
+    def __init__(self, component, config, refinement='both'):
         """
         Create the test case
 
@@ -31,39 +49,73 @@ class InertialGravityWave(Task):
         ----------
         component : polaris.ocean.Ocean
             The ocean component that this task belongs to
-        """
-        name = 'inertial_gravity_wave'
-        subdir = f'planar/{name}'
-        super().__init__(component=component, name=name, subdir=subdir)
 
-        self.resolutions = [200., 100., 50., 25.]
+        config : polaris.config.PolarisConfigParser
+            A shared config parser
+
+        refinement : str, optional
+            Whether to refine in space, time or both space and time
+        """
+        name = f'inertial_gravity_wave_convergence_{refinement}'
+        basedir = 'planar/inertial_gravity_wave'
+        subdir = f'{basedir}/convergence_{refinement}'
+        config_filename = 'inertial_gravity_wave.cfg'
+        super().__init__(component=component, name=name, subdir=subdir)
+        self.set_shared_config(config, link=config_filename)
+
         analysis_dependencies: Dict[str, Dict[float, Step]] = (
             dict(mesh=dict(), init=dict(), forward=dict()))
-        for resolution in self.resolutions:
+
+        refinement_factors = self.config.getlist(
+            'convergence', 'refinement_factors', dtype=float)
+        timesteps = list()
+        resolutions = list()
+        for refinement_factor in refinement_factors:
+            resolution = get_resolution_for_task(
+                self.config, refinement_factor, refinement=refinement)
             mesh_name = resolution_to_subdir(resolution)
-            init_step = Init(component=component, resolution=resolution,
-                             taskdir=self.subdir)
-            self.add_step(init_step)
-            forward_step = Forward(component=component,
-                                   name=f'forward_{mesh_name}',
-                                   resolution=resolution,
-                                   subdir=f'{self.subdir}/forward/{mesh_name}',
-                                   init=init_step)
-            self.add_step(forward_step)
-            analysis_dependencies['mesh'][resolution] = init_step
-            analysis_dependencies['init'][resolution] = init_step
-            analysis_dependencies['forward'][resolution] = forward_step
+
+            subdir = f'{basedir}/init/{mesh_name}'
+            symlink = f'init/{mesh_name}'
+            if subdir in component.steps:
+                init_step = component.steps[subdir]
+            else:
+                init_step = Init(component=component, resolution=resolution,
+                                 subdir=subdir)
+                init_step.set_shared_config(self.config, link=config_filename)
+            if resolution not in resolutions:
+                self.add_step(init_step, symlink=symlink)
+                resolutions.append(resolution)
+
+            timestep, _ = get_timestep_for_task(
+                config, refinement_factor, refinement=refinement)
+            timestep = ceil(timestep)
+            timesteps.append(timestep)
+
+            subdir = f'{basedir}/forward/{mesh_name}_{timestep}s'
+            symlink = f'forward/{mesh_name}_{timestep}s'
+            if subdir in component.steps:
+                forward_step = component.steps[subdir]
+            else:
+                forward_step = Forward(
+                    component=component,
+                    refinement=refinement,
+                    refinement_factor=refinement_factor,
+                    name=f'forward_{mesh_name}_{timestep}s',
+                    subdir=subdir,
+                    init=init_step)
+                forward_step.set_shared_config(
+                    config, link=config_filename)
+            self.add_step(forward_step, symlink=symlink)
+
+            analysis_dependencies['mesh'][refinement_factor] = init_step
+            analysis_dependencies['init'][refinement_factor] = init_step
+            analysis_dependencies['forward'][refinement_factor] = forward_step
 
         self.add_step(Analysis(component=component,
-                               resolutions=self.resolutions,
-                               subdir=f'{subdir}/analysis',
+                               subdir=f'{self.subdir}/analysis',
+                               refinement=refinement,
                                dependencies=analysis_dependencies))
-        self.add_step(Viz(component=component, resolutions=self.resolutions,
+        self.add_step(Viz(component=component, resolutions=resolutions,
                           taskdir=self.subdir),
                       run_by_default=False)
-
-        self.config.add_from_package('polaris.ocean.convergence',
-                                     'convergence.cfg')
-        self.config.add_from_package(
-            'polaris.ocean.tasks.inertial_gravity_wave',
-            'inertial_gravity_wave.cfg')

--- a/polaris/ocean/tasks/inertial_gravity_wave/__init__.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/__init__.py
@@ -66,8 +66,12 @@ class InertialGravityWave(Task):
         analysis_dependencies: Dict[str, Dict[float, Step]] = (
             dict(mesh=dict(), init=dict(), forward=dict()))
 
+        if refinement == 'time':
+            option = 'refinement_factors_time'
+        else:
+            option = 'refinement_factors_space'
         refinement_factors = self.config.getlist(
-            'convergence', 'refinement_factors', dtype=float)
+            'convergence', option, dtype=float)
         timesteps = list()
         resolutions = list()
         for refinement_factor in refinement_factors:
@@ -119,3 +123,8 @@ class InertialGravityWave(Task):
         self.add_step(Viz(component=component, resolutions=resolutions,
                           taskdir=self.subdir),
                       run_by_default=False)
+        config.add_from_package('polaris.ocean.convergence',
+                                'convergence.cfg')
+        config.add_from_package(
+            'polaris.ocean.tasks.inertial_gravity_wave',
+            config_filename)

--- a/polaris/ocean/tasks/inertial_gravity_wave/analysis.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/analysis.py
@@ -33,6 +33,9 @@ class Analysis(ConvergenceAnalysis):
 
         dependencies : dict of dict of polaris.Steps
             The dependencies of this step
+
+        refinement : str, optional
+            Whether to refine in space, time or both space and time
         """
         convergence_vars = [{'name': 'ssh',
                              'title': 'SSH',
@@ -48,8 +51,8 @@ class Analysis(ConvergenceAnalysis):
 
         Parameters
         ----------
-        mesh_name : str
-            The mesh name which is the prefix for the initial condition file
+        refinement_factor : float
+            The factor by which to scale space, time or both
 
         field_name : str
             The name of the variable of which we evaluate convergence

--- a/polaris/ocean/tasks/inertial_gravity_wave/analysis.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/analysis.py
@@ -1,6 +1,6 @@
 import xarray as xr
 
-from polaris.ocean.convergence import ConvergenceAnalysis
+from polaris.ocean.convergence.analysis import ConvergenceAnalysis
 from polaris.ocean.tasks.inertial_gravity_wave.exact_solution import (
     ExactSolution,
 )
@@ -16,7 +16,7 @@ class Analysis(ConvergenceAnalysis):
     resolutions : list of float
         The resolutions of the meshes that have been run
     """
-    def __init__(self, component, resolutions, subdir, dependencies):
+    def __init__(self, component, subdir, dependencies, refinement='both'):
         """
         Create the step
 
@@ -38,11 +38,11 @@ class Analysis(ConvergenceAnalysis):
                              'title': 'SSH',
                              'zidx': None}]
         super().__init__(component=component, subdir=subdir,
-                         resolutions=resolutions,
                          dependencies=dependencies,
-                         convergence_vars=convergence_vars)
+                         convergence_vars=convergence_vars,
+                         refinement=refinement)
 
-    def exact_solution(self, mesh_name, field_name, time, zidx=None):
+    def exact_solution(self, refinement_factor, field_name, time, zidx=None):
         """
         Get the exact solution
 
@@ -69,7 +69,7 @@ class Analysis(ConvergenceAnalysis):
         solution : xarray.DataArray
             The exact solution as derived from the initial condition
         """
-        init = xr.open_dataset(f'{mesh_name}_init.nc')
+        init = xr.open_dataset(f'init_r{refinement_factor:02g}.nc')
         exact = ExactSolution(init, self.config)
         if field_name != 'ssh':
             raise ValueError(f'{field_name} is not currently supported')

--- a/polaris/ocean/tasks/inertial_gravity_wave/forward.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/forward.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
-from polaris.ocean.convergence import ConvergenceForward
+from polaris.ocean.convergence import get_resolution_for_task
+from polaris.ocean.convergence.forward import ConvergenceForward
 
 
 class Forward(ConvergenceForward):
@@ -14,7 +15,8 @@ class Forward(ConvergenceForward):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, component, name, resolution, subdir, init):
+    def __init__(self, component, name, refinement_factor, subdir,
+                 init, refinement='both'):
         """
         Create a new test case
 
@@ -34,7 +36,9 @@ class Forward(ConvergenceForward):
         """
         super().__init__(component=component,
                          name=name, subdir=subdir,
-                         resolution=resolution, mesh=init, init=init,
+                         refinement=refinement,
+                         refinement_factor=refinement_factor,
+                         mesh=init, init=init,
                          package='polaris.ocean.tasks.inertial_gravity_wave',
                          yaml_filename='forward.yaml',
                          graph_target=f'{init.path}/culled_graph.info',
@@ -52,8 +56,10 @@ class Forward(ConvergenceForward):
             The approximate number of cells in the mesh
         """
         section = self.config['inertial_gravity_wave']
+        resolution = get_resolution_for_task(
+            self.config, self.refinement_factor, refinement=self.refinement)
         lx = section.getfloat('lx')
         ly = np.sqrt(3.0) / 2.0 * lx
-        nx, ny = compute_planar_hex_nx_ny(lx, ly, self.resolution)
+        nx, ny = compute_planar_hex_nx_ny(lx, ly, resolution)
         cell_count = nx * ny
         return cell_count

--- a/polaris/ocean/tasks/inertial_gravity_wave/forward.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/forward.py
@@ -12,8 +12,12 @@ class Forward(ConvergenceForward):
 
     Attributes
     ----------
-    resolution : float
-        The resolution of the test case in km
+    refinement_factor : float
+        The factor by which to scale space, time or both
+
+    refinement : str
+        Refinement type. One of 'space', 'time' or 'both' indicating both
+        space and time
     """
     def __init__(self, component, name, refinement_factor, subdir,
                  init, refinement='both'):
@@ -25,14 +29,20 @@ class Forward(ConvergenceForward):
         component : polaris.Component
             The component the step belongs to
 
-        resolution : km
-            The resolution of the test case in km
+        name : str
+            The name of the step
 
+        refinement_factor : float
+            The factor by which to scale space, time or both
         subdir : str
-            The subdirectory that the step belongs to
+            The subdirectory that the task belongs to
 
         init : polaris.Step
             The step which generates the mesh and initial condition
+
+        refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         super().__init__(component=component,
                          name=name, subdir=subdir,

--- a/polaris/ocean/tasks/inertial_gravity_wave/inertial_gravity_wave.cfg
+++ b/polaris/ocean/tasks/inertial_gravity_wave/inertial_gravity_wave.cfg
@@ -57,7 +57,11 @@ convergence_thresh = ${inertial_gravity_wave:conv_thresh}
 # Type of error to compute
 error_type = l2
 
+# the base mesh resolution (km) to which refinement_factors
+# are applied if refinement is 'space' or 'both' on a planar mesh
 base_resolution = 100.
+
+# refinement factors for a planar mesh applied to either space or time
 refinement_factors = 2., 1., 0.5, 0.25
 
 # config options for spherical convergence tests

--- a/polaris/ocean/tasks/inertial_gravity_wave/inertial_gravity_wave.cfg
+++ b/polaris/ocean/tasks/inertial_gravity_wave/inertial_gravity_wave.cfg
@@ -57,6 +57,8 @@ convergence_thresh = ${inertial_gravity_wave:conv_thresh}
 # Type of error to compute
 error_type = l2
 
+base_resolution = 100.
+refinement_factors = 2., 1., 0.5, 0.25
 
 # config options for spherical convergence tests
 [convergence_forward]

--- a/polaris/ocean/tasks/inertial_gravity_wave/inertial_gravity_wave.cfg
+++ b/polaris/ocean/tasks/inertial_gravity_wave/inertial_gravity_wave.cfg
@@ -62,7 +62,8 @@ error_type = l2
 base_resolution = 100.
 
 # refinement factors for a planar mesh applied to either space or time
-refinement_factors = 2., 1., 0.5, 0.25
+refinement_factors_space = 2., 1., 0.5, 0.25
+refinement_factors_time = 1., 0.5, 0.25
 
 # config options for spherical convergence tests
 [convergence_forward]

--- a/polaris/ocean/tasks/inertial_gravity_wave/init.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/init.py
@@ -23,7 +23,7 @@ class Init(Step):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, component, resolution, taskdir):
+    def __init__(self, component, resolution, subdir):
         """
         Create the step
 
@@ -35,13 +35,13 @@ class Init(Step):
         resolution : float
             The resolution of the test case in km
 
-        taskdir : str
+        subdir : str
             The subdirectory that the task belongs to
         """
         mesh_name = resolution_to_subdir(resolution)
         super().__init__(component=component,
                          name=f'init_{mesh_name}',
-                         subdir=f'{taskdir}/init/{mesh_name}')
+                         subdir=subdir)
         self.resolution = resolution
         for filename in ['culled_mesh.nc', 'initial_state.nc',
                          'culled_graph.info']:

--- a/polaris/ocean/tasks/manufactured_solution/__init__.py
+++ b/polaris/ocean/tasks/manufactured_solution/__init__.py
@@ -26,6 +26,11 @@ def add_manufactured_solution_tasks(component):
     config_filename = 'manufactured_solution.cfg'
     filepath = f'{basedir}/{config_filename}'
     config = PolarisConfigParser(filepath=filepath)
+    config.add_from_package('polaris.ocean.convergence',
+                            'convergence.cfg')
+    config.add_from_package(
+        'polaris.ocean.tasks.manufactured_solution',
+        config_filename)
     for refinement in ['space', 'time', 'both']:
         component.add_task(ManufacturedSolution(component=component,
                                                 config=config,
@@ -62,8 +67,12 @@ class ManufacturedSolution(Task):
         analysis_dependencies: Dict[str, Dict[float, Step]] = (
             dict(mesh=dict(), init=dict(), forward=dict()))
 
+        if refinement == 'time':
+            option = 'refinement_factors_time'
+        else:
+            option = 'refinement_factors_space'
         refinement_factors = self.config.getlist(
-            'convergence', 'refinement_factors', dtype=float)
+            'convergence', option, dtype=float)
         timesteps = list()
         resolutions = list()
         for refinement_factor in refinement_factors:

--- a/polaris/ocean/tasks/manufactured_solution/__init__.py
+++ b/polaris/ocean/tasks/manufactured_solution/__init__.py
@@ -1,6 +1,12 @@
+from math import ceil
 from typing import Dict
 
 from polaris import Step, Task
+from polaris.config import PolarisConfigParser
+from polaris.ocean.convergence import (
+    get_resolution_for_task,
+    get_timestep_for_task,
+)
 from polaris.ocean.resolution import resolution_to_subdir
 from polaris.ocean.tasks.manufactured_solution.analysis import Analysis
 from polaris.ocean.tasks.manufactured_solution.forward import Forward
@@ -16,19 +22,22 @@ def add_manufactured_solution_tasks(component):
     component : polaris.ocean.Ocean
         the ocean component that the task will be added to
     """
-    component.add_task(ManufacturedSolution(component=component))
+    basedir = 'planar/manufactured_solution'
+    config_filename = 'manufactured_solution.cfg'
+    filepath = f'{basedir}/{config_filename}'
+    config = PolarisConfigParser(filepath=filepath)
+    for refinement in ['space', 'time', 'both']:
+        component.add_task(ManufacturedSolution(component=component,
+                                                config=config,
+                                                refinement=refinement))
 
 
 class ManufacturedSolution(Task):
     """
     The convergence test case using the method of manufactured solutions
-
-    Attributes
-    ----------
-    resolutions : list of floats
-        The resolutions of the test case in km
     """
-    def __init__(self, component):
+
+    def __init__(self, component, config, refinement='both'):
         """
         Create the test case
 
@@ -36,38 +45,78 @@ class ManufacturedSolution(Task):
         ----------
         component : polaris.ocean.Ocean
             The ocean component that this task belongs to
-        """
-        name = 'manufactured_solution'
-        subdir = f'planar/{name}'
-        super().__init__(component=component, name=name, subdir=subdir)
 
-        self.resolutions = [200., 100., 50., 25.]
+        config : polaris.config.PolarisConfigParser
+            A shared config parser
+
+        refinement : str, optional
+            Whether to refine in space, time or both space and time
+        """
+        name = f'manufactured_solution_convergence_{refinement}'
+        basedir = 'planar/manufactured_solution'
+        subdir = f'{basedir}/convergence_{refinement}'
+        config_filename = 'manufactured_solution.cfg'
+        super().__init__(component=component, name=name, subdir=subdir)
+        self.set_shared_config(config, link=config_filename)
+
         analysis_dependencies: Dict[str, Dict[float, Step]] = (
             dict(mesh=dict(), init=dict(), forward=dict()))
-        for resolution in self.resolutions:
+
+        refinement_factors = self.config.getlist(
+            'convergence', 'refinement_factors', dtype=float)
+        timesteps = list()
+        resolutions = list()
+        for refinement_factor in refinement_factors:
+            resolution = get_resolution_for_task(
+                self.config, refinement_factor, refinement=refinement)
             mesh_name = resolution_to_subdir(resolution)
-            init_step = Init(component=component, resolution=resolution,
-                             taskdir=self.subdir)
-            self.add_step(init_step)
-            forward_step = Forward(component=component, resolution=resolution,
-                                   name=f'forward_{mesh_name}',
-                                   subdir=f'{self.subdir}/forward/{mesh_name}',
-                                   init=init_step)
-            self.add_step(forward_step)
-            analysis_dependencies['mesh'][resolution] = init_step
-            analysis_dependencies['init'][resolution] = init_step
-            analysis_dependencies['forward'][resolution] = forward_step
+
+            subdir = f'{basedir}/init/{mesh_name}'
+            symlink = f'init/{mesh_name}'
+            if subdir in component.steps:
+                init_step = component.steps[subdir]
+            else:
+                init_step = Init(component=component, resolution=resolution,
+                                 subdir=subdir)
+                init_step.set_shared_config(self.config, link=config_filename)
+            if resolution not in resolutions:
+                self.add_step(init_step, symlink=symlink)
+                resolutions.append(resolution)
+
+            timestep, _ = get_timestep_for_task(
+                config, refinement_factor, refinement=refinement)
+            timestep = ceil(timestep)
+            timesteps.append(timestep)
+
+            subdir = f'{basedir}/forward/{mesh_name}_{timestep}s'
+            symlink = f'forward/{mesh_name}_{timestep}s'
+            if subdir in component.steps:
+                forward_step = component.steps[subdir]
+            else:
+                forward_step = Forward(
+                    component=component,
+                    refinement=refinement,
+                    refinement_factor=refinement_factor,
+                    name=f'forward_{mesh_name}_{timestep}s',
+                    subdir=subdir,
+                    init=init_step)
+                forward_step.set_shared_config(
+                    config, link=config_filename)
+            self.add_step(forward_step, symlink=symlink)
+
+            analysis_dependencies['mesh'][refinement_factor] = init_step
+            analysis_dependencies['init'][refinement_factor] = init_step
+            analysis_dependencies['forward'][refinement_factor] = forward_step
 
         self.add_step(Analysis(component=component,
-                               resolutions=self.resolutions,
                                subdir=f'{self.subdir}/analysis',
+                               refinement=refinement,
                                dependencies=analysis_dependencies))
-        self.add_step(Viz(component=component, resolutions=self.resolutions,
+        self.add_step(Viz(component=component, resolutions=resolutions,
                           taskdir=self.subdir),
                       run_by_default=False)
-
-        self.config.add_from_package('polaris.ocean.convergence',
-                                     'convergence.cfg')
-        self.config.add_from_package(
+        config.add_from_package('polaris.ocean.convergence',
+                                'convergence.cfg')
+        config.add_from_package(
             'polaris.ocean.tasks.manufactured_solution',
-            'manufactured_solution.cfg')
+            config_filename)

--- a/polaris/ocean/tasks/manufactured_solution/analysis.py
+++ b/polaris/ocean/tasks/manufactured_solution/analysis.py
@@ -31,6 +31,9 @@ class Analysis(ConvergenceAnalysis):
 
         dependencies : dict of dict of polaris.Steps
             The dependencies of this step
+
+        refinement : str, optional
+            Whether to refine in space, time or both space and time
         """
         convergence_vars = [{'name': 'ssh',
                              'title': 'SSH',
@@ -46,8 +49,8 @@ class Analysis(ConvergenceAnalysis):
 
         Parameters
         ----------
-        mesh_name : str
-            The mesh name which is the prefix for the initial condition file
+        refinement_factor : float
+            The factor by which to scale space, time or both
 
         field_name : str
             The name of the variable of which we evaluate convergence

--- a/polaris/ocean/tasks/manufactured_solution/analysis.py
+++ b/polaris/ocean/tasks/manufactured_solution/analysis.py
@@ -1,4 +1,4 @@
-from polaris.ocean.convergence import ConvergenceAnalysis
+from polaris.ocean.convergence.analysis import ConvergenceAnalysis
 from polaris.ocean.tasks.manufactured_solution.exact_solution import (
     ExactSolution,
 )
@@ -14,7 +14,7 @@ class Analysis(ConvergenceAnalysis):
     resolutions : list of float
         The resolutions of the meshes that have been run
     """
-    def __init__(self, component, resolutions, subdir, dependencies):
+    def __init__(self, component, subdir, dependencies, refinement='both'):
         """
         Create the step
 
@@ -36,11 +36,11 @@ class Analysis(ConvergenceAnalysis):
                              'title': 'SSH',
                              'zidx': None}]
         super().__init__(component=component, subdir=subdir,
-                         resolutions=resolutions,
                          dependencies=dependencies,
-                         convergence_vars=convergence_vars)
+                         convergence_vars=convergence_vars,
+                         refinement=refinement)
 
-    def exact_solution(self, mesh_name, field_name, time, zidx=None):
+    def exact_solution(self, refinement_factor, field_name, time, zidx=None):
         """
         Get the exact solution
 
@@ -67,7 +67,7 @@ class Analysis(ConvergenceAnalysis):
         solution : xarray.DataArray
             The exact solution as derived from the initial condition
         """
-        init = self.open_model_dataset(f'{mesh_name}_init.nc')
+        init = self.open_model_dataset(f'init_r{refinement_factor:02g}.nc')
         exact = ExactSolution(self.config, init)
         if field_name != 'ssh':
             raise ValueError(f'{field_name} is not currently supported')

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -15,8 +15,12 @@ class Forward(ConvergenceForward):
 
     Attributes
     ----------
-    resolution : float
-        The resolution of the test case in km
+    refinement_factor : float
+        The factor by which to scale space, time or both
+
+    refinement : str
+        Refinement type. One of 'space', 'time' or 'both' indicating both
+        space and time
     """
     def __init__(self, component, name, refinement_factor, subdir,
                  init, refinement='both'):
@@ -28,14 +32,21 @@ class Forward(ConvergenceForward):
         component : polaris.Component
             The component the step belongs to
 
-        resolution : km
-            The resolution of the test case in km
+        name : str
+            The name of the step
+
+        refinement_factor : float
+            The factor by which to scale space, time or both
 
         subdir : str
             The subdirectory that the task belongs to
 
         init : polaris.Step
             The step which generates the mesh and initial condition
+
+        refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         super().__init__(component=component,
                          name=name, subdir=subdir,

--- a/polaris/ocean/tasks/manufactured_solution/forward.py
+++ b/polaris/ocean/tasks/manufactured_solution/forward.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
-from polaris.ocean.convergence import ConvergenceForward
+from polaris.ocean.convergence import get_resolution_for_task
+from polaris.ocean.convergence.forward import ConvergenceForward
 from polaris.ocean.tasks.manufactured_solution.exact_solution import (
     ExactSolution,
 )
@@ -17,7 +18,8 @@ class Forward(ConvergenceForward):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, component, name, resolution, subdir, init):
+    def __init__(self, component, name, refinement_factor, subdir,
+                 init, refinement='both'):
         """
         Create a new test case
 
@@ -37,7 +39,8 @@ class Forward(ConvergenceForward):
         """
         super().__init__(component=component,
                          name=name, subdir=subdir,
-                         resolution=resolution, mesh=init, init=init,
+                         refinement_factor=refinement_factor,
+                         mesh=init, init=init, refinement=refinement,
                          package='polaris.ocean.tasks.manufactured_solution',
                          yaml_filename='forward.yaml',
                          graph_target=f'{init.path}/culled_graph.info',
@@ -66,10 +69,12 @@ class Forward(ConvergenceForward):
             The approximate number of cells in the mesh
         """
         # no file to read from, so we'll compute it based on config options
+        resolution = get_resolution_for_task(
+            self.config, self.refinement_factor, refinement=self.refinement)
         section = self.config['manufactured_solution']
         lx = section.getfloat('lx')
         ly = np.sqrt(3.0) / 2.0 * lx
-        nx, ny = compute_planar_hex_nx_ny(lx, ly, self.resolution)
+        nx, ny = compute_planar_hex_nx_ny(lx, ly, resolution)
         cell_count = nx * ny
         return cell_count
 

--- a/polaris/ocean/tasks/manufactured_solution/init.py
+++ b/polaris/ocean/tasks/manufactured_solution/init.py
@@ -22,7 +22,7 @@ class Init(OceanIOStep):
     resolution : float
         The resolution of the test case in km
     """
-    def __init__(self, component, resolution, taskdir):
+    def __init__(self, component, resolution, subdir):
         """
         Create the step
 
@@ -40,7 +40,7 @@ class Init(OceanIOStep):
         mesh_name = resolution_to_subdir(resolution)
         super().__init__(component=component,
                          name=f'init_{mesh_name}',
-                         subdir=f'{taskdir}/init/{mesh_name}')
+                         subdir=subdir)
         self.resolution = resolution
 
     def setup(self):

--- a/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
+++ b/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
@@ -70,7 +70,8 @@ error_type = l2
 base_resolution = 50.
 
 # refinement factors for a planar mesh applied to either space or time
-refinement_factors = 4., 2., 1., 0.5
+refinement_factors_space = 4., 2., 1., 0.5
+refinement_factors_time = 1., 0.5, 0.25
 
 # config options for spherical convergence tests
 [convergence_forward]

--- a/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
+++ b/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
@@ -56,6 +56,8 @@ min_pc_fraction = 0.1
 # config options for spherical convergence tests
 [convergence]
 
+base_resolution = 50.
+refinement_factors = 4., 2., 1., 0.5
 # Evaluation time for convergence analysis (in hours)
 convergence_eval_time = ${manufactured_solution:run_duration}
 

--- a/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
+++ b/polaris/ocean/tasks/manufactured_solution/manufactured_solution.cfg
@@ -56,8 +56,6 @@ min_pc_fraction = 0.1
 # config options for spherical convergence tests
 [convergence]
 
-base_resolution = 50.
-refinement_factors = 4., 2., 1., 0.5
 # Evaluation time for convergence analysis (in hours)
 convergence_eval_time = ${manufactured_solution:run_duration}
 
@@ -67,6 +65,12 @@ convergence_thresh = ${manufactured_solution:conv_thresh}
 # Type of error to compute
 error_type = l2
 
+# the base mesh resolution (km) to which refinement_factors
+# are applied if refinement is 'space' or 'both' on a planar mesh
+base_resolution = 50.
+
+# refinement factors for a planar mesh applied to either space or time
+refinement_factors = 4., 2., 1., 0.5
 
 # config options for spherical convergence tests
 [convergence_forward]

--- a/polaris/ocean/tasks/sphere_transport/__init__.py
+++ b/polaris/ocean/tasks/sphere_transport/__init__.py
@@ -128,7 +128,7 @@ class SphereTransport(Task):
         # set up the steps again in case a user has provided new resolutions
         self._setup_steps(self.refinement)
 
-    def _setup_steps(self, refinement):
+    def _setup_steps(self, refinement):  # noqa: C901
         """ setup steps given resolutions """
         case_name = self.case_name
         icosahedral = self.icosahedral
@@ -140,15 +140,16 @@ class SphereTransport(Task):
         else:
             prefix = 'qu'
 
+        if refinement == 'time':
+            option = 'refinement_factors_time'
+        else:
+            option = 'refinement_factors_space'
         refinement_factors = config.getlist('spherical_convergence',
-                                            f'{prefix}_refinement_factors',
-                                            dtype=str)
+                                            f'{prefix}_{option}', dtype=str)
         refinement_factors = ', '.join(refinement_factors)
-        config.set('convergence', 'refinement_factors',
-                   value=refinement_factors)
+        config.set('convergence', option, value=refinement_factors)
         refinement_factors = config.getlist('convergence',
-                                            'refinement_factors',
-                                            dtype=float)
+                                            option, dtype=float)
 
         base_resolution = config.getfloat('spherical_convergence',
                                           f'{prefix}_base_resolution')

--- a/polaris/ocean/tasks/sphere_transport/__init__.py
+++ b/polaris/ocean/tasks/sphere_transport/__init__.py
@@ -55,6 +55,10 @@ class SphereTransport(Task):
     resolutions : list of float
         A list of mesh resolutions
 
+    refinement : str
+        Refinement type. One of 'space', 'time' or 'both' indicating both
+        space and time
+
     icosahedral : bool
         Whether to use icosahedral, as opposed to less regular, JIGSAW meshes
 
@@ -84,6 +88,10 @@ class SphereTransport(Task):
 
         include_viz : bool
             Include VizMap and Viz steps for each resolution
+
+        refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         if icosahedral:
             prefix = 'icos'

--- a/polaris/ocean/tasks/sphere_transport/__init__.py
+++ b/polaris/ocean/tasks/sphere_transport/__init__.py
@@ -1,7 +1,12 @@
+from math import ceil
 from typing import Dict
 
 from polaris import Step, Task
 from polaris.config import PolarisConfigParser
+from polaris.ocean.convergence import (
+    get_resolution_for_task,
+    get_timestep_for_task,
+)
 from polaris.ocean.mesh.spherical import add_spherical_base_mesh_step
 from polaris.ocean.tasks.sphere_transport.analysis import Analysis
 from polaris.ocean.tasks.sphere_transport.filament_analysis import (
@@ -56,7 +61,8 @@ class SphereTransport(Task):
     include_viz : bool
         Include VizMap and Viz steps for each resolution
     """
-    def __init__(self, component, config, case_name, icosahedral, include_viz):
+    def __init__(self, component, config, case_name, icosahedral, include_viz,
+                 refinement='both'):
         """
         Create test case for creating a global MPAS-Ocean mesh
 
@@ -95,6 +101,7 @@ class SphereTransport(Task):
             link = None
         super().__init__(component=component, name=name, subdir=subdir)
         self.resolutions = list()
+        self.refinement = refinement
         self.icosahedral = icosahedral
         self.case_name = case_name
         self.include_viz = include_viz
@@ -102,7 +109,7 @@ class SphereTransport(Task):
         self.set_shared_config(config, link=link)
 
         # add the steps with default resolutions so they can be listed
-        self._setup_steps()
+        self._setup_steps(refinement=refinement)
 
     def configure(self):
         """
@@ -111,9 +118,9 @@ class SphereTransport(Task):
         super().configure()
 
         # set up the steps again in case a user has provided new resolutions
-        self._setup_steps()
+        self._setup_steps(self.refinement)
 
-    def _setup_steps(self):
+    def _setup_steps(self, refinement):
         """ setup steps given resolutions """
         case_name = self.case_name
         icosahedral = self.icosahedral
@@ -125,17 +132,26 @@ class SphereTransport(Task):
         else:
             prefix = 'qu'
 
-        resolutions = config.getlist('spherical_convergence',
-                                     f'{prefix}_resolutions', dtype=float)
+        refinement_factors = config.getlist('spherical_convergence',
+                                            f'{prefix}_refinement_factors',
+                                            dtype=str)
+        refinement_factors = ', '.join(refinement_factors)
+        config.set('convergence', 'refinement_factors',
+                   value=refinement_factors)
+        refinement_factors = config.getlist('convergence',
+                                            'refinement_factors',
+                                            dtype=float)
 
-        if self.resolutions == resolutions:
-            return
+        base_resolution = config.getfloat('spherical_convergence',
+                                          f'{prefix}_base_resolution')
+        config.set('convergence', 'base_resolution',
+                   value=f'{base_resolution:03g}')
 
         # start fresh with no steps
         for step in list(self.steps.values()):
             self.remove_step(step)
 
-        self.resolutions = resolutions
+        resolutions = self.resolutions
 
         component = self.component
 
@@ -143,49 +159,62 @@ class SphereTransport(Task):
 
         analysis_dependencies: Dict[str, Dict[str, Step]] = (
             dict(mesh=dict(), init=dict(), forward=dict()))
-        for resolution in resolutions:
-            base_mesh_step, mesh_name = add_spherical_base_mesh_step(
-                component, resolution, icosahedral)
-            self.add_step(base_mesh_step, symlink=f'base_mesh/{mesh_name}')
-            analysis_dependencies['mesh'][resolution] = base_mesh_step
+        timesteps = list()
+        for idx, refinement_factor in enumerate(refinement_factors):
+            resolution = get_resolution_for_task(
+                config, refinement_factor, refinement=refinement)
+            if resolution not in self.resolutions:
+                resolutions.append(resolution)
+                base_mesh_step, mesh_name = add_spherical_base_mesh_step(
+                    component, resolution, icosahedral)
+                self.add_step(base_mesh_step, symlink=f'base_mesh/{mesh_name}')
+                analysis_dependencies['mesh'][resolution] = base_mesh_step
 
-            name = f'{prefix}_init_{mesh_name}'
-            subdir = f'{sph_trans_dir}/init/{mesh_name}'
-            if self.include_viz:
-                symlink = f'init/{mesh_name}'
-            else:
-                symlink = None
-            if subdir in component.steps:
-                init_step = component.steps[subdir]
-            else:
-                init_step = Init(component=component, name=name, subdir=subdir,
-                                 base_mesh=base_mesh_step, case_name=case_name)
-                init_step.set_shared_config(config, link=config_filename)
-            self.add_step(init_step, symlink=symlink)
-            analysis_dependencies['init'][resolution] = init_step
+                name = f'{prefix}_init_{mesh_name}'
+                subdir = f'{sph_trans_dir}/init/{mesh_name}'
+                if self.include_viz:
+                    symlink = f'init/{mesh_name}'
+                else:
+                    symlink = None
+                if subdir in component.steps:
+                    init_step = component.steps[subdir]
+                else:
+                    init_step = Init(component=component, name=name,
+                                     subdir=subdir, base_mesh=base_mesh_step,
+                                     case_name=case_name)
+                    init_step.set_shared_config(config, link=config_filename)
+                self.add_step(init_step, symlink=symlink)
+                analysis_dependencies['init'][resolution] = init_step
 
-            name = f'{prefix}_forward_{mesh_name}'
-            subdir = f'{sph_trans_dir}/forward/{mesh_name}'
+            timestep, _ = get_timestep_for_task(
+                config, refinement_factor, refinement=refinement)
+            timestep = ceil(timestep)
+            timesteps.append(timestep)
+            name = f'{prefix}_forward_{mesh_name}_{timestep}s'
+            subdir = f'{sph_trans_dir}/forward/{mesh_name}_{timestep}s'
             if self.include_viz:
-                symlink = f'forward/{mesh_name}'
+                symlink = f'forward/{mesh_name}_{timestep}s'
             else:
                 symlink = None
             if subdir in component.steps:
                 forward_step = component.steps[subdir]
             else:
-                forward_step = Forward(component=component, name=name,
-                                       subdir=subdir, resolution=resolution,
-                                       base_mesh=base_mesh_step,
-                                       init=init_step,
-                                       case_name=case_name)
+                forward_step = Forward(
+                    component=component, name=name,
+                    subdir=subdir,
+                    base_mesh=base_mesh_step,
+                    init=init_step,
+                    case_name=case_name,
+                    refinement_factor=refinement_factor,
+                    refinement=refinement)
                 forward_step.set_shared_config(config, link=config_filename)
             self.add_step(forward_step, symlink=symlink)
             analysis_dependencies['forward'][resolution] = forward_step
 
             if self.include_viz:
                 with_viz_dir = f'{sph_trans_dir}/with_viz'
-                name = f'{prefix}_viz_{mesh_name}'
-                subdir = f'{with_viz_dir}/viz/{mesh_name}'
+                name = f'{prefix}_viz_{mesh_name}_{timestep}s'
+                subdir = f'{with_viz_dir}/viz/{mesh_name}_{timestep}s'
                 step = Viz(component=component, name=name,
                            subdir=subdir, base_mesh=base_mesh_step,
                            init=init_step, forward=forward_step,
@@ -193,9 +222,9 @@ class SphereTransport(Task):
                 step.set_shared_config(config, link=config_filename)
                 self.add_step(step)
 
-        subdir = f'{sph_trans_dir}/analysis'
+        subdir = f'{sph_trans_dir}/analysis/{refinement}'
         if self.include_viz:
-            symlink = 'analysis'
+            symlink = f'analysis_{refinement}'
         else:
             symlink = None
         if subdir in component.steps:
@@ -203,9 +232,10 @@ class SphereTransport(Task):
             step.resolutions = resolutions
             step.dependencies_dict = analysis_dependencies
         else:
-            step = Analysis(component=component, resolutions=resolutions,
+            step = Analysis(component=component,
                             subdir=subdir, case_name=case_name,
-                            dependencies=analysis_dependencies)
+                            dependencies=analysis_dependencies,
+                            refinement=refinement)
             step.set_shared_config(config, link=config_filename)
         self.add_step(step, symlink=symlink)
 

--- a/polaris/ocean/tasks/sphere_transport/analysis.py
+++ b/polaris/ocean/tasks/sphere_transport/analysis.py
@@ -31,6 +31,10 @@ class Analysis(ConvergenceAnalysis):
 
         dependencies : dict of dict of polaris.Steps
             The dependencies of this step
+
+        refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         self.case_name = case_name
         convergence_vars = [{'name': 'tracer1',

--- a/polaris/ocean/tasks/sphere_transport/analysis.py
+++ b/polaris/ocean/tasks/sphere_transport/analysis.py
@@ -1,4 +1,4 @@
-from polaris.ocean.convergence import ConvergenceAnalysis
+from polaris.ocean.convergence.analysis import ConvergenceAnalysis
 
 
 class Analysis(ConvergenceAnalysis):
@@ -13,8 +13,8 @@ class Analysis(ConvergenceAnalysis):
     case_name : str
         The name of the test case
     """
-    def __init__(self, component, resolutions, subdir, case_name,
-                 dependencies):
+    def __init__(self, component, subdir, case_name,
+                 dependencies, refinement='both'):
         """
         Create the step
 
@@ -22,9 +22,6 @@ class Analysis(ConvergenceAnalysis):
         ----------
         component : polaris.Component
             The component the step belongs to
-
-        resolutions : list of float
-            The resolutions of the meshes that have been run
 
         subdir : str
             The subdirectory that the step resides in
@@ -46,9 +43,9 @@ class Analysis(ConvergenceAnalysis):
                              'title': 'tracer3',
                              'zidx': 1}]
         super().__init__(component=component, subdir=subdir,
-                         resolutions=resolutions,
                          dependencies=dependencies,
-                         convergence_vars=convergence_vars)
+                         convergence_vars=convergence_vars,
+                         refinement=refinement)
         # Note: there is no need to overwrite the default method exact_solution
         # which uses the initial condition
 

--- a/polaris/ocean/tasks/sphere_transport/forward.py
+++ b/polaris/ocean/tasks/sphere_transport/forward.py
@@ -31,6 +31,13 @@ class Forward(SphericalConvergenceForward):
 
         case_name: str
             The name of the test case
+
+        refinement_factor : float
+            The factor by which to scale space, time or both
+
+        refinement : str, optional
+            Refinement type. One of 'space', 'time' or 'both' indicating both
+            space and time
         """
         package = 'polaris.ocean.tasks.sphere_transport'
         flow_id = {'rotation_2d': 1,

--- a/polaris/ocean/tasks/sphere_transport/forward.py
+++ b/polaris/ocean/tasks/sphere_transport/forward.py
@@ -7,8 +7,8 @@ class Forward(SphericalConvergenceForward):
     transport test case
     """
 
-    def __init__(self, component, name, subdir, resolution, base_mesh, init,
-                 case_name):
+    def __init__(self, component, name, subdir, base_mesh, init,
+                 case_name, refinement_factor, refinement):
         """
         Create a new step
 
@@ -22,9 +22,6 @@ class Forward(SphericalConvergenceForward):
 
         subdir : str
             The subdirectory for the step
-
-        resolution : float
-            The resolution of the (uniform) mesh in km
 
         base_mesh : polaris.Step
             The base mesh step
@@ -47,10 +44,12 @@ class Forward(SphericalConvergenceForward):
         }
         validate_vars = ['normalVelocity', 'tracer1', 'tracer2', 'tracer3']
         super().__init__(component=component, name=name, subdir=subdir,
-                         resolution=resolution, mesh=base_mesh,
+                         mesh=base_mesh,
                          init=init, package=package,
                          yaml_filename='forward.yaml',
                          output_filename='output.nc',
                          validate_vars=validate_vars,
                          options=namelist_options,
-                         graph_target=f'{base_mesh.path}/graph.info')
+                         graph_target=f'{base_mesh.path}/graph.info',
+                         refinement_factor=refinement_factor,
+                         refinement=refinement)

--- a/polaris/ocean/tasks/sphere_transport/forward.yaml
+++ b/polaris/ocean/tasks/sphere_transport/forward.yaml
@@ -49,6 +49,8 @@ mpas-ocean:
       - tracers
       - mesh
       - xtime
+      - velocityZonal
+      - velocityMeridional
       - normalVelocity
       - layerThickness
       - refZMid

--- a/polaris/ocean/tasks/sphere_transport/resources/flow_types.py
+++ b/polaris/ocean/tasks/sphere_transport/resources/flow_types.py
@@ -43,7 +43,7 @@ def flow_nondivergent(t, lon, lat, u_0, tau):
 
 def flow_divergent(t, lon, lat, u_0, tau):
     """
-    Compute a nondivergent velocity field
+    Compute a divergent velocity field
 
     Parameters
     ----------
@@ -81,7 +81,7 @@ def flow_divergent(t, lon, lat, u_0, tau):
 
 def flow_rotation(lon, lat, omega, tau, sphere_radius):
     """
-    Compute a nondivergent velocity field
+    Compute a rotational velocity field
 
     Parameters
     ----------


### PR DESCRIPTION
This PR extends the convergence test framework to accommodate convergence in space, time or both. This PR also adds additional tests for space-only and time-only convergence for the `cosine_bell`, `geostrophic`, `manufactured_solution`, and `inertial_gravity_wave` groups. The `convergence_time` cases have not been optimized (in terms of resolution and time steps) nor have separate convergence thresholds been specified.

Checklist
* [X] User's Guide has been updated
* [X] Developer's Guide has been updated
* [X] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes
* [X] New tests have been added to a test suite