### PR TITLE
Update to v0.9.0-alpha.2 with mpas_tools v1.3.2

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -1,4 +1,4 @@
-name: CI/CD Build Workflow
+name: Build and Test Polaris
 
 on:
   push:
@@ -30,10 +30,10 @@ jobs:
         uses: actions/checkout@v5
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        name: Set up Python 3.10
+        name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         id: file_changes
@@ -51,7 +51,7 @@ jobs:
           extra_args: --files ${{ steps.file_changes.outputs.files}}
 
   build:
-    name: test polaris - python ${{ matrix.python-version }}
+    name: test polaris - py ${{ matrix.python-version }}${{ matrix.env_only && ' (env_only)' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
@@ -60,6 +60,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        env_only: [false]
+        include:
+          - python-version: "3.13"
+            env_only: true
       fail-fast: false
     steps:
       - id: skip_check
@@ -78,10 +82,8 @@ jobs:
           # Increase this value to reset cache if conda-dev-spec.template has not changed in the workflow
           CACHE_NUMBER: 0
         with:
-          path: ~/conda_pkgs_dir_py${{ matrix.python-version }}
-          key:
-            ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('configure_polaris_envs.py,deploy/*') }}
+          path: ~/conda_pkgs_dir_py${{ matrix.python-version }}${{ matrix.env_only && '_envonly' || '' }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}${{ matrix.env_only && '-envonly' || '' }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('configure_polaris_envs.py,deploy/*') }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
@@ -101,16 +103,30 @@ jobs:
         name: Install polaris
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          ./configure_polaris_envs.py \
-            --env_name polaris_test \
-            --verbose \
-            --python=${{ matrix.python-version }}
-          source load_polaris_test_mpich.sh
+          if [ "${{ matrix.env_only }}" = "true" ]; then
+            ./configure_polaris_envs.py \
+              --conda_env_only \
+              --env_name polaris_test \
+              --verbose \
+              --python=${{ matrix.python-version }}
+            source load_polaris_test.sh
+          else
+            ./configure_polaris_envs.py \
+              --env_name polaris_test \
+              --verbose \
+              --python=${{ matrix.python-version }}
+            source load_polaris_test_mpich.sh
+          fi
           python -c "import polaris; import polaris.version; print(polaris.version.__version__)"
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs
         run: |
-          source load_polaris_test_mpich.sh
+          if [ "${{ matrix.env_only }}" = "true" ]; then
+            source load_polaris_test.sh
+          else
+            source load_polaris_test_mpich.sh
+          fi
+          DOCS_VERSION=test
           cd docs
-          DOCS_VERSION=test make versioned-html
+          DOCS_VERSION=$DOCS_VERSION make versioned-html

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -7,6 +7,8 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+
 env:
   PYTHON_VERSION: "3.13"
 
@@ -16,7 +18,7 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -1,4 +1,4 @@
-name: CI/CD Release Workflow
+name: Publish Docs
 
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
         with:

--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -1,5 +1,5 @@
 # Base
-python>=3.10,<=3.13
+python>=3.10,<3.14
 cartopy
 cartopy_offlinedata
 cmocean

--- a/deploy/default.cfg
+++ b/deploy/default.cfg
@@ -23,7 +23,7 @@ mpi = nompi
 geometric_features = 1.6.1
 mache = 1.32.0
 conda_moab = 5.5.1
-mpas_tools = 1.3.0
+mpas_tools = 1.3.2
 otps = 2021.10
 parallelio = 2.6.6
 

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.9.0-alpha.1'
+__version__ = '0.9.0-alpha.2'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR brings in some bug fixes from mpas_tools v1.3.1 and v1.3.2 and, along with it, compatibility with the latest lxml library (needed to get the `--conda_env_only` environment to work). 

This PR also introduces a new test of the `--conda_env_only` environment creation for PRs.  It cleans up CI a bit with some renaming and by updating workflows with a single python version to use 3.13 (instead of 3.10).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
