### PR TITLE
Drop support for Python 3.9 and add support for Python 3.13

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     steps:
       - id: skip_check

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -8,7 +8,7 @@ on:
     types: [published]
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   publish-docs:

--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -1,5 +1,5 @@
 # Base
-python>=3.9,<3.13
+python>=3.10,<=3.13
 cartopy
 cartopy_offlinedata
 cmocean

--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -14,7 +14,7 @@ recreate = False
 suffix =
 
 # the python version
-python = 3.12
+python = 3.13
 
 # the MPI version (nompi, mpich or openmpi)
 mpi = nompi

--- a/docs/users_guide/quick_start.md
+++ b/docs/users_guide/quick_start.md
@@ -73,7 +73,7 @@ if you don't already have it.  Then, create a new conda environment (called
 `polaris` in this example) as follows:
 
 ```bash
-conda create -n polaris -c conda-forge -c e3sm/label/polaris python=3.12 \
+conda create -n polaris -c conda-forge -c e3sm/label/polaris python=3.13 \
     "polaris=*=mpi_mpich*"
 ```
 
@@ -85,7 +85,7 @@ system with its own MPI), use `"polaris=*=nompi*"`
 To get a specific version of polaris, you can instead run:
 
 ```bash
-conda create -n polaris -c conda-forge -c e3sm/label/polaris python=3.12 \
+conda create -n polaris -c conda-forge -c e3sm/label/polaris python=3.13 \
     "polaris=1.0.0=mpi_mpich*"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,13 @@ authors = [
 description = "Testing and analysis for Omega, MPAS-Ocean, MALI and MPAS-Seaice"
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     # these are only for searching/browsing projects on PyPI
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR updates the supported python versions for `polaris` to 3.10-3.13 to accommodate the `mosaic` package. Thus, this PR will be merged in when #256 is merged. 
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
