### PR TITLE
Switch time-step format to `DDDD_hh:mm:ss`

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -554,6 +554,7 @@
    OceanModelStep.map_yaml_configs
 
    get_time_interval_string
+   get_time_step_string
 ```
 
 

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -139,16 +139,24 @@ cells to each core, but it will allow as many as 2000.
 It is often useful to be able to convert a `float` time interval in days or
 seconds to a model config option in the form `DDDD_HH:MM:SS.S`.  The
 {py:func}`polaris.ocean.model.get_time_interval_string()` function will do this
-for you.  For example, if you have `resolution` in km and a config `section`
-with options `dt_per_km` (in s/km) and `run_duration` (in days), you can use
-the function to get appropriate strings for filling in a template model config
-file:
+for you.
+
+Omega time step config options (e.g. ``config_dt`` and ``config_btr_dt``)
+require a day prefix and underscore, even when the number of days is 0.  For
+example, use ``0000_00:10:00`` rather than ``00:10:00``.  Omega can
+misinterpret the latter form.  The
+{py:func}`polaris.ocean.model.get_time_step_string()` function can be used to
+format time steps in the required ``DDDD_HH:MM:SS`` form.
+
+For example, if you have `resolution` in km and a config `section` with options
+`dt_per_km` (in s/km) and `run_duration` (in days), you can use these functions
+to get appropriate strings for filling in a template model config file:
 ```python
-from polaris.ocean.model import get_time_interval_string
+from polaris.ocean.model import get_time_interval_string, get_time_step_string
 
 
 dt_per_km = section.getfloat('dt_per_km')
-dt_str = get_time_interval_string(seconds=dt_per_km * resolution)
+dt_str = get_time_step_string(seconds=dt_per_km * resolution)
 
 run_duration = section.getfloat('run_duration')
 run_duration_str = get_time_interval_string(days=run_duration)

--- a/polaris/ocean/convergence/forward.py
+++ b/polaris/ocean/convergence/forward.py
@@ -1,5 +1,9 @@
 from polaris.ocean.convergence import get_timestep_for_task
-from polaris.ocean.model import OceanModelStep, get_time_interval_string
+from polaris.ocean.model import (
+    OceanModelStep,
+    get_time_interval_string,
+    get_time_step_string,
+)
 
 
 class ConvergenceForward(OceanModelStep):
@@ -163,8 +167,8 @@ class ConvergenceForward(OceanModelStep):
         timestep, btr_timestep = get_timestep_for_task(
             config, refinement_factor, refinement=self.refinement
         )
-        dt_str = get_time_interval_string(seconds=timestep)
-        btr_dt_str = get_time_interval_string(seconds=btr_timestep)
+        dt_str = get_time_step_string(seconds=timestep)
+        btr_dt_str = get_time_step_string(seconds=btr_timestep)
 
         s_per_hour = 3600.0
         section = config['convergence_forward']

--- a/polaris/ocean/ice_shelf/ssh_forward.py
+++ b/polaris/ocean/ice_shelf/ssh_forward.py
@@ -1,4 +1,8 @@
-from polaris.ocean.model import OceanModelStep, get_time_interval_string
+from polaris.ocean.model import (
+    OceanModelStep,
+    get_time_interval_string,
+    get_time_step_string,
+)
 
 
 class SshForward(OceanModelStep):
@@ -160,13 +164,12 @@ class SshForward(OceanModelStep):
             dt_per_km = section.getfloat('rk4_dt_per_km')
         else:
             dt_per_km = section.getfloat('split_dt_per_km')
-        dt_str = get_time_interval_string(
-            seconds=dt_per_km * self.min_resolution
-        )
+
+        dt_str = get_time_step_string(seconds=dt_per_km * self.min_resolution)
 
         # btr_dt is also proportional to resolution
         btr_dt_per_km = section.getfloat('btr_dt_per_km')
