### PR TITLE
Switch to writing files in CDF5 (`NETCDF3_64BIT_DATA`) format 

### DIFF
--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -23,7 +23,7 @@ mpi = nompi
 geometric_features = 1.6.1
 mache = 1.31.0
 conda_moab = 5.5.1
-mpas_tools = 1.1.0
+mpas_tools = 1.2.0
 otps = 2021.10
 parallelio = 2.6.6
 

--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -31,7 +31,7 @@ parallelio = 2.6.6
 esmf = 8.8.1
 metis = 5.1.0
 netcdf_c = 4.9.2
-netcdf_fortran = 4.6.1
+netcdf_fortran = 4.6.2
 pnetcdf = 1.14.0
 
 # versions of spack packages

--- a/docs/developers_guide/framework/model.md
+++ b/docs/developers_guide/framework/model.md
@@ -430,3 +430,97 @@ call {py:func}`polaris.model_step.make_graph_file()` to produce a graph file
 from an MPAS mesh file.  Optionally, you can provide the name of an MPAS field
 on cells in the mesh file that gives different weight to different cells
 (`weight_field`) in the partitioning process.
+
+## Detailed Documentation: polaris.namelist, polaris.streams, and polaris.yaml
+
+### `polaris.namelist`
+
+This module provides utilities for reading, parsing, updating, and writing
+MPAS-style namelist files. It is used to manage namelist options for E3SM
+components.
+
+**Key Functions:**
+- `parse_replacements(package, namelist)`: Reads a namelist file from a
+  package and returns a dictionary of option replacements.
+- `ingest(defaults_filename)`: Reads a full namelist file and returns a nested
+  dictionary of records and options.
+- `replace(namelist, replacements)`: Applies replacements to a namelist
+  dictionary.
+- `write(namelist, filename)`: Writes a nested namelist dictionary to a file.
+
+**Example Usage:**
+```python
+from polaris import namelist
+
+replacements = namelist.parse_replacements('my_package', 'namelist.forward')
+namelist_dict = namelist.ingest('namelist.defaults')
+updated = namelist.replace(namelist_dict, replacements)
+namelist.write(updated, 'namelist.input')
+```
+
+### `polaris.streams`
+
+This module provides tools for reading, updating, and writing MPAS streams XML
+files, including support for Jinja2 templating.
+
+**Key Functions:**
+- `read(package, streams_filename, tree=None, replacements=None)`: Reads a
+  streams XML file (optionally as a Jinja2 template) and returns an XML tree.
+- `write(streams, out_filename)`: Writes a streams XML tree to a file.
+- `update_tree(tree, new_tree)`: Updates an existing streams tree with new
+  streams.
+- `set_default_io_type(tree, io_type='pnetcdf,cdf5')`: Sets the `io_type`
+  attribute for output streams if not already set.
+
+**Example Usage:**
+```python
+from polaris import streams
+
+tree = streams.read('my_package', 'streams.forward')
+streams.write(tree, 'streams.xml')
+```
+
+### `polaris.yaml`
+
+This module provides a class for reading, writing, and updating YAML
+configuration files for E3SM components, including support for Jinja2
+templating and conversion between YAML and MPAS namelist/streams formats.
+
+**Key Classes and Functions:**
+- `PolarisYaml`: Main class for managing YAML configs.
+  - `PolarisYaml.read(filename, package=None, replacements=None, ...)`: Reads
+    a YAML file (optionally as a Jinja2 template).
+  - `PolarisYaml.update(configs=None, options=None, quiet=True)`: Updates the
+    config with new options.
+  - `PolarisYaml.write(filename)`: Writes the config to a YAML file.
+- `mpas_namelist_and_streams_to_yaml(...)`: Converts MPAS namelist and streams
+  files to a YAML config.
+
+**Example Usage:**
+```python
+from polaris.yaml import PolarisYaml
+
+yaml_cfg = PolarisYaml.read('config.yaml')
+yaml_cfg.update(options={'config_dt': '00:10:00'})
+yaml_cfg.write('updated_config.yaml')
+```
+
+**See also:**
+Refer to the API documentation for each module for a full list of functions
+and classes:
+* {py:func}`polaris.namelist.parse_replacements`
+* {py:func}`polaris.namelist.ingest`
+* {py:func}`polaris.namelist.replace`
+* {py:func}`polaris.namelist.write`
+* {py:func}`polaris.streams.read`
+* {py:func}`polaris.streams.write`
+* {py:func}`polaris.streams.update_defaults`
+* {py:func}`polaris.streams.update_tree`
+* {py:func}`polaris.streams.set_default_io_type`
+* {py:class}`polaris.yaml.PolarisYaml`
+* {py:meth}`polaris.yaml.PolarisYaml.read`
+* {py:meth}`polaris.yaml.PolarisYaml.update`
+* {py:meth}`polaris.yaml.PolarisYaml.write`
+* {py:func}`polaris.yaml.mpas_namelist_and_streams_to_yaml`
+* {py:func}`polaris.yaml.yaml_to_mpas_streams`
+* {py:func}`polaris.yaml.main_mpas_to_yaml`

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -20,7 +20,7 @@ Some steps are shared between multiple tasks to avoid redundant computation and
 to ensure consistency of results. Shared steps are created at the highest
 directory level common to all tasks that use them. To facilitate this, the
 `Component` class provides the method
-{py:method}`polaris.Component.get_or_create_shared_step()`.
+{py:meth}`polaris.Component.get_or_create_shared_step()`.
 
 This function checks if a step already exists in a component's `steps`
 dictionary under a given subdirectory. If it does, it returns the existing

