### PR TITLE
Remove YAKL as Omega build dependency

### DIFF
--- a/polaris/build/build_omega.template
+++ b/polaris/build/build_omega.template
@@ -23,7 +23,6 @@ fi
 cd {{ omega_base_dir }}
 
 git submodule update --init --recursive \
-    externals/YAKL \
     externals/ekat \
     externals/scorpio \
     externals/cpptrace \


### PR DESCRIPTION
YAKL is no longer needed as Omega build dependency as of https://github.com/E3SM-Project/Omega/pull/74.