### PR TITLE
Fix planar plots with log norm

### DIFF
--- a/polaris/viz/planar.py
+++ b/polaris/viz/planar.py
@@ -41,10 +41,12 @@ def plot_horiz_field(ds_mesh, field, out_file_name=None,  # noqa: C901
         The title of the plot
 
     vmin : float, optional
-        The minimum values for the colorbar
+        The minimum values for the colorbar; if provided, must be positive if
+        ``cmap_scale == 'log'``
 
     vmax : float, optional
-        The maximum values for the colorbar
+        The maximum values for the colorbar; if provided, must be positive if
+        ``cmap_scale == 'log'``
 
     show_patch_edges : boolean, optional
         If true, patches will be plotted with visible edges
@@ -165,8 +167,10 @@ def plot_horiz_field(ds_mesh, field, out_file_name=None,  # noqa: C901
 
     if cmap_scale == 'log':
         pcolor_kwargs['norm'] = LogNorm(
-            vmin=max(1e-10, vmin), vmax=vmax, clip=False
+            vmin=vmin, vmax=vmax, clip=False
         )
+        pcolor_kwargs.pop('vmin', None)
+        pcolor_kwargs.pop('vmax', None)
 
     if figsize is None:
         width = ds_mesh.xCell.max() - ds_mesh.xCell.min()


### PR DESCRIPTION
We can't pass `vmin` and `vmax` along with `norm` that also tried to define the min and max:
```
ValueError: Passing a Normalize instance simultaneously with vmin/vmax is not supported.  Please pass vmin/vmax directly to the norm when creating it.
```

This merge also drops an attempt to keep `vmin` positive for log norm, instead requiring the calling code to set reasonable bounds for log plots.


<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
