### PR TITLE
Fix refinement factors in cosine bell

### DIFF
--- a/polaris/ocean/convergence/__init__.py
+++ b/polaris/ocean/convergence/__init__.py
@@ -87,14 +87,13 @@ def get_timestep_for_task(config, refinement_factor,
     else:
         dt_per_km = section.getfloat('split_dt_per_km')
         btr_dt_per_km = section.getfloat('btr_dt_per_km')
-        for idx, refinement_factor in enumerate(refinement_factors):
-            if refinement == 'time':
-                btr_timestep = btr_dt_per_km * base_resolution * \
-                    refinement_factor
-            elif refinement == 'space':
-                btr_timestep = btr_dt_per_km * base_resolution
-            else:
-                btr_timestep = btr_dt_per_km * resolution
+        if refinement == 'time':
+            btr_timestep = btr_dt_per_km * base_resolution * \
+                refinement_factor
+        elif refinement == 'space':
+            btr_timestep = btr_dt_per_km * base_resolution
+        else:
+            btr_timestep = btr_dt_per_km * resolution
     if refinement == 'time':
         timestep = dt_per_km * refinement_factor * resolution
     elif refinement == 'space':

--- a/polaris/ocean/tasks/cosine_bell/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/__init__.py
@@ -69,7 +69,9 @@ class CosineBell(Task):
         space and time
 
     prefix : str
-        The prefix indicating the mesh type ('icos' or 'qu')
+        The prefix on the mesh name, step names and a subdirectory in the
+        work directory indicating the mesh type ('icos': uniform or
+        'qu': less regular JIGSAW meshes)
 
     include_viz : bool
         Include VizMap and Viz steps for each resolution
@@ -88,7 +90,9 @@ class CosineBell(Task):
             A shared config parser
 
         prefix : str
-            The prefix indicating the mesh type ('icos' or 'qu')
+            The prefix on the mesh name, step names and a subdirectory in the
+            work directory indicating the mesh type ('icos': uniform or
+            'qu': less regular JIGSAW meshes)
 
         include_viz : bool
             Include VizMap and Viz steps for each resolution

--- a/polaris/ocean/tasks/cosine_bell/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/__init__.py
@@ -151,7 +151,10 @@ class CosineBell(Task):
         else:
             option = 'refinement_factors_space'
 
-        refinement_factors = config.getlist('convergence', option, dtype=float)
+        _set_convergence_configs(config, prefix)
+
+        refinement_factors = config.getlist('convergence',
+                                            option, dtype=float)
 
         # start fresh with no steps
         for step in list(self.steps.values()):
@@ -250,8 +253,6 @@ def _set_convergence_configs(config, prefix):
                                             f'{prefix}_{option}', dtype=str)
         refinement_factors = ', '.join(refinement_factors)
         config.set('convergence', option, value=refinement_factors)
-        refinement_factors = config.getlist('convergence',
-                                            option, dtype=float)
 
         base_resolution = config.getfloat('spherical_convergence',
                                           f'{prefix}_base_resolution')

