### PR TITLE
Make sure auto-build raises an error on build failures

### DIFF
--- a/polaris/build/mpas_ocean.py
+++ b/polaris/build/mpas_ocean.py
@@ -86,7 +86,8 @@ def build_mpas_ocean(
         if quiet:
             command += f' > {log_filename} 2>&1 '
         else:
-            command += f' 2>&1 | tee {log_filename}'
+            # use pipefail so a build failure is not masked by tee's exit code
+            command = f'set -o pipefail; {command} 2>&1 | tee {log_filename}'
     subprocess.check_call(command, shell=True)
 
     print(f'MPAS-Ocean builds script written to:\n  {script_filename}\n')

--- a/polaris/build/omega.py
+++ b/polaris/build/omega.py
@@ -84,7 +84,8 @@ def build_omega(
         if quiet:
             command += f' > {log_filename} 2>&1 '
         else:
-            command += f' 2>&1 | tee {log_filename}'
+            # use pipefail so a build failure is not masked by tee's exit code
+            command = f'set -o pipefail; {command} 2>&1 | tee {log_filename}'
     subprocess.check_call(command, shell=True)
 
     print(f'Omega builds script written to:\n  {script_filename}\n')


### PR DESCRIPTION
Previously, the error code from Omega or MPAS-Ocean builds was not getting trapped because of the use of the `tee` command.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
