### PR TITLE
Reduce tracer3 convergence threshold in `rotation_2d`

### DIFF
--- a/polaris/tasks/ocean/sphere_transport/rotation_2d.cfg
+++ b/polaris/tasks/ocean/sphere_transport/rotation_2d.cfg
@@ -12,4 +12,4 @@ convergence_thresh_tracer3_order3 = 0.4
 # convergence threshold below which the test fails for order 2
 convergence_thresh_tracer1_order2 = 0.6
 convergence_thresh_tracer2_order2 = 1.4
-convergence_thresh_tracer3_order2 = 0.3
+convergence_thresh_tracer3_order2 = 0.27


### PR DESCRIPTION
This seems to be necessary after having dropped the 60 km mesh from the test.

See https://github.com/E3SM-Project/polaris/pull/457#issuecomment-3837300450

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
