### PR TITLE
Generalize `topo/combine` to work on lat-lon grids

### DIFF
--- a/docs/developers_guide/e3sm/init/api.md
+++ b/docs/developers_guide/e3sm/init/api.md
@@ -26,7 +26,10 @@
    CombineStep.setup
    CombineStep.constrain_resources
    CombineStep.run
-   CombineTask
+   get_cubed_sphere_topo_steps
+   get_lat_lon_topo_steps
+   CubedSphereCombineTask
+   LatLonCombineTask
    VizCombinedStep
    VizCombinedStep.setup
    VizCombinedStep.run

--- a/docs/developers_guide/e3sm/init/tasks/topo/combine.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/combine.md
@@ -18,32 +18,37 @@ and Antarctic topography datasets into a single dataset suitable for use in
 E3SM simulations. The step supports blending datasets across specified latitude
 ranges and remapping them to a target grid.
 
-The {py:class}`polaris.tasks.e3sm.init.topo.combine.CombineTask` wraps the
-`CombineStep` into a task that can be used to generate and cache combined
-topography datasets for reuse in other contexts.
+The
+{py:class}`polaris.tasks.e3sm.init.topo.combine.CubedSphereCombineTask`
+and
+{py:class}`polaris.tasks.e3sm.init.topo.combine.LatLonCombineTask`
+wrap the `CombineStep` into tasks that can be used to generate and cache
+combined topography datasets for reuse in other contexts.
 
 The {py:class}`polaris.tasks.e3sm.init.topo.combine.VizCombinedStep` step is
 an optional visualization step that can be added to the workflow to create
 plots of the combined topography dataset. This step is particularly useful for
 debugging or analyzing the combined dataset.
 
-## High-Resolution and Low-Resolution Versions
+## Target Grids and Resolutions
 
-There are two versions of the combine steps and task:
+The combine framework is now organized explicitly around the target grid and
+resolution rather than around a special “low-resolution” mode. Current tasks
+include:
 
-1. **Standard (High-Resolution) Version**: This version maps to a
-   high-resolution (ne3000, ~1 km) cubed-sphere grid by default, producing
-   topogrpahy that is suitable for remapping to standard and high-resolution
-   MPAS meshes (~60 km and finer).
+1. Cubed-sphere topography on `ne3000`
+2. Cubed-sphere topography on `ne120`
+3. Latitude-longitude topography on `0.2500_degree`
 
-2. **Low-Resolution Version**: This version uses a coarser ne120 (~25 km) grid
-   for faster remapping to coarse-resolution MPAS meshes (e.g., Icos240). It is
-   designed to reduce computational cost while still providing adequate accuracy
-   for low-resolution simulations used for regression testing rather than
-   science.
+These appear in task paths such as:
 
-The low-resolution version can be selected by setting the `low_res` parameter
-to `True` when creating the `CombineStep` or `CombineTask`.
+- `e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne3000/task`
+- `e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne120/task`
+- `e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.2500_degree/task`
+
+This structure makes it easier for downstream consumers such as ocean
+hydrography preprocessing to reuse combined topography products without
+embedding product-specific names into `e3sm/init`.
 
 ## Key Features
 
@@ -73,9 +78,6 @@ the configuration file. Key options include:
 - `lat_tiles` and `lon_tiles`: Number of tiles to split the global dataset for parallel remapping.
 - `renorm_thresh`: Threshold for renormalizing Antarctic variables during blending.
 
-For the low-resolution version, additional configuration options are provided
-in the `combine_low_res.cfg` file.
-
 ## Workflow
 
 1. **Setup**: The step downloads required datasets and sets up input/output
@@ -98,21 +100,30 @@ task:
 from polaris.tasks.e3sm.init.topo.combine import CombineStep
 
 component = task.component
-subdir = CombineStep.get_subdir(low_res=False)
+subdir = CombineStep.get_subdir()
 if subdir in component.steps:
     step = component.steps[subdir]
 else:
-    step = CombineStep(component=component, low_res=False)
+    step = CombineStep(component=component, subdir=subdir)
     component.add_step(step)
 task.add_step(step)
 ```
 
-To create a `CombineTask` for caching combined datasets:
+To create a cubed-sphere combine task for caching combined datasets:
 
 ```python
-from polaris.tasks.e3sm.init.topo.combine import CombineTask
+from polaris.tasks.e3sm.init.topo.combine import CubedSphereCombineTask
 
-combine_task = CombineTask(component=my_component, low_res=False)
+combine_task = CubedSphereCombineTask(component=my_component, resolution=3000)
+my_component.add_task(combine_task)
+```
+
+To create a latitude-longitude combine task:
+
+```python
+from polaris.tasks.e3sm.init.topo.combine import LatLonCombineTask
+
+combine_task = LatLonCombineTask(component=my_component, resolution=0.25)
 my_component.add_task(combine_task)
 ```
 
@@ -133,7 +144,8 @@ The `VizCombinedStep` is typically added only when visualization is explicitly r
 
 For more details, refer to the source code of the
 {py:class}`polaris.tasks.e3sm.init.topo.combine.CombineStep` and
-{py:class}`polaris.tasks.e3sm.init.topo.combine.CombineTask` classes.
+{py:class}`polaris.tasks.e3sm.init.topo.combine.CubedSphereCombineTask` and
+{py:class}`polaris.tasks.e3sm.init.topo.combine.LatLonCombineTask` classes.
 
 ```{note}
 Since this step is expensive and time-consuming to run, most tasks will

--- a/docs/developers_guide/e3sm/init/tasks/topo/combine.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/combine.md
@@ -38,13 +38,36 @@ include:
 
 1. Cubed-sphere topography on `ne3000`
 2. Cubed-sphere topography on `ne120`
