### PR TITLE
Add `--account` to CTest instructions

### DIFF
--- a/utils/omega/ctest/README.md
+++ b/utils/omega/ctest/README.md
@@ -53,6 +53,9 @@ CTests and can optionally submit the job script.
    * `-s`: if running the utility on a login node, submit the job script that
      the utility generates (does nothing on a compute node)
 
+   * `--account`: specify the account to supply in the job script (necessary
+     on some machines, such as Chicoma)
+
    * `-d`: build Omega in debug mode
 
    * `--cmake_flags="<flags>"`: Extra flags to pass to the `cmake` command


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR just adds a line in the README about the `--account` argument you might need to specify when running the CTest utility.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
