### PR TITLE
Add a step for combining topography at low res (ne120)

### DIFF
--- a/polaris/e3sm/init/cached_files.json
+++ b/polaris/e3sm/init/cached_files.json
@@ -1,5 +1,8 @@
 {
     "e3sm/init/topo/combine_bedmap3_gebco2023/ne3000.scrip.nc": "topo/combine_bedmap3_gebco2023/ne3000.scrip.250509.nc",
     "e3sm/init/topo/combine_bedmap3_gebco2023/bedmap3_gebco2023_ne3000.nc": "topo/combine_bedmap3_gebco2023/bedmap3_gebco2023_ne3000.250509.nc",
-    "e3sm/init/topo/combine_bedmap3_gebco2023/ne3000.g": "topo/combine_bedmap3_gebco2023/ne3000.250509.g"
+    "e3sm/init/topo/combine_bedmap3_gebco2023/ne3000.g": "topo/combine_bedmap3_gebco2023/ne3000.250509.g",
+    "e3sm/init/topo/combine_bedmap3_gebco2023_low_res/ne120.scrip.nc": "topo/combine_bedmap3_gebco2023_low_res/ne120.scrip.250515.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023_low_res/bedmap3_gebco2023_ne120.nc": "topo/combine_bedmap3_gebco2023_low_res/bedmap3_gebco2023_ne120.250515.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023_low_res/ne120.g": "topo/combine_bedmap3_gebco2023_low_res/ne120.250515.g"
 }

--- a/polaris/tasks/e3sm/init/add_tasks.py
+++ b/polaris/tasks/e3sm/init/add_tasks.py
@@ -8,4 +8,7 @@ def add_e3sm_init_tasks(component):
     component : polaris.Component
         the e3sm/init component that the tasks will be added to
     """
-    component.add_task(CombineTopoTask(component=component))
+    for low_res in [False, True]:
+        component.add_task(
+            CombineTopoTask(component=component, low_res=low_res)
+        )

--- a/polaris/tasks/e3sm/init/topo/combine/combine.cfg
+++ b/polaris/tasks/e3sm/init/topo/combine/combine.cfg
@@ -7,6 +7,8 @@ target_grid = cubed_sphere
 # target resolution (degrees or NExxx)
 resolution_latlon = 0.0125
 resolution_cubedsphere = 3000
+
+# interpolation method: bilinear or conserve
 method = bilinear
 
 # threshold for masks below which interpolated variables are not renormalized

--- a/polaris/tasks/e3sm/init/topo/combine/combine_low_res.cfg
+++ b/polaris/tasks/e3sm/init/topo/combine/combine_low_res.cfg
@@ -1,0 +1,6 @@
+# config options related combining Antarctic and global topograph datasets
+[combine_topo]
+
+# target resolution (degrees or NExxx)
+resolution_latlon = 0.5
+resolution_cubedsphere = 120

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -58,16 +58,21 @@ class CombineStep(Step):
     }
 
     @staticmethod
-    def get_subdir():
+    def get_subdir(low_res):
         """
         Get the subdirectory for the step based on the datasets
+        Parameters
+        ----------
+        low_res : bool, optional
+            Whether to use the low resolution configuration options
         """
-        return os.path.join(
-            'topo',
-            f'combine_{CombineStep.ANTARCTIC}_{CombineStep.GLOBAL}',
+        suffix = '_low_res' if low_res else ''
+        subdir = (
+            f'combine_{CombineStep.ANTARCTIC}_{CombineStep.GLOBAL}{suffix}'
         )
+        return os.path.join('topo', subdir)
 
-    def __init__(self, component):
+    def __init__(self, component, low_res=False):
         """
         Create a new step
 
@@ -75,11 +80,15 @@ class CombineStep(Step):
         ----------
         component : polaris.Component
             The component the step belongs to
+
+        low_res : bool, optional
+            Whether to use the low resolution configuration options
         """
         antarctic_dataset = self.ANTARCTIC
         global_dataset = self.GLOBAL
-        name = f'combine_topo_{antarctic_dataset}_{global_dataset}'
-        subdir = self.get_subdir()
+        suffix = '_low_res' if low_res else ''
+        name = f'combine_topo_{antarctic_dataset}_{global_dataset}{suffix}'
+        subdir = self.get_subdir(low_res=low_res)
         super().__init__(
             component=component,
             name=name,
@@ -102,6 +111,10 @@ class CombineStep(Step):
         config.add_from_package(
             'polaris.tasks.e3sm.init.topo.combine', 'combine.cfg'
         )
+        if low_res:
+            config.add_from_package(
+                'polaris.tasks.e3sm.init.topo.combine', 'combine_low_res.cfg'
+            )
         self.set_shared_config(config)
 
     def setup(self):

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -9,7 +9,6 @@ import xarray as xr
 from mpas_tools.logging import check_call
 from pyremap import ProjectionGridDescriptor, get_lat_lon_descriptor
 
-from polaris.config import PolarisConfigParser
 from polaris.parallel import run_command
 from polaris.step import Step
 
@@ -72,7 +71,7 @@ class CombineStep(Step):
         )
         return os.path.join('topo', subdir)
 
-    def __init__(self, component, low_res=False):
+    def __init__(self, component, config, low_res=False):
         """
         Create a new step
 
