### PR TITLE
Remove `craygnu-hipcc compiler` from frontier spack

### DIFF
--- a/deploy/albany_supported.txt
+++ b/deploy/albany_supported.txt
@@ -5,7 +5,6 @@ chicoma-cpu, gnu, mpich
 chrysalis, gnu, openmpi
 compy, gnu, openmpi
 frontier, craygnu, mpich
-frontier, craygnu-hipcc, mpich
 frontier, craygnu-mphipcc, mpich
 frontier, craycray, mpich
 frontier, craycray-mphipcc, mpich

--- a/docs/developers_guide/machines/index.md
+++ b/docs/developers_guide/machines/index.md
@@ -104,8 +104,6 @@ E3SM default for the given machine an compiler.
 +--------------+------------------+-----------+
 | frontier     | craygnu          | mpich     |
 |              +------------------+-----------+
-|              | craygnu-hipcc    | mpich     |
-|              +------------------+-----------+
 |              | craygnu-mphipcc  | mpich     |
 |              +------------------+-----------+
 |              | crayamd          | mpich     |

--- a/docs/developers_guide/updating_spack/updating_packages.md
+++ b/docs/developers_guide/updating_spack/updating_packages.md
@@ -111,7 +111,6 @@ update Spack dependencies in Polaris.
        - [ ] gnu
      - [ ] frontier (@xylar)
        - [ ] craygnu
-       - [ ] craygnu-hipcc
        - [ ] craygnu-mphipcc
        - [ ] craycray
        - [ ] craycray-mphipcc
@@ -155,7 +154,6 @@ update Spack dependencies in Polaris.
        - [ ] gnu
      - [ ] frontier (@xylar)
        - [ ] craygnu
-       - [ ] craygnu-hipcc
        - [ ] craygnu-mphipcc
        - [ ] craycray
        - [ ] craycray-mphipcc

--- a/docs/users_guide/machines/frontier.md
+++ b/docs/users_guide/machines/frontier.md
@@ -44,9 +44,6 @@ software_compiler = craygnu
 # the system MPI library to use for craygnu compiler
 mpi_craygnu = mpich
 
-# the system MPI library to use for craygnu-hipcc compiler
-mpi_craygnu_hipcc = mpich
-
 # the system MPI library to use for craygnu-mphipcc compiler
 mpi_craygnu_mphipcc = mpich
 

--- a/polaris/machines/frontier.cfg
+++ b/polaris/machines/frontier.cfg
@@ -21,9 +21,6 @@ software_compiler = craygnu
 # the system MPI library to use for craygnu compiler
 mpi_craygnu = mpich
 
-# the system MPI library to use for craygnu-hipcc compiler
-mpi_craygnu_hipcc = mpich
-
 # the system MPI library to use for craygnu-mphipcc compiler
 mpi_craygnu_mphipcc = mpich
 


### PR DESCRIPTION
This compiler is now redundant with `craygnu-mphipcc` and we need not support both.

