### PR TITLE
Fix small typo in ctest path

### DIFF
--- a/utils/omega/ctest/README.md
+++ b/utils/omega/ctest/README.md
@@ -28,7 +28,7 @@ CTests and can optionally submit the job script.
 
 3. Run the utility:
    ```
-   ./util/omega/ctest/omega_ctest.py
+   ./utils/omega/ctest/omega_ctest.py
    ```
    The utility will check out submodules and build Omega with the compilers
    associated with the Polaris load script (e.g. `intel` in the example above).


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
There is a small typo in the ctest path which causes copying and pasting the command from the README to break.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