@@ -80,6 +79,9 @@ class CombineStep(Step):
         ----------
         component : polaris.Component
             The component the step belongs to
+
+        config : polaris.config.PolarisConfigParser
+            The shared config options for the step
 
         low_res : bool, optional
             Whether to use the low resolution configuration options
@@ -102,19 +104,8 @@ class CombineStep(Step):
         self.dst_scrip_filename = None
         self.exodus_filename = None
 
-        # add default config options for combining topo -- since this is a
-        # shared step, they need to be defined separately from any task this
-        # may be added to
-        config_filename = 'combine_topo.cfg'
-        filepath = os.path.join(component.name, subdir, config_filename)
-        config = PolarisConfigParser(filepath=filepath)
-        config.add_from_package(
-            'polaris.tasks.e3sm.init.topo.combine', 'combine.cfg'
-        )
-        if low_res:
-            config.add_from_package(
-                'polaris.tasks.e3sm.init.topo.combine', 'combine_low_res.cfg'
-            )
+        # Set the config options for this step.  Since the shared config
+        # file is in the step's work directory, we don't need a symlink
         self.set_shared_config(config)
 
     def setup(self):

--- a/polaris/tasks/e3sm/init/topo/combine/steps.py
+++ b/polaris/tasks/e3sm/init/topo/combine/steps.py
@@ -5,9 +5,7 @@ from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
 from polaris.tasks.e3sm.init.topo.combine.viz import VizCombinedStep
 
 
-def get_combine_topo_steps(
-    component, cached=True, include_viz=False, low_res=False
-):
+def get_combine_topo_steps(component, include_viz=False, low_res=False):
     """
     Get the shared combine topo step for the given component, adding it if
     it doesn't exist
@@ -17,12 +15,9 @@ def get_combine_topo_steps(
     component : polaris.Component
         The component that the steps will be added to
 
-    cached : bool, optional
-        Whether to use cached data for the step or not
-
     include_viz : bool, optional
         Whether to include the visualization step or not
-        Default is False, ignored if ``cached == True``.
+        Default is False.
 
     low_res : bool, optional
         Whether to use low resolution config options
@@ -59,11 +54,10 @@ def get_combine_topo_steps(
         combine_step = CombineStep(
             component=component, config=config, low_res=low_res
         )
-        combine_step.cached = cached
         component.add_step(combine_step)
     steps.append(combine_step)
 
-    if not cached and include_viz:
+    if include_viz:
         viz_step = VizCombinedStep(
             component=component, config=config, combine_step=combine_step
         )

--- a/polaris/tasks/e3sm/init/topo/combine/steps.py
+++ b/polaris/tasks/e3sm/init/topo/combine/steps.py
@@ -2,7 +2,9 @@ from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
 from polaris.tasks.e3sm.init.topo.combine.viz import VizCombinedStep
 
 
-def get_combine_topo_steps(component, cached=True, include_viz=False):
+def get_combine_topo_steps(
+    component, cached=True, include_viz=False, low_res=False
+):
     """
     Get the shared combine topo step for the given component, adding it if
     it doesn't exist
@@ -19,17 +21,20 @@ def get_combine_topo_steps(component, cached=True, include_viz=False):
         Whether to include the visualization step or not
         Default is False, ignored if ``cached == True``.
 