--- a/polaris/ocean/tasks/cosine_bell/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/__init__.py
@@ -24,8 +24,7 @@ def add_cosine_bell_tasks(component):
         the ocean component that the tasks will be added to
     """
 
-    for icosahedral, prefix, single_refinement in [(True, 'icos', 8.0),
-                                                   (False, 'qu', 2.0)]:
+    for prefix, single_refinement in [('icos', 8.0), ('qu', 2.0)]:
 
         filepath = f'spherical/{prefix}/cosine_bell/cosine_bell.cfg'
         config = PolarisConfigParser(filepath=filepath)
@@ -37,23 +36,23 @@ def add_cosine_bell_tasks(component):
                                 'cosine_bell.cfg')
         _set_convergence_configs(config, prefix)
 
-        for refinement in ['space', 'time', 'both']:
+        for refinement in ['both', 'space', 'time']:
             for include_viz in [False, True]:
                 component.add_task(CosineBell(component=component,
                                               config=config,
-                                              icosahedral=icosahedral,
+                                              prefix=prefix,
                                               include_viz=include_viz,
                                               refinement=refinement))
 
         component.add_task(Restart(component=component,
                                    config=config,
-                                   icosahedral=icosahedral,
+                                   prefix=prefix,
                                    refinement_factor=single_refinement,
                                    refinement='both'))
 
         component.add_task(Decomp(component=component,
                                   config=config,
-                                  icosahedral=icosahedral,
+                                  prefix=prefix,
                                   refinement_factor=single_refinement,
                                   refinement='both',
                                   proc_counts=[12, 24]))
@@ -69,13 +68,13 @@ class CosineBell(Task):
         Refinement type. One of 'space', 'time' or 'both' indicating both
         space and time
 
-    icosahedral : bool
-        Whether to use icosahedral, as opposed to less regular, JIGSAW meshes
+    prefix : str
+        The prefix indicating the mesh type ('icos' or 'qu')
 
     include_viz : bool
         Include VizMap and Viz steps for each resolution
     """