-3. Latitude-longitude topography on `0.2500_degree`
+3. Latitude-longitude topography on `1.0000_degree`
+4. Latitude-longitude topography on `0.2500_degree`
+5. Latitude-longitude topography on `0.0625_degree`
+
+These resolutions are intended for different downstream uses:
+
+- `ne3000` is the standard high-resolution cubed-sphere product. At roughly
+   1 km resolution, it is suitable for remapping topography to standard and
+   high-resolution MPAS meshes, approximately 60 km and finer, for scientific
+   applications.
+- `ne120` is a lower-cost cubed-sphere product at roughly 25 km resolution.
+   It is useful for remapping to coarse meshes such as Icos240 and for
+   regression testing or other non-scientific workflows where the full
+   high-resolution product is not needed.
+- `1.0000_degree` is intended for quick, non-scientific testing when a very
+   coarse latitude-longitude product is sufficient.
+- `0.2500_degree` aligns with the WOA23 (World Ocean Atlas 2023) dataset and
+   can also be used when defining mesh resolution at moderate scales, roughly
+   down to 30 km.
+- `0.0625_degree` is intended for defining mesh resolution for most
+   scientific runs and will be used by the E3SM v4 unified MPAS mesh across
+   land, river, ocean, and sea-ice.
 
 These appear in task paths such as:
 
 - `e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne3000/task`
 - `e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne120/task`
+- `e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/1.0000_degree/task`
 - `e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.2500_degree/task`
+- `e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.0625_degree/task`
 
 This structure makes it easier for downstream consumers such as ocean
 hydrography preprocessing to reuse combined topography products without

--- a/docs/developers_guide/e3sm/init/tasks/topo/combine.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/combine.md
@@ -61,7 +61,8 @@ These resolutions are intended for different downstream uses:
    scientific runs and will be used by the E3SM v4 unified MPAS mesh across
    land, river, ocean, and sea-ice.
 
-These appear in task paths such as:
+A series of standalone tasks are available to create each topography dataset
+on its own:
 
 - `e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne3000/task`
 - `e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne120/task`
@@ -69,9 +70,10 @@ These appear in task paths such as:
 - `e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.2500_degree/task`
 - `e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.0625_degree/task`
 
-This structure makes it easier for downstream consumers such as ocean
-hydrography preprocessing to reuse combined topography products without
-embedding product-specific names into `e3sm/init`.
+Downstream workflows such as topography remapping to the MPAS mesh,
+extrapolation of the WOA23 dataset and defining mesh resolution for unified
+E3SM v4 meshes will use shared `topo/combine` steps referenced by their
+grid and resolution.
 
 ## Key Features
 

--- a/polaris/tasks/e3sm/init/add_tasks.py
+++ b/polaris/tasks/e3sm/init/add_tasks.py
@@ -1,4 +1,7 @@
-from polaris.tasks.e3sm.init.topo.combine import CombineTask as CombineTopoTask
+from polaris.tasks.e3sm.init.topo.combine import (
+    CubedSphereCombineTask,
+    LatLonCombineTask,
+)
 from polaris.tasks.e3sm.init.topo.cull import add_cull_topo_tasks
 from polaris.tasks.e3sm.init.topo.remap import add_remap_topo_tasks
 
@@ -10,10 +13,11 @@ def add_e3sm_init_tasks(component):
     component : polaris.Component
         the e3sm/init component that the tasks will be added to
     """
-    for low_res in [False, True]:
+    for resolution in [3000, 120]:
         component.add_task(
-            CombineTopoTask(component=component, low_res=low_res)
+            CubedSphereCombineTask(component=component, resolution=resolution)
         )
+    component.add_task(LatLonCombineTask(component=component, resolution=0.25))
 
     add_remap_topo_tasks(component=component)
 

--- a/polaris/tasks/e3sm/init/add_tasks.py
+++ b/polaris/tasks/e3sm/init/add_tasks.py
@@ -13,11 +13,16 @@ def add_e3sm_init_tasks(component):
     component : polaris.Component
         the e3sm/init component that the tasks will be added to
     """
-    for resolution in [3000, 120]:
+    for cubed_sphere_res in [3000, 120]:
         component.add_task(
-            CubedSphereCombineTask(component=component, resolution=resolution)
+            CubedSphereCombineTask(
+                component=component, resolution=cubed_sphere_res
+            )
         )
-    component.add_task(LatLonCombineTask(component=component, resolution=0.25))
+    for lat_lon_res in [0.0625, 0.25, 1.0]:
+        component.add_task(
+            LatLonCombineTask(component=component, resolution=lat_lon_res)
+        )
 
     add_remap_topo_tasks(component=component)
 

--- a/polaris/tasks/e3sm/init/add_tasks.py
+++ b/polaris/tasks/e3sm/init/add_tasks.py
@@ -1,3 +1,7 @@
+from polaris.tasks.e3sm.init.topo import (
+    CUBED_SPHERE_RESOLUTIONS,
+    LAT_LON_RESOLUTIONS,
+)
 from polaris.tasks.e3sm.init.topo.combine import (
     CubedSphereCombineTask,
     LatLonCombineTask,
@@ -13,13 +17,13 @@ def add_e3sm_init_tasks(component):
     component : polaris.Component
         the e3sm/init component that the tasks will be added to
     """
-    for cubed_sphere_res in [3000, 120]:
+    for cubed_sphere_res in CUBED_SPHERE_RESOLUTIONS:
         component.add_task(
             CubedSphereCombineTask(
                 component=component, resolution=cubed_sphere_res
             )
         )
-    for lat_lon_res in [0.0625, 0.25, 1.0]:
+    for lat_lon_res in LAT_LON_RESOLUTIONS:
         component.add_task(
             LatLonCombineTask(component=component, resolution=lat_lon_res)
         )

--- a/polaris/tasks/e3sm/init/topo/__init__.py
+++ b/polaris/tasks/e3sm/init/topo/__init__.py
@@ -1,0 +1,12 @@
+from polaris.tasks.e3sm.init.topo.resolutions import (
+    CUBED_SPHERE_RESOLUTIONS as CUBED_SPHERE_RESOLUTIONS,
+)
+from polaris.tasks.e3sm.init.topo.resolutions import (
+    LAT_LON_RESOLUTIONS as LAT_LON_RESOLUTIONS,
+)
+from polaris.tasks.e3sm.init.topo.resolutions import (
+    get_cubed_sphere_resolution as get_cubed_sphere_resolution,
+)
+from polaris.tasks.e3sm.init.topo.resolutions import (
+    uses_low_res_cubed_sphere as uses_low_res_cubed_sphere,
+)

--- a/polaris/tasks/e3sm/init/topo/combine/__init__.py
+++ b/polaris/tasks/e3sm/init/topo/combine/__init__.py
@@ -2,10 +2,16 @@ from polaris.tasks.e3sm.init.topo.combine.step import (
     CombineStep as CombineStep,
 )
 from polaris.tasks.e3sm.init.topo.combine.steps import (
-    get_combine_topo_steps as get_combine_topo_steps,
+    get_cubed_sphere_topo_steps as get_cubed_sphere_topo_steps,
+)
+from polaris.tasks.e3sm.init.topo.combine.steps import (
+    get_lat_lon_topo_steps as get_lat_lon_topo_steps,
 )
 from polaris.tasks.e3sm.init.topo.combine.task import (
-    CombineTask as CombineTask,
+    CubedSphereCombineTask as CubedSphereCombineTask,
+)
+from polaris.tasks.e3sm.init.topo.combine.task import (
+    LatLonCombineTask as LatLonCombineTask,
 )
 from polaris.tasks.e3sm.init.topo.combine.viz import (
     VizCombinedStep as VizCombinedStep,

--- a/polaris/tasks/e3sm/init/topo/combine/combine.cfg
+++ b/polaris/tasks/e3sm/init/topo/combine/combine.cfg
@@ -26,3 +26,39 @@ latmax = -60.
 # tractable
 lat_tiles = 3
 lon_tiles = 6
+
+
+[viz_combine_topo_base_elevation]
+colormap_name = cmo.topo
+norm_type = linear
+norm_args = {'vmin': -9000, 'vmax': 9000}
+under_color = black
+over_color = yellow
+
+[viz_combine_topo_ice_thickness]
+colormap_name = cmo.ice_r
+norm_type = linear
+norm_args = {'vmin': 0, 'vmax': 4000}
+under_color = cyan
+over_color = black
+
+[viz_combine_topo_ice_draft]
+colormap_name = cmo.topo
+norm_type = linear
+norm_args = {'vmin': -2000, 'vmax': 2000}
+under_color = black
+over_color = yellow
+
+[viz_combine_topo_ice_mask]
+colormap_name = cmo.amp_r
+norm_type = linear
+norm_args = {'vmin': 0, 'vmax': 1}
+under_color = red
+over_color = yellow
+
+[viz_combine_topo_grounded_mask]
+colormap_name = cmo.amp_r
+norm_type = linear
+norm_args = {'vmin': 0, 'vmax': 1}
+under_color = red
+over_color = yellow

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -276,10 +276,10 @@ class CombineStep(Step):
 
     def _modify_gebco(self, in_filename, out_filename):
         """
-        Modify GEBCO to include lon/lat bounds located at grid edges
+        Modify GEBCO to include lon/lat bounds and an ocean mask
         """
         logger = self.logger
-        logger.info('Adding bounds to GEBCO lat/lon')
+        logger.info('Adding bounds and an ocean mask to GEBCO')
 
         # Modify GEBCO
         gebco = xr.open_dataset(in_filename)
@@ -293,6 +293,7 @@ class CombineStep(Step):
         gebco['lon_bnds'] = lon_bnds.transpose('lon', 'bnds')
         gebco.lat.attrs['bounds'] = 'lat_bnds'
         gebco.lon.attrs['bounds'] = 'lon_bnds'
+        gebco['ocean_mask'] = (gebco.elevation < 0.0).astype(float)
 
         # Write modified GEBCO to netCDF
         _write_netcdf_with_fill_values(gebco, out_filename)
@@ -704,14 +705,14 @@ class CombineStep(Step):
 
                 # Add tile to remapped global topography
                 logger.info(f'    adding {remapped_filename}')
-                elevation = xr.open_dataset(remapped_filename).elevation
-                elevation = elevation.where(elevation.notnull(), 0.0)
-                if 'elevation' in global_remapped:
-                    global_remapped['elevation'] = (
-                        global_remapped.elevation + elevation
-                    )
-                else:
-                    global_remapped['elevation'] = elevation
+                ds_tile = xr.open_dataset(remapped_filename)
+                for field in ['elevation', 'ocean_mask']:
+                    da = ds_tile[field]
+                    da = da.where(da.notnull(), 0.0)
+                    if field in global_remapped:
+                        global_remapped[field] = global_remapped[field] + da
+                    else:
+                        global_remapped[field] = da
 
         # Write tile to netCDF
         logger.info(f'    writing {out_filename}')
@@ -783,6 +784,10 @@ class CombineStep(Step):
         global_elevation = global_elevation.where(
             global_elevation.notnull(), 0.0
         )
+        global_ocean_mask = ds_global.ocean_mask
+        global_ocean_mask = global_ocean_mask.where(
+            global_ocean_mask.notnull(), 0.0
+        )
 
         # Load and mask Antarctic dataset
         ds_antarctic = xr.open_dataset(antarctic_filename)
@@ -797,6 +802,7 @@ class CombineStep(Step):
             'ice_draft',
             'ice_mask',
             'grounded_mask',
+            'ocean_mask',
         ]
 
         for var in vars:
@@ -824,6 +830,12 @@ class CombineStep(Step):
         # Add masks
         for field in ['ice_mask', 'grounded_mask']:
             combined[field] = ds_antarctic[field]
+        antarctic_ocean_mask = ds_antarctic.ocean_mask.where(
+            ds_antarctic.ocean_mask.notnull(), global_ocean_mask
+        )
+        combined['ocean_mask'] = (
+            alpha * global_ocean_mask + (1.0 - alpha) * antarctic_ocean_mask
+        )
 
         # Add fill values
         fill_vals = {
@@ -831,6 +843,7 @@ class CombineStep(Step):
             'ice_thickness': 0.0,
             'ice_mask': 0.0,
             'grounded_mask': 0.0,
+            'ocean_mask': 0.0,
         }
         for field, fill_val in fill_vals.items():
             valid = combined[field].notnull()

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -256,11 +256,15 @@ class CombineStep(Step):
                 f'{res_name}.nc',
             ]
         )
-        self.exodus_filename = f'{self.resolution_name}.g'
+        if target_grid == 'cubed_sphere':
+            self.exodus_filename = f'{self.resolution_name}.g'
+        else:
+            self.exodus_filename = None
 
         self.add_output_file(filename=self.dst_scrip_filename)
         self.add_output_file(filename=self.combined_filename)
-        self.add_output_file(filename=self.exodus_filename)
+        if self.exodus_filename is not None:
+            self.add_output_file(filename=self.exodus_filename)
 
         if update:
             # We need to set absolute paths

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -56,21 +56,14 @@ class CombineStep(Step):
     }
 
     @staticmethod
-    def get_subdir(low_res):
+    def get_subdir():
         """
-        Get the subdirectory for the step based on the datasets
-        Parameters
-        ----------
-        low_res : bool, optional
-            Whether to use the low resolution configuration options
+        Get the base subdirectory for the step based on the datasets.
         """
-        suffix = '_low_res' if low_res else ''
-        subdir = (
-            f'combine_{CombineStep.ANTARCTIC}_{CombineStep.GLOBAL}{suffix}'
-        )
+        subdir = f'combine_{CombineStep.ANTARCTIC}_{CombineStep.GLOBAL}'
         return os.path.join('topo', subdir)
 
-    def __init__(self, component, subdir, low_res=False):
+    def __init__(self, component, subdir):
         """
         Create a new step
 
@@ -82,13 +75,10 @@ class CombineStep(Step):
         subdir : str
             The subdirectory within the component's work directory
 
-        low_res : bool, optional
-            Whether to use the low resolution configuration options
         """
         antarctic_dataset = self.ANTARCTIC
         global_dataset = self.GLOBAL
-        suffix = '_low_res' if low_res else ''
-        name = f'combine_topo_{antarctic_dataset}_{global_dataset}{suffix}'
+        name = f'combine_topo_{antarctic_dataset}_{global_dataset}'
         super().__init__(
             component=component,
             name=name,

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -441,10 +441,18 @@ class CombineStep(Step):
 
         # Select tile from dataset
         tile = ds.isel(lat=lat_indices, lon=lon_indices)
+        lat = tile.lat.values.copy()
+        lat_attrs = tile.lat.attrs.copy()
+        # xarray may expose coordinate views from ``isel()`` as read-only.
+        # Reassign corrected pole coordinates instead of mutating in place,
+        # while preserving CF metadata that ESMF uses to detect CFGRID files.
         if lat_tile == 0:
-            tile.lat.values[0] = -90.0  # Correct south pole
+            lat[0] = -90.0  # Correct south pole
         if lat_tile == lat_tiles - 1:
-            tile.lat.values[-1] = 90.0  # Correct north pole
+            lat[-1] = 90.0  # Correct north pole
+        tile = tile.assign_coords(
+            lat=xr.DataArray(lat, dims=tile.lat.dims, attrs=lat_attrs)
+        )
 
         # Write tile to netCDF
         _write_netcdf_with_fill_values(tile, out_filename)

--- a/polaris/tasks/e3sm/init/topo/combine/steps.py
+++ b/polaris/tasks/e3sm/init/topo/combine/steps.py
@@ -5,64 +5,131 @@ from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
 from polaris.tasks.e3sm.init.topo.combine.viz import VizCombinedStep
 
 
-def get_combine_topo_steps(component, include_viz=False, low_res=False):
+def get_cubed_sphere_topo_steps(component, resolution, include_viz=False):
     """
-    Get the shared combine topo step for the given component, adding it if
-    it doesn't exist
+    Get shared combined-topography steps for a cubed-sphere target grid.
 
     Parameters
     ----------
     component : polaris.Component
-        The component that the steps will be added to
+        The component that the steps will be added to.
+
+    resolution : int
+        The cubed-sphere resolution, such as 3000 or 120.
 
     include_viz : bool, optional
-        Whether to include the visualization step or not
-        Default is False.
-
-    low_res : bool, optional
-        Whether to use low resolution config options
+        Whether to include the visualization step or not.
 
     Returns
     -------
     steps : list of polaris.Step
-        The combine topo step and optional visualization step
+        The combine topo step and optional visualization step.
 
     config : polaris.config.PolarisConfigParser
-        The shared config options
+        The shared config options.
     """
+    return _get_target_topo_steps(
+        component=component,
+        target_grid='cubed_sphere',
+        resolution=resolution,
+        include_viz=include_viz,
+    )
 
-    subdir = CombineStep.get_subdir(low_res=low_res)
 
-    # add default config options for combining topo -- since these are
-    # shared steps, the config options need to be defined separately from any
-    # task this may be added to
+def get_lat_lon_topo_steps(component, resolution, include_viz=False):
+    """
+    Get shared combined-topography steps for a latitude-longitude target grid.
+
+    Parameters
+    ----------
+    component : polaris.Component
+        The component that the steps will be added to.
+
+    resolution : float
+        The latitude-longitude resolution in degrees.
+
+    include_viz : bool, optional
+        Whether to include the visualization step or not.
+
+    Returns
+    -------
+    steps : list of polaris.Step
+        The combine topo step and optional visualization step.
+
+    config : polaris.config.PolarisConfigParser
+        The shared config options.
+    """
+    return _get_target_topo_steps(
+        component=component,
+        target_grid='lat_lon',
+        resolution=resolution,
+        include_viz=include_viz,
+    )
+
+
+def _get_target_topo_steps(component, target_grid, resolution, include_viz):
+    """
+    Get shared combined-topography steps for a target grid and resolution.
+
+    Parameters
+    ----------
+    component : polaris.Component
+        The component that the steps will be added to.
+
+    target_grid : {'cubed_sphere', 'lat_lon'}
+        The type of target grid.
+
+    resolution : int or float
+        The target resolution as a cubed-sphere face count or degrees.
+
+    include_viz : bool
+        Whether to include the visualization step or not.
+
+    Returns
+    -------
+    steps : list of polaris.Step
+        The combine topo step and optional visualization step.
+
+    config : polaris.config.PolarisConfigParser
+        The shared config options.
+    """
+    if target_grid == 'cubed_sphere':
+        resolution_name = f'ne{int(resolution)}'
+    elif target_grid == 'lat_lon':
+        resolution_name = f'{float(resolution):.4f}_degree'
+    else:
+        raise ValueError(f'Unexpected target grid: {target_grid}')
+
+    subdir = os.path.join(
+        CombineStep.get_subdir(), target_grid, resolution_name
+    )
+
     config_filename = 'combine_topo.cfg'
     filepath = os.path.join(component.name, subdir, config_filename)
     config = PolarisConfigParser(filepath=filepath)
     config.add_from_package(
         'polaris.tasks.e3sm.init.topo.combine', 'combine.cfg'
     )
-    if low_res:
-        config.add_from_package(
-            'polaris.tasks.e3sm.init.topo.combine', 'combine_low_res.cfg'
-        )
+    config.set('combine_topo', 'target_grid', target_grid)
+    if target_grid == 'cubed_sphere':
+        config.set('combine_topo', 'resolution_cubedsphere', f'{resolution}')
+    else:
+        config.set('combine_topo', 'resolution_latlon', f'{resolution}')
 
     steps = []
-    # no config_filename is needed here since the shared config file is
-    # in this steps work directory
     combine_step = component.get_or_create_shared_step(
         step_cls=CombineStep,
         subdir=subdir,
         config=config,
-        low_res=low_res,
     )
+    combine_step._set_res_and_outputs(update=False)
     steps.append(combine_step)
 
     if include_viz:
-        subdir = os.path.join(combine_step.subdir, 'viz')
+        viz_subdir = os.path.join(combine_step.subdir, 'viz')
         viz_step = component.get_or_create_shared_step(
             step_cls=VizCombinedStep,
-            subdir=subdir,
+            subdir=viz_subdir,
             config=config,
             config_filename='combine_topo.cfg',
             combine_step=combine_step,

--- a/polaris/tasks/e3sm/init/topo/combine/steps.py
+++ b/polaris/tasks/e3sm/init/topo/combine/steps.py
@@ -4,6 +4,9 @@ from polaris.config import PolarisConfigParser
 from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
 from polaris.tasks.e3sm.init.topo.combine.viz import VizCombinedStep
 
+_MIN_CUBED_SPHERE_RESOLUTION = 120
+_MAX_LAT_LON_RESOLUTION = 1.0
+
 
 def get_cubed_sphere_topo_steps(component, resolution, include_viz=False):
     """
@@ -94,9 +97,11 @@ def _get_target_topo_steps(component, target_grid, resolution, include_viz):
         The shared config options.
     """
     if target_grid == 'cubed_sphere':
-        resolution_name = f'ne{int(resolution)}'
+        resolution, resolution_name = _validate_cubed_sphere_resolution(
+            resolution
+        )
     elif target_grid == 'lat_lon':
-        resolution_name = f'{float(resolution):.4f}_degree'
+        resolution, resolution_name = _validate_lat_lon_resolution(resolution)
     else:
         raise ValueError(f'Unexpected target grid: {target_grid}')
 
@@ -137,3 +142,77 @@ def _get_target_topo_steps(component, target_grid, resolution, include_viz):
         steps.append(viz_step)
 
     return steps, config
+
+
+def _validate_cubed_sphere_resolution(resolution):
+    """
+    Validate and normalize a cubed-sphere resolution.
+
+    Parameters
+    ----------
+    resolution : int or float
+        The cubed-sphere resolution.
+
+    Returns
+    -------
+    resolution : int
+        The validated cubed-sphere resolution.
+
+    resolution_name : str
+        The corresponding resolution name.
+    """
+    resolution = float(resolution)
+    if resolution <= 0.0:
+        raise ValueError(
+            f'Cubed-sphere resolution must be positive, got {resolution}.'
+        )
+
+    if not resolution.is_integer():
+        raise ValueError(
+            'Cubed-sphere resolution must be an integer face count, '
+            f'got {resolution}.'
+        )
+
+    resolution = int(resolution)
+    if resolution < _MIN_CUBED_SPHERE_RESOLUTION:
+        raise ValueError(
+            'Cubed-sphere resolution is implausibly coarse for combined '
+            f'topography: ne{resolution}. Expected ne'
+            f'{_MIN_CUBED_SPHERE_RESOLUTION} or finer.'
+        )
+
+    return resolution, f'ne{resolution}'
+
+
+def _validate_lat_lon_resolution(resolution):
+    """
+    Validate and normalize a latitude-longitude resolution.
+
+    Parameters
+    ----------
+    resolution : float
+        The latitude-longitude resolution in degrees.
+
+    Returns
+    -------
+    resolution : float
+        The validated latitude-longitude resolution.
+
+    resolution_name : str
+        The corresponding resolution name.
+    """
+    resolution = float(resolution)
+    if resolution <= 0.0:
+        raise ValueError(
+            'Latitude-longitude resolution must be positive, '
+            f'got {resolution}.'
+        )
+
+    if resolution > _MAX_LAT_LON_RESOLUTION:
+        raise ValueError(
+            'Latitude-longitude resolution is implausibly coarse for '
+            f'combined topography: {resolution} degree. Expected '
+            f'{_MAX_LAT_LON_RESOLUTION} degree or finer.'
+        )
+
+    return resolution, f'{resolution:.4f}_degree'

--- a/polaris/tasks/e3sm/init/topo/combine/task.py
+++ b/polaris/tasks/e3sm/init/topo/combine/task.py
@@ -84,7 +84,7 @@ class LatLonCombineTask(Task):
         steps, config = get_lat_lon_topo_steps(
             component=component,
             resolution=resolution,
-            include_viz=False,
+            include_viz=True,
         )
         self.set_shared_config(config, link='combine_topo.cfg')
         for step in steps:

--- a/polaris/tasks/e3sm/init/topo/combine/task.py
+++ b/polaris/tasks/e3sm/init/topo/combine/task.py
@@ -2,43 +2,89 @@ import os
 
 from polaris.task import Task
 from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
-from polaris.tasks.e3sm.init.topo.combine.steps import get_combine_topo_steps
+from polaris.tasks.e3sm.init.topo.combine.steps import (
+    get_cubed_sphere_topo_steps,
+    get_lat_lon_topo_steps,
+)
 
 
-class CombineTask(Task):
+class CubedSphereCombineTask(Task):
     """
-    A task for creating the combined topography dataset, used to create the
-    files to be cached for use in all other contexts
+    A task for creating combined topography on a cubed-sphere target grid.
     """
 
-    def __init__(self, component, low_res):
+    def __init__(self, component, resolution):
         """
-        Create a new task
+        Create a new task.
 
         Parameters
         ----------
         component : polaris.Component
-            The component the task belongs to
+            The component the task belongs to.
 
-        low_res : bool
-            Whether to use low resolution config options
+        resolution : int
+            The cubed-sphere resolution, such as 3000 or 120.
         """
         antarctic_dataset = CombineStep.ANTARCTIC
         global_dataset = CombineStep.GLOBAL
-        suffix = '_low_res' if low_res else ''
         name = (
-            f'combine_topo_{antarctic_dataset}_{global_dataset}{suffix}_task'
+            f'combine_topo_{antarctic_dataset}_{global_dataset}_'
+            f'cubed_sphere_ne{resolution}_task'
         )
-        subdir = os.path.join(CombineStep.get_subdir(low_res=low_res), 'task')
+        subdir = os.path.join(
+            CombineStep.get_subdir(),
+            'cubed_sphere',
+            f'ne{resolution}',
+            'task',
+        )
         super().__init__(
             component=component,
             name=name,
             subdir=subdir,
         )
-        steps, config = get_combine_topo_steps(
+        steps, config = get_cubed_sphere_topo_steps(
             component=component,
+            resolution=resolution,
             include_viz=True,
-            low_res=low_res,
+        )
+        self.set_shared_config(config, link='combine_topo.cfg')
+        for step in steps:
+            self.add_step(step)
+
+
+class LatLonCombineTask(Task):
+    """
+    A task for creating combined topography on a latitude-longitude grid.
+    """
+
+    def __init__(self, component, resolution):
+        """
+        Create a new task.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the task belongs to.
+
+        resolution : float
+            The latitude-longitude resolution in degrees.
+        """
+        resolution_name = f'{resolution:.4f}_degree'
+        subdir = os.path.join(
+            CombineStep.get_subdir(),
+            'lat_lon',
+            resolution_name,
+            'task',
+        )
+        super().__init__(
+            component=component,
+            name=f'combine_topo_lat_lon_{resolution_name}_task',
+            subdir=subdir,
+        )
+        steps, config = get_lat_lon_topo_steps(
+            component=component,
+            resolution=resolution,
+            include_viz=False,
         )
         self.set_shared_config(config, link='combine_topo.cfg')
         for step in steps:

--- a/polaris/tasks/e3sm/init/topo/combine/viz.py
+++ b/polaris/tasks/e3sm/init/topo/combine/viz.py
@@ -1,5 +1,6 @@
 import os
 
+import cmocean  # noqa: F401
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -8,6 +9,7 @@ from matplotlib.colors import Normalize
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from polaris.step import Step
+from polaris.viz import plot_global_lat_lon_field
 
 
 class VizCombinedStep(Step):
@@ -60,15 +62,45 @@ class VizCombinedStep(Step):
             work_dir_target=os.path.join(combine_step.path, topo_filename),
         )
 
-        self.add_input_file(
-            filename='cubed_sphere.g',
-            work_dir_target=os.path.join(combine_step.path, exodus_filename),
-        )
+        if exodus_filename is not None:
+            self.add_input_file(
+                filename='cubed_sphere.g',
+                work_dir_target=os.path.join(
+                    combine_step.path, exodus_filename
+                ),
+            )
 
     def run(self):
         """
         Run this step
         """
+
+        colormap_sections = {
+            'base_elevation': 'viz_combine_topo_base_elevation',
+            'ice_thickness': 'viz_combine_topo_ice_thickness',
+            'ice_draft': 'viz_combine_topo_ice_draft',
+            'ice_mask': 'viz_combine_topo_ice_mask',
+            'grounded_mask': 'viz_combine_topo_grounded_mask',
+        }
+
+        ds_data = xr.open_dataset('topography.nc')
+        target_grid = self.config.get('combine_topo', 'target_grid')
+
+        if target_grid == 'cubed_sphere':
+            self._plot_cubed_sphere_fields(ds_data)
+        elif target_grid == 'lat_lon':
+            self._plot_lat_lon_fields(ds_data, colormap_sections)
+        else:
+            raise ValueError(f'Unexpected target grid: {target_grid}')
+
+    def _plot_cubed_sphere_fields(self, ds_data):
+        """
+        Plot fields on the cubed-sphere target grid.
+        """
+        valid_mask = np.isfinite(ds_data['base_elevation'].values)
+        vertices, tris = self._load_trimesh_geometry(
+            'cubed_sphere.g', valid_mask
+        )
 
         colormaps = {
             'base_elevation': 'cmo.deep_r',
@@ -78,21 +110,34 @@ class VizCombinedStep(Step):
             'grounded_mask': 'cmo.amp_r',
         }
 
-        ds_data = xr.open_dataset('topography.nc')
-
-        # Use one field to define the valid mask (they all share indexing)
-        valid_mask = np.isfinite(ds_data['base_elevation'].values)
-
-        # Build mesh only once
-        vertices, tris = self._load_trimesh_geometry(
-            'cubed_sphere.g', valid_mask
-        )
-
-        # Plot each field
         for field, colormap in colormaps.items():
             self.logger.info(f'Plotting field: {field}')
             data = ds_data[field].values[valid_mask]
-            self._plot_field(vertices, tris, data, field, colormap)
+            self._plot_cubed_sphere_field(
+                vertices, tris, data, field, colormap
+            )
+
+    def _plot_lat_lon_fields(self, ds_data, colormap_sections):
+        """
+        Plot fields on the latitude-longitude target grid.
+        """
+        lon = ds_data.lon.values
+        lat = ds_data.lat.values
+
+        for field, section in colormap_sections.items():
+            self.logger.info(f'Plotting field: {field}')
+            data_array = ds_data[field].transpose('lat', 'lon').values
+            plot_global_lat_lon_field(
+                lon=lon,
+                lat=lat,
+                data_array=data_array,
+                out_filename=f'{field}.png',
+                config=self.config,
+                colormap_section=section,
+                title=f'{self.combine_step.resolution_name} {field}',
+                plot_land=False,
+                colorbar_label=field,
+            )
 
     @staticmethod
     def _load_trimesh_geometry(exodus_path, valid_mask):
@@ -125,7 +170,9 @@ class VizCombinedStep(Step):
 
         return vertices, tris
 
-    def _plot_field(self, vertices, tris, field_data, field_name, cmap):
+    def _plot_cubed_sphere_field(
+        self, vertices, tris, field_data, field_name, cmap
+    ):
         """
         Rasterize and save a trisurf-style field image using Datashader.
         """

--- a/polaris/tasks/e3sm/init/topo/combine/viz.py
+++ b/polaris/tasks/e3sm/init/topo/combine/viz.py
@@ -5,11 +5,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import xarray as xr
-from matplotlib.colors import Normalize
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from polaris.step import Step
-from polaris.viz import plot_global_lat_lon_field
+from polaris.viz import plot_global_lat_lon_field, setup_colormap
 
 
 class VizCombinedStep(Step):
@@ -87,13 +86,13 @@ class VizCombinedStep(Step):
         target_grid = self.config.get('combine_topo', 'target_grid')
 
         if target_grid == 'cubed_sphere':
-            self._plot_cubed_sphere_fields(ds_data)
+            self._plot_cubed_sphere_fields(ds_data, colormap_sections)
         elif target_grid == 'lat_lon':
             self._plot_lat_lon_fields(ds_data, colormap_sections)
         else:
             raise ValueError(f'Unexpected target grid: {target_grid}')
 
-    def _plot_cubed_sphere_fields(self, ds_data):
+    def _plot_cubed_sphere_fields(self, ds_data, colormap_sections):
         """
         Plot fields on the cubed-sphere target grid.
         """
@@ -102,19 +101,15 @@ class VizCombinedStep(Step):
             'cubed_sphere.g', valid_mask
         )
 
-        colormaps = {
-            'base_elevation': 'cmo.deep_r',
-            'ice_thickness': 'cmo.ice_r',
-            'ice_draft': 'cmo.deep_r',
-            'ice_mask': 'cmo.amp_r',
-            'grounded_mask': 'cmo.amp_r',
-        }
-
-        for field, colormap in colormaps.items():
+        for field, section in colormap_sections.items():
             self.logger.info(f'Plotting field: {field}')
             data = ds_data[field].values[valid_mask]
             self._plot_cubed_sphere_field(
-                vertices, tris, data, field, colormap
+                vertices,
+                tris,
+                data,
+                field,
+                colormap_section=section,
             )
 
     def _plot_lat_lon_fields(self, ds_data, colormap_sections):
@@ -171,7 +166,7 @@ class VizCombinedStep(Step):
         return vertices, tris
 
     def _plot_cubed_sphere_field(
-        self, vertices, tris, field_data, field_name, cmap
+        self, vertices, tris, field_data, field_name, colormap_section
     ):
         """
         Rasterize and save a trisurf-style field image using Datashader.
@@ -204,12 +199,24 @@ class VizCombinedStep(Step):
         agg = canvas.trimesh(
             simplices=tris, vertices=vertices, agg=datashader.mean('value')
         )
+        colormap, norm, ticks = setup_colormap(self.config, colormap_section)
         self._plot_with_colorbar(
-            agg, cmap=cmap, field_name=field_name, filename=image_filename
+            agg,
+            colormap=colormap,
+            norm=norm,
+            ticks=ticks,
+            field_name=field_name,
+            filename=image_filename,
         )
 
     def _plot_with_colorbar(
-        self, agg, cmap, field_name, vmin=None, vmax=None, filename=None
+        self,
+        agg,
+        colormap,
+        norm,
+        ticks,
+        field_name,
+        filename=None,
     ):
         """
         Render a datashader aggregate with matplotlib colorbar.
@@ -218,21 +225,22 @@ class VizCombinedStep(Step):
         # mask background
         img_data = np.ma.masked_invalid(agg.data).astype('float32')
 
-        # Normalize range
-        norm = Normalize(
-            vmin=np.nanmin(img_data) if vmin is None else vmin,
-            vmax=np.nanmax(img_data) if vmax is None else vmax,
-        )
-
         # Plot
         fig, ax = plt.subplots(figsize=(22, 10))
         im = ax.imshow(
-            img_data, cmap=cmap, norm=norm, origin='lower', aspect='equal'
+            img_data,
+            cmap=colormap,
+            norm=norm,
+            origin='lower',
+            aspect='equal',
         )
 
         divider = make_axes_locatable(ax)
         cax = divider.append_axes('right', size='2%', pad=0.05)
-        plt.colorbar(im, cax=cax, label=field_name)
+        colorbar = plt.colorbar(im, cax=cax, label=field_name, extend='both')
+        if ticks is not None:
+            colorbar.set_ticks(ticks)
+            colorbar.set_ticklabels([f'{tick}' for tick in ticks])
         ax.axis('off')
 
         plt.savefig(filename, dpi=150, bbox_inches='tight')

--- a/polaris/tasks/e3sm/init/topo/cull/tasks.py
+++ b/polaris/tasks/e3sm/init/topo/cull/tasks.py
@@ -1,5 +1,7 @@
 from polaris.mesh.base import get_base_mesh_steps
-from polaris.tasks.e3sm.init.topo.combine.steps import get_combine_topo_steps
+from polaris.tasks.e3sm.init.topo.combine.steps import (
+    get_cubed_sphere_topo_steps,
+)
 from polaris.tasks.e3sm.init.topo.cull.task import CullTopoTask
 from polaris.tasks.e3sm.init.topo.remap.steps import (
     get_default_remap_topo_steps,
@@ -16,8 +18,9 @@ def add_cull_topo_tasks(component):
 
     combine_steps = {}
     for low_res in [False, True]:
-        combine_topo_steps, _ = get_combine_topo_steps(
-            component=component, low_res=low_res
+        resolution = 120 if low_res else 3000
+        combine_topo_steps, _ = get_cubed_sphere_topo_steps(
+            component=component, resolution=resolution
         )
         combine_steps[low_res] = combine_topo_steps[0]
 

--- a/polaris/tasks/e3sm/init/topo/cull/tasks.py
+++ b/polaris/tasks/e3sm/init/topo/cull/tasks.py
@@ -1,5 +1,9 @@
 from polaris.mesh.base import get_base_mesh_steps
-from polaris.tasks.e3sm.init.topo.combine.steps import (
+from polaris.tasks.e3sm.init.topo import (
+    get_cubed_sphere_resolution,
+    uses_low_res_cubed_sphere,
+)
+from polaris.tasks.e3sm.init.topo.combine import (
     get_cubed_sphere_topo_steps,
 )
 from polaris.tasks.e3sm.init.topo.cull.task import CullTopoTask
@@ -18,7 +22,7 @@ def add_cull_topo_tasks(component):
 
     combine_steps = {}
     for low_res in [False, True]:
-        resolution = 120 if low_res else 3000
+        resolution = get_cubed_sphere_resolution(low_res)
         combine_topo_steps, _ = get_cubed_sphere_topo_steps(
             component=component, resolution=resolution
         )
@@ -27,8 +31,7 @@ def add_cull_topo_tasks(component):
     base_mesh_steps = get_base_mesh_steps()
 
     for base_mesh_step in base_mesh_steps:
-        res = base_mesh_step.cell_width
-        low_res = res is not None and res >= 120.0
+        low_res = uses_low_res_cubed_sphere(base_mesh_step.cell_width)
         combine_topo_step = combine_steps[low_res]
 
         remap_topo_steps, _ = get_default_remap_topo_steps(

--- a/polaris/tasks/e3sm/init/topo/remap/tasks.py
+++ b/polaris/tasks/e3sm/init/topo/remap/tasks.py
@@ -1,5 +1,9 @@
 from polaris.mesh.base import get_base_mesh_steps
-from polaris.tasks.e3sm.init.topo.combine.steps import (
+from polaris.tasks.e3sm.init.topo import (
+    get_cubed_sphere_resolution,
+    uses_low_res_cubed_sphere,
+)
+from polaris.tasks.e3sm.init.topo.combine import (
     get_cubed_sphere_topo_steps,
 )
 from polaris.tasks.e3sm.init.topo.remap import RemapTopoTask
@@ -15,7 +19,7 @@ def add_remap_topo_tasks(component):
 
     combine_steps = {}
     for low_res in [False, True]:
-        resolution = 120 if low_res else 3000
+        resolution = get_cubed_sphere_resolution(low_res)
         combine_topo_steps, _ = get_cubed_sphere_topo_steps(
             component=component, resolution=resolution
         )
@@ -24,8 +28,7 @@ def add_remap_topo_tasks(component):
     base_mesh_steps = get_base_mesh_steps()
 
     for base_mesh_step in base_mesh_steps:
-        res = base_mesh_step.cell_width
-        low_res = res is not None and res >= 120.0
+        low_res = uses_low_res_cubed_sphere(base_mesh_step.cell_width)
         task = RemapTopoTask(
             component=component,
             base_mesh_step=base_mesh_step,

--- a/polaris/tasks/e3sm/init/topo/remap/tasks.py
+++ b/polaris/tasks/e3sm/init/topo/remap/tasks.py
@@ -1,5 +1,7 @@
 from polaris.mesh.base import get_base_mesh_steps
-from polaris.tasks.e3sm.init.topo.combine.steps import get_combine_topo_steps
+from polaris.tasks.e3sm.init.topo.combine.steps import (
+    get_cubed_sphere_topo_steps,
+)
 from polaris.tasks.e3sm.init.topo.remap import RemapTopoTask
 
 
@@ -13,8 +15,9 @@ def add_remap_topo_tasks(component):
 
     combine_steps = {}
     for low_res in [False, True]:
-        combine_topo_steps, _ = get_combine_topo_steps(
-            component=component, low_res=low_res
+        resolution = 120 if low_res else 3000
+        combine_topo_steps, _ = get_cubed_sphere_topo_steps(
+            component=component, resolution=resolution
         )
         combine_steps[low_res] = combine_topo_steps[0]
 

--- a/polaris/tasks/e3sm/init/topo/resolutions.py
+++ b/polaris/tasks/e3sm/init/topo/resolutions.py
@@ -1,0 +1,53 @@
+"""
+Shared resolution definitions for e3sm/init topography workflows.
+"""
+
+STANDARD_CUBED_SPHERE_RESOLUTION = 3000
+LOW_RES_CUBED_SPHERE_RESOLUTION = 120
+LOW_RES_BASE_MESH_CELL_WIDTH = 120.0
+
+CUBED_SPHERE_RESOLUTIONS = (
+    STANDARD_CUBED_SPHERE_RESOLUTION,
+    LOW_RES_CUBED_SPHERE_RESOLUTION,
+)
+
+LAT_LON_RESOLUTIONS = (0.0625, 0.25, 1.0)
+
+
+def get_cubed_sphere_resolution(low_res):
+    """
+    Get the cubed-sphere source-topography resolution for a mode.
+
+    Parameters
+    ----------
+    low_res : bool
+        Whether the lower-resolution cubed-sphere product should be used.
+
+    Returns
+    -------
+    resolution : int
+        The cubed-sphere resolution.
+    """
+    if low_res:
+        return LOW_RES_CUBED_SPHERE_RESOLUTION
+
+    return STANDARD_CUBED_SPHERE_RESOLUTION
+
+
+def uses_low_res_cubed_sphere(cell_width):
+    """
+    Determine whether a base mesh should use lower-resolution topography.
+
+    Parameters
+    ----------
+    cell_width : float or None
+        The representative base-mesh cell width in km.
+
+    Returns
+    -------
+    low_res : bool
+        Whether to use the lower-resolution cubed-sphere source topography.
+    """
+    return (
+        cell_width is not None and cell_width >= LOW_RES_BASE_MESH_CELL_WIDTH
+    )

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -14,4 +14,5 @@ from polaris.viz.spherical import (
 from polaris.viz.spherical import (
     plot_global_mpas_field as plot_global_mpas_field,
 )
+from polaris.viz.spherical import setup_colormap as setup_colormap
 from polaris.viz.style import use_mplstyle as use_mplstyle

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -140,7 +140,7 @@ def plot_global_mpas_field(
     if title is not None:
         fig.suptitle(title, y=0.935)
 
-    colormap, norm, ticks = _setup_colormap(config, colormap_section)
+    colormap, norm, ticks = setup_colormap(config, colormap_section)
 
     pcolor_kwargs = dict(cmap=colormap, norm=norm, zorder=1, edgecolors='face')
 
@@ -281,7 +281,7 @@ def plot_global_lat_lon_field(
 
     extent = [lon_corner[0], lon_corner[-1], lat_corner[0], lat_corner[-1]]
 
-    colormap, norm, ticks = _setup_colormap(config, colormap_section)
+    colormap, norm, ticks = setup_colormap(config, colormap_section)
 
     ax = plt.subplot(subplots[0], projection=projection)
 
@@ -331,7 +331,7 @@ def plot_global_lat_lon_field(
     plt.close()
 
 
-def _setup_colormap(config, colormap_section):
+def setup_colormap(config, colormap_section):
     """
     Set up a colormap from the registry
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR generalizes the `topo/combine` workflow in `e3sm/init` to support lat/lon target grids, not just the cubed-sphere grid previously supported.  This workflow combines the Bedmap3 topography data around Antarctica with the GEBCO data over the rest of the globe.

The PR adds support for 3 resolutions: 1, 0.25 and 0.0625 degrees.  The first will just be used for very coarse, non-scientific meshes (if at all).  The second might be used for low-res meshes and will be used for extrapolating the WOA 2023 dataset into ice-shelf cavities and land (WOA23 is on a 0.25 degree grid).  The finest of these will be used as part of defining resolution for high-res unified MPAS meshes.

This PR also adds support for visualizing the topography on the lat-lon grid.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
