### PR TITLE
Bump `mosaic` version and tighten planar periodic axis limits

### DIFF
--- a/deploy/conda-dev-spec.template
+++ b/deploy/conda-dev-spec.template
@@ -17,7 +17,7 @@ mache={{ mache }}
 matplotlib-base>=3.9.0
 metis={{ metis }}
 moab={{ moab }}=*_tempest_*
-mosaic>=1.2.0,<2.0.0
+mosaic>=1.2.1,<2.0.0
 mpas_tools={{ mpas_tools }}
 nco
 netcdf4=*=nompi_*

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.9.0-alpha.4'
+__version__ = '0.9.0-alpha.5'

--- a/polaris/viz/planar.py
+++ b/polaris/viz/planar.py
@@ -219,17 +219,14 @@ def plot_horiz_field(  # noqa: C901
     ax.set_xlabel('x (km)')
     ax.set_ylabel('y (km)')
     ax.set_aspect('equal')
-    ax.autoscale(tight=True)
 
-    # uncomment below once mosaic can mirror patches across periodic axis:
-    # --------------------------------------------------------------------
-    # if descriptor.is_periodic:
-    #     if descriptor.x_period and not descriptor.y_period:
-    #         ax.autoscale(axis='y', tight=True)
-    #     elif not descriptor.x_period and descriptor.y_period:
-    #         ax.autoscale(axis='x', tight=True)
-    # else:
-    #     ax.autoscale(axis='both', tight=True)
+    if descriptor.is_periodic:
+        if descriptor.x_period and not descriptor.y_period:
+            ax.autoscale(axis='y', tight=True)
+        elif not descriptor.x_period and descriptor.y_period:
+            ax.autoscale(axis='x', tight=True)
+    else:
+        ax.autoscale(axis='both', tight=True)
 
     # scale ticks to be in kilometers
     ax.xaxis.set_major_formatter(lambda x, pos: f'{x / 1e3:g}')


### PR DESCRIPTION
Bumps `mosaic` version to `1.2.1`, which includes a fix to [E3SM-Project/mosaic/#44](https://github.com/E3SM-Project/mosaic/issues/44). 

Planar periodic mirroring was added to `mosaic` in version `1.2.0` and the norm issue for constant fields ([E3SM-Project/mosaic/#45](https://github.com/E3SM-Project/mosaic/issues/45))  has been fixed  as of `v1.2.1`. **So**, we now use the "tight" axis limits set by `mosaic` for planar periodic meshes. 

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes


<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
