### PR TITLE
Fix suite name during setup

### DIFF
--- a/polaris/suite.py
+++ b/polaris/suite.py
@@ -45,6 +45,7 @@ def setup_suite(
         work_dir=work_dir,
         task_list=tasks,
         cached=cached,
+        suite_name=suite_name,
         **kwargs,
     )
 


### PR DESCRIPTION
The keyword argument is now passed through from the suite to the setup function.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
fixes #414 