### PR TITLE
Add pseudothickness to write_model_dataset for Omega

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -656,6 +656,8 @@
 
    vertical.init_vertical_coord
    vertical.compute_zint_zmid_from_layer_thickness
+   vertical.diagnostics.geom_thickness_from_ds
+   vertical.diagnostics.pseudothickness_from_ds
    vertical.diagnostics.depth_from_thickness
    vertical.grid_1d.generate_1d_grid
    vertical.grid_1d.write_1d_grid

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -29,7 +29,12 @@ respectively. The `open_model_dataset()` method also supports reconstructing
 normal vector components to their zonal and meridional equivalents by passing
 a list of variable names to
 {py:class}`mpas_tools.vector.reconstruct.reconstruct_variables`, along with the mesh and
-reconstruction coefficient files. As new variables are added to Omega, they
+reconstruction coefficient files. In addition,
+`open_model_dataset()` derives `PseudoThickness` from the ocean state when it
+is not present in the dataset. This provides a way of using the same initial
+conditions for MPAS-Ocean and Omega when the geometric thickness is the state
+variable for MPAS-Ocean and the pseudo-thickness is the state variable for
+Omega. As new variables are added to Omega, they
 should be added to the `variables` section in the
 [mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml)
 file.
@@ -604,6 +609,12 @@ For workflows that need pseudo-height/pressure conversion, the
 For sigma coordinates, shared functionality for direct thickness computation is
 available in
 {py:func}`polaris.ocean.vertical.sigma.compute_sigma_layer_thickness()`.
+
+The `polaris.ocean.vertical.diagnostics` module provides utilities:
+
+- {py:func}`polaris.ocean.vertical.diagnostics.geom_thickness_from_ds()`
+- {py:func}`polaris.ocean.vertical.diagnostics.pseudothickness_from_ds()`
+- {py:func}`polaris.ocean.vertical.diagnostics.depth_from_thickness()`
 
 (dev-ocean-rpe)=
 

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -434,7 +434,9 @@ class ConvergenceAnalysis(OceanIOStep):
             The exact solution as derived from the initial condition
         """
 
-        ds_init = self.open_model_dataset(f'init_r{refinement_factor:02g}.nc')
+        ds_init = self.open_model_dataset(
+            f'init_r{refinement_factor:02g}.nc', self.config
+        )
         ds_init = ds_init.isel(Time=0)
         if zidx is not None:
             ds_init = ds_init.isel(nVertLevels=zidx)
@@ -466,7 +468,7 @@ class ConvergenceAnalysis(OceanIOStep):
         """
         config = self.config
         ds_out = self.open_model_dataset(
-            f'output_r{refinement_factor:02g}.nc', decode_times=False
+            f'output_r{refinement_factor:02g}.nc', config, decode_times=False
         )
 
         model = config.get('ocean', 'model')

