### PR TITLE
Clean up the docs

### DIFF
--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -76,11 +76,10 @@ cfchecker
 udunits2
 
 # Documentation
-sphinx
+sphinx >=7.0.0
 sphinx_rtd_theme
 myst-parser
 sphinx-multiversion
-rst-to-myst
 
 # Visualization
 ncview

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,10 +6,6 @@
 
 import os
 from datetime import date
-import sphinx_rtd_theme
-
-from sphinx.application import Sphinx
-from sphinx.transforms.post_transforms import SphinxPostTransform
 
 from polaris.version import __version__
 
@@ -98,7 +94,6 @@ myst_enable_checkboxes = True
 # -- HTML output -------------------------------------------------
 
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_title = ""
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -114,4 +109,4 @@ html_sidebars = {
 
 smv_tag_whitelist = r"^\d+\.\d+.\d+$"  # Include tags like "tags/2.5.0"
 smv_branch_whitelist = "main"
-smv_remote_whitelist = r"^(origin|upstream)$"  # Use branches from origin
+smv_remote_whitelist = "origin"


### PR DESCRIPTION
This merge removes `myst-to-rst` (which is not being maintained) and constrain sphinx to newer versions (>= 7.0.0).

It also includes some cleanup of the config script for the docs, including removing unused imports and removing an unneeded path to the read-the-docs theme files.