-    def __init__(self, component, config, icosahedral, include_viz,
+    def __init__(self, component, config, prefix, include_viz,
                  refinement='both'):
         """
         Create the convergence test
@@ -88,9 +87,8 @@ class CosineBell(Task):
         config : polaris.config.PolarisConfigParser
             A shared config parser
 
-        icosahedral : bool
-            Whether to use icosahedral, as opposed to less regular, JIGSAW
-            meshes
+        prefix : str
+            The prefix indicating the mesh type ('icos' or 'qu')
 
         include_viz : bool
             Include VizMap and Viz steps for each resolution
@@ -99,11 +97,6 @@ class CosineBell(Task):
             Refinement type. One of 'space', 'time' or 'both' indicating both
             space and time
         """
-        if icosahedral:
-            prefix = 'icos'
-        else:
-            prefix = 'qu'
-
         subdir = f'spherical/{prefix}/cosine_bell/convergence_{refinement}'
         name = f'{prefix}_cosine_bell_convergence_{refinement}'
         if include_viz:
@@ -112,7 +105,7 @@ class CosineBell(Task):
         link = 'cosine_bell.cfg'
         super().__init__(component=component, name=name, subdir=subdir)
         self.refinement = refinement
-        self.icosahedral = icosahedral
+        self.prefix = prefix
         self.include_viz = include_viz
 
         self.set_shared_config(config, link=link)
@@ -137,14 +130,9 @@ class CosineBell(Task):
         refinement : str
            refinement type. One of 'space', 'time' or 'both'
         """
-        icosahedral = self.icosahedral
+        prefix = self.prefix
         config = self.config
         config_filename = self.config_filename
-
-        if icosahedral:
-            prefix = 'icos'
-        else:
-            prefix = 'qu'
 
         if refinement == 'time':
             option = 'refinement_factors_time'
@@ -175,7 +163,7 @@ class CosineBell(Task):
                 config, refinement_factor, refinement=refinement)
 
             base_mesh_step, mesh_name = add_spherical_base_mesh_step(
-                component, resolution, icosahedral)
+                component, resolution, icosahedral=(prefix == 'icos'))
             analysis_dependencies['mesh'][refinement_factor] = base_mesh_step
 
             name = f'{prefix}_init_{mesh_name}'

--- a/polaris/ocean/tasks/cosine_bell/decomp.py
+++ b/polaris/ocean/tasks/cosine_bell/decomp.py
@@ -26,7 +26,9 @@ class Decomp(Task):
             A shared config parser
 
         prefix : str
-            The prefix indicating the mesh type ('icos' or 'qu')
+            The prefix on the mesh name, step names and a subdirectory in the
+            work directory indicating the mesh type ('icos': uniform or
+            'qu': less regular JIGSAW meshes)
 
         refinement_factor : float
             The factor by which to scale space, time or both

--- a/polaris/ocean/tasks/cosine_bell/decomp.py
+++ b/polaris/ocean/tasks/cosine_bell/decomp.py
@@ -12,7 +12,7 @@ class Decomp(Task):
     identical results on different numbers of cores.
     """
 
-    def __init__(self, component, config, icosahedral, refinement_factor,
+    def __init__(self, component, config, prefix, refinement_factor,
                  refinement, proc_counts):
         """
         Create the convergence test
@@ -25,9 +25,8 @@ class Decomp(Task):
         config : polaris.config.PolarisConfigParser
             A shared config parser
 
-        icosahedral : bool
-            Whether to use icosahedral, as opposed to less regular, JIGSAW
-            meshes
+        prefix : str
+            The prefix indicating the mesh type ('icos' or 'qu')
 
         refinement_factor : float
             The factor by which to scale space, time or both
@@ -39,12 +38,6 @@ class Decomp(Task):
         proc_counts : list of int
             The number of processors to run each step on
         """
-
-        if icosahedral:
-            prefix = 'icos'
-        else:
-            prefix = 'qu'
-
         task_subdir = f'spherical/{prefix}/cosine_bell/decomp'
         name = f'{prefix}_cosine_bell_decomp'
         config_filename = 'cosine_bell.cfg'
@@ -56,6 +49,7 @@ class Decomp(Task):
         resolution = get_resolution_for_task(
             config, refinement_factor, refinement=refinement)
 
+        icosahedral = (prefix == 'icos')
         base_mesh_step, mesh_name = add_spherical_base_mesh_step(
             component, resolution, icosahedral)
 

--- a/polaris/ocean/tasks/cosine_bell/restart/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/restart/__init__.py
@@ -13,7 +13,7 @@ class Restart(Task):
     in between.
     """
 
-    def __init__(self, component, config, icosahedral, refinement_factor,
+    def __init__(self, component, config, prefix, refinement_factor,
                  refinement):
         """
         Create the convergence test
@@ -26,9 +26,8 @@ class Restart(Task):
         config : polaris.config.PolarisConfigParser
             A shared config parser
 
-        icosahedral : bool
-            Whether to use icosahedral, as opposed to less regular, JIGSAW
-            meshes
+        prefix : str
+            The prefix indicating the mesh type ('icos' or 'qu')
 
         refinement_factor : float
             The factor by which to scale space, time or both
@@ -37,11 +36,6 @@ class Restart(Task):
             Refinement type. One of 'space', 'time' or 'both' indicating both
             space and time
         """
-
-        if icosahedral:
-            prefix = 'icos'
-        else:
-            prefix = 'qu'
 
         task_subdir = f'spherical/{prefix}/cosine_bell/restart'
         name = f'{prefix}_cosine_bell_restart'
@@ -54,6 +48,7 @@ class Restart(Task):
         resolution = get_resolution_for_task(
             config, refinement_factor, refinement=refinement)
 
+        icosahedral = (prefix == 'icos')
         base_mesh_step, mesh_name = add_spherical_base_mesh_step(
             component, resolution, icosahedral)
 

--- a/polaris/ocean/tasks/cosine_bell/restart/__init__.py
+++ b/polaris/ocean/tasks/cosine_bell/restart/__init__.py
@@ -27,7 +27,9 @@ class Restart(Task):
             A shared config parser
 
         prefix : str
-            The prefix indicating the mesh type ('icos' or 'qu')
+            The prefix on the mesh name, step names and a subdirectory in the
+            work directory indicating the mesh type ('icos': uniform or
+            'qu': less regular JIGSAW meshes)
 
         refinement_factor : float
             The factor by which to scale space, time or both


### PR DESCRIPTION
These need to come from the spherical values, not the planar ones.

In the process, I cleaned up the cosine bell a little bit by switching it to use only `prefix` and not the `icosahedral` boolean.

Finally, this merge fixes a bug in the split-explicit computation of time steps.  There is a for-loop over refinement factors that I don't think should be there.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #257 