--- a/polaris/ocean/eos/__init__.py
+++ b/polaris/ocean/eos/__init__.py
@@ -37,6 +37,7 @@ def compute_density(
         Computed density (in-situ or reference) of the seawater.
     """
     eos_type = config.get('ocean', 'eos_type')
+    eos_type = eos_type.strip()
     if eos_type == 'constant':
         density = compute_constant_density(config, temperature)
     elif eos_type == 'linear':
@@ -88,7 +89,10 @@ def compute_specvol(
         Computed specific volume (in-situ or reference) of the seawater.
     """
     eos_type = config.get('ocean', 'eos_type')
-    if eos_type == 'linear':
+    eos_type = eos_type.strip()
+    if eos_type == 'constant':
+        specvol = 1.0 / compute_constant_density(config, temperature)
+    elif eos_type == 'linear':
         specvol = 1.0 / compute_linear_density(config, temperature, salinity)
     elif eos_type == 'teos-10':
         if pressure is None:

--- a/polaris/ocean/eos/constant.py
+++ b/polaris/ocean/eos/constant.py
@@ -25,10 +25,10 @@ def compute_constant_density(
         Computed density of the seawater.
     """
     section = config['ocean']
-    rhoref = section.getfloat('eos_rhoref')
+    rhoref = section.getfloat('eos_constant_rhoref')
     assert rhoref is not None, (
-        'eos_rho_ref must be specified in the config options for eos type '
-        'constant.'
+        'eos_constant_rhoref must be specified in the config options for eos '
+        'type constant.'
     )
     # Return density of same type and size as temperature
     # (needs to work for both float and xarray DataArray)

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -32,7 +32,7 @@ class OceanIOStep(Step):
         """
         return self.component.map_to_native_model_vars(ds)
 
-    def write_model_dataset(self, ds, filename):
+    def write_model_dataset(self, ds, filename, config=None):
         """
         Write out the given dataset, mapping dimension and variable names from
         MPAS-Ocean to Omega names if appropriate
@@ -45,7 +45,7 @@ class OceanIOStep(Step):
         filename : str
             The path for the NetCDF file to write
         """
-        self.component.write_model_dataset(ds, filename)
+        self.component.write_model_dataset(ds, filename, config=config)
 
     def map_from_native_model_vars(self, ds):
         """

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -65,7 +65,7 @@ class OceanIOStep(Step):
         """
         return self.component.map_from_native_model_vars(ds)
 
-    def open_model_dataset(self, filename, **kwargs):
+    def open_model_dataset(self, filename, config=None, **kwargs):
         """
         Open the given dataset, mapping variable and dimension names from Omega
         to MPAS-Ocean names if appropriate
@@ -83,4 +83,6 @@ class OceanIOStep(Step):
         ds : xarray.Dataset
             The dataset with variables named as expected in MPAS-Ocean
         """
-        return self.component.open_model_dataset(filename, **kwargs)
+        return self.component.open_model_dataset(
+            filename, config=config, **kwargs
+        )

--- a/polaris/ocean/ocean.cfg
+++ b/polaris/ocean/ocean.cfg
@@ -43,6 +43,9 @@ iterations = 10
 # Options related to the vertical grid
 [vertical_grid]
 
+# The initial surface pressure when not spatially-varying in Pascals
+surface_pressure = 0.
+
 # The minimum number of vertical levels for z-star coordinate
 min_vert_levels = 1
 

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -1,6 +1,37 @@
 import numpy as np
 import xarray as xr
 
+from polaris.ocean.vertical.ztilde import (
+    pressure_and_spec_vol_from_state_at_geom_height,
+    pseudothickness_from_pressure,
+)
+
+
+def pseudothickness_from_ds(ds, config):
+    if 'temperature' not in ds.keys() or 'salinity' not in ds.keys():
+        print(
+            'PseudoThickness is not present in the '
+            'initial condition and T,S are not present '
+            'to compute it'
+        )
+        return
+
+    surface_pressure = config.getfloat('vertical_grid', 'surface_pressure')
+    rho0 = config.getfloat('vertical_grid', 'rho0')
+
+    p_interface, _, _ = pressure_and_spec_vol_from_state_at_geom_height(
+        config,
+        ds.layerThickness,
+        ds.temperature,
+        ds.salinity,
+        surface_pressure * xr.ones_like(ds.ssh),
+        iter_count=1,
+    )
+
+    pseudothickness = pseudothickness_from_pressure(p_interface, rho0)
+
+    return pseudothickness
+
 
 def depth_from_thickness(ds):
     """

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -7,6 +7,20 @@ from polaris.ocean.vertical.ztilde import (
 )
 
 
+def geom_thickness_from_ds(ds, config):
+    rho0 = config.getfloat('vertical_grid', 'rho0')
+    if 'layerThickness' in ds.keys():
+        return ds['layerThickness']
+    elif 'SpecVol' in ds.keys() and 'PseudoThickness' in ds.keys():
+        return rho0 * ds['SpecVol'] * ds['layerThickness']
+    else:
+        raise ValueError(
+            'Geometric layerThickness is not present in the '
+            'initial condition and SpecVol is not present '
+            'to compute it'
+        )
+
+
 def pseudothickness_from_ds(ds, config):
     if 'temperature' not in ds.keys() or 'salinity' not in ds.keys():
         print(

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -1,18 +1,20 @@
 import numpy as np
 import xarray as xr
 
+from polaris.constants import get_constant
 from polaris.ocean.vertical.ztilde import (
     pressure_and_spec_vol_from_state_at_geom_height,
     pseudothickness_from_pressure,
 )
 
+RhoSw = get_constant('seawater_density_reference')
+
 
 def geom_thickness_from_ds(ds, config):
-    rho0 = config.getfloat('vertical_grid', 'rho0')
     if 'layerThickness' in ds.keys():
         return ds['layerThickness']
     elif 'SpecVol' in ds.keys() and 'PseudoThickness' in ds.keys():
-        return rho0 * ds['SpecVol'] * ds['layerThickness']
+        return RhoSw * ds['SpecVol'] * ds['layerThickness']
     else:
         raise ValueError(
             'Geometric layerThickness is not present in the '
@@ -31,7 +33,6 @@ def pseudothickness_from_ds(ds, config):
         return
 
     surface_pressure = config.getfloat('vertical_grid', 'surface_pressure')
-    rho0 = config.getfloat('vertical_grid', 'rho0')
     p_interface, _, _ = pressure_and_spec_vol_from_state_at_geom_height(
         config,
         ds.layerThickness,
@@ -41,7 +42,7 @@ def pseudothickness_from_ds(ds, config):
         iter_count=1,
     )
 
-    pseudothickness = pseudothickness_from_pressure(p_interface, rho0)
+    pseudothickness = pseudothickness_from_pressure(p_interface)
 
     return pseudothickness
 

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -18,7 +18,6 @@ def pseudothickness_from_ds(ds, config):
 
     surface_pressure = config.getfloat('vertical_grid', 'surface_pressure')
     rho0 = config.getfloat('vertical_grid', 'rho0')
-
     p_interface, _, _ = pressure_and_spec_vol_from_state_at_geom_height(
         config,
         ds.layerThickness,

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -11,6 +11,29 @@ RhoSw = get_constant('seawater_density_reference')
 
 
 def geom_thickness_from_ds(ds, config):
+    """
+    Extract or compute geometric layer thickness from dataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        An ocean dataset containing either 'layerThickness' directly, or
+        'SpecVol' and 'PseudoThickness' to compute it
+
+    config : polaris.config.PolarisConfigParser
+        Configuration options for the test case
+
+    Returns
+    -------
+    layer_thickness : xarray.DataArray
+        The geometric layer thickness in meters
+
+    Raises
+    ------
+    ValueError
+        If neither layerThickness nor the variables needed to compute it
+        are present in the dataset
+    """
     if 'layerThickness' in ds.keys():
         return ds['layerThickness']
     elif 'SpecVol' in ds.keys() and 'PseudoThickness' in ds.keys():
@@ -24,6 +47,25 @@ def geom_thickness_from_ds(ds, config):
 
 
 def pseudothickness_from_ds(ds, config):
+    """
+    Compute pseudothickness from temperature and salinity in dataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        An ocean dataset containing 'temperature', 'salinity',
+        'layerThickness', and 'ssh'
+
+    config : polaris.config.PolarisConfigParser
+        Configuration options for the test case, including
+        'vertical_grid:surface_pressure'
+
+    Returns
+    -------
+    pseudothickness : xarray.DataArray or None
+        The pseudothickness computed from pressure, or None if
+        temperature and salinity are not available
+    """
     if 'temperature' not in ds.keys() or 'salinity' not in ds.keys():
         print(
             'PseudoThickness is not present in the '
@@ -49,23 +91,30 @@ def pseudothickness_from_ds(ds, config):
 
 def depth_from_thickness(ds):
     """
-    Compute the depth of the midpoint of each layer from `layerThickness`. It
-    is assumed that the `layerThickness` of invalid levels is 0. If
+    Compute the depth of the midpoint of each layer from `layerThickness`.
+
+    It is assumed that the `layerThickness` of invalid levels is 0. If
     `ssh` is present in the dataset, depths will be offset by `ssh`. If
-    `bottomDepth` is present in the dataset, the location of the bottom of the
-    bottommost vertical level will be compared with `bottomDepth`.
+    `bottomDepth` is present in the dataset, the location of the bottom
+    of the bottommost vertical level will be compared with `bottomDepth`.
 
     Parameters
     ----------
-    ds: xarray.Dataset
+    ds : xarray.Dataset
         An ocean dataset containing `layerThickness` and optionally `ssh`
         and `bottomDepth`
 
     Returns
     -------
     z_mid : xarray.DataArray
-        The location in meters from the sea surface of the midpoint of each
-        layer (level), positive upward
+        The location in meters from the sea surface of the midpoint of
+        each layer (level), positive upward
+
+    Raises
+    ------
+    ValueError
+        If `layerThickness` is not present in the dataset, or if required
+        dimensions are missing
     """
     # TODO when Omega supports these variables, just fetch them
     # if 'zMid' in ds.keys():

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -2,9 +2,9 @@
 Conversions between Omega pseudo-height and pressure.
 
 Omega's vertical coordinate is pseudo-height
-    z_tilde = -p / (rho0 * g)
+    z_tilde = -p / (RhoSw * g)
 with z_tilde positive upward. Here, ``p`` is sea pressure in Pascals (Pa),
-``rho0`` is a reference density (kg m^-3), and ``g`` is gravitational
+``RhoSw`` is a reference density (kg m^-3), and ``g`` is gravitational
 acceleration as defined by ``polaris.constants`` via the Physical Constants
 Dictionary.
 """
@@ -31,20 +31,17 @@ RhoSw = get_constant('seawater_density_reference')
 
 
 def pseudothickness_from_pressure(
-    p: xr.DataArray, rho0: float
+    p: xr.DataArray,
 ) -> xr.DataArray:
     """
     Convert sea pressure to pseudo-thickness.
 
-    z_tilde = -p / (rho0 * g)
+    z_tilde = -p / (RhoSw * g)
 
     Parameters
     ----------
     p : xarray.DataArray
         Sea pressure in Pascals (Pa) at layer interfaces.
-
-    rho0 : float
-        Reference density in kg m^-3.
 
     Returns
     -------
@@ -65,7 +62,7 @@ def pseudothickness_from_pressure(
         {
             'long_name': 'pseudo-thickness',
             'units': 'm',
-            'note': 'h_tilde = -dp / (rho0 * g)',
+            'note': 'h_tilde = -dp / (RhoSw * g)',
         }
     )
 
@@ -74,7 +71,7 @@ def z_tilde_from_pressure(p: xr.DataArray) -> xr.DataArray:
     """
     Convert sea pressure to pseudo-height.
 
-    z_tilde = -p / (rho0 * g)
+    z_tilde = -p / (RhoSw * g)
 
     Parameters
     ----------
@@ -92,7 +89,7 @@ def z_tilde_from_pressure(p: xr.DataArray) -> xr.DataArray:
         {
             'long_name': 'pseudo-height',
             'units': 'm',
-            'note': 'z_tilde = -p / (rho0 * g)',
+            'note': 'z_tilde = -p / (RhoSw * g)',
         }
     )
 
@@ -101,7 +98,7 @@ def pressure_from_z_tilde(z_tilde: xr.DataArray) -> xr.DataArray:
     """
     Convert pseudo-height to sea pressure.
 
-    p = -z_tilde * (rho0 * g)
+    p = -z_tilde * (RhoSw * g)
 
     Parameters
     ----------
@@ -119,7 +116,7 @@ def pressure_from_z_tilde(z_tilde: xr.DataArray) -> xr.DataArray:
         {
             'long_name': 'sea pressure',
             'units': 'Pa',
-            'note': 'p = -rho0 * g * z_tilde',
+            'note': 'p = -RhoSw * g * z_tilde',
         }
     )
 

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -20,6 +20,7 @@ from polaris.ocean.eos import compute_specvol
 
 __all__ = [
     'z_tilde_from_pressure',
+    'pseudothickness_from_pressure',
     'pressure_from_z_tilde',
     'pressure_and_spec_vol_from_state_at_geom_height',
     'pressure_from_geom_thickness',
@@ -27,6 +28,46 @@ __all__ = [
 
 Gravity = get_constant('standard_acceleration_of_gravity')
 RhoSw = get_constant('seawater_density_reference')
+
+
+def pseudothickness_from_pressure(
+    p: xr.DataArray, rho0: float
+) -> xr.DataArray:
+    """
+    Convert sea pressure to pseudo-thickness.
+
+    z_tilde = -p / (rho0 * g)
+
+    Parameters
+    ----------
+    p : xarray.DataArray
+        Sea pressure in Pascals (Pa) at layer interfaces.
+
+    rho0 : float
+        Reference density in kg m^-3.
+
+    Returns
+    -------
+    xarray.DataArray
+        Pseudo-thickness at layer mid-points with dimensions NCells by
+        NVertLayers (one less layer than ``p``) (units: m).
+    """
+
+    p_top = p.isel(nVertLevelsP1=slice(0, -1))
+    p_bot = p.isel(nVertLevelsP1=slice(1, None))
+    dims = list(p.dims)
+    dims = [item.replace('nVertLevelsP1', 'nVertLevels') for item in dims]
+    h = xr.DataArray(
+        (p_bot - p_top) / (RhoSw * Gravity),
+        dims=tuple(dims),
+    )
+    return h.assign_attrs(
+        {
+            'long_name': 'pseudo-thickness',
+            'units': 'm',
+            'note': 'h_tilde = -dp / (rho0 * g)',
+        }
+    )
 
 
 def z_tilde_from_pressure(p: xr.DataArray) -> xr.DataArray:

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -179,6 +179,7 @@ class Ocean(Component):
             and config is not None
         ):
             ds['PseudoThickness'] = pseudothickness_from_ds(ds, config=config)
+            ds['layerThickness'] = ds['PseudoThickness'].copy()
         ds = self.map_to_native_model_vars(ds)
         write_netcdf(ds=ds, fileName=filename)
 
@@ -287,14 +288,14 @@ class Ocean(Component):
             The dataset with variables named as expected in MPAS-Ocean
         """
         ds = xr.open_dataset(filename, **kwargs)
-        ds = self.map_from_native_model_vars(ds)
         if (
             self.model == 'omega'
-            and 'layerThickness' in ds.keys()
+            and 'LayerThickness' in ds.keys()
             and config is not None
         ):
-            ds['PseudoThickness'] = ds.layerThickness
-            ds['layerThickness'] = geom_thickness_from_ds(ds, config=config)
+            ds['PseudoThickness'] = ds.LayerThickness
+            ds['LayerThickness'] = geom_thickness_from_ds(ds, config=config)
+        ds = self.map_from_native_model_vars(ds)
         ds = _add_reconstructed_variables_to_dataset(
             ds, reconstruct_variables, mesh_filename, coeffs_filename
         )

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -169,9 +169,14 @@ class Ocean(Component):
         filename : str
             The path for the NetCDF file to write
         """
-        ds = self.map_to_native_model_vars(ds)
-        if self.model == 'omega' and 'PseudoThickness' not in ds.keys():
+        if (
+            self.model == 'omega'
+            and 'layerThickness' in ds.keys()
+            and 'PseudoThickness' not in ds.keys()
+            and config is not None
+        ):
             ds['PseudoThickness'] = pseudothickness_from_ds(ds, config=config)
+        ds = self.map_to_native_model_vars(ds)
         write_netcdf(ds=ds, fileName=filename)
 
     def map_from_native_model_vars(self, ds):

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -8,7 +8,10 @@ from mpas_tools.vector.reconstruct import reconstruct_variable
 from ruamel.yaml import YAML
 
 from polaris import Component
-from polaris.ocean.vertical.diagnostics import pseudothickness_from_ds
+from polaris.ocean.vertical.diagnostics import (
+    geom_thickness_from_ds,
+    pseudothickness_from_ds,
+)
 
 
 class Ocean(Component):
@@ -245,6 +248,7 @@ class Ocean(Component):
     def open_model_dataset(
         self,
         filename,
+        config=None,
         mesh_filename=None,
         reconstruct_variables=None,
         coeffs_filename=None,
@@ -259,8 +263,8 @@ class Ocean(Component):
         filename : str
             The path for the NetCDF file to open
 
-        ds_mesh : xr.Dataset
-            The MPAS mesh dataset for the ocean model.
+        config : polaris.Config, optional
+            The configuration object for the simulation.
 
         mesh_filename : str, optional
             Path to the mesh NetCDF file.
@@ -284,6 +288,13 @@ class Ocean(Component):
         """
         ds = xr.open_dataset(filename, **kwargs)
         ds = self.map_from_native_model_vars(ds)
+        if (
+            self.model == 'omega'
+            and 'layerThickness' in ds.keys()
+            and config is not None
+        ):
+            ds['PseudoThickness'] = ds.layerThickness
+            ds['layerThickness'] = geom_thickness_from_ds(ds, config=config)
         ds = _add_reconstructed_variables_to_dataset(
             ds, reconstruct_variables, mesh_filename, coeffs_filename
         )

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -8,6 +8,7 @@ from mpas_tools.vector.reconstruct import reconstruct_variable
 from ruamel.yaml import YAML
 
 from polaris import Component
+from polaris.ocean.vertical.diagnostics import pseudothickness_from_ds
 
 
 class Ocean(Component):
@@ -155,7 +156,7 @@ class Ocean(Component):
             ]
         return renamed_vars
 
