### PR TITLE
Lower the threshold for tracer1 convergence in rotation_2d

### DIFF
--- a/polaris/tasks/ocean/sphere_transport/rotation_2d.cfg
+++ b/polaris/tasks/ocean/sphere_transport/rotation_2d.cfg
@@ -10,6 +10,6 @@ convergence_thresh_tracer2_order3 = 2.0
 convergence_thresh_tracer3_order3 = 0.4
 
 # convergence threshold below which the test fails for order 2
-convergence_thresh_tracer1_order2 = 0.6
+convergence_thresh_tracer1_order2 = 0.4
 convergence_thresh_tracer2_order2 = 1.4
 convergence_thresh_tracer3_order2 = 0.27


### PR DESCRIPTION
This is necessary on Chrysalis, where JIGSAW seems to be producing a mesh at QU90km resolution that results in an unusually noisy tracer1 field.  In general, QU meshes result in noise tracer1 that does not decrease monotonically with increasing resolution over the range of resolutions we are testing. See #487 for details.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
fixes #487 