### PR TITLE
Update tests to support Omega time slices

### DIFF
--- a/polaris/ocean/tasks/cosine_bell/forward.yaml
+++ b/polaris/ocean/tasks/cosine_bell/forward.yaml
@@ -91,6 +91,10 @@ Omega:
       Filename: output.nc
       Freq: {{ output_freq }}
       FreqUnits: seconds
+      IfExists: append
+      # effectively never
+      FileFreq: 9999
+      FileFreqUnits: years
       Contents:
         - Tracers
         - LayerThickness

--- a/polaris/ocean/tasks/manufactured_solution/forward.yaml
+++ b/polaris/ocean/tasks/manufactured_solution/forward.yaml
@@ -57,6 +57,10 @@ Omega:
       Filename: output.nc
       Freq: {{ output_freq }}
       FreqUnits: Seconds
+      IfExists: append
+      # effectively never
+      FileFreq: 9999
+      FileFreqUnits: years
       Contents:
       - NormalVelocity
       - LayerThickness

--- a/polaris/ocean/tasks/sphere_transport/forward.yaml
+++ b/polaris/ocean/tasks/sphere_transport/forward.yaml
@@ -83,6 +83,10 @@ Omega:
       Filename: output.nc
       Freq: {{ output_freq }}
       FreqUnits: seconds
+      IfExists: append
+      # effectively never
+      FileFreq: 9999
+      FileFreqUnits: years
       Contents:
         - Tracers
         - LayerThickness


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge Updates `manufactured_solution`, `cosine_bell` and `sphere_transport` tests to support time-slice capabilities brought in by https://github.com/E3SM-Project/Omega/pull/189

Some incorrect task names in the `omega_pr`suite have also been fixed.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
