### PR TITLE
Fix colormap limits for spherical viz

### DIFF
--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -290,6 +290,13 @@ def _setup_colormap(config, colormap_section):
     except configparser.NoOptionError:
         ticks = None
 
+    if config.has_option(colormap_section, 'under_color'):
+        under_color = config.get(colormap_section, 'under_color')
+        colormap.set_under(under_color)
+    if config.has_option(colormap_section, 'over_color'):
+        over_color = config.get(colormap_section, 'over_color')
+        colormap.set_over(over_color)
+
     return colormap, norm, ticks
 
 


### PR DESCRIPTION
Colormap over/under settings from config files were not being used for spherical viz. Omega submodule is also updated.

Checklist
* [X] `Testing` comment in the PR documents testing used to verify the changes