### PR TITLE
Drop `externals/cpptrace` and update Omega submodule

### DIFF
--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -460,7 +460,6 @@ git submodule update --init --recursive \
     externals/YAKL \
     externals/ekat \
     externals/scorpio \
-    externals/cpptrace \
     components/omega/external \
     cime
 cd components/omega

--- a/polaris/build/build_omega.template
+++ b/polaris/build/build_omega.template
@@ -25,7 +25,6 @@ cd {{ omega_base_dir }}
 git submodule update --init --recursive \
     externals/ekat \
     externals/scorpio \
-    externals/cpptrace \
     components/omega/external \
     cime
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Following https://github.com/E3SM-Project/Omega/pull/358, we need to update the auto-build capability to no longer try to check out `externals/cpptrace`.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
