### PR TITLE
Fix `zidx` in `sphere_transport` analysis

### DIFF
--- a/polaris/tasks/ocean/sphere_transport/filament_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/filament_analysis.py
@@ -101,7 +101,7 @@ class FilamentAnalysis(Step):
         section = config[self.case_name]
         eval_time = section.getfloat('filament_evaluation_time')
         s_per_day = 86400.0
-        zidx = 1
+        zidx = 0
         variable_name = 'tracer2'
         num_tau = 21
         filament_tau = np.linspace(0, 1, num_tau)

--- a/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
@@ -103,7 +103,7 @@ class MixingAnalysis(Step):
         section = config[self.case_name]
         eval_time = section.getfloat('mixing_evaluation_time')
         s_per_day = 86400.0
-        zidx = 1
+        zidx = 0
         nrows = int(ceil(len(resolutions) / 2))
         use_mplstyle()
         fig, axes = plt.subplots(


### PR DESCRIPTION
It appears there is only a single vertical level but the analysis was attempting to index vertical level 1.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