--- a/docs/users_guide/ocean/tasks/overflow.md
+++ b/docs/users_guide/ocean/tasks/overflow.md
@@ -3,9 +3,7 @@
 # overflow
 
 The ``ocean/overflow`` test group induces a density current flowing down a
-continental slope and includes two test cases. 
-
-(ocean-category-of-task-task-name)=
+continental slope and includes two test cases.
 
 ## suppported models
 
@@ -31,7 +29,7 @@ The mesh is planar and the resolution is specified by config option
 `overflow:resolution`, which defaults to 1 km.
 
 The horizontal dimensions of the domain are set by config options
-`overflow:lx` and `overflow:ly`, defaulting to 200 km by 40 km. 
+`overflow:lx` and `overflow:ly`, defaulting to 200 km by 40 km.
 
 The domain is periodic on the zonal boundaries and solid on the meridional
 boundaries.

--- a/docs/users_guide/ocean/tasks/template.md
+++ b/docs/users_guide/ocean/tasks/template.md
@@ -4,8 +4,6 @@
 
 Description of common characteristics of the tasks.
 
-(ocean-category-of-task-task-name)=
-
 ## suppported models
 
 This section should have one of the following lines, as appropriate, or if
@@ -17,6 +15,8 @@ These tasks support both MPAS-Ocean and Omega.
 These tasks support only MPAS-Ocean.
 
 These tasks support only Omega.
+
+(ocean-category-of-task-task-name)=
 
 ## task_name
 

--- a/polaris/default.cfg
+++ b/polaris/default.cfg
@@ -36,14 +36,11 @@ login_cores = 4
 [io]
 
 # the NetCDF file format: NETCDF4, NETCDF4_CLASSIC, NETCDF3_64BIT, or
-# NETCDF3_CLASSIC
-format = NETCDF3_64BIT
+# NETCDF3_CLASSIC, NETCDF3_64BIT_DATA
+format = NETCDF3_64BIT_DATA
 
-# the NetCDF output engine: netcdf4 or scipy
-# the netcdf4 engine is not performing well on Chrysalis and Anvil, so we will
-# try scipy for now.  If we can switch to NETCDF4 format, netcdf4 will be
-# required
-engine = scipy
+# the NetCDF output engine: netcdf4, h5netcdf or scipy
+engine = netcdf4
 
 
 # Config options related to creating a job script

--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -699,6 +699,9 @@ class ModelStep(Step):
                     'Trying to write a streams file but no '
                     'streams XML tree was created.'
                 )
+            io_format = self.config.get('io', 'format')
+            if io_format == 'NETCDF3_64BIT_DATA':
+                polaris.streams.set_default_io_type(self._streams_tree)
             polaris.streams.write(self._streams_tree, streams_filename)
         # set these back to None because we don't need to keep them around
         # and the streams tree can't be pickled

--- a/polaris/streams.py
+++ b/polaris/streams.py
@@ -197,3 +197,18 @@ def _update_element(new_child, elements):
     if not found:
         # add a deep copy of the element
         elements.append(deepcopy(new_child))
+
+
+def set_default_io_type(tree, io_type='pnetcdf,cdf5'):
+    """
+    Set io_type attribute for all <stream> and <immutable_stream>
+    elements if not already set, except for immutable_stream with name 'mesh'.
+    """
+    streams = next(tree.iter('streams'))
+    all_streams = streams.findall('stream') + streams.findall(
+        'immutable_stream'
+    )
+    for stream in all_streams:
+        stream_type = stream.attrib.get('type')
+        if 'io_type' not in stream.attrib and 'output' in stream_type:
+            stream.attrib['io_type'] = io_type

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8.0-alpha.1'
+__version__ = '0.8.0-alpha.2'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This is E3SM's preferred fromat for large files.  Since E3SM can't support `NETCDF4` format, it is the only option that we
can be sure will work for both small and large meshes, and saves us the hassle of having different fromats for different mesh sizes.

Good performance does require first writing a `NETCDF4` file from `xarray` and then converting to `NETCDF3_64BIT_DATA`.  This is handled by a new version of `mpas_tools`, see https://github.com/MPAS-Dev/MPAS-Tools/pull/633.

## Copilot summary

This pull request introduces changes to improve NetCDF file handling and streamline the codebase in `polaris`. Key updates include modifying the default NetCDF format, refactoring imports for clarity, and adding functionality to set default I/O types for streams. Below is a breakdown of the most important changes:

### NetCDF File Handling Improvements:
* Updated the default NetCDF format to `NETCDF3_64BIT_DATA` in `polaris/default.cfg` to align with improved compatibility and performance. The output engine was also switched from `scipy` to `netcdf4`.
* Added logic in `polaris/model_step.py` to set the default I/O type for streams when the format is `NETCDF3_64BIT_DATA`.
* Introduced the `set_default_io_type` function in `polaris/streams.py` to set the `io_type` attribute for streams and immutable streams, except for immutable streams named 'mesh'.

### Codebase Refactoring:
* Refactored imports in `polaris/mesh/spherical.py`, replacing `xarray` with an alias `xr` and adding `write_netcdf` for improved readability and functionality.
* Updated instances of `xarray.DataArray` and `xarray.open_dataset` to use the alias `xr` for consistency in `polaris/mesh/spherical.py`. [[1]](diffhunk://#diff-83b323ec080a8c06a01bbe154e913a64bce6dc6403e6437c271e4bb055d02aebL73-R74) [[2]](diffhunk://#diff-83b323ec080a8c06a01bbe154e913a64bce6dc6403e6437c271e4bb055d02aebL121-R132)
* Enhanced the `run` method in `polaris/mesh/spherical.py` to rewrite temporary mesh files in the desired NetCDF format using `write_netcdf`.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
