### PR TITLE
Temporarily constrain dask

### DIFF
--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -4,6 +4,8 @@ antimeridian
 cartopy
 cartopy_offlinedata
 cmocean
+# temporary constraint on dask due to hvplot and bokeh issue
+dask <2025.1.0
 esmf={{ esmf }}={{ mpi_prefix }}_*
 ffmpeg
 geometric_features={{ geometric_features }}


### PR DESCRIPTION
There seems to be an issue with hvplot and bokeh with the latest dask:
```
WARNING:param.hvplot_extension: bokeh backend hook <function _load_bokeh at 0x7fb7511e7e20> failed with following exception: module 'dask.dataframe.core' has no attribute 'DataFrame'
```

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
