### PR TITLE
Fix baseline comparison for tasks that have already run 

### DIFF
--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -447,6 +447,38 @@ def _log_and_run_task(
     return result_str, success, task_time, exec_failed, diff_failed
 
 
+def _read_baseline_status_from_logs(step_work_dir: str) -> Optional[bool]:
+    """Get baseline comparison status from existing log markers.
+
+    Returns
+    -------
+    Optional[bool]
+        True if ``baseline_passed.log`` exists, False if
+        ``baseline_failed.log`` exists, otherwise None.
+    """
+    baseline_pass_filename = os.path.join(step_work_dir, 'baseline_passed.log')
+    baseline_fail_filename = os.path.join(step_work_dir, 'baseline_failed.log')
+
+    if os.path.exists(baseline_pass_filename):
+        return True
+    if os.path.exists(baseline_fail_filename):
+        return False
+    return None
+
+
+def _accumulate_baselines(
+    baselines_passed: Optional[bool], status: bool
+) -> Optional[bool]:
+    """Aggregate baseline results across steps.
+
+    None means no baseline comparisons were performed. If any comparison fails,
+    the aggregate becomes False.
+    """
+    if baselines_passed is None:
+        return status
+    return baselines_passed and status
+
+
 def _run_task(task, available_resources):
     """
     Run each step of the task
@@ -465,36 +497,20 @@ def _run_task(task, available_resources):
         if os.path.exists(complete_filename):
             _print_to_stdout(task, '          already completed')
             # print results of baseline comparison if it was done
-            baseline_pass_filename = os.path.join(
-                step.work_dir, 'baseline_passed.log'
-            )
-            baseline_fail_filename = os.path.join(
-                step.work_dir, 'baseline_failed.log'
-            )
-
-            baseline_status = None
-            if os.path.exists(baseline_pass_filename):
-                baseline_str = pass_str
-                baseline_status = True
-            elif os.path.exists(baseline_fail_filename):
-                baseline_str = fail_str
-                baseline_status = False
-            else:
-                baseline_str = None
-
-            if baseline_str is not None:
+            baseline_status = _read_baseline_status_from_logs(step.work_dir)
+            if baseline_status is not None:
+                baseline_str = pass_str if baseline_status else fail_str
                 _print_to_stdout(
                     task, f'          baseline comp.:   {baseline_str}'
                 )
-
-            if baseline_status is not None:
-                if baselines_passed is None:
-                    baselines_passed = baseline_status
-                elif not baseline_status:
-                    baselines_passed = False
+                baselines_passed = _accumulate_baselines(
+                    baselines_passed, baseline_status
+                )
             continue
         if step.cached:
             _print_to_stdout(task, '          cached')
+            # cached steps never perform baseline comparisons; leave
+            # baselines_passed unchanged
             continue
 
         step_start = time.time()
@@ -519,8 +535,11 @@ def _run_task(task, available_resources):
         except Exception:
             _print_to_stdout(task, f'          execution:        {error_str}')
             raise
+        finally:
+            # Always restore the working directory, even if a step fails.
+            os.chdir(cwd)
+
         _print_to_stdout(task, f'          execution:        {success_str}')
-        os.chdir(cwd)
         step_time = time.time() - step_start
         step_time_str = str(timedelta(seconds=round(step_time)))
 
@@ -533,10 +552,7 @@ def _run_task(task, available_resources):
             _print_to_stdout(
                 task, f'          baseline comp.:   {baseline_str}'
             )
-            if baselines_passed is None:
-                baselines_passed = status
-            elif not status:
-                baselines_passed = False
+            baselines_passed = _accumulate_baselines(baselines_passed, status)
 
         _print_to_stdout(
             task,


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
The baseline comparison now passes only if all steps' baseline comparison passes and fails if any step's baseline comparison fails.  (It is only skipped if no step have a baseline comparison.)

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #433 