### PR TITLE
Add `cpptrace` submodule to Omega CTest utility

### DIFF
--- a/utils/omega/ctest/build_and_ctest.template
+++ b/utils/omega/ctest/build_and_ctest.template
@@ -18,8 +18,12 @@ git submodule update --init e3sm_submodules/Omega
 
 cd {{ omega_base_dir }}
 
-git submodule update --init --recursive externals/YAKL externals/ekat \
-    externals/scorpio cime
+git submodule update --init --recursive \
+    externals/YAKL \
+    externals/ekat \
+    externals/scorpio \
+    externals/cpptrace \
+    cime
 
 cd ${cwd}
 


### PR DESCRIPTION
This submodule is require to build Omega following https://github.com/E3SM-Project/Omega/pull/218.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
