### PR TITLE
Support the Omega `time` coordinate

### DIFF
--- a/polaris/mpas/__init__.py
+++ b/polaris/mpas/__init__.py
@@ -1,2 +1,2 @@
 from polaris.mpas.area import area_for_field
-from polaris.mpas.time import time_index_from_xtime
+from polaris.mpas.time import time_index_from_xtime, time_since_start

--- a/polaris/mpas/time.py
+++ b/polaris/mpas/time.py
@@ -23,6 +23,28 @@ def time_index_from_xtime(xtime, dt_target, start_xtime=None):
     time_index : int
         Index in xtime that is closest to dt_target
     """
+    dt = time_since_start(xtime, start_xtime)
+    time_index = np.argmin(np.abs(np.subtract(dt, dt_target)))
+    return time_index
+
+
+def time_since_start(xtime, start_xtime=None):
+    """
+    Determine the time elapsed since the start of the simulation
+
+    Parameters
+    ----------
+    xtime : numpy.ndarray of numpy.char
+        Times in the dataset
+
+    start_xtime : str, optional
+        The start time, the first entry in ``xtime`` by default
+
+    Returns
+    -------
+    dt : numpy.ndarray
+        The elapsed time in seconds corresponding to each entry in xtime
+    """
     if start_xtime is None:
         start_xtime = xtime[0].decode()
 
@@ -32,5 +54,4 @@ def time_index_from_xtime(xtime, dt_target, start_xtime=None):
         t = datetime.datetime.strptime(xt.decode(),
                                        '%Y-%m-%d_%H:%M:%S')
         dt[idx] = (t - t0).total_seconds()
-    time_index = np.argmin(np.abs(np.subtract(dt, dt_target)))
-    return time_index
+    return dt

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from polaris.mpas import area_for_field, time_index_from_xtime
+from polaris.mpas import area_for_field, time_since_start
 from polaris.ocean.convergence import (
     get_resolution_for_task,
     get_timestep_for_task,
@@ -401,10 +401,12 @@ class ConvergenceAnalysis(OceanIOStep):
 
         model = config.get('ocean', 'model')
         if model == 'mpas-o':
-            tidx = time_index_from_xtime(ds_out.xtime.values, time)
+            dt = time_since_start(ds_out.xtime.values)
         else:
             # time is seconds since the start of the simulation in Omega
-            tidx = np.argmin(np.abs(ds_out.Time.values - time))
+            dt = ds_out.Time.values
+
+        tidx = np.argmin(np.abs(dt - time))
 
         ds_out = ds_out.isel(Time=tidx)
         field_mpas = ds_out[field_name]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge fixes the manufactured solution analysis task in Omega by using the `time` coordinate instead of the MPAS-Ocean `xtime` variable.

It also attempts to use `time` in the viz step but testing is currently inhibited by #248 

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
