### PR TITLE
Add support for Omega's `PseudoThickness` variable

### DIFF
--- a/polaris/component.py
+++ b/polaris/component.py
@@ -265,7 +265,7 @@ class Component:
         self.add_step(step)
         return step
 
-    def open_model_dataset(self, filename, **kwargs):
+    def open_model_dataset(self, filename, config, **kwargs):
         """
         Open the given dataset, mapping variable and dimension names from Omega
         to MPAS-Ocean names if appropriate
@@ -274,6 +274,11 @@ class Component:
         ----------
         filename : str
             The path for the NetCDF file to open
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; passed to model-specific subclasses
+            that need it (e.g. to compute layer thickness from pseudo-thickness
+            for Omega). The base implementation ignores it.
 
         kwargs
             keyword arguments passed to `xarray.open_dataset()`
@@ -286,7 +291,7 @@ class Component:
         ds = xr.open_dataset(filename, **kwargs)
         return ds
 
-    def write_model_dataset(self, ds, filename):
+    def write_model_dataset(self, ds, filename, config):
         """
         Write out the given dataset, mapping dimension and variable names from
         MPAS-Ocean to Omega names if appropriate
@@ -298,6 +303,11 @@ class Component:
 
         filename : str
             The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; passed to model-specific subclasses
+            that need it (e.g. to convert layer thickness to pseudo-thickness
+            for Omega). The base implementation ignores it.
         """
         write_netcdf(ds=ds, fileName=filename)
 

--- a/polaris/ocean/conservation.py
+++ b/polaris/ocean/conservation.py
@@ -11,7 +11,7 @@ def compute_total_mass(ds_mesh, ds):
     """
     ds = _reduce_dataset_time_dim(ds)
     area_cell = ds_mesh.areaCell
-    layer_thickness = ds.layerThickness
+    layer_thickness = _get_layer_thickness(ds)
     total_mass = rho_sw * (
         area_cell * layer_thickness.sum(dim='nVertLevels')
     ).sum(dim='nCells')
@@ -20,11 +20,11 @@ def compute_total_mass(ds_mesh, ds):
 
 def compute_total_energy(ds_mesh, ds):
     """
-    Compute the total heat content an ocean model output file
+    Compute the total heat content in an ocean model output file
     """
     ds = _reduce_dataset_time_dim(ds)
     area_cell = ds_mesh.areaCell