-    def write_model_dataset(self, ds, filename):
+    def write_model_dataset(self, ds, filename, config=None):
         """
         Write out the given dataset, mapping dimension and variable names from
         MPAS-Ocean to Omega names if appropriate
@@ -169,6 +170,8 @@ class Ocean(Component):
             The path for the NetCDF file to write
         """
         ds = self.map_to_native_model_vars(ds)
+        if self.model == 'omega' and 'PseudoThickness' not in ds.keys():
+            ds['PseudoThickness'] = pseudothickness_from_ds(ds, config=config)
         write_netcdf(ds=ds, fileName=filename)
 
     def map_from_native_model_vars(self, ds):

--- a/polaris/tasks/ocean/barotropic_channel/init.py
+++ b/polaris/tasks/ocean/barotropic_channel/init.py
@@ -4,12 +4,12 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
-from polaris import Step
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
 
-class Init(Step):
+class Init(OceanIOStep):
     """
     A step for creating a mesh and initial condition for barotropic channel
     tasks
@@ -102,7 +102,7 @@ class Init(Step):
         ds['fCell'] = xr.zeros_like(ds.xCell)
         ds['fEdge'] = xr.zeros_like(ds.xEdge)
         ds['fVertex'] = xr.zeros_like(ds.xVertex)
-        write_netcdf(ds, 'initial_state.nc')
+        self.write_model_dataset(ds, 'initial_state.nc', config)
 
         # set the wind stress forcing
         ds_forcing = xr.Dataset()
@@ -114,4 +114,4 @@ class Init(Step):
         ds_forcing['windStressMeridional'] = (
             wind_stress_meridional.expand_dims(dim='Time', axis=0)
         )
-        write_netcdf(ds_forcing, 'forcing.nc')
+        self.write_model_dataset(ds_forcing, 'forcing.nc')

--- a/polaris/tasks/ocean/barotropic_channel/viz.py
+++ b/polaris/tasks/ocean/barotropic_channel/viz.py
@@ -40,8 +40,8 @@ class Viz(OceanIOStep):
         Run this step of the task
         """
         ds_mesh = self.open_model_dataset('mesh.nc')