-        btr_dt_str = get_time_interval_string(
+        btr_dt_str = get_time_step_string(
             seconds=btr_dt_per_km * self.min_resolution
         )
 

--- a/polaris/ocean/model/__init__.py
+++ b/polaris/ocean/model/__init__.py
@@ -5,3 +5,6 @@ from polaris.ocean.model.ocean_model_step import (
 from polaris.ocean.model.time import (
     get_time_interval_string as get_time_interval_string,
 )
+from polaris.ocean.model.time import (
+    get_time_step_string as get_time_step_string,
+)

--- a/polaris/ocean/model/time.py
+++ b/polaris/ocean/model/time.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 import numpy as np
@@ -36,3 +37,86 @@ def get_time_interval_string(days=None, seconds=None):
     seconds_str = time.strftime('%H:%M:%S', time.gmtime(sec_part))
     time_str = f'{day_part:04d}_{seconds_str}.{int(sec_decimal * 1e3):03d}'
     return time_str
+
+
+def get_time_step_string(days=None, seconds=None, time_str=None):
+    """Format a time step for model config options.
+
+    Omega currently requires the day prefix and underscore (e.g.
+    ``0000_00:10:00``) and will misinterpret ``hh:mm:ss``.
+
+    Parameters
+    ----------
+    days : float, optional
+        A time interval in days
+
+    seconds : float, optional
+        A time interval in seconds
+
+    time_str : str, optional
+        An existing time string in either ``hh:mm:ss`` or ``DDDD_hh:mm:ss``
+        format (optionally with a decimal fraction of seconds).
+
+    Returns
+    -------
+    time_step : str
+        The time step as a string in the format ``DDDD_HH:MM:SS``.
+    """
+    if time_str is not None:
+        stripped = str(time_str).strip()
+        with_day = re.match(
+            (
+                r'^(?P<days>\d+)_(?P<hours>\d+):(?P<minutes>\d{2}):'
+                r'(?P<seconds>\d{2})(?:\.(?P<fraction>\d+))?$'
+            ),
+            stripped,
+        )
+        without_day = re.match(
+            (
+                r'^(?P<hours>\d+):(?P<minutes>\d{2}):'
+                r'(?P<seconds>\d{2})(?:\.(?P<fraction>\d+))?$'
+            ),
+            stripped,
+        )
+
+        if with_day is None and without_day is None:
+            raise ValueError(
+                'Unrecognized time string format. Expected hh:mm:ss or '
+                'DDDD_hh:mm:ss (optionally with .sss) but got: '
+                f'{time_str}'
+            )
+
+        match = with_day if with_day is not None else without_day
+        assert match is not None
+        parsed_days = int(match.groupdict().get('days') or 0)
+        parsed_hours = int(match.group('hours'))
+        parsed_minutes = int(match.group('minutes'))
+        parsed_seconds = int(match.group('seconds'))
+
+        total_seconds = (
+            parsed_days * 86400
+            + parsed_hours * 3600
+            + parsed_minutes * 60
+            + parsed_seconds
+        )
+        seconds = float(total_seconds)
+        days = None
+
+    sec_per_day = 86400
+    total = 0.0
+    if seconds is not None:
+        total += seconds
+    if days is not None:
+        total += sec_per_day * days
+
+    if total < 0.0:
+        raise ValueError('Time step must be non-negative')
+
+    total_int = int(total)
+    day_part, sec_part = divmod(total_int, sec_per_day)
+    hour_part, sec_part = divmod(sec_part, 3600)
+    minute_part, second_part = divmod(sec_part, 60)
+
+    return (
+        f'{day_part:04d}_{hour_part:02d}:{minute_part:02d}:{second_part:02d}'
+    )

--- a/polaris/tasks/ocean/baroclinic_channel/forward.py
+++ b/polaris/tasks/ocean/baroclinic_channel/forward.py
@@ -1,7 +1,9 @@
-import time
-
 from polaris.mesh.planar import compute_planar_hex_nx_ny
-from polaris.ocean.model import OceanModelStep
+from polaris.ocean.model import (
+    OceanModelStep,
+    get_time_interval_string,
+    get_time_step_string,
+)
 
 
 class Forward(OceanModelStep):
@@ -164,23 +166,20 @@ class Forward(OceanModelStep):
         # dt is proportional to resolution: default 30 seconds per km
         dt_per_km = config.getfloat('baroclinic_channel', 'dt_per_km')
         dt = dt_per_km * self.resolution
-        # https://stackoverflow.com/a/1384565/7728169
-        options['config_dt'] = time.strftime('%H:%M:%S', time.gmtime(dt))
+        options['config_dt'] = get_time_step_string(seconds=dt)
 
         if self.run_time_steps is not None:
             # default run duration is a few time steps
             run_seconds = self.run_time_steps * dt
-            options['config_run_duration'] = time.strftime(
-                '%H:%M:%S', time.gmtime(run_seconds)
+            options['config_run_duration'] = get_time_interval_string(
+                seconds=run_seconds
             )
             options['config_stop_time'] = 'none'
 
         # btr_dt is also proportional to resolution: default 1.5 seconds per km
         btr_dt_per_km = config.getfloat('baroclinic_channel', 'btr_dt_per_km')
         btr_dt = btr_dt_per_km * self.resolution
-        options['config_btr_dt'] = time.strftime(
-            '%H:%M:%S', time.gmtime(btr_dt)
-        )
+        options['config_btr_dt'] = get_time_step_string(seconds=btr_dt)
 
         self.dt = dt
         self.btr_dt = btr_dt

--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -3,7 +3,7 @@ ocean:
     config_stop_time: none
     config_run_duration: 0002_00:00:00
   time_integration:
-    config_dt: 00:00:01
+    config_dt: 0000_00:00:01
   hmix_del2:
     config_use_mom_del2: true
     config_mom_del2: {{ nu }}
@@ -32,7 +32,7 @@ mpas-ocean:
     config_cvmix_background_scheme: none
     config_use_cvmix_convection: true
   split_explicit_ts:
-    config_btr_dt: 00:00:05
+    config_btr_dt: 0000_00:00:05
   bottom_drag:
     config_bottom_drag_mode: explicit
   forcing:

--- a/polaris/tasks/ocean/barotropic_gyre/forward.py
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.py
@@ -4,7 +4,11 @@ from math import ceil, floor, pi
 import numpy as np
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
-from polaris.ocean.model import OceanModelStep, get_time_interval_string
+from polaris.ocean.model import (
+    OceanModelStep,
+    get_time_interval_string,
+    get_time_step_string,
+)
 
 
 class Forward(OceanModelStep):
@@ -195,8 +199,8 @@ class Forward(OceanModelStep):
             )
 
         dt = floor(dt_max / 5.0)
-        dt_str = get_time_interval_string(seconds=dt)
-        dt_btr_str = get_time_interval_string(seconds=dt / 20.0)
+        dt_str = get_time_step_string(seconds=dt)
+        dt_btr_str = get_time_step_string(seconds=dt / 20.0)
 
         nu_max = stability_parameter_max * (resolution * 1.0e3) ** 2.0 / dt
         if nu > nu_max:

--- a/polaris/tasks/ocean/external_gravity_wave/forward.py
+++ b/polaris/tasks/ocean/external_gravity_wave/forward.py
@@ -1,7 +1,9 @@
-import time as time
-
 from polaris.ocean.convergence.spherical import SphericalConvergenceForward
-from polaris.ocean.model import OceanModelStep, get_time_interval_string
+from polaris.ocean.model import (
+    OceanModelStep,
+    get_time_interval_string,
+    get_time_step_string,
+)
 
 
 class Forward(SphericalConvergenceForward):
@@ -228,7 +230,7 @@ class ReferenceForward(OceanModelStep):
         if not at_setup and vert_levels == 1:
             self.add_yaml_file('polaris.ocean.config', 'single_layer.yaml')
 
-        dt_str = get_time_interval_string(seconds=dt)
+        dt_str = get_time_step_string(seconds=dt)
 
         s_per_hour = 3600.0
         section = config['convergence_forward']

--- a/polaris/tasks/ocean/ice_shelf_2d/forward.py
+++ b/polaris/tasks/ocean/ice_shelf_2d/forward.py
@@ -3,7 +3,11 @@ from math import floor
 from mpas_tools.cime.constants import constants
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
-from polaris.ocean.model import OceanModelStep, get_time_interval_string
+from polaris.ocean.model import (
+    OceanModelStep,
+    get_time_interval_string,
+    get_time_step_string,
+)
 
 
 class Forward(OceanModelStep):
@@ -159,11 +163,11 @@ class Forward(OceanModelStep):
         else:
             dt_per_km = section.getfloat('split_dt_per_km')
         dt = dt_per_km * self.resolution
-        dt_str = get_time_interval_string(seconds=dt)
+        dt_str = get_time_step_string(seconds=dt)
 
         # btr_dt is also proportional to resolution: default 1.5 seconds per km
         btr_dt_per_km = section.getfloat('btr_dt_per_km')
-        btr_dt_str = get_time_interval_string(
+        btr_dt_str = get_time_step_string(
             seconds=btr_dt_per_km * self.resolution
         )
 

--- a/polaris/tasks/ocean/internal_wave/forward.py
+++ b/polaris/tasks/ocean/internal_wave/forward.py
@@ -1,7 +1,9 @@
-import time
-
 from polaris.mesh.planar import compute_planar_hex_nx_ny
-from polaris.ocean.model import OceanModelStep
+from polaris.ocean.model import (
+    OceanModelStep,
+    get_time_interval_string,
+    get_time_step_string,
+)
 
 
 class Forward(OceanModelStep):
@@ -151,14 +153,13 @@ class Forward(OceanModelStep):
         resolution = config.getfloat('internal_wave', 'resolution')
         dt_per_km = config.getfloat('internal_wave', 'dt_per_km')
         dt = dt_per_km * resolution
-        # https://stackoverflow.com/a/1384565/7728169
-        options['config_dt'] = time.strftime('%H:%M:%S', time.gmtime(dt))
+        options['config_dt'] = get_time_step_string(seconds=dt)
 
         if self.run_time_steps is not None:
             # default run duration is a few time steps
             run_seconds = self.run_time_steps * dt
-            options['config_run_duration'] = time.strftime(
-                '%H:%M:%S', time.gmtime(run_seconds)
+            options['config_run_duration'] = get_time_interval_string(
+                seconds=run_seconds
             )
             options['config_stop_time'] = 'none'
         self.add_model_config_options(

--- a/polaris/tasks/ocean/internal_wave/forward.yaml
+++ b/polaris/tasks/ocean/internal_wave/forward.yaml
@@ -16,7 +16,7 @@ mpas-ocean:
     config_cvmix_background_scheme: none
     config_use_cvmix_convection: true
   split_explicit_ts:
-    config_btr_dt: 00:00:15
+    config_btr_dt: 0000_00:00:15
   streams:
     mesh:
       filename_template: initial_state.nc

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -1,5 +1,9 @@
 from polaris.mesh.planar import compute_planar_hex_nx_ny
-from polaris.ocean.model import OceanModelStep, get_time_interval_string
+from polaris.ocean.model import (
+    OceanModelStep,
+    get_time_interval_string,
+    get_time_step_string,
+)
 
 
 class Forward(OceanModelStep):
@@ -112,10 +116,8 @@ class Forward(OceanModelStep):
         resolution = config.getfloat('overflow', 'resolution')
         dt_per_km = config.getfloat('overflow', 'dt_per_km')
         btr_dt_per_km = config.getfloat('overflow', 'btr_dt_per_km')
-        dt_str = get_time_interval_string(seconds=dt_per_km * resolution)
-        btr_dt_str = get_time_interval_string(
-            seconds=btr_dt_per_km * resolution
-        )
+        dt_str = get_time_step_string(seconds=dt_per_km * resolution)
+        btr_dt_str = get_time_step_string(seconds=btr_dt_per_km * resolution)
         section = config[f'overflow_{self.task_name}']
         run_duration = section.getfloat('run_duration')
         output_interval = section.getfloat('output_interval')

--- a/polaris/tasks/ocean/seamount/forward.py
+++ b/polaris/tasks/ocean/seamount/forward.py
@@ -1,5 +1,9 @@
 from polaris.mesh.planar import compute_planar_hex_nx_ny
-from polaris.ocean.model import OceanModelStep, get_time_interval_string
+from polaris.ocean.model import (
+    OceanModelStep,
+    get_time_interval_string,
+    get_time_step_string,
+)
 
 
 class Forward(OceanModelStep):
@@ -112,10 +116,8 @@ class Forward(OceanModelStep):
         resolution = config.getfloat('seamount', 'resolution')
         dt_per_km = config.getfloat('seamount', 'dt_per_km')
         btr_dt_per_km = config.getfloat('seamount', 'btr_dt_per_km')
-        dt_str = get_time_interval_string(seconds=dt_per_km * resolution)
-        btr_dt_str = get_time_interval_string(
-            seconds=btr_dt_per_km * resolution
-        )
+        dt_str = get_time_step_string(seconds=dt_per_km * resolution)
+        btr_dt_str = get_time_step_string(seconds=btr_dt_per_km * resolution)
         section = config[f'seamount_{self.task_name}']
         run_duration = section.getfloat('run_duration')
         output_interval = section.getfloat('output_interval')

--- a/polaris/tasks/ocean/single_column/forward.yaml
+++ b/polaris/tasks/ocean/single_column/forward.yaml
@@ -4,7 +4,7 @@ mpas-ocean:
   time_management:
     config_stop_time: none
   time_integration:
-    config_dt: 00:10:00
+    config_dt: 0000_00:10:00
   split_explicit_ts:
     config_btr_dt: 0000_00:00:30
   forcing:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This is needed for Omega compatibility, at least for now.

This merge also makes sure `RunDuration` is in `DDDD_hh:mm:ss` for Omega unless it is already in `YYYY-MM-DD_hh:mm:ss`.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #444 