### PR TITLE
Remove git from polaris environment

### DIFF
--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -11,7 +11,6 @@ esmf={{ esmf }}={{ mpi_prefix }}_*
 ffmpeg
 geometric_features={{ geometric_features }}
 geoviews
-git
 holoviews
 hvplot
 importlib_resources


### PR DESCRIPTION
We will need to use system git, as the conda-forge version brings in perl, which interferes with Omega's build system.