-        ds_init = self.open_model_dataset('init.nc')
-        ds_out = self.open_model_dataset('output.nc')
+        ds_init = self.open_model_dataset('init.nc', self.config)
+        ds_out = self.open_model_dataset('output.nc', self.config)
 
         cell_mask = ds_init.maxLevelCell >= 1
         vertex_mask = ds_init.boundaryVertex == 0

--- a/polaris/tasks/ocean/barotropic_gyre/init.py
+++ b/polaris/tasks/ocean/barotropic_gyre/init.py
@@ -142,7 +142,7 @@ class Init(OceanIOStep):
         )
 
         # write the initial condition file
-        self.write_model_dataset(ds, 'init.nc')
+        self.write_model_dataset(ds, 'init.nc', config)
 
         cell_mask = ds.maxLevelCell >= 1
 

--- a/polaris/tasks/ocean/cosine_bell/analysis.py
+++ b/polaris/tasks/ocean/cosine_bell/analysis.py
@@ -83,7 +83,9 @@ class Analysis(ConvergenceAnalysis):
         ds_mesh = xr.open_dataset(f'mesh_r{refinement_factor:02g}.nc')
         sphere_radius = ds_mesh.sphere_radius
 
-        ds_init = self.open_model_dataset(f'init_r{refinement_factor:02g}.nc')
+        ds_init = self.open_model_dataset(
+            f'init_r{refinement_factor:02g}.nc', config
+        )
         latCell = ds_init.latCell.values
         lonCell = ds_init.lonCell.values
 