-    layer_thickness = ds.layerThickness
+    layer_thickness = _get_layer_thickness(ds)
     temperature = ds.temperature
     total_energy = (
         rho_sw
@@ -42,7 +42,7 @@ def compute_total_tracer(ds_mesh, ds, tracer_name='tracer1'):
     """
     ds = _reduce_dataset_time_dim(ds)
     area_cell = ds_mesh.areaCell
-    layer_thickness = ds.layerThickness
+    layer_thickness = _get_layer_thickness(ds)
     tracer = ds[tracer_name]
     total_tracer = (
         area_cell * (layer_thickness * tracer).sum(dim='nVertLevels')
@@ -68,3 +68,15 @@ def _reduce_dataset_time_dim(ds):
             else:
                 ds = ds.isel(time_dim=0)
     return ds
+
+
+def _get_layer_thickness(ds):
+    if 'PseudoThickness' in ds:
+        return ds.PseudoThickness
+    elif 'layerThickness' in ds:
+        return ds.layerThickness
+    else:
+        raise ValueError(
+            'compute_total_energy requires either PseudoThickness or '
+            'layerThickness to be present in the dataset'
+        )

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -365,8 +365,10 @@ class ConvergenceAnalysis(OceanIOStep):
             The error of the variable given by variable_name
         """
         norm_type = {'l2': None, 'inf': np.inf}
-        ds_mesh = self.open_model_dataset(f'mesh_r{refinement_factor:02g}.nc')
         config = self.config
+        ds_mesh = self.open_model_dataset(
+            f'mesh_r{refinement_factor:02g}.nc', config
+        )
         section = config['convergence']
         eval_time = section.getfloat('convergence_eval_time')
         s_per_hour = 3600.0

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -37,7 +37,7 @@ variables:
   tracer3: Debug3
 
   # state
-  layerThickness: LayerThickness
+  layerThickness: GeomLayerThickness
   normalVelocity: NormalVelocity
 
   vertVelocityTop: VerticalVelocity
@@ -47,6 +47,12 @@ variables:
   windStressZonal: WindStressZonal
   windStressMeridional: WindStressMeridional
   relativeVorticity: RelVortVertex
+
+  # vertical coordinate
+  zMid: GeomZMid
+  zInterface: GeomZInterface
+  pressure: PressureMid
+
 
 config:
 - section:

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -25,8 +25,7 @@ variables:
   # vertical coordinate
   minLevelCell: MinLayerCell
   maxLevelCell: MaxLayerCell
-  # currently hard-coded in horizontal mesh
-  # bottomDepth: BottomDepth
+  bottomDepth: BottomGeomDepth
   vertCoordMovementWeights: VertCoordMovementWeights
 
   # tracers

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -39,7 +39,8 @@ variables:
   # Note: layerThickness in MPAS-Ocean has no Omega equivalent and
   #       PseudoThickness in Omega has no MPAS-Ocean equivalent
   normalVelocity: NormalVelocity
-  vertVelocityTop: VerticalPseudoVelocity
+  # Note: vertVelocityTop in MPAS-Ocean has no Omega equivalent and
+  #       VerticalPseudoVelocity in Omega has no MPAS-Ocean equivalent
 
   # auxiliary state
   ssh: SshCell

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -39,7 +39,7 @@ variables:
   layerThickness: GeomLayerThickness
   normalVelocity: NormalVelocity
 
-  vertVelocityTop: VerticalVelocity
+  vertVelocityTop: VerticalPseudoVelocity
 
   # auxiliary state
   ssh: SshCell

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -36,9 +36,9 @@ variables:
   tracer3: Debug3
 
   # state
-  layerThickness: GeomLayerThickness
+  # Note: layerThickness in MPAS-Ocean has no Omega equivalent and
+  #       PseudoThickness in Omega has no MPAS-Ocean equivalent
   normalVelocity: NormalVelocity
-
   vertVelocityTop: VerticalPseudoVelocity
 
   # auxiliary state

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -32,7 +32,7 @@ class OceanIOStep(Step):
         """
         return self.component.map_to_native_model_vars(ds)
 
-    def write_model_dataset(self, ds, filename, config=None):
+    def write_model_dataset(self, ds, filename, config):
         """
         Write out the given dataset, mapping dimension and variable names from
         MPAS-Ocean to Omega names if appropriate
@@ -44,6 +44,9 @@ class OceanIOStep(Step):
 
         filename : str
             The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; forwarded to the Ocean component.
         """
         self.component.write_model_dataset(ds, filename, config=config)
 
@@ -65,7 +68,7 @@ class OceanIOStep(Step):
         """
         return self.component.map_from_native_model_vars(ds)
 
-    def open_model_dataset(self, filename, config=None, **kwargs):
+    def open_model_dataset(self, filename, config, **kwargs):
         """
         Open the given dataset, mapping variable and dimension names from Omega
         to MPAS-Ocean names if appropriate
@@ -74,6 +77,9 @@ class OceanIOStep(Step):
         ----------
         filename : str
             The path for the NetCDF file to open
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; forwarded to the Ocean component.
 
         kwargs
             keyword arguments passed to `xarray.open_dataset()`

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -9,7 +9,6 @@ from polaris.model_step import ModelStep
 from polaris.ocean.conservation import (
     compute_total_energy,
     compute_total_mass,
-    # compute_total_mass_nonboussinesq, # Add when Omega EOS is used
     compute_total_salt,
     compute_total_tracer,
 )
@@ -457,12 +456,6 @@ class OceanModelStep(ModelStep):
                     tol = self.config.getfloat(
                         'ocean', 'mass_conservation_tolerance'
                     )
-                    # Add when Omega EOS is used
-                    # if self.config.get('ocean', 'model') == 'omega':
-                    # relative_error  = self._compute_rel_err(
-                    #    compute_total_mass_nonboussinesq, ds_mesh, ds
-                    # )
-                    # else:
                     relative_error = self._compute_rel_err(
                         compute_total_mass, ds_mesh=ds_mesh, ds=ds
                     )

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -431,8 +431,10 @@ class OceanModelStep(ModelStep):
             filename = str(filename)
             mesh_filename = os.path.join(self.work_dir, 'mesh.nc')
             this_filename = os.path.join(self.work_dir, filename)
-            ds_mesh = self.component.open_model_dataset(mesh_filename)
-            ds = self.component.open_model_dataset(this_filename)
+            ds_mesh = self.component.open_model_dataset(
+                mesh_filename, self.config
+            )
+            ds = self.component.open_model_dataset(this_filename, self.config)
             if 'tracer conservation' in properties:
                 # All tracers in mpaso_to_omega.yaml
                 tracers_to_check = [

--- a/polaris/ocean/vertical/__init__.py
+++ b/polaris/ocean/vertical/__init__.py
@@ -85,10 +85,15 @@ def init_vertical_coord(config, ds):
 
     if coord_type == 'z-level':
         init_z_level_vertical_coord(config, ds)
-    elif coord_type == 'z-star' or coord_type == 'z-tilde':
+    elif coord_type == 'z-star':
         init_z_star_vertical_coord(config, ds)
     elif coord_type == 'sigma':
         init_sigma_vertical_coord(config, ds)
+    elif coord_type == 'z-tilde':
+        raise ValueError(
+            'z-tilde coordinate requires calling '
+            'init_z_tilde_vertical_coord() directly.'
+        )
     elif coord_type == 'haney-number':
         raise ValueError('Haney Number coordinate not yet supported.')
     else:

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -41,8 +41,8 @@ def geom_thickness_from_ds(ds, config):
     else:
         raise ValueError(
             'Geometric layerThickness is not present in the '
-            'initial condition and SpecVol is not present '
-            'to compute it'
+            'initial condition and PseudoThickness and SpecVol are not '
+            'present to compute it'
         )
 
 

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -3,6 +3,7 @@ import xarray as xr
 
 from polaris.constants import get_constant
 from polaris.ocean.vertical.ztilde import (
+    get_iter_count_for_eos,
     pressure_and_spec_vol_from_state_at_geom_height,
     pseudothickness_from_pressure,
 )
@@ -90,15 +91,7 @@ def pseudothickness_from_ds(
         return None, None
 
     if iter_count is None:
-        eos_type = config.get('ocean', 'eos_type')
-        if eos_type in ['constant', 'linear']:
-            iter_count = 1
-        elif eos_type == 'teos-10':
-            iter_count = config.getint(
-                'vertical_grid', 'pseudothickness_iter_count'
-            )
-        else:
-            raise ValueError(f'Unsupported equation of state type: {eos_type}')
+        iter_count = get_iter_count_for_eos(config)
 
     surface_pressure = config.getfloat('vertical_grid', 'surface_pressure')
     p_interface, _, spec_vol = pressure_and_spec_vol_from_state_at_geom_height(

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -94,9 +94,13 @@ def pseudothickness_from_ds(
         iter_count = get_iter_count_for_eos(config)
 
     surface_pressure = config.getfloat('vertical_grid', 'surface_pressure')
+    src_var = ds[src_var_name]
+    src_has_time = 'Time' in src_var.dims
+    if not src_has_time:
+        src_var = src_var.expand_dims(dim='Time', axis=0)
     p_interface, _, spec_vol = pressure_and_spec_vol_from_state_at_geom_height(
         config,
-        ds[src_var_name],
+        src_var,
         ds.temperature,
         ds.salinity,
         surface_pressure * xr.ones_like(ds.ssh),
@@ -104,6 +108,10 @@ def pseudothickness_from_ds(
     )
 
     pseudothickness = pseudothickness_from_pressure(p_interface)
+
+    if not src_has_time:
+        pseudothickness = pseudothickness.squeeze(dim='Time')
+        spec_vol = spec_vol.squeeze(dim='Time')
 
     return pseudothickness, spec_vol
 

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -347,3 +347,27 @@ def geom_height_from_pseudo_height(
     geom_z_mid = geom_z_mid.transpose(*z_mid_dims)
 
     return geom_z_inter, geom_z_mid
+
+
+def get_iter_count_for_eos(config: PolarisConfigParser) -> int:
+    """
+    Get the number of iterations to perform when adjusting the
+    pseudo-bottom-depth to hit the right geometric bottom depth.  Default is
+    from the `pseudothickness_iter_count` config option for TEOS-10 and 1 for
+    other equations of state.
+
+    Parameters
+    ----------
+    config : polaris.config.PolarisConfigParser
+        Configuration options with parameters defining the equation of state.
+
+    Returns
+    -------
+    int
+        The number of iterations to perform.
+    """
+    eos_type = config.get('ocean', 'eos_type')
+    if eos_type == 'teos-10':
+        return config.getint('vertical_grid', 'pseudothickness_iter_count')
+    else:
+        return 1

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -447,6 +447,16 @@ def init_z_tilde_vertical_coord(config, ds):
         config, pseudo_column_thickness, ref_pseudo_depth_bot, max_level_cell
     )
 
+    # Recompute pseudo_bottom_depth from the adjusted column thickness so
+    # ZTildeInterface is anchored at the correct (post-snap) pseudo-height, and
+    # update BottomPressure so downstream callers see the effective value.
+    pseudo_bottom_depth = (
+        ds.SurfacePressure / (RhoSw * Gravity) + pseudo_column_thickness
+    )
+    ds['BottomPressure'] = ds.SurfacePressure + pseudo_column_thickness * (
+        RhoSw * Gravity
+    )
+
     pseudo_thickness = _compute_pseudo_thickness(
         ref_pseudo_depth_top,
         ref_pseudo_depth_bot,

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -230,7 +230,6 @@ def pressure_and_spec_vol_from_state_at_geom_height(
     spec_vol : xarray.DataArray
         The specific volume at layer midpoints.
     """
-
     spec_vol = 1.0 / RhoSw * xr.ones_like(geom_layer_thickness)
 
     p_interface, p_mid = pressure_from_geom_thickness(
@@ -462,12 +461,13 @@ def init_z_tilde_vertical_coord(config, ds):
     )
     ds['cellMask'] = cell_mask
 
-    # mask layerThickness and restingThickness
-    ds['PseudoThickness'] = pseudo_thickness.where(cell_mask)
-    ds['RefPseudoThickness'] = ds.PseudoThickness.copy()
+    pseudo_thickness = pseudo_thickness.where(cell_mask)
+    ds['RefPseudoThickness'] = pseudo_thickness.copy()
 
-    # add Time dimension
-    ds['PseudoThickness'] = ds.PseudoThickness.expand_dims(dim='Time', axis=0)
+    pseudo_thickness = pseudo_thickness.expand_dims(dim='Time', axis=0)
+
+    # add Time dimension to PseudoThickness but not RefPseudoThickness
+    ds['PseudoThickness'] = pseudo_thickness
 
     ds['ZTildeInterface'], ds['ZTildeMid'] = (
         compute_zint_zmid_from_layer_thickness(

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -510,7 +510,7 @@ def _compute_min_max_level_cell(
     ).transpose('nCells', 'nVertLevels')
     cell_mask = np.logical_and(above_bot_mask, valid)
 
-    # nonzero top index isn't supporeted at least for now
+    # nonzero top index isn't supported at least for now
     min_level_cell = xr.zeros_like(pseudo_column_thickness).astype(int)
     max_level_cell = (cell_mask.sum(dim='nVertLevels') - 1).where(valid, 0)
     max_level_cell = np.maximum(

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -17,6 +17,8 @@ import xarray as xr
 from polaris.config import PolarisConfigParser
 from polaris.constants import get_constant
 from polaris.ocean.eos import compute_specvol
+from polaris.ocean.vertical import compute_zint_zmid_from_layer_thickness
+from polaris.ocean.vertical.grid_1d import generate_1d_grid
 
 __all__ = [
     'z_tilde_from_pressure',
@@ -371,3 +373,258 @@ def get_iter_count_for_eos(config: PolarisConfigParser) -> int:
         return config.getint('vertical_grid', 'pseudothickness_iter_count')
     else:
         return 1
+
+
+def init_z_tilde_vertical_coord(config, ds):
+    """
+    Create a z-tilde vertical coordinate based on the config options in the
+    ``vertical_grid`` section and the ``BottomPressure`` and
+    ``SurfacePressure`` variables of the mesh data set.
+
+    The following new variables will be added to the data set:
+
+      * ``minLevelCell`` - the index of the top valid layer
+
+      * ``maxLevelCell`` - the index of the bottom valid layer
+
+      * ``cellMask`` - a mask of where cells are valid
+
+      * ``PseudoThickness`` - the pseudo-thickness of each layer
+
+      * ``RefPseudoThickness`` - the same as pseudo-thickness, used for the
+        p* vertical coordinate
+
+      * ``zTildeMid`` - the pseudo height of the midpoint of each layer
+
+      * ``zTildeInterface`` - the pseudo height of the interfaces between
+        layers
+
+      * ``vertCoordMovementWeights`` - the weights (all ones) for coordinate
+        movement
+
+    Note: since bottom pressure is typically not known at initialization, the
+    calling code will likely need to iteratively adjust the bottom pressure
+    to obtain the desire geometric bottom depth.
+
+    Parameters
+    ----------
+    config : polaris.config.PolarisConfigParser
+        Configuration options with parameters used to construct the vertical
+        grid
+
+    ds : xarray.Dataset
+        A data set containing ``bottomDepth`` and ``SurfacePressure`` variables
+        used to construct the vertical coordinate
+    """
+
+    interfaces = generate_1d_grid(config=config)
+    ref_pseudo_depth_top = xr.DataArray(interfaces[:-1], dims=['nVertLevels'])
+    ref_pseudo_depth_bot = xr.DataArray(interfaces[1:], dims=['nVertLevels'])
+
+    ds['vertCoordMovementWeights'] = xr.ones_like(ref_pseudo_depth_bot)
+
+    min_vert_levels = config.getint('vertical_grid', 'min_vert_levels')
+    min_layer_thickness = config.getfloat(
+        'vertical_grid', 'min_layer_thickness'
+    )
+
+    pseudo_bottom_depth = ds.BottomPressure / (RhoSw * Gravity)
+
+    pseudo_column_thickness = (ds.BottomPressure - ds.SurfacePressure) / (
+        RhoSw * Gravity
+    )
+
+    if 'Time' in pseudo_column_thickness.dims:
+        pseudo_column_thickness = pseudo_column_thickness.isel(Time=0)
+
+    min_level_cell, max_level_cell = _compute_min_max_level_cell(
+        ref_pseudo_depth_top,
+        pseudo_column_thickness,
+        min_vert_levels,
+        min_layer_thickness,
+    )
+
+    pseudo_column_thickness, max_level_cell = _alter_pseudo_column_thickness(
+        config, pseudo_column_thickness, ref_pseudo_depth_bot, max_level_cell
+    )
+
+    pseudo_thickness = _compute_pseudo_thickness(
+        ref_pseudo_depth_top,
+        ref_pseudo_depth_bot,
+        pseudo_column_thickness,
+        min_level_cell,
+        max_level_cell,
+    )
+
+    # recompute the cell mask since min/max indices may have changed
+    cell_mask = _compute_cell_mask(
+        min_level_cell, max_level_cell, ds.sizes['nVertLevels']
+    )
+    ds['cellMask'] = cell_mask
+
+    # mask layerThickness and restingThickness
+    ds['PseudoThickness'] = pseudo_thickness.where(cell_mask)
+    ds['RefPseudoThickness'] = ds.PseudoThickness.copy()
+
+    # add Time dimension
+    ds['PseudoThickness'] = ds.PseudoThickness.expand_dims(dim='Time', axis=0)
+
+    ds['ZTildeInterface'], ds['ZTildeMid'] = (
+        compute_zint_zmid_from_layer_thickness(
+            layer_thickness=pseudo_thickness,
+            bottom_depth=pseudo_bottom_depth,
+            min_level_cell=min_level_cell,
+            max_level_cell=max_level_cell,
+        )
+    )
+
+    # fortran 1-based indexing
+    ds['minLevelCell'] = min_level_cell + 1
+    ds['maxLevelCell'] = max_level_cell + 1
+
+
+def _compute_min_max_level_cell(
+    ref_pseudo_depth_top,
+    pseudo_column_thickness,
+    min_vert_levels,
+    min_layer_thickness,
+):
+    """
+    Compute ``minLevelCell`` and ``maxLevelCell`` indices as well as a cell
+    mask for the given reference grid and bottom topography.
+    """
+    valid = pseudo_column_thickness >= min_layer_thickness * min_vert_levels
+
+    above_bot_mask = (
+        ref_pseudo_depth_top < pseudo_column_thickness
+    ).transpose('nCells', 'nVertLevels')
+    cell_mask = np.logical_and(above_bot_mask, valid)
+
+    # nonzero top index isn't supporeted at least for now
+    min_level_cell = xr.zeros_like(pseudo_column_thickness).astype(int)
+    max_level_cell = (cell_mask.sum(dim='nVertLevels') - 1).where(valid, 0)
+    max_level_cell = np.maximum(
+        max_level_cell, min_level_cell + min_vert_levels - 1
+    )
+
+    return min_level_cell, max_level_cell
+
+
+def _compute_cell_mask(min_level_cell, max_level_cell, n_vert_levels):
+    z_index = xr.DataArray(np.arange(n_vert_levels), dims=['nVertLevels'])
+    return np.logical_and(
+        z_index >= min_level_cell, z_index <= max_level_cell
+    ).transpose('nCells', 'nVertLevels')
+
+
+def _alter_pseudo_column_thickness(
+    config, pseudo_column_thickness, ref_pseudo_depth_bot, max_level_cell
+):
+    """
+    Alter ``pseudo_column_thickness`` and ``max_level_cell`` for full or
+    partial bottom cells, if requested
+    """
+    section = config['vertical_grid']
+    partial_cell_type = 'none'
+    min_pc_fraction = 0.0
+    if config.has_option('vertical_grid', 'partial_cell_type'):
+        partial_cell_type = section.get('partial_cell_type').lower()
+        min_pc_fraction = section.getfloat('min_pc_fraction')
+
+    if partial_cell_type == 'full':
+        pseudo_column_thickness = _compute_full_cells_pseudo_depth(
+            ref_pseudo_depth_bot, max_level_cell
+        )
+    elif partial_cell_type == 'partial':
+        pseudo_column_thickness, max_level_cell = (
+            _alter_pseudo_column_thickness_for_partial_cells(
+                pseudo_column_thickness,
+                ref_pseudo_depth_bot,
+                max_level_cell,
+                min_pc_fraction,
+            )
+        )
+    elif partial_cell_type != 'none':
+        raise ValueError(f'Unexpected partial cell type {partial_cell_type}')
+
+    return pseudo_column_thickness, max_level_cell
+
+
+def _compute_full_cells_pseudo_depth(ref_pseudo_depth_bot, level_index):
+    """
+    Compute the full cell bottom depth given a level index
+    """
+
+    pseudo_depth = ref_pseudo_depth_bot.isel(nVertLevels=level_index).where(
+        level_index >= 0, other=0.0
+    )
+    return pseudo_depth
+
+
+def _alter_pseudo_column_thickness_for_partial_cells(
+    pseudo_column_thickness,
+    ref_pseudo_depth_bot,
+    max_level_cell,
+    min_pc_fraction,
+):
+    """
+    Alter pseudo_column_thickness and max_level_cell for partial cells
+    """
+
+    full_bot = _compute_full_cells_pseudo_depth(
+        ref_pseudo_depth_bot, max_level_cell
+    )
+
+    full_top = _compute_full_cells_pseudo_depth(
+        ref_pseudo_depth_bot, max_level_cell - 1
+    )
+
+    full_thickness = full_bot - full_top
+
+    pseudo_depth_min_bot = full_bot - (1.0 - min_pc_fraction) * full_thickness
+
+    pseudo_depth_min_bot_mid = 0.5 * (pseudo_depth_min_bot + full_top)
+
+    # where the bottom depth is far too shallow, we're going to fill in the
+    # last level
+    mask = pseudo_column_thickness < pseudo_depth_min_bot_mid
+    max_level_cell = xr.where(mask, max_level_cell - 1, max_level_cell)
+    pseudo_column_thickness = xr.where(mask, full_top, pseudo_column_thickness)
+
+    # where the bottom depth only a bit too shallows, we move it deeper
+    mask = np.logical_and(
+        np.logical_not(mask), pseudo_column_thickness < pseudo_depth_min_bot
+    )
+    pseudo_column_thickness = xr.where(
+        mask, pseudo_depth_min_bot, pseudo_column_thickness
+    )
+
+    return pseudo_column_thickness, max_level_cell
+
+
+def _compute_pseudo_thickness(
+    ref_pseudo_depth_top,
+    ref_pseudo_depth_bot,
+    pseudo_column_thickness,
+    min_level_cell,
+    max_level_cell,
+):
+    """
+    Compute z-tilde layer thickness by stretching restingThickness based on
+    pseudo_column_thickness
+    """
+
+    n_vert_levels = ref_pseudo_depth_bot.sizes['nVertLevels']
+    z_index = xr.DataArray(np.arange(n_vert_levels), dims=['nVertLevels'])
+    mask = np.logical_and(
+        z_index >= min_level_cell, z_index <= max_level_cell
+    ).transpose('nCells', 'nVertLevels')
+
+    pseudo_depth_bot = np.minimum(
+        pseudo_column_thickness, ref_pseudo_depth_bot
+    )
+    pseudo_thickness = (pseudo_depth_bot - ref_pseudo_depth_top).transpose(
+        'nCells', 'nVertLevels'
+    )
+
+    return pseudo_thickness.where(mask, 0.0)

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -653,6 +653,7 @@ class Step:
                     this_filename,
                     baseline_filename,
                     logger=logger,
+                    config=self.config,
                 )
                 success = success and result
                 compared = True

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -187,7 +187,6 @@ class Ocean(Component):
                         ds[omega_var] = pseudothickness
                         if mpas_var == 'layerThickness':
                             ds['SpecVol'] = spec_vol
-                            ds['layerThickness'] = ds['PseudoThickness'].copy()
 
         # After map_to_native_model_vars, the dataset contains
         # LayerThickness and PseudoThickness which are both
@@ -303,13 +302,14 @@ class Ocean(Component):
         ds = xr.open_dataset(filename, **kwargs)
         if (
             self.model == 'omega'
-            and 'LayerThickness' in ds.keys()
+            and 'GeomLayerThickness' not in ds.keys()
+            and 'PseudoThickness' in ds.keys()
             and 'SpecVol' in ds.keys()
             and config is not None
         ):
-            # Omega's LayerThickness is actually pseudo-thickness
-            ds['PseudoThickness'] = ds.LayerThickness
-            ds['LayerThickness'] = geom_thickness_from_ds(ds, config=config)
+            ds['GeomLayerThickness'] = geom_thickness_from_ds(
+                ds, config=config
+            )
         ds = self.map_from_native_model_vars(ds)
         ds = _add_reconstructed_variables_to_dataset(
             ds, reconstruct_variables, mesh_filename, coeffs_filename

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -302,14 +302,12 @@ class Ocean(Component):
         ds = xr.open_dataset(filename, **kwargs)
         if (
             self.model == 'omega'
-            and 'GeomLayerThickness' not in ds.keys()
+            and 'layerThickness' not in ds.keys()
             and 'PseudoThickness' in ds.keys()
             and 'SpecVol' in ds.keys()
             and config is not None
         ):
-            ds['GeomLayerThickness'] = geom_thickness_from_ds(
-                ds, config=config
-            )
+            ds['layerThickness'] = geom_thickness_from_ds(ds, config=config)
         ds = self.map_from_native_model_vars(ds)
         ds = _add_reconstructed_variables_to_dataset(
             ds, reconstruct_variables, mesh_filename, coeffs_filename

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -159,7 +159,7 @@ class Ocean(Component):
             ]
         return renamed_vars
 
-    def write_model_dataset(self, ds, filename, config=None):
+    def write_model_dataset(self, ds, filename, config):
         """
         Write out the given dataset, mapping dimension and variable names from
         MPAS-Ocean to Omega names if appropriate
@@ -171,8 +171,13 @@ class Ocean(Component):
 
         filename : str
             The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; used when the model is Omega to
+            convert geometric layer thickness to pseudo-thickness before
+            writing.
         """
-        if self.model == 'omega' and config is not None:
+        if self.model == 'omega':
             # fields to be converted from geometric to pseudo thickness
             mpas_to_omega_vars = {
                 'layerThickness': 'PseudoThickness',
@@ -261,7 +266,7 @@ class Ocean(Component):
     def open_model_dataset(
         self,
         filename,
-        config=None,
+        config,
         mesh_filename=None,
         reconstruct_variables=None,
         coeffs_filename=None,
@@ -276,17 +281,15 @@ class Ocean(Component):
         filename : str
             The path for the NetCDF file to open
 
-        config : polaris.Config, optional
-            The configuration object for the simulation.
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; used when the model is Omega to
+            compute geometric layer thickness from pseudo-thickness.
 
         mesh_filename : str, optional
             Path to the mesh NetCDF file.
 
         reconstruct_variables : list of str, optional
             List of variable names to reconstruct in the dataset.
-
-        coeffs_reconstruct : xarray.DataArray, optional
-            Coefficients used for reconstructing variables.
 
         coeffs_filename : str, optional
             Path to the coefficients NetCDF file.
@@ -305,7 +308,6 @@ class Ocean(Component):
             and 'layerThickness' not in ds.keys()
             and 'PseudoThickness' in ds.keys()
             and 'SpecVol' in ds.keys()
-            and config is not None
         ):
             ds['layerThickness'] = geom_thickness_from_ds(ds, config=config)
         ds = self.map_from_native_model_vars(ds)

--- a/polaris/tasks/ocean/baroclinic_channel/validate.py
+++ b/polaris/tasks/ocean/baroclinic_channel/validate.py
@@ -55,6 +55,7 @@ class Validate(Step):
             filename1=self.inputs[0],
             filename2=self.inputs[1],
             logger=self.logger,
+            config=self.config,
         )
         if not all_pass:
             raise ValueError(

--- a/polaris/tasks/ocean/barotropic_channel/init.py
+++ b/polaris/tasks/ocean/barotropic_channel/init.py
@@ -114,4 +114,4 @@ class Init(OceanIOStep):
         ds_forcing['windStressMeridional'] = (
             wind_stress_meridional.expand_dims(dim='Time', axis=0)
         )
-        self.write_model_dataset(ds_forcing, 'forcing.nc')
+        self.write_model_dataset(ds_forcing, 'forcing.nc', config)

--- a/polaris/tasks/ocean/barotropic_channel/viz.py
+++ b/polaris/tasks/ocean/barotropic_channel/viz.py
@@ -39,7 +39,7 @@ class Viz(OceanIOStep):
         """
         Run this step of the task
         """
-        ds_mesh = self.open_model_dataset('mesh.nc')
+        ds_mesh = self.open_model_dataset('mesh.nc', self.config)
         ds_init = self.open_model_dataset('init.nc', self.config)
         ds_out = self.open_model_dataset('output.nc', self.config)
 

--- a/polaris/tasks/ocean/barotropic_gyre/analysis.py
+++ b/polaris/tasks/ocean/barotropic_gyre/analysis.py
@@ -62,9 +62,9 @@ class Analysis(OceanIOStep):
 
     def run(self):
         logger = self.logger
-        ds_mesh = self.open_model_dataset('mesh.nc')
-        ds_init = self.open_model_dataset('init.nc')
-        ds = self.open_model_dataset('output.nc')
+        ds_mesh = self.open_model_dataset('mesh.nc', self.config)
+        ds_init = self.open_model_dataset('init.nc', self.config)
+        ds = self.open_model_dataset('output.nc', self.config)
 
         field_mpas = compute_barotropic_streamfunction(
             ds_init.isel(Time=0), ds, prefix='', time_index=-1

--- a/polaris/tasks/ocean/barotropic_gyre/init.py
+++ b/polaris/tasks/ocean/barotropic_gyre/init.py
@@ -81,13 +81,13 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=True, nonperiodic_y=True
         )
-        self.write_model_dataset(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         # vertical coordinate parameters
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')

--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -98,6 +98,6 @@ Omega:
       FileFreqUnits: years
       Contents:
         - Tracers
-        - LayerThickness
+        - PseudoThickness
         - NormalVelocity
         - Eos

--- a/polaris/tasks/ocean/cosine_bell/validate.py
+++ b/polaris/tasks/ocean/cosine_bell/validate.py
@@ -67,6 +67,7 @@ class Validate(OceanIOStep):
                 filename1=filename1,
                 filename2=filename2,
                 logger=logger,
+                config=self.config,
                 ds1=ds1,
                 ds2=ds2,
             )

--- a/polaris/tasks/ocean/cosine_bell/viz.py
+++ b/polaris/tasks/ocean/cosine_bell/viz.py
@@ -81,7 +81,7 @@ class Viz(OceanIOStep):
             central_longitude=180.0,
         )
 
-        ds_out = self.open_model_dataset('output.nc')
+        ds_out = self.open_model_dataset('output.nc', config)
         da = ds_out['tracer1'].isel(Time=-1, nVertLevels=0)
 
         plot_global_mpas_field(

--- a/polaris/tasks/ocean/customizable_viz/viz_horiz_field.py
+++ b/polaris/tasks/ocean/customizable_viz/viz_horiz_field.py
@@ -72,7 +72,7 @@ class VizHorizField(OceanIOStep):
         descriptor = None
 
         ds_mesh = self.open_model_dataset(
-            self.mesh_file, decode_timedelta=False
+            self.mesh_file, self.config, decode_timedelta=False
         )
         min_latitude = section.getfloat('min_latitude')
         max_latitude = section.getfloat('max_latitude')
@@ -138,7 +138,9 @@ class VizHorizField(OceanIOStep):
             else:
                 z_index = 0
 
-        ds = self.open_model_dataset(self.input_file, decode_timedelta=False)
+        ds = self.open_model_dataset(
+            self.input_file, self.config, decode_timedelta=False
+        )
 
         if 'Time' in ds.sizes:
             t_index = 0

--- a/polaris/tasks/ocean/customizable_viz/viz_transect.py
+++ b/polaris/tasks/ocean/customizable_viz/viz_transect.py
@@ -48,8 +48,10 @@ class VizTransect(OceanIOStep):
         x = xr.DataArray(data=[x_start, x_end])
         y = xr.DataArray(data=[y_start, y_end])
 
-        ds_mesh = self.open_model_dataset(self.mesh_file)
-        ds = self.open_model_dataset(self.input_file, decode_timedelta=False)
+        ds_mesh = self.open_model_dataset(self.mesh_file, self.config)
+        ds = self.open_model_dataset(
+            self.input_file, self.config, decode_timedelta=False
+        )
         # TODO support time selection from config file
         if 'Time' in ds.dims:
             t_index = 0

--- a/polaris/tasks/ocean/external_gravity_wave/init.py
+++ b/polaris/tasks/ocean/external_gravity_wave/init.py
@@ -93,7 +93,7 @@ class Init(OceanIOStep):
         ds['fEdge'] = xr.zeros_like(ds_mesh.xEdge)
         ds['fVertex'] = xr.zeros_like(ds_mesh.xVertex)
 
-        self.write_model_dataset(ds, 'initial_state.nc')
+        self.write_model_dataset(ds, 'initial_state.nc', config)
 
 
 def gaussian_bump(lat_center, lon_center, latCell, lonCell):

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -358,7 +358,7 @@ def _get_forward_z_tilde_edge_mid(
     Compute edge-centered pseudo-height at layer midpoints from Omega output
     pressure.
     """
-    pressure_mid = ds_out.PressureMid.isel(Time=0)
+    pressure_mid = ds_out.pressure.isel(Time=0)
     pressure_edge_mid = 0.5 * (
         pressure_mid.isel(nCells=cell0) + pressure_mid.isel(nCells=cell1)
     )

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -134,7 +134,7 @@ class Analysis(OceanIOStep):
             'must be set in the "horiz_press_grad" section.'
         )
 
-        ds_ref = self.open_model_dataset('reference_solution.nc')
+        ds_ref = self.open_model_dataset('reference_solution.nc', self.config)
         if ds_ref.sizes.get('nCells', 0) <= 2:
             raise ValueError(
                 'The reference solution requires at least 3 columns so that '
@@ -149,9 +149,13 @@ class Analysis(OceanIOStep):
         py_errors = []
 
         for resolution in horiz_resolutions:
-            ds_init = self.open_model_dataset(f'init_r{resolution:02g}.nc')
+            ds_init = self.open_model_dataset(
+                f'init_r{resolution:02g}.nc', self.config
+            )
             ds_out = self.open_model_dataset(
-                f'output_r{resolution:02g}.nc', decode_times=False
+                f'output_r{resolution:02g}.nc',
+                self.config,
+                decode_times=False,
             )
 
             edge_index, cells_on_edge = _get_internal_edge(ds_init)

--- a/polaris/tasks/ocean/horiz_press_grad/forward.yaml
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.yaml
@@ -33,11 +33,11 @@ Omega:
       FileFreq: 9999
       FileFreqUnits: years
       Contents:
-      - ZMid
-      - ZInterface
+      - GeomZMid
+      - GeomZInterface
       - PressureMid
       - PressureInterface
-      - LayerThickness
+      - PseudoThickness
       - Temperature
       - Salinity
       - SpecVol

--- a/polaris/tasks/ocean/horiz_press_grad/forward.yaml
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.yaml
@@ -43,6 +43,6 @@ Omega:
       - SpecVol
       - GeopotentialMid
       - NormalVelocityTend
-      - BottomDepth
+      - BottomGeomDepth
       - MinLayerCell
       - MaxLayerCell

--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -65,9 +65,6 @@ salinity_mid = [35.6, 35.4, 35.0, 34.8, 34.75]
 # g/kg / km
 salinity_grad = [0.0, 0.0, 0.0, 0.0, 0.0]
 
-# number of iterations over which to allow water column adjustments
-water_col_adjust_iter_count = 6
-
 # Early stopping threshold for fractional change in geometric water-column
 # thickness between adjustment iterations
 water_col_adjust_frac_change_threshold = 1.0e-12

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -166,9 +166,31 @@ class Init(OceanIOStep):
             )
 
         prev_geom_water_column_thickness: xr.DataArray | None = None
+        prev_adjusted_bottom_pressure: xr.DataArray | None = None
 
         for iter in range(pseudothickness_iter_count):
             ds = self._init_z_tilde_vert_coord(ds_mesh, bottom_pressure, x)
+            # ds.BottomPressure reflects the post-partial-cell-adjustment value
+            adjusted_bottom_pressure = ds.BottomPressure
+
+            # When partial_cell_type == 'full', the snap constrains the column
+            # to a fixed reference level regardless of the raw bottom_pressure.
+            # Detect this by checking if the adjusted pressure is unchanged.
+            if (
+                prev_adjusted_bottom_pressure is not None
+                and (
+                    adjusted_bottom_pressure == prev_adjusted_bottom_pressure
+                ).all()
+            ):
+                logger.warning(
+                    f'Iteration {iter}: full-cell snap is holding '
+                    'BottomPressure constant — stopping early to avoid '
+                    'non-convergence. bottomDepth will reflect the actual '
+                    'cell bottom rather than the target bathymetry.'
+                )
+                break
+
+            prev_adjusted_bottom_pressure = adjusted_bottom_pressure
 
             z_tilde_mid = ds.ZTildeMid
             h_tilde = ds.PseudoThickness
@@ -270,7 +292,9 @@ class Init(OceanIOStep):
                 f'max scaling factor = {max_scaling_factor:.6f}'
             )
 
-            bottom_pressure = bottom_pressure * scaling_factor
+            # Scale from the post-adjustment pressure so we move relative to
+            # the effective (snapped) bottom, not the raw input.
+            bottom_pressure = adjusted_bottom_pressure * scaling_factor
 
             logger.info(
                 f'Iteration {iter}: bottom pressures = '
@@ -292,9 +316,10 @@ class Init(OceanIOStep):
             },
         )
 
-        # bottomDepth needs to be the geometric bottom depth of the bathymetry,
-        # not the pseudo-bottom depth used for the vertical coordinate
-        ds['bottomDepth'] = -geom_z_bot
+        # Use the actual per-cell geometric water column at convergence so that
+        # SSH == 0 holds exactly at initialization even when partial cells push
+        # the effective bathymetry shallower than the target.
+        ds['bottomDepth'] = geom_water_column_thickness
         ds.bottomDepth.attrs['long_name'] = 'seafloor geometric height'
         ds.bottomDepth.attrs['units'] = 'm'
 

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -375,7 +375,7 @@ class Init(OceanIOStep):
         ds.attrs['nx'] = nx
         ds.attrs['ny'] = ny
         ds.attrs['dc'] = dc
-        self.write_model_dataset(ds, 'initial_state.nc')
+        self.write_model_dataset(ds, 'initial_state.nc', config)
 
     def _compute_montgomery_and_hpga(
         self,

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -306,9 +306,13 @@ class Init(OceanIOStep):
         ds.Density.attrs['long_name'] = 'density'
         ds.Density.attrs['units'] = 'kg m-3'
 
-        ds['ZTildeMid'] = ds.zMid
         ds.ZTildeMid.attrs['long_name'] = 'pseudo-height at layer midpoints'
         ds.ZTildeMid.attrs['units'] = 'm'
+
+        ds.ZTildeInterface.attrs['long_name'] = (
+            'pseudo-height at layer interfaces'
+        )
+        ds.ZTildeInterface.attrs['units'] = 'm'
 
         ds['GeomZMid'] = geom_z_mid
         ds.GeomZMid.attrs['long_name'] = 'geometric height at layer midpoints'
@@ -386,16 +390,16 @@ class Init(OceanIOStep):
         # Interface quantities: Omega treats alpha as constant within each
         # layer, so interface values are represented as bounds for each layer
         # (top and bottom), with discontinuities permitted between layers.
-        z_tilde_top = ds.zInterface.isel(nVertLevelsP1=slice(0, -1)).rename(
+        z_tilde_top = ds.ZTildeInterface.isel(
+            nVertLevelsP1=slice(0, -1)
+        ).rename({'nVertLevelsP1': 'nVertLevels'})
+        z_tilde_bot = ds.ZTildeInterface.isel(
+            nVertLevelsP1=slice(1, None)
+        ).rename({'nVertLevelsP1': 'nVertLevels'})
+        z_top = ds.GeomZInterface.isel(nVertLevelsP1=slice(0, -1)).rename(
             {'nVertLevelsP1': 'nVertLevels'}
         )
-        z_tilde_bot = ds.zInterface.isel(nVertLevelsP1=slice(1, None)).rename(
-            {'nVertLevelsP1': 'nVertLevels'}
-        )
-        z_top = ds.GeomZInter.isel(nVertLevelsP1=slice(0, -1)).rename(
-            {'nVertLevelsP1': 'nVertLevels'}
-        )
-        z_bot = ds.GeomZInter.isel(nVertLevelsP1=slice(1, None)).rename(
+        z_bot = ds.GeomZInterface.isel(nVertLevelsP1=slice(1, None)).rename(
             {'nVertLevelsP1': 'nVertLevels'}
         )
 

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -6,12 +6,11 @@ from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.ocean.eos import compute_specvol
 from polaris.ocean.model import OceanIOStep
-from polaris.ocean.vertical import init_vertical_coord
 from polaris.ocean.vertical.ztilde import (
-    # temporary until we can get this for GCD
     Gravity,
     RhoSw,
     geom_height_from_pseudo_height,
+    init_z_tilde_vertical_coord,
     pressure_from_z_tilde,
 )
 from polaris.resolution import resolution_to_string
@@ -137,18 +136,19 @@ class Init(OceanIOStep):
 
         goal_geom_water_column_thickness = geom_ssh - geom_z_bot
 
-        # first guess at the pseudo bottom depth is the geometric
-        # water column thickness
-        pseudo_bottom_depth = goal_geom_water_column_thickness
+        # first guess at the bottom pressure is based on the geometric water
+        # column thickness and a constant density.  It will be iteratively
+        # adjusted until we get the desired geometric bottom depth
+        bottom_pressure = RhoSw * Gravity * goal_geom_water_column_thickness
 
-        water_col_adjust_iter_count = config.getint(
-            'horiz_press_grad', 'water_col_adjust_iter_count'
+        pseudothickness_iter_count = config.getint(
+            'vertical_grid', 'pseudothickness_iter_count'
         )
 
-        if water_col_adjust_iter_count is None:
+        if pseudothickness_iter_count is None:
             raise ValueError(
-                'The "water_col_adjust_iter_count" configuration option '
-                'must be set in the "horiz_press_grad" section.'
+                'The "pseudothickness_iter_count" configuration option '
+                'must be set in the "vertical_grid" section.'
             )
 
         water_col_adjust_frac_change_threshold = hpg_section.getfloat(
@@ -167,11 +167,11 @@ class Init(OceanIOStep):
 
         prev_geom_water_column_thickness: xr.DataArray | None = None
 
-        for iter in range(water_col_adjust_iter_count):
-            ds = self._init_z_tilde_vert_coord(ds_mesh, pseudo_bottom_depth, x)
+        for iter in range(pseudothickness_iter_count):
+            ds = self._init_z_tilde_vert_coord(ds_mesh, bottom_pressure, x)
 
-            z_tilde_mid = ds.zMid
-            h_tilde = ds.layerThickness
+            z_tilde_mid = ds.ZTildeMid
+            h_tilde = ds.PseudoThickness
 
             logger.debug(f'z_tilde_mid = {z_tilde_mid}')
             logger.debug(f'h_tilde = {h_tilde}')
@@ -195,6 +195,7 @@ class Init(OceanIOStep):
                 salinity=sa,
                 pressure=p_mid,
             )
+            assert isinstance(spec_vol, xr.DataArray)
 
             logger.debug(f'geom_z_bot = {geom_z_bot}')
             logger.debug(f'spec_vol = {spec_vol}')
@@ -269,11 +270,11 @@ class Init(OceanIOStep):
                 f'max scaling factor = {max_scaling_factor:.6f}'
             )
 
-            pseudo_bottom_depth = pseudo_bottom_depth * scaling_factor
+            bottom_pressure = bottom_pressure * scaling_factor
 
             logger.info(
-                f'Iteration {iter}: pseudo bottom depths = '
-                f'{pseudo_bottom_depth.values}'
+                f'Iteration {iter}: bottom pressures = '
+                f'{bottom_pressure.values}'
             )
 
             prev_geom_water_column_thickness = geom_water_column_thickness
@@ -297,9 +298,9 @@ class Init(OceanIOStep):
         ds.bottomDepth.attrs['long_name'] = 'seafloor geometric height'
         ds.bottomDepth.attrs['units'] = 'm'
 
-        ds['PressureMid'] = p_mid
-        ds.PressureMid.attrs['long_name'] = 'pressure at layer midpoints'
-        ds.PressureMid.attrs['units'] = 'Pa'
+        ds['pressure'] = p_mid
+        ds.pressure.attrs['long_name'] = 'pressure at layer midpoints'
+        ds.pressure.attrs['units'] = 'Pa'
 
         ds['Density'] = 1.0 / ds['SpecVol']
         ds.Density.attrs['long_name'] = 'density'
@@ -313,19 +314,19 @@ class Init(OceanIOStep):
         ds.GeomZMid.attrs['long_name'] = 'geometric height at layer midpoints'
         ds.GeomZMid.attrs['units'] = 'm'
 
-        ds['GeomZInter'] = geom_z_inter
-        ds.GeomZInter.attrs['long_name'] = (
+        ds['GeomZInterface'] = geom_z_inter
+        ds.GeomZInterface.attrs['long_name'] = (
             'geometric height at layer interfaces'
         )
-        ds.GeomZInter.attrs['units'] = 'm'
+        ds.GeomZInterface.attrs['units'] = 'm'
 
         self._compute_montgomery_and_hpga(ds=ds, dx=dx, p_mid=p_mid)
 
-        ds.layerThickness.attrs['long_name'] = 'pseudo-layer thickness'
-        ds.layerThickness.attrs['units'] = 'm'
+        ds.PseudoThickness.attrs['long_name'] = 'pseudo-layer thickness'
+        ds.PseudoThickness.attrs['units'] = 'm'
 
-        ds.zMid.attrs['long_name'] = 'pseudo-height at layer midpoints'
-        ds.zMid.attrs['units'] = 'm'
+        ds.ZTildeMid.attrs['long_name'] = 'pseudo-height at layer midpoints'
+        ds.ZTildeMid.attrs['units'] = 'm'
 
         nedges = ds_mesh.sizes['nEdges']
         nvertlevels = ds.sizes['nVertLevels']
@@ -516,7 +517,7 @@ class Init(OceanIOStep):
     def _init_z_tilde_vert_coord(
         self,
         ds_mesh: xr.Dataset,
-        pseudo_bottom_depth: xr.DataArray,
+        bottom_pressure: xr.DataArray,
         x: np.ndarray,
     ) -> xr.Dataset:
         """
@@ -528,13 +529,13 @@ class Init(OceanIOStep):
 
         ds = ds_mesh.copy()
 
-        ds['bottomDepth'] = pseudo_bottom_depth
-        ds.bottomDepth.attrs['long_name'] = 'seafloor pseudo-height'
-        ds.bottomDepth.attrs['units'] = 'm'
-        # the pseudo-ssh is always zero (like the surface pressure)
-        ds['ssh'] = xr.zeros_like(pseudo_bottom_depth)
-        ds.ssh.attrs['long_name'] = 'sea surface pseudo-height'
-        ds.ssh.attrs['units'] = 'm'
+        ds['BottomPressure'] = bottom_pressure
+        ds.BottomPressure.attrs['long_name'] = 'seafloor pressure'
+        ds.BottomPressure.attrs['units'] = 'Pa'
+        # the surface pressure is always zero
+        ds['SurfacePressure'] = xr.zeros_like(bottom_pressure)
+        ds.SurfacePressure.attrs['long_name'] = 'sea surface pressure'
+        ds.SurfacePressure.attrs['units'] = 'Pa'
         ds_list: list[xr.Dataset] = []
         for icell in range(ds.sizes['nCells']):
             # initialize the vertical coordinate for each column separately
@@ -547,7 +548,7 @@ class Init(OceanIOStep):
                 'vertical_grid', 'bottom_depth', str(pseudo_bottom_depth)
             )
 
-            init_vertical_coord(local_config, ds_cell)
+            init_z_tilde_vertical_coord(local_config, ds_cell)
             cell_vars = [
                 var
                 for var in ds_cell.data_vars

--- a/polaris/tasks/ocean/horiz_press_grad/reference.py
+++ b/polaris/tasks/ocean/horiz_press_grad/reference.py
@@ -350,7 +350,7 @@ class Reference(OceanIOStep):
             },
         )
 
-        self.write_model_dataset(ds, 'reference_solution.nc')
+        self.write_model_dataset(ds, 'reference_solution.nc', config)
 
     def _get_ssh_z_bot(
         self, x: np.ndarray

--- a/polaris/tasks/ocean/horiz_press_grad/reference.py
+++ b/polaris/tasks/ocean/horiz_press_grad/reference.py
@@ -9,8 +9,6 @@ import numpy as np
 import xarray as xr
 
 from polaris.ocean.model import OceanIOStep
-
-# temporary until we can get this for GCD
 from polaris.ocean.vertical.ztilde import Gravity, RhoSw
 from polaris.tasks.ocean.horiz_press_grad.column import (
     get_array_from_mid_grad,
@@ -444,12 +442,12 @@ class Reference(OceanIOStep):
             'The "reference_quadrature_method" configuration option must be '
             'set in the "horiz_press_grad" section.'
         )
-        water_col_adjust_iter_count = section.getint(
-            'water_col_adjust_iter_count'
+        pseudothickness_iter_count = config.getint(
+            'vertical_grid', 'pseudothickness_iter_count'
         )
-        assert water_col_adjust_iter_count is not None, (
-            'The "water_col_adjust_iter_count" configuration option must be '
-            'set in the "horiz_press_grad" section.'
+        assert pseudothickness_iter_count is not None, (
+            'The "pseudothickness_iter_count" configuration option must be '
+            'set in the "vertical_grid" section.'
         )
 
         goal_geom_water_column_thickness = geom_ssh - geom_z_bot
@@ -463,7 +461,7 @@ class Reference(OceanIOStep):
             f'{goal_geom_water_column_thickness:.12f}'
         )
 
-        for iter in range(water_col_adjust_iter_count):
+        for iter in range(pseudothickness_iter_count):
             z_tilde_inter, max_layer, uniform_layer_mask_inter = (
                 self._init_z_tilde_interface(
                     pseudo_bottom_depth=pseudo_bottom_depth,

--- a/polaris/tasks/ocean/ice_shelf_2d/validate.py
+++ b/polaris/tasks/ocean/ice_shelf_2d/validate.py
@@ -94,6 +94,7 @@ class Validate(Step):
             filename1=self.inputs[0],
             filename2=self.inputs[3],
             logger=self.logger,
+            config=self.config,
         )
         land_ice_pass = compare_variables(
             component=self.component,
@@ -101,6 +102,7 @@ class Validate(Step):
             filename1=self.inputs[1],
             filename2=self.inputs[4],
             logger=self.logger,
+            config=self.config,
         )
         frazil_pass = compare_variables(
             component=self.component,
@@ -108,6 +110,7 @@ class Validate(Step):
             filename1=self.inputs[2],
             filename2=self.inputs[5],
             logger=self.logger,
+            config=self.config,
         )
         if not output_pass:
             raise ValueError(

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -55,7 +55,7 @@ Omega:
       Filename: init.nc
       Contents:
       - NormalVelocity
-      - LayerThickness
+      - PseudoThickness
     History:
       Filename: output.nc
       Freq: {{ output_freq }}
@@ -66,6 +66,6 @@ Omega:
       FileFreqUnits: years
       Contents:
       - NormalVelocity
-      - LayerThickness
+      - PseudoThickness
       - Eos
       - SshCell

--- a/polaris/tasks/ocean/manufactured_solution/init.py
+++ b/polaris/tasks/ocean/manufactured_solution/init.py
@@ -69,13 +69,13 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=False
         )
-        self.write_model_dataset(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
 

--- a/polaris/tasks/ocean/merry_go_round/__init__.py
+++ b/polaris/tasks/ocean/merry_go_round/__init__.py
@@ -4,6 +4,7 @@ from typing import Dict as Dict
 
 from polaris import Step, Task
 from polaris.config import PolarisConfigParser
+from polaris.constants import get_constant
 from polaris.ocean.convergence import (
     get_resolution_for_task,
     get_timestep_for_task,
@@ -28,9 +29,18 @@ def add_merry_go_round_tasks(component):
     config_filename = 'merry_go_round.cfg'
     filepath = os.path.join(component.name, basedir, config_filename)
     config = PolarisConfigParser(filepath=filepath)
+    config.add_from_package('polaris.ocean.eos', 'constant.cfg')
     config.add_from_package('polaris.ocean.convergence', 'convergence.cfg')
     config.add_from_package(
         'polaris.tasks.ocean.merry_go_round', config_filename
+    )
+    # Set rhoref to the PCD value only at setup so that if the
+    # user wants to run with a different value by changing the cfg
+    # before runtime, they can
+    config.set(
+        'ocean',
+        'eos_constant_rhoref',
+        value=f'{get_constant("seawater_density_reference"):02g}',
     )
 
     base_resolution = get_resolution_for_task(config, 1.0, refinement='both')

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -93,9 +93,9 @@ class Viz(OceanIOStep):
         s_per_hour = 3600.0
         time = eval_time * s_per_hour
 
-        ds_mesh = self.open_model_dataset('mesh.nc')
-        ds_init = self.open_model_dataset('init.nc')
-        ds = self.open_model_dataset('output.nc', decode_times=False)
+        ds_mesh = self.open_model_dataset('mesh.nc', config)
+        ds_init = self.open_model_dataset('init.nc', config)
+        ds = self.open_model_dataset('output.nc', config, decode_times=False)
 
         x_min = ds_mesh.xVertex.min().values
         x_max = ds_mesh.xVertex.max().values

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -150,8 +150,8 @@ Omega:
       Contents:
         - Tracers
         - State
-        - VerticalVelocity
-        - TotalVerticalVelocity
+        - VerticalPseudoVelocity
+        - TotalVerticalPseudoVelocity
     Highfreq:
       UsePointerFile: false
       Filename: ocn.hifreq.$Y-$M

--- a/polaris/tasks/ocean/merry_go_round/init.py
+++ b/polaris/tasks/ocean/merry_go_round/init.py
@@ -130,7 +130,7 @@ class Init(OceanIOStep):
         temperature = temperature.expand_dims(dim='Time', axis=0)
         ds['temperature'] = temperature
 
-        # Initialize temperature
+        # Initialize salinity
         ds['salinity'] = salinity_background * xr.ones_like(temperature)
 
         # Initialize normalVelocity
@@ -171,4 +171,4 @@ class Init(OceanIOStep):
         ds['tracer2'] = tracer2_background * xr.ones_like(temperature)
         ds['tracer3'] = tracer3_background * xr.ones_like(temperature)
 
-        self.write_model_dataset(ds, 'initial_state.nc')
+        self.write_model_dataset(ds, 'initial_state.nc', config=config)

--- a/polaris/tasks/ocean/merry_go_round/init.py
+++ b/polaris/tasks/ocean/merry_go_round/init.py
@@ -83,13 +83,13 @@ class Init(OceanIOStep):
             nonperiodic_x=True,
             nonperiodic_y=False,
         )
-        self.write_model_dataset(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()
 

--- a/polaris/tasks/ocean/merry_go_round/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/viz.py
@@ -161,13 +161,15 @@ class Viz(OceanIOStep):
             )
 
             ds_mesh = self.open_model_dataset(
-                f'mesh_r{refinement_factor:02g}.nc'
+                f'mesh_r{refinement_factor:02g}.nc', config
             )
             ds_init = self.open_model_dataset(
-                f'init_r{refinement_factor:02g}.nc'
+                f'init_r{refinement_factor:02g}.nc', config
             )
             ds = self.open_model_dataset(
-                f'output_r{refinement_factor:02g}.nc', decode_times=False
+                f'output_r{refinement_factor:02g}.nc',
+                config,
+                decode_times=False,
             )
 
             dz = ds_init.layerThickness.mean().values

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -120,5 +120,5 @@ Omega:
         - State
         - KineticEnergyCell
         - SpecVol
-        - BottomDepth
+        - BottomGeomDepth
         - SshCell

--- a/polaris/tasks/ocean/overflow/init.py
+++ b/polaris/tasks/ocean/overflow/init.py
@@ -57,13 +57,13 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=True, nonperiodic_y=False
         )
-        self.write_model_dataset(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         max_bottom_depth = section.getfloat('max_bottom_depth')
         shelf_depth = section.getfloat('shelf_depth')

--- a/polaris/tasks/ocean/seamount/init.py
+++ b/polaris/tasks/ocean/seamount/init.py
@@ -56,13 +56,13 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=False
         )
-        self.write_model_dataset(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         # from overflow. Delete when not needed.
         max_bottom_depth = section.getfloat('max_bottom_depth')
@@ -159,7 +159,7 @@ class Init(OceanIOStep):
         ds.attrs['dc'] = dc
 
         # finalize and write file
-        self.write_model_dataset(ds, 'init.nc')
+        self.write_model_dataset(ds, 'init.nc', config)
         # May not be needed.
 
 

--- a/polaris/tasks/ocean/seamount/viz.py
+++ b/polaris/tasks/ocean/seamount/viz.py
@@ -39,7 +39,7 @@ class Viz(OceanIOStep):
         """
         Run this step of the task
         """
-        ds_mesh = self.open_model_dataset('mesh.nc')
+        ds_mesh = self.open_model_dataset('mesh.nc', self.config)
         ds_init = self.open_model_dataset('init.nc', self.config)
         ds = self.open_model_dataset(
             'output.nc', self.config, decode_times=True

--- a/polaris/tasks/ocean/sphere_transport/filament_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/filament_analysis.py
@@ -109,9 +109,11 @@ class FilamentAnalysis(OceanIOStep):
         for i, refinement_factor in enumerate(self.refinement_factors):
             mesh_name = resolution_to_string(resolutions[i])
             ds_mesh = self.open_model_dataset(
-                f'mesh_r{refinement_factor:02g}.nc'
+                f'mesh_r{refinement_factor:02g}.nc', self.config
             )
-            ds = self.open_model_dataset(f'output_r{refinement_factor:02g}.nc')
+            ds = self.open_model_dataset(
+                f'output_r{refinement_factor:02g}.nc', self.config
+            )
             t_days = get_days_since_start(ds)
             time_index = np.argmin(
                 np.abs(np.subtract(t_days, eval_time * s_per_day))

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -97,6 +97,6 @@ Omega:
       FileFreqUnits: years
       Contents:
         - Tracers
-        - LayerThickness
+        - PseudoThickness
         - NormalVelocity
         - Eos

--- a/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
@@ -119,7 +119,9 @@ class MixingAnalysis(OceanIOStep):
             _init_triplot_axes(ax)
             mesh_name = resolution_to_string(resolutions[i])
             ax.set(title=mesh_name)
-            ds = self.open_model_dataset(f'output_r{refinement_factor:02g}.nc')
+            ds = self.open_model_dataset(
+                f'output_r{refinement_factor:02g}.nc', self.config
+            )
             if i % 2 == 0:
                 ax.set_ylabel('tracer3')
             if int(i / 2) == nrows - 1:

--- a/polaris/tasks/seaice/single_column/exact_restart/validate.py
+++ b/polaris/tasks/seaice/single_column/exact_restart/validate.py
@@ -64,6 +64,7 @@ class Validate(Step):
             filename1=self.inputs[0],
             filename2=self.inputs[1],
             logger=self.logger,
+            config=self.config,
         )
         if not all_pass:
             raise ValueError(

--- a/polaris/validate.py
+++ b/polaris/validate.py
@@ -10,6 +10,7 @@ def compare_variables(
     filename1,
     filename2,
     logger,
+    config,
     l1_norm=0.0,
     l2_norm=0.0,
     linf_norm=0.0,
@@ -41,6 +42,11 @@ def compare_variables(
 
     logger: logging.Logger
         The logger to log validation output to
+
+    config : polaris.config.PolarisConfigParser
+        Configuration for the task; forwarded to
+        ``component.open_model_dataset()`` when datasets are not pre-loaded
+        via ``ds1``/``ds2``.
 
     l1_norm : float, optional
         The maximum allowed L1 norm difference between the variables in
@@ -83,10 +89,10 @@ def compare_variables(
             return False
 
     if ds1 is None:
-        ds1 = component.open_model_dataset(filename1)
+        ds1 = component.open_model_dataset(filename1, config)
 
     if ds2 is None:
-        ds2 = component.open_model_dataset(filename2)
+        ds2 = component.open_model_dataset(filename2, config)
 
     all_pass = True
 

--- a/utils/omega/ctest/omega_ctest.py
+++ b/utils/omega/ctest/omega_ctest.py
@@ -128,9 +128,9 @@ def download_meshes(config):
     base_url = 'https://web.lcrc.anl.gov/public/e3sm/polaris/'
 
     files = [
-        'ocean.QU.240km.151209.nc',
-        'PlanarPeriodic48x48.nc',
-        'cosine_bell_icos480_initial_state.230220.nc',
+        'ocean.QU.240km.omega_vars.251219.nc',
+        'PlanarPeriodic48x48.omega_vars.251219.nc',
+        'cosine_bell_icos480.omega_vars.250219.nc',
     ]
 
     database_path = 'ocean/omega_ctest'

--- a/utils/omega/ctest/omega_ctest.py
+++ b/utils/omega/ctest/omega_ctest.py
@@ -128,9 +128,9 @@ def download_meshes(config):
     base_url = 'https://web.lcrc.anl.gov/public/e3sm/polaris/'
 
     files = [
-        'ocean.QU.240km.omega_vars.260506.nc',
-        'PlanarPeriodic48x48.omega_vars.260506.nc',
-        'cosine_bell_icos480.omega_vars.260506.nc',
+        'ocean.QU.240km.omega_vars.260518.nc',
+        'PlanarPeriodic48x48.omega_vars.260518.nc',
+        'cosine_bell_icos480.omega_vars.260518.nc',
     ]
 
     database_path = 'ocean/omega_ctest'

--- a/utils/omega/ctest/omega_ctest.py
+++ b/utils/omega/ctest/omega_ctest.py
@@ -128,9 +128,9 @@ def download_meshes(config):
     base_url = 'https://web.lcrc.anl.gov/public/e3sm/polaris/'
 
     files = [
-        'ocean.QU.240km.omega_vars.251219.nc',
-        'PlanarPeriodic48x48.omega_vars.251219.nc',
-        'cosine_bell_icos480.omega_vars.250219.nc',
+        'ocean.QU.240km.omega_vars.260506.nc',
+        'PlanarPeriodic48x48.omega_vars.260506.nc',
+        'cosine_bell_icos480.omega_vars.260506.nc',
     ]
 
     database_path = 'ocean/omega_ctest'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

# Summary

This PR updates Polaris to track a set of variable renames in Omega that clarify the distinction between pseudo-thickness (the prognostic z-star/z-tilde coordinate variable) and true geometric layer thickness. The renames affect both the MPAS-Ocean → Omega variable mapping and the forward-run output specifications. A secondary fix corrects two bugs in the merry-go-round test exposed by this work.

## Implementation details

### Variable renames (`mpaso_to_omega.yaml` and forward YAMLs)

The following Omega variable names changed, and the MPAS-Ocean → Omega mapping plus any task-specific forward YAML output lists are updated accordingly:

| Old name | New name |
|---|---|
| `LayerThickness` | `PseudoThickness` |
| `VerticalVelocity` | `VerticalPseudoVelocity` |
| `TotalVerticalVelocity` | `TotalVerticalPseudoVelocity` |
| `BottomDepth` | `BottomGeomDepth` |
| `ZMid` | `GeomZMid` |
| `ZInterface` | `GeomZInterface` |

The pseudo/geometric thickness conversion in `ocean_model_step.py` was reworked so that `PseudoThickness` and `SpecVol` are written directly, and `GeomLayerThickness` is computed on read-back rather than assumed to be stored.

### Z-tilde rework (`polaris/ocean/vertical/ztilde.py`)

The z-tilde vertical coordinate was rewritten to be independent of z-star infrastructure. Previously the two shared code paths, but after the renaming this became unnecessarily complicated. `ztilde.py` now has its own self-contained implementation, and `horiz_press_grad` (the only task using z-tilde) was updated accordingly.

### Merry-go-round fixes

Two bugs in the merry-go-round test were fixed:
1. **Initial state conversion** — incorrect variable was used when converting the initial state.
2. **Constant EOS** — the task now registers a constant equation of state, which is required for the test to run correctly under Omega.

### Omega submodule

Update Omega submodule to [54d85d8c4f](https://github.com/E3SM-Project/Omega/tree/54d85d8c4fd24e969af8bb4764d108df9caaa0c5)
This bring in:
* https://github.com/E3SM-Project/Omega/pull/335
* https://github.com/E3SM-Project/Omega/pull/381
* https://github.com/E3SM-Project/Omega/pull/400
* https://github.com/E3SM-Project/Omega/pull/414
* https://github.com/E3SM-Project/Omega/pull/327

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
