### PR TITLE
Update to 0.9.0 alpha.1

### DIFF
--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -28,7 +28,7 @@ otps = 2021.10
 parallelio = 2.6.6
 
 # versions of conda or spack packages (depending on machine type)
-esmf = 8.8.1
+esmf = 8.9.0
 metis = 5.1.0
 netcdf_c = 4.9.2
 netcdf_fortran = 4.6.2

--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -43,4 +43,4 @@ lapack = 3.9.1
 spack_moab = master
 parmetis = 4.0.3
 petsc = 3.19.1
-scorpio = 1.7.0
+scorpio = 1.8.2

--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -21,7 +21,7 @@ mpi = nompi
 
 # versions of conda packages
 geometric_features = 1.6.1
-mache = 1.31.0
+mache = 1.32.0
 conda_moab = 5.5.1
 mpas_tools = 1.3.0
 otps = 2021.10

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8.0-alpha.4'
+__version__ = '0.9.0-alpha.1'

--- a/utils/omega/ctest/build_and_ctest.template
+++ b/utils/omega/ctest/build_and_ctest.template
@@ -23,6 +23,7 @@ git submodule update --init --recursive \
     externals/ekat \
     externals/scorpio \
     externals/cpptrace \
+    components/omega/external \
     cime
 
 cd ${cwd}

--- a/utils/omega/ctest/omega_ctest.py
+++ b/utils/omega/ctest/omega_ctest.py
@@ -207,6 +207,9 @@ def main():
     config.add_from_package('mache.machines', f'{machine}.cfg')
     config.add_from_package('polaris.machines', f'{machine}.cfg')
 
+    job_name = f'omega_ctest_{machine}_{compiler}'
+    config.set('job', 'job_name', job_name)
+
     submit = args.submit
     branch = args.omega_branch
     debug = args.debug


### PR DESCRIPTION
## Updates:
- esmf v8.9.0
- mache v1.32.0 -- brings in a fix to the libfabric module on Perlmutter
- moab master -- brings in bug fix related to remapping from cubed-sphere grids to MPAS meshes
- scorpio v1.8.2
 
Drops python 3.9, which has been dropped by conda-forge.

This merge includes various fixes to the Omega CTest utility needed to get it working with the latest Omega/develop.

## Testing

MPAS-Ocean with `pr`:
- [x] chrysalis (@xylar)
  - [x] intel and openmpi
  - [x] gnu and openmpi
- [x] pm-cpu (@xylar)
  - [x] gnu and mpich
  - [x] intel and mpich - still seeing #205 

Omega CTests:
- [x] chrysalis (@xylar)
  - [x] intel
  - [x] gnu
- [x] pm-cpu (@xylar)
  - [x] gnu
  - [x] intel
- [x] pm-gpu (@xylar)
  - [x] gnugpu

## Deploying

MPAS-Ocean with `pr`:
- [x] anvil (@xylar)
  - [x] intel and impi
  - [x] intel and openmpi
  - [x] gnu and openmpi
- [x] chrysalis (@xylar)
  - [x] intel and openmpi
  - [x] gnu and openmpi
- [x] frontier (@xylar)
  - [x] craygnu and mpich
  - [x] craycray and mpich
- [x] pm-cpu (@xylar)
  - [x] gnu and mpich
  - [x] intel and mpich

Omega CTests:
- [x] aurora (@xylar)
  - [x] oneapi-ifx
- [x] chrysalis (@xylar)
  - [x] intel
  - [x] gnu
- [x] frontier (@xylar)
  - [x] craygnu
  - [x] craygnu-mphipcc
  - [x] craycray
  - [x] craycray-mphipcc
  - [x] crayamd
  - [x] crayamd-mphipcc
- [x] pm-cpu (@xylar)
  - [x] gnu
  - [x] intel
- [x] pm-gpu (@xylar)
  - [x] gnugpu
