### PR TITLE
Write `POLARIS TASK: PASS/FAIL` to task log file

### DIFF
--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -406,6 +406,7 @@ def _log_and_run_task(
             )
 
         status = f'  task execution:   {run_status}'
+        task_logger.info(f'POLARIS TASK: {"PASS" if task_pass else "FAIL"}')
         if task_pass:
             stdout_logger.info(status)
             if baselines_passed is None:
@@ -422,6 +423,10 @@ def _log_and_run_task(
                     success = False
                 status = f'  baseline comp.:   {baseline_str}'
                 stdout_logger.info(status)
+                task_logger.info(
+                    f'POLARIS BASELINE: '
+                    f'{"PASS" if baselines_passed else "FAIL"}'
+                )
 
         else:
             stdout_logger.error(status)


### PR DESCRIPTION
Also write `POLARIS BASELINE: PASS/FAIL` if a baseline comparison is performed.

This should help CDash to be able to determine pass/fail more robustly.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
