### PR TITLE
Fix assigning resolution for fixed-res base meshes

### DIFF
--- a/polaris/mesh/base/add.py
+++ b/polaris/mesh/base/add.py
@@ -87,7 +87,7 @@ def add_spherical_base_mesh_step(prefix, min_res, max_res=None):
         'name': name,
         'mesh_name': mesh_name,
     }
-    if prefix in ['Icos', 'QU']:
+    if prefix in ['icos', 'qu']:
         kwargs['cell_width'] = min_res
 
     base_mesh = component.get_or_create_shared_step(**kwargs)


### PR DESCRIPTION
The prefixes in the check need to be lowercase.

Missed in #359.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