--- a/polaris/tasks/ocean/cosine_bell/init.py
+++ b/polaris/tasks/ocean/cosine_bell/init.py
@@ -112,7 +112,7 @@ class Init(OceanIOStep):
         ds['fEdge'] = xr.zeros_like(ds_mesh.xEdge)
         ds['fVertex'] = xr.zeros_like(ds_mesh.xVertex)
 
-        self.write_model_dataset(ds, 'initial_state.nc')
+        self.write_model_dataset(ds, 'initial_state.nc', config)
 
 
 def cosine_bell(max_value, ri, r):

--- a/polaris/tasks/ocean/cosine_bell/validate.py
+++ b/polaris/tasks/ocean/cosine_bell/validate.py
@@ -58,8 +58,8 @@ class Validate(OceanIOStep):
                 all_pass = False
 
         if all_pass:
-            ds1 = self.open_model_dataset(filename1)
-            ds2 = self.open_model_dataset(filename2)
+            ds1 = self.open_model_dataset(filename1, self.config)
+            ds2 = self.open_model_dataset(filename2, self.config)
 
             all_pass = compare_variables(
                 component=self.component,

--- a/polaris/tasks/ocean/cosine_bell/viz.py
+++ b/polaris/tasks/ocean/cosine_bell/viz.py
@@ -67,7 +67,7 @@ class Viz(OceanIOStep):
         mesh_name = self.mesh_name
         run_duration = config.getfloat('convergence_forward', 'run_duration')
 
-        ds_init = self.open_model_dataset('initial_state.nc')
+        ds_init = self.open_model_dataset('initial_state.nc', config)
         da = ds_init['tracer1'].isel(Time=0, nVertLevels=0)
 
         plot_global_mpas_field(

--- a/polaris/tasks/ocean/manufactured_solution/__init__.py
+++ b/polaris/tasks/ocean/manufactured_solution/__init__.py
@@ -4,6 +4,7 @@ from typing import Dict as Dict
 
 from polaris import Step, Task
 from polaris.config import PolarisConfigParser as PolarisConfigParser
+from polaris.constants import get_constant
 from polaris.ocean.convergence import (
     get_resolution_for_task as get_resolution_for_task,
 )
@@ -33,6 +34,12 @@ def add_manufactured_solution_tasks(component):
     config_filename = 'manufactured_solution.cfg'
     filepath = os.path.join(component.name, basedir, config_filename)
     config = PolarisConfigParser(filepath=filepath)
+    config.add_from_package('polaris.ocean.eos', 'constant.cfg')
+    config.set(
+        'ocean',
+        'eos_constant_rhoref',
+        value=f'{get_constant("seawater_density_reference"):02g}',
+    )
     config.add_from_package('polaris.ocean.convergence', 'convergence.cfg')
     config.add_from_package(
         'polaris.tasks.ocean.manufactured_solution', config_filename

--- a/polaris/tasks/ocean/manufactured_solution/analysis.py
+++ b/polaris/tasks/ocean/manufactured_solution/analysis.py
@@ -67,7 +67,9 @@ class Analysis(ConvergenceAnalysis):
         solution : xarray.DataArray
             The exact solution as derived from the initial condition
         """
-        init = self.open_model_dataset(f'init_r{refinement_factor:02g}.nc')
+        init = self.open_model_dataset(
+            f'init_r{refinement_factor:02g}.nc', self.config
+        )
         exact = ExactSolution(self.config, init)
         if field_name != 'ssh':
             raise ValueError(f'{field_name} is not currently supported')

--- a/polaris/tasks/ocean/manufactured_solution/init.py
+++ b/polaris/tasks/ocean/manufactured_solution/init.py
@@ -69,7 +69,7 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=False
         )
-        self.write_model_dataset(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(

--- a/polaris/tasks/ocean/manufactured_solution/init.py
+++ b/polaris/tasks/ocean/manufactured_solution/init.py
@@ -69,7 +69,7 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=False
         )
-        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc')
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
@@ -109,5 +109,7 @@ class Init(OceanIOStep):
             'Time', 'nCells', 'nVertLevels'
         )
         ds['layerThickness'] = layer_thickness
+        ds['temperature'] = xr.zeros_like(layer_thickness)
+        ds['salinity'] = xr.ones_like(layer_thickness)
 
-        self.write_model_dataset(ds, 'initial_state.nc')
+        self.write_model_dataset(ds, 'initial_state.nc', config)

--- a/polaris/tasks/ocean/manufactured_solution/viz.py
+++ b/polaris/tasks/ocean/manufactured_solution/viz.py
@@ -149,13 +149,15 @@ class Viz(OceanIOStep):
 
         for i, refinement_factor in enumerate(refinement_factors):
             ds_mesh = self.open_model_dataset(
-                f'mesh_r{refinement_factor:02g}.nc'
+                f'mesh_r{refinement_factor:02g}.nc', config
             )
             ds_init = self.open_model_dataset(
-                f'init_r{refinement_factor:02g}.nc'
+                f'init_r{refinement_factor:02g}.nc', config
             )
             ds = self.open_model_dataset(
-                f'output_r{refinement_factor:02g}.nc', decode_times=False
+                f'output_r{refinement_factor:02g}.nc',
+                config,
+                decode_times=False,
             )
 
             exact = ExactSolution(config, ds_init)

--- a/polaris/tasks/ocean/sphere_transport/init.py
+++ b/polaris/tasks/ocean/sphere_transport/init.py
@@ -199,4 +199,4 @@ class Init(OceanIOStep):
         ds['fEdge'] = xr.zeros_like(ds_mesh.xEdge)
         ds['fVertex'] = xr.zeros_like(ds_mesh.xVertex)
 
-        self.write_model_dataset(ds, 'initial_state.nc')
+        self.write_model_dataset(ds, 'initial_state.nc', config)

--- a/polaris/tasks/ocean/sphere_transport/viz.py
+++ b/polaris/tasks/ocean/sphere_transport/viz.py
@@ -94,8 +94,10 @@ class Viz(OceanIOStep):
         run_duration = config.getfloat('convergence_forward', 'run_duration')
 
         variables_to_plot = self.variables_to_plot
+
         ds_init = self.open_model_dataset(
             'initial_state.nc',
+            config,
             decode_times=False,
             mesh_filename='mesh.nc',
             reconstruct_variables=['normalVelocity'],
@@ -108,6 +110,7 @@ class Viz(OceanIOStep):
 
         ds_out = self.open_model_dataset(
             'output.nc',
+            config,
             decode_times=False,
             mesh_filename='mesh.nc',
             reconstruct_variables=['normalVelocity'],


### PR DESCRIPTION
Add the pseudo-thickness to model datasets for Omega initial conditions.

Surface pressure (constant value from config file), temperature, salinity and layer thickness are used to compute the pressure at layer interfaces. One iteration is currently used, pending testing of how many iterations is needed for convergence to desired accuracy.

The pressure at interfaces and a reference density (from config file) are then used to compute the pseudo-thickness.

The pseudo-thickness is automatically added to any `write_model_dataset` call when Omega is the ocean model AND the optional config argument is provided. (Note: checks for presence of config argument are still needed)

Fixes https://github.com/E3SM-Project/polaris/issues/461

~~Depends on https://github.com/E3SM-Project/Omega/pull/327 to rename `LayerThickness` to `PseudoThickness`~~
**OR we can map variable name `PseudoThickness` (added to MPAS-O dataset before variable mapping) to `LayerThickness`**

Checklist
* [N/A] User's Guide has been updated
* [X] Developer's Guide has been updated
* [X] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes