### PR TITLE
Fix inertial gravity wave test

### DIFF
--- a/polaris/ocean/tasks/inertial_gravity_wave/__init__.py
+++ b/polaris/ocean/tasks/inertial_gravity_wave/__init__.py
@@ -120,8 +120,10 @@ class InertialGravityWave(Task):
                                subdir=f'{self.subdir}/analysis',
                                refinement=refinement,
                                dependencies=analysis_dependencies))
-        self.add_step(Viz(component=component, resolutions=resolutions,
-                          taskdir=self.subdir),
+        self.add_step(Viz(component=component,
+                          taskdir=self.subdir,
+                          refinement=refinement,
+                          dependencies=analysis_dependencies),
                       run_by_default=False)
         config.add_from_package('polaris.ocean.convergence',
                                 'convergence.cfg')

--- a/polaris/ocean/tasks/inertial_gravity_wave/forward.yaml
+++ b/polaris/ocean/tasks/inertial_gravity_wave/forward.yaml
@@ -14,6 +14,7 @@ mpas-ocean:
   debug:
     config_disable_vel_hadv: true
     config_disable_vel_hmix: true
+    config_disable_tr_all_tend: true
   streams:
     mesh:
       filename_template: init.nc


### PR DESCRIPTION
The `viz` step didn't get updated when we added refinement in just space and just time separately, so that is the main fix here.  The `viz` step is now more similar to the manufactured solution step, which was fixed in #250.

This merge also sets the namelist option `config_disable_tr_all_tend = .true.`, which was correctly dropped from the `single_layer.yaml` in #262 but which now is correctly included in this test's `forward.yaml`.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
