### PR TITLE
Update combine topo to leave land surface elevation

### DIFF
--- a/docs/developers_guide/e3sm/init/tasks/topo.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo.md
@@ -13,20 +13,10 @@ datasets, supporting various grid types like lat-lon and cubed-sphere grids.
 :width: 500 px
 ```
 
-Global bathymetry datasets do not typically include the latest datasets around
-Antarctica needed for ice-sheet and ice-shelf modeling. For this reason, we
-typically combine a global topography dataset north of the Southern Ocean with
-one for Antarctica.
-
-```{note}
-At the moment, the step for combining these datasets provides fields that are
-masked to locations where the bed topography (bathymetry) is below sea level.
-This avoids the risk of interpolated topography resulting in a bed that is
-above sea level in ocean regions when we perform further interpolation of
-the data to an MPAS mesh. However, a more general topography dataset will
-likely be needed in the future that accommodates both the ocean and land/river
-components.
-```
+Global datasets of base elevation (land surface elevation and ocean bathymetry)
+do not typically include the latest datasets around Antarctica needed for
+ice-sheet and ice-shelf modeling. For this reason, we typically combine a
+global topography dataset north of the Southern Ocean with one for Antarctica.
 
 The {py:class}`polaris.tasks.e3sm.init.topo.combine.CombineStep` step is a key
 component of the topography framework. It is responsible for combining global
@@ -73,7 +63,7 @@ to `True` when creating the `CombineStep` or `CombineTask`.
 - **Output**: Produces combined topography datasets with consistent variables
   and attributes.
 - **Visualization**: Generates rasterized images of various fields (e.g.,
-  bathymetry, ice draft) using the `datashader` library.
+  base elevation, ice draft) using the `datashader` library.
 
 ### Configuration Options
 
@@ -86,6 +76,8 @@ the configuration file. Key options include:
 - `latmin` and `latmax`: Latitude range for blending datasets.
 - `ntasks` and `min_tasks`: Number of MPI tasks for remapping.
 - `method`: Remapping method (e.g., `bilinear`).
+- `lat_tiles` and `lon_tiles`: Number of tiles to split the global dataset for parallel remapping.
+- `renorm_thresh`: Threshold for renormalizing Antarctic variables during blending.
 
 For the low-resolution version, additional configuration options are provided
 in the `combine_low_res.cfg` file.

--- a/polaris/tasks/e3sm/init/topo/combine/viz.py
+++ b/polaris/tasks/e3sm/init/topo/combine/viz.py
@@ -71,20 +71,17 @@ class VizCombinedStep(Step):
         """
 
         colormaps = {
-            'bathymetry': 'cmo.deep_r',
-            'thickness': 'cmo.ice_r',
+            'base_elevation': 'cmo.deep_r',
+            'ice_thickness': 'cmo.ice_r',
             'ice_draft': 'cmo.deep_r',
             'ice_mask': 'cmo.amp_r',
-            'bathymetry_mask': 'cmo.amp_r',
             'grounded_mask': 'cmo.amp_r',
-            'ocean_mask': 'cmo.amp_r',
-            'water_column': 'cmo.deep',
         }
 
         ds_data = xr.open_dataset('topography.nc')
 
         # Use one field to define the valid mask (they all share indexing)
-        valid_mask = np.isfinite(ds_data['bathymetry'].values)
+        valid_mask = np.isfinite(ds_data['base_elevation'].values)
 
         # Build mesh only once
         vertices, tris = self._load_trimesh_geometry(


### PR DESCRIPTION
This merge updates the output from `e3sm/init/topo/combine` to no longer mask the topography to just locations where the bathymetry is below sea level.

We have switched to more neutral terminology:
* `base_elevation` instead of `bathymetry`
* `ice_thickness` instead of `thickness`

We have removed some fields that can be derived later:
* `ocean_mask` -- may want to include grounded ice and "dry" coastal regions
* `bathymetry_mask` -- may want to include "dry" regions

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
