### PR TITLE
Exclude latest uxarray 2025.01.0 

### DIFF
--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -38,7 +38,7 @@ requests
 scipy>=1.8.0
 shapely>=2.0,<3.0
 spatialpandas
-uxarray
+uxarray <2025.01.0
 xarray
 
 # Static typing

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.5.0-alpha.1'
+__version__ = '0.5.0-alpha.2'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
It has introduced syntax that is not compatible with python 3.9.

This requires updating to v0.5.0-alpha.2, since a dependency has changed.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
See https://github.com/UXARRAY/uxarray/issues/1133