### PR TITLE
Map time integrator for convergence tests

### DIFF
--- a/polaris/ocean/convergence/forward.py
+++ b/polaris/ocean/convergence/forward.py
@@ -117,7 +117,6 @@ class ConvergenceForward(OceanModelStep):
         section = config['convergence_forward']
 
         time_integrator = section.get('time_integrator')
-
         # dt is proportional to resolution: default 30 seconds per km
         if time_integrator == 'RK4':
             dt_per_km = section.getfloat('rk4_dt_per_km')
@@ -138,6 +137,16 @@ class ConvergenceForward(OceanModelStep):
         output_interval = section.getfloat('output_interval')
         output_interval_str = get_time_interval_string(
             seconds=output_interval * s_per_hour)
+
+        time_integrator_map = dict([('RK4', 'RungeKutta4')])
+        model = config.get('ocean', 'model')
+        if model == 'omega':
+            if time_integrator in time_integrator_map.keys():
+                time_integrator = time_integrator_map[time_integrator]
+            else:
+                print('Warning: mapping from time integrator '
+                      f'{time_integrator} to omega not found, '
+                      'retaining name given in config')
 
         replacements = dict(
             time_integrator=time_integrator,

--- a/polaris/ocean/tasks/manufactured_solution/__init__.py
+++ b/polaris/ocean/tasks/manufactured_solution/__init__.py
@@ -71,13 +71,3 @@ class ManufacturedSolution(Task):
         self.config.add_from_package(
             'polaris.ocean.tasks.manufactured_solution',
             'manufactured_solution.cfg')
-
-    def configure(self):
-        """
-        Set omega default config options
-        """
-        super().configure()
-        config = self.config
-        model = config.get('ocean', 'model')
-        if model == 'omega':
-            config.set('convergence_forward', 'time_integrator', 'RungeKutta4')


### PR DESCRIPTION
This PR uses a mapping between MPAS-O and Omega time integrator namelist options in the convergence forward step rather than in the manufactured solution test case. As more non-convergence Omega tests and supported Omega time integration schemes are added, this mapping may be moved.