### PR TITLE
Use separate conda cache directories in CI

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -78,7 +78,7 @@ jobs:
           # Increase this value to reset cache if conda-dev-spec.template has not changed in the workflow
           CACHE_NUMBER: 0
         with:
-          path: ~/conda_pkgs_dir
+          path: ~/conda_pkgs_dir_py${{ matrix.python-version }}
           key:
             ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('configure_polaris_envs.py,deploy/*') }}

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [published]
 
+env:
+  PYTHON_VERSION: "3.10"
+
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
@@ -39,7 +42,7 @@ jobs:
           channels: conda-forge,e3sm/label/polaris
           channel-priority: strict
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install polaris
@@ -49,7 +52,7 @@ jobs:
             --conda_env_only \
             --env_name polaris_test \
             --verbose \
-            --python=${{ matrix.python-version }}
+            --python=${{ env.PYTHON_VERSION }}
           source load_polaris_test.sh
 
       - name: Build Sphinx Docs

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   UP_TO_DATE: false
+  PYTHON_VERSION: "3.10"
 
 jobs:
   auto-update:
@@ -22,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install pre-commit
         run: pip install pre-commit


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR updates the build workflow to use separate directories for each python version for conda caching. Issues with this seem to have been crashing CI runs lately.

I also fixed a bug in the docs workflow, where it was referring to a nonexistent python version matrix (likely a remnant of copying from the build workflow). Instead, I set this to be an environment variable called `PYTHON_VERSION` which will allow us to more easily specify and update the python version we use for the documentation without having to change it in a couple different places. I also copied this convention into the pre-commit update workflow for consistency.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
