### PR TITLE
Fix CTest support template and script

### DIFF
--- a/utils/omega/ctest/build_and_ctest.template
+++ b/utils/omega/ctest/build_and_ctest.template
@@ -50,11 +50,9 @@ cmake \
 
 ./omega_build.sh
 
-cd test
-
-ln -sfn {{ omega_mesh_filename }} OmegaMesh.nc
-ln -sfn {{ omega_planar_mesh_filename }} OmegaPlanarMesh.nc
-ln -sfn {{ omega_sphere_mesh_filename }} OmegaSphereMesh.nc
+ln -sfn {{ omega_mesh_filename }} test/OmegaMesh.nc
+ln -sfn {{ omega_planar_mesh_filename }} test/OmegaPlanarMesh.nc
+ln -sfn {{ omega_sphere_mesh_filename }} test/OmegaSphereMesh.nc
 
 {%- if run_ctest %}
 ./omega_ctest.sh

--- a/utils/omega/ctest/omega_ctest.py
+++ b/utils/omega/ctest/omega_ctest.py
@@ -220,6 +220,7 @@ def main():
     if 'SLURM_JOB_ID' in os.environ:
         # already on a comptue node so we will just run ctests directly
         submit = False
+        build_only = False
     else:
         build_only = True
 


### PR DESCRIPTION
* Added build_only = False when SLURM_JOB_ID is set in os.environ within omega_ctest.py
* Updated paths to the mesh NetCDF files in the build/test script template

This PR fixes issues found from running Omega ctest on Chrysalis.
```
changing permissions on downloaded files
100% |#################################################################################| Time:  0:00:00
  done.
Traceback (most recent call last):
  File "/lcrc/group/e3sm/ac.kimy/omega/polaris/utils/omega/ctest/./omega_ctest.py", line 273, in <module>
    main()
    ~~~~^^
  File "/lcrc/group/e3sm/ac.kimy/omega/polaris/utils/omega/ctest/./omega_ctest.py", line 234, in main
    build_only=build_only,
               ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'build_only' where it is not associated with a value
```
and
```
[100%] Linking CXX executable testField.exe
icpc: warning #10237: -lcilkrts linked in dynamically, static library not available
[100%] Built target testField.exe
+ cd test
+ ln -sfn /lcrc/group/e3sm/public_html/polaris/ocean/omega_ctest/ocean.QU.240km.151209.nc OmegaMesh.nc
+ ln -sfn /lcrc/group/e3sm/public_html/polaris/ocean/omega_ctest/PlanarPeriodic48x48.nc OmegaPlanarMesh.nc
+ ln -sfn /lcrc/group/e3sm/public_html/polaris/ocean/omega_ctest/cosine_bell_icos480_initial_state.230220.nc OmegaSphereMesh.nc
+ ./omega_ctest.sh
/lcrc/group/e3sm/ac.kimy/omega/polaris/build_omega/build_and_ctest_omega_chrysalis_intel.sh: line 51: ./omega_ctest.sh: No such file or directory
```
