### PR TITLE
Make mapping filename an absolute path

### DIFF
--- a/polaris/remap/mapping_file_step.py
+++ b/polaris/remap/mapping_file_step.py
@@ -97,3 +97,4 @@ class MappingFileStep(Step):
                 )
 
         remapper.build_map(logger=self.logger)
+        remapper.map_filename = os.path.abspath(remapper.map_filename)


### PR DESCRIPTION
In the `MappingFileStep`, it is important that we make not just the scrip files but also the mapping file itself have an absolute path so other steps that have the mapping step as a dependency can find the mapping file.  Otherwise, they unnecessarily recreated it (and do so without proper logging).

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
