### PR TITLE
Fix the load script to reinstall polaris when needed

### DIFF
--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -1058,7 +1058,7 @@ def _write_load_polaris(options, prefix, spack_script, env_vars):
     if env_type == 'dev':
         update_polaris = \
             """
-            if [[ -z "${NO_POLARIS_REINSTALL}" && -f "./setup.py" && \\
+            if [[ -z "${NO_POLARIS_REINSTALL}" && -f "./pyproject.toml" && \\
                   -d "polaris" ]]; then
                # safe to assume we're in the polaris repo
                # update the polaris installation to point here


### PR DESCRIPTION
It was looking for `setup.py` but this has been replaced by `pyproject.toml` in the root of the repo.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
