### PR TITLE
Modify AI agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,13 @@ Follow the repository's automated style configuration in
 `pyproject.toml` and `.pre-commit-config.yaml`.
 
 - Keep changes consistent with existing Polaris patterns.
+- Treat `deploy.py` and `deploy/cli_spec.json` as contract files shared
+  with the `mache` package.
+- Do not modify `deploy.py` or `deploy/cli_spec.json` directly in
+  Polaris.
+- If a change appears necessary, stop and note that the change must be
+  made in `mache` first, then synced back into Polaris using the normal
+  upstream update process.
 - For Python, follow the path-specific instructions in
   `.github/instructions/python.instructions.md`.
 - For documentation in `docs/`, follow the path-specific instructions in

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,5 +15,8 @@ Follow the repository's automated style configuration in
   `.github/instructions/python.instructions.md`.
 - For documentation in `docs/`, follow the path-specific instructions in
   `.github/instructions/docs.instructions.md`.
+- Run pre-commit on changed files is required before finishing; if sandboxed
+  execution fails, request escalation and do not close the task until it has
+  run or the user declines.
 - Prefer changes that pass the configured pre-commit hooks without
   adding ignores or suppressions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,16 @@ These instructions apply to the whole repository unless a deeper
 - Prefer starting from the existing template instead of creating task
   documentation pages from scratch.
 
+## Contracts
+
+- Treat `deploy.py` and `deploy/cli_spec.json` as contract files shared
+  with the `mache` package.
+- Do not modify `deploy.py` or `deploy/cli_spec.json` directly in
+  Polaris.
+- If a change appears necessary, stop and note that the change must be
+  made in `mache` first, then synced back into Polaris using the normal
+  upstream update process.
+
 ## Validation
 
 - Run relevant pre-commit hooks on changed files before finishing when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ These instructions apply to the whole repository unless a deeper
 
 ## Validation
 
-- Run relevant pre-commit hooks on changed files before finishing when
-  practical.
+- Run pre-commit on changed files is required before finishing; if sandboxed
+  execution fails, request escalation and do not close the task until it has
+  run or the user declines.
 - Prefer fixing lint and formatting issues rather than suppressing them.


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge tells AI agents not to alter `deploy.py` and other files that are "owned" by `mache`.

It also makes more forceful the requirement to run `pre-commit`, as I found that the agents would not find an environment to use and would skip the step as a result.