### PR TITLE
Fix directory permissions not being updated

### DIFF
--- a/deploy/bootstrap.py
+++ b/deploy/bootstrap.py
@@ -1334,7 +1334,7 @@ def _ignore_file_errors(f):
 
     def _wrapper(*args, **kwargs):
         try:
-            f(*args, **kwargs)
+            return f(*args, **kwargs)
         except (PermissionError, FileNotFoundError):
             pass
     return _wrapper


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
As noted in #252, the configure script was not setting the group of deployed environments to `e3sm`. This was due to an object being passed incorrectly through a decorator. I've fixed the issue in this PR.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
closes #252 
