### PR TITLE
Allow reuse of mosaic descriptor in spherical plots

### DIFF
--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -25,6 +25,7 @@ def plot_global_mpas_field(
     figsize=(8, 4.5),
     dpi=200,
     patch_edge_color=None,
+    descriptor=None,
 ):
     """
     Plots a data set as a longitude-latitude map
@@ -72,6 +73,15 @@ def plot_global_mpas_field(
 
     patch_edge_color : str, optional
         The color of patch edges (if not the same as the face)
+
+    descriptor : mosaic.Descriptor, optional
+        Descriptor from a previous call to ``plot_global_mpas_field()``
+
+    Returns
+    -------
+    descriptor : mosaic.Descriptor
+        For reuse with future plots. Patches are cached, so the Descriptor only
+        needs to be created once per mesh file.
     """
 
     use_mplstyle()
@@ -80,9 +90,13 @@ def plot_global_mpas_field(
     projection = cartopy.crs.PlateCarree(central_longitude=central_longitude)
 
     mesh_ds = xr.open_dataset(mesh_filename)
-    descriptor = mosaic.Descriptor(
-        mesh_ds, projection=projection, transform=transform, use_latlon=True
-    )
+    if descriptor is None:
+        descriptor = mosaic.Descriptor(
+            mesh_ds,
+            projection=projection,
+            transform=transform,
+            use_latlon=True,
+        )
 
     fig, ax = plt.subplots(
         figsize=figsize,


### PR DESCRIPTION
This should make multiple plots with the same spherical MPAS mesh and projection much more efficient.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