+    low_res : bool, optional
+        Whether to use low resolution config options
+
     Returns
     -------
     steps : list of polaris.Step
         The combine topo step and optional visualization step
     """
     steps = []
-    subdir = CombineStep.get_subdir()
+    subdir = CombineStep.get_subdir(low_res=low_res)
     if subdir in component.steps:
         combine_step = component.steps[subdir]
     else:
-        combine_step = CombineStep(component=component)
+        combine_step = CombineStep(component=component, low_res=low_res)
         combine_step.cached = cached
         component.add_step(combine_step)
     steps.append(combine_step)

--- a/polaris/tasks/e3sm/init/topo/combine/task.py
+++ b/polaris/tasks/e3sm/init/topo/combine/task.py
@@ -35,14 +35,12 @@ class CombineTask(Task):
             name=name,
             subdir=subdir,
         )
-        self.config.add_from_package(
-            'polaris.tasks.e3sm.init.topo.combine', 'combine.cfg'
-        )
-        steps = get_combine_topo_steps(
+        steps, config = get_combine_topo_steps(
             component=component,
             cached=False,
             include_viz=True,
             low_res=low_res,
         )
+        self.set_shared_config(config, link='combine_topo.cfg')
         for step in steps:
             self.add_step(step)

--- a/polaris/tasks/e3sm/init/topo/combine/task.py
+++ b/polaris/tasks/e3sm/init/topo/combine/task.py
@@ -11,7 +11,7 @@ class CombineTask(Task):
     files to be cached for use in all other contexts
     """
 
-    def __init__(self, component):
+    def __init__(self, component, low_res):
         """
         Create a new task
 
@@ -19,11 +19,17 @@ class CombineTask(Task):
         ----------
         component : polaris.Component
             The component the task belongs to
+
+        low_res : bool
+            Whether to use low resolution config options
         """
         antarctic_dataset = CombineStep.ANTARCTIC
         global_dataset = CombineStep.GLOBAL
-        name = f'combine_topo_{antarctic_dataset}_{global_dataset}_task'
-        subdir = os.path.join(CombineStep.get_subdir(), 'task')
+        suffix = '_low_res' if low_res else ''
+        name = (
+            f'combine_topo_{antarctic_dataset}_{global_dataset}{suffix}_task'
+        )
+        subdir = os.path.join(CombineStep.get_subdir(low_res=low_res), 'task')
         super().__init__(
             component=component,
             name=name,
@@ -36,6 +42,7 @@ class CombineTask(Task):
             component=component,
             cached=False,
             include_viz=True,
+            low_res=low_res,
         )
         for step in steps:
             self.add_step(step)

--- a/polaris/tasks/e3sm/init/topo/combine/task.py
+++ b/polaris/tasks/e3sm/init/topo/combine/task.py
@@ -37,7 +37,6 @@ class CombineTask(Task):
         )
         steps, config = get_combine_topo_steps(
             component=component,
-            cached=False,
             include_viz=True,
             low_res=low_res,
         )

--- a/polaris/tasks/e3sm/init/topo/combine/viz.py
+++ b/polaris/tasks/e3sm/init/topo/combine/viz.py
@@ -21,7 +21,7 @@ class VizCombinedStep(Step):
 
     """
 
-    def __init__(self, component, combine_step):
+    def __init__(self, component, config, combine_step):
         """
         Create a new step
 
@@ -29,6 +29,9 @@ class VizCombinedStep(Step):
         ----------
         component : polaris.Component
             The component the step belongs
+
+        config : polaris.config.PolarisConfigParser
+            The config options for the step
 
         combine_step : polaris.tasks.e3sm.init.topo.combine.CombineStep
             The combine step to use for visualization
@@ -41,6 +44,7 @@ class VizCombinedStep(Step):
             min_cpus_per_task=1,
         )
         self.combine_step = combine_step
+        self.set_shared_config(config, link='combine_topo.cfg')
 
     def setup(self):
         """

--- a/polaris/tasks/e3sm/init/topo/combine/viz.py
+++ b/polaris/tasks/e3sm/init/topo/combine/viz.py
@@ -8,7 +8,6 @@ from matplotlib.colors import Normalize
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from polaris.step import Step
-from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
 
 
 class VizCombinedStep(Step):
@@ -37,7 +36,7 @@ class VizCombinedStep(Step):
         super().__init__(
             component=component,
             name='viz_combine_topo',
-            subdir=os.path.join(CombineStep.get_subdir(), 'viz'),
+            subdir=os.path.join(combine_step.subdir, 'viz'),
             cpus_per_task=128,
             min_cpus_per_task=1,
         )


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This is needed for efficiency for coarser (e.g. Icos240) MPAS meshes.

The results from the low-res step have also been cached for more efficient use in other `e3sm/init` workflows.

This merge also fixes an issue with the shared config file for the combine-topo steps.  Previously, the task and step were using different config files, whereas with this fix, they use a single, shared config file as intended.

It also fixes a bug with the approach for caching combined topography.  We can't simply cache it by setting the `cached` attribute at construction, we need to set it in specific tasks at setup.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
