### PR TITLE
Update to 1.0.0-alpha.3

### DIFF
--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "polaris",
-    "mache_version": "3.2.0",
+    "mache_version": "3.3.0",
     "description": "Deploy polaris environment"
   },
   "arguments": [
@@ -18,9 +18,9 @@
       "route": ["deploy", "bootstrap", "run"]
     },
     {
-      "flags": ["--prefix"],
-      "dest": "prefix",
-      "help": "Install the environment into this prefix (directory). Overrides deploy/config.yaml.j2.",
+      "flags": ["--pixi-path", "--prefix"],
+      "dest": "pixi_path",
+      "help": "Install the pixi environment at this path (directory). Overrides deploy/config.yaml.j2. `--prefix` is deprecated.",
       "route": ["deploy", "bootstrap", "run"]
     },
     {

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -3,7 +3,7 @@
 bootstrap_python = 3.14
 python = 3.14
 geometric_features = 1.6.1
-mache = 3.2.0
+mache = 3.3.0
 mpas_tools = 1.4.0
 otps = 2021.10
 parallelio = 2.6.9

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.0-alpha.2'
+__version__ = '1.0.0-alpha.3'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This brings in mache 3.3.0, which fixes an issue on Perlmuter-GPU (`--gpu_bind=none`).

It also updates the `Omega` submodule to add:
* https://github.com/E3SM-Project/Omega/pull/362
* https://github.com/E3SM-Project/Omega/pull/359
* https://github.com/E3SM-Project/Omega/pull/374

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
