### PR TITLE
Support configurable horizontal mesh stream in Omega

### DIFF
--- a/docs/developers_guide/framework/model.md
+++ b/docs/developers_guide/framework/model.md
@@ -74,8 +74,6 @@ ocean:
     config_time_integrator: RK4
 
   streams:
-    mesh:
-      filename_template: init.nc
     input:
       filename_template: init.nc
     restart:

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -26,8 +26,10 @@ and writing easier, we also provide
 {py:meth}`polaris.ocean.model.OceanIOStep.open_model_dataset()`, which take
 care of of the mapping in addition to writing and opening a dataset,
 respectively. As new variables are added to Omega, they should be added to the
-`variables` section in the
+`dimensions` and `variables` sections in the
 [mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml)
+file. This includes horizontal mesh variables such as coordinates, geometric
+factors and Coriolis fields when Omega reads the mesh from a separate NetCDF
 file.
 
 ### Running an E3SM component
@@ -40,6 +42,11 @@ discussion in {ref}`dev-model`.
 If the graph partition file has been constructed prior to the ocean model step,
 the path to the graph file should be provided in the `graph_target` argument
 to the constructor {py:class}`polaris.ocean.model.OceanModelStep()`.
+If a task reads its horizontal mesh from a local file such as `mesh.nc`, set
+`self.horiz_mesh_filename` in the step's constructor. Polaris will then update
+the model mesh stream for both MPAS-Ocean and Omega, including
+`Omega/IOStreams/HorzMeshIn/Filename`, without any `OmegaMesh.nc` symlink
+workaround.
 
 #### YAML files vs. namelists and streams
 
@@ -443,7 +450,9 @@ not be performed.
 
 The `mesh` step should be created with the function described in
 {ref}`dev-ocean-spherical-meshes`, and the `init` step should produce a file
-`init.nc` that will be the initial condition for the forward run.
+`init.nc` that will be the initial condition for the forward run. The forward
+step should use the mesh file from the mesh step directly for the model mesh
+stream.
 
 The `forward.yaml` file should be a YAML file with Jinja templating for the
 time integrator, time step, run duration and output interval, e.g.:
@@ -458,8 +467,6 @@ ocean:
     config_btr_dt: {{ btr_dt }}
 mpas-ocean:
   streams:
-    mesh:
-      filename_template: init.nc
     input:
       filename_template: init.nc
     restart: {}
@@ -474,6 +481,10 @@ mpas-ocean:
       - normalVelocity
       - layerThickness
 ```
+The horizontal mesh filename does not need to appear in `forward.yaml` if the
+step sets `self.horiz_mesh_filename`; `OceanModelStep` will inject the
+appropriate MPAS-Ocean and Omega stream overrides.
+
 `ConvergenceForward` takes care of filling in the template based
 on the associated config options (first at setup and again at runtime in case
 the config options have changed).

--- a/polaris/ocean/config/horiz_mesh.yaml
+++ b/polaris/ocean/config/horiz_mesh.yaml
@@ -1,0 +1,9 @@
+mpas-ocean:
+  streams:
+    mesh:
+      filename_template: {{ horiz_mesh_filename }}
+
+Omega:
+  IOStreams:
+    HorzMeshIn:
+      Filename: {{ horiz_mesh_filename }}

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -13,6 +13,8 @@ dimensions:
 
 variables:
   # mesh
+  nEdgesOnCell: NEdgesOnCell
+  nEdgesOnEdge: NEdgesOnEdge
   cellsOnCell: CellsOnCell
   edgesOnCell: EdgesOnCell
   verticesOnCell: VerticesOnCell
@@ -21,6 +23,32 @@ variables:
   verticesOnEdge: VerticesOnEdge
   cellsOnVertex: CellsOnVertex
   edgesOnVertex: EdgesOnVertex
+  xCell: XCell
+  yCell: YCell
+  zCell: ZCell
+  latCell: LatCell
+  lonCell: LonCell
+  xEdge: XEdge
+  yEdge: YEdge
+  zEdge: ZEdge
+  latEdge: LatEdge
+  lonEdge: LonEdge
+  xVertex: XVertex
+  yVertex: YVertex
+  zVertex: ZVertex
+  latVertex: LatVertex
+  lonVertex: LonVertex
+  areaCell: AreaCell
+  meshDensity: MeshDensity
+  areaTriangle: AreaTriangle
+  dvEdge: DvEdge
+  dcEdge: DcEdge
+  angleEdge: AngleEdge
+  kiteAreasOnVertex: KiteAreasOnVertex
+  weightsOnEdge: WeightsOnEdge
+  fCell: FCell
+  fEdge: FEdge
+  fVertex: FVertex
 
   # tracers
   temperature: Temperature

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -47,6 +47,10 @@ class OceanModelStep(ModelStep):
     graph_target : str
         The name of the graph partition file to link to (relative to the base
         working directory)
+
+    horiz_mesh_filename : str or None
+        The local input filename the model should use for the horizontal
+        mesh stream
     """
 
     # make sure component is of type Ocean
@@ -170,6 +174,7 @@ class OceanModelStep(ModelStep):
         ] = None
         self.graph_target = graph_target
         self.update_eos = update_eos
+        self.horiz_mesh_filename: Optional[str] = None
 
     def setup(self) -> None:
         """
@@ -195,6 +200,15 @@ class OceanModelStep(ModelStep):
             self.streams_section = 'streams'
         else:
             raise ValueError(f'Unexpected ocean model: {model}')
+
+        if self.horiz_mesh_filename is not None:
+            self.add_yaml_file(
+                'polaris.ocean.config',
+                'horiz_mesh.yaml',
+                template_replacements=dict(
+                    horiz_mesh_filename=self.horiz_mesh_filename
+                ),
+            )
 
         self.dynamic_ntasks = self.ntasks is None and self.min_tasks is None
 

--- a/polaris/tasks/ocean/barotropic_channel/forward.py
+++ b/polaris/tasks/ocean/barotropic_channel/forward.py
@@ -78,6 +78,11 @@ class Forward(OceanModelStep):
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
         self.add_input_file(
+            filename='mesh.nc',
+            target='../init/culled_mesh.nc',
+        )
+
+        self.add_input_file(
             filename='init.nc',
             target='../init/initial_state.nc',
         )
@@ -95,16 +100,7 @@ class Forward(OceanModelStep):
                 'temperature',
             ],
         )
-
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
+        self.horiz_mesh_filename = 'mesh.nc'
 
     def dynamic_model_config(self, at_setup):
         super().dynamic_model_config(at_setup=at_setup)

--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -40,8 +40,6 @@ mpas-ocean:
   debug:
     config_disable_vel_coriolis: true
   streams:
-    mesh:
-      filename_template: init.nc
     input:
       filename_template: init.nc
     restart:

--- a/polaris/tasks/ocean/barotropic_channel/init.py
+++ b/polaris/tasks/ocean/barotropic_channel/init.py
@@ -4,12 +4,12 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
-from polaris import Step
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
 
-class Init(Step):
+class Init(OceanIOStep):
     """
     A step for creating a mesh and initial condition for barotropic channel
     tasks
@@ -70,13 +70,13 @@ class Init(Step):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=True
         )
-        write_netcdf(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc')
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        write_netcdf(ds_mesh, 'culled_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'culled_mesh.nc')
 
         ds = ds_mesh.copy()
 
@@ -102,12 +102,19 @@ class Init(Step):
         ds['fCell'] = xr.zeros_like(ds.xCell)
         ds['fEdge'] = xr.zeros_like(ds.xEdge)
         ds['fVertex'] = xr.zeros_like(ds.xVertex)
-        write_netcdf(ds, 'initial_state.nc')
 
         # set the wind stress forcing
-        ds_forcing = xr.Dataset()
         wind_stress_zonal = u_wind * xr.ones_like(ds.xCell)
         wind_stress_meridional = v_wind * xr.ones_like(ds.xCell)
+        ds['windStressZonal'] = wind_stress_zonal.expand_dims(
+            dim='Time', axis=0
+        )
+        ds['windStressMeridional'] = wind_stress_meridional.expand_dims(
+            dim='Time', axis=0
+        )
+        self.write_model_dataset(ds, 'initial_state.nc')
+
+        ds_forcing = xr.Dataset()
         ds_forcing['windStressZonal'] = wind_stress_zonal.expand_dims(
             dim='Time', axis=0
         )

--- a/polaris/tasks/ocean/barotropic_gyre/forward.py
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.py
@@ -112,6 +112,7 @@ class Forward(OceanModelStep):
 
         self.package = 'polaris.tasks.ocean.barotropic_gyre'
         self.yaml_filename = 'forward.yaml'
+        self.horiz_mesh_filename = 'mesh.nc'
 
     def compute_cell_count(self):
         """
@@ -267,16 +268,6 @@ class Forward(OceanModelStep):
             self.yaml_filename,
             template_replacements=replacements,
         )
-
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
 
     def compute_max_time_step(self, config):
         """

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -31,8 +31,6 @@ mpas-ocean:
     config_disable_tr_all_tend: true
 
   streams:
-    mesh:
-      filename_template: init.nc
     input:
       filename_template: init.nc
     forcing:

--- a/polaris/tasks/ocean/cosine_bell/forward.py
+++ b/polaris/tasks/ocean/cosine_bell/forward.py
@@ -72,13 +72,4 @@ class Forward(SphericalConvergenceForward):
             refinement=refinement,
         )
         self.do_restart = do_restart
-
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
+        self.horiz_mesh_filename = 'mesh.nc'

--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -45,8 +45,6 @@ mpas-ocean:
   AM_mixedLayerDepths:
     config_AM_mixedLayerDepths_enable: false
   streams:
-    mesh:
-      filename_template: init.nc
     input:
       filename_template: init.nc
     restart:

--- a/polaris/tasks/ocean/external_gravity_wave/forward.py
+++ b/polaris/tasks/ocean/external_gravity_wave/forward.py
@@ -75,6 +75,7 @@ class Forward(SphericalConvergenceForward):
             refinement=refinement,
         )
         self.dt_type = dt_type
+        self.horiz_mesh_filename = 'mesh.nc'
 
         if dt_type == 'local':
             self.add_yaml_file(
@@ -180,6 +181,10 @@ class ReferenceForward(OceanModelStep):
             filename='init.nc',
             work_dir_target=f'{init.path}/initial_state.nc',
         )
+        self.add_input_file(
+            filename='mesh.nc',
+            work_dir_target=f'{mesh.path}/base_mesh.nc',
+        )
 
         if dt_type == 'local':
             self.add_yaml_file(
@@ -195,6 +200,7 @@ class ReferenceForward(OceanModelStep):
         self.dt = dt
         self.package = package
         self.yaml_filename = yaml_filename
+        self.horiz_mesh_filename = 'mesh.nc'
 
     def compute_cell_count(self):
         """
@@ -271,13 +277,3 @@ class ReferenceForward(OceanModelStep):
             self.yaml_filename,
             template_replacements=replacements,
         )
-
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')

--- a/polaris/tasks/ocean/external_gravity_wave/forward.yaml
+++ b/polaris/tasks/ocean/external_gravity_wave/forward.yaml
@@ -41,8 +41,6 @@ mpas-ocean:
   AM_mixedLayerDepths:
     config_AM_mixedLayerDepths_enable: false
   streams:
-    mesh:
-      filename_template: init.nc
     input:
       filename_template: init.nc
     restart:

--- a/polaris/tasks/ocean/manufactured_solution/forward.py
+++ b/polaris/tasks/ocean/manufactured_solution/forward.py
@@ -91,17 +91,7 @@ class Forward(ConvergenceForward):
         )
         self.del2 = del2
         self.del4 = del4
-
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        config = self.config
-        model = config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
+        self.horiz_mesh_filename = 'mesh.nc'
 
     def compute_cell_count(self):
         """

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -22,8 +22,6 @@ mpas-ocean:
     config_disable_vel_vmix: true
     config_disable_tr_all_tend: true
   streams:
-    mesh:
-      filename_template: init.nc
     input:
       filename_template: init.nc
     restart: {}

--- a/polaris/tasks/ocean/merry_go_round/forward.py
+++ b/polaris/tasks/ocean/merry_go_round/forward.py
@@ -75,17 +75,7 @@ class Forward(ConvergenceForward):
         )
         self.order = vert_adv_order
         self.limiter = limiter
-
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        config = self.config
-        model = config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
+        self.horiz_mesh_filename = 'mesh.nc'
 
     def dynamic_model_config(self, at_setup):
         """

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -53,8 +53,6 @@ mpas-ocean:
   AM_mixedLayerDepths:
     config_AM_mixedLayerDepths_enable: false
   streams:
-    mesh:
-      filename_template: init.nc
     input:
       filename_template: init.nc
     restart: {}
@@ -91,7 +89,7 @@ Omega:
   IOStreams:
     InitialVertCoord:
       UsePointerFile: false
-      Filename: OmegaMesh.nc
+      Filename: init.nc
       Mode: read
       Precision: double
       Freq: 1
@@ -104,7 +102,7 @@ Omega:
     # "OnStartup" to "never" so that the initial state file is not read.
     InitialState:
       UsePointerFile: false
-      Filename: OmegaMesh.nc
+      Filename: init.nc
       Mode: read
       Precision: double
       Freq: 1

--- a/polaris/tasks/ocean/overflow/init.py
+++ b/polaris/tasks/ocean/overflow/init.py
@@ -125,27 +125,9 @@ class Init(OceanIOStep):
         )
 
         # Coriolis parameter is zero
-        ds['fCell'] = (
-            (
-                'nCells',
-                'nVertLevels',
-            ),
-            np.zeros([ds.sizes['nCells'], ds.sizes['nVertLevels']]),
-        )
-        ds['fEdge'] = (
-            (
-                'nEdges',
-                'nVertLevels',
-            ),
-            np.zeros([ds.sizes['nEdges'], ds.sizes['nVertLevels']]),
-        )
-        ds['fVertex'] = (
-            (
-                'nVertices',
-                'nVertLevels',
-            ),
-            np.zeros([ds.sizes['nVertices'], ds.sizes['nVertLevels']]),
-        )
+        ds['fCell'] = xr.zeros_like(ds.xCell)
+        ds['fEdge'] = xr.zeros_like(ds.xEdge)
+        ds['fVertex'] = xr.zeros_like(ds.xVertex)
 
         # finalize and write file
         self.write_model_dataset(ds, 'init.nc')

--- a/polaris/tasks/ocean/seamount/init.py
+++ b/polaris/tasks/ocean/seamount/init.py
@@ -149,7 +149,7 @@ class Init(OceanIOStep):
             ),
             np.zeros([1, ds.sizes['nEdges'], ds.sizes['nVertLevels']]),
         )
-        ds['fCell'] = coriolis_parameter * xr.ones_like(temperature)
+        ds['fCell'] = coriolis_parameter * xr.ones_like(ds.xCell)
         ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
         ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
 

--- a/polaris/tasks/ocean/sphere_transport/forward.py
+++ b/polaris/tasks/ocean/sphere_transport/forward.py
@@ -78,13 +78,4 @@ class Forward(SphericalConvergenceForward):
             refinement_factor=refinement_factor,
             refinement=refinement,
         )
-
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
+        self.horiz_mesh_filename = 'mesh.nc'

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -35,8 +35,6 @@ mpas-ocean:
   tracer_forcing_debugTracers:
     config_use_debugTracers: true
   streams:
-    mesh:
-      filename_template: init.nc
     input:
       filename_template: init.nc
     restart:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR updates Polaris to support Omega’s configurable horizontal mesh
input, so tasks no longer need to rely on the hard-coded `OmegaMesh.nc`
filename. It splits horizontal mesh and initial-state inputs where
needed, updates the MPAS-Ocean and Omega stream configuration
accordingly, and extends the MPAS-Ocean-to-Omega variable mapping so
separate mesh files contain the horizontal fields Omega expects.

It also fixes a bug in a couple of ocean tasks where `fCell`, `fEdge`,
and `fVertex` were written with an incorrect vertical dimension instead
of being purely horizontal mesh fields.

- Framework
  - Add support in `OceanModelStep` for overriding Omega’s `HorzMeshIn`
    filename.
  - Add a YAML overlay for the Omega horizontal mesh stream.
  - Expand the MPAS-Ocean to Omega variable map to include horizontal
    mesh geometry and Coriolis fields needed when mesh and state are
    split.

- Task updates
  - Update `barotropic_channel` to stage a separate mesh file and keep
    Omega-compatible initial-state inputs.
  - Update `barotropic_gyre`, `manufactured_solution`, and
    `merry_go_round` to use `mesh.nc` for the mesh stream instead of
    relying on `OmegaMesh.nc`.
  - Update `cosine_bell`, `sphere_transport`, and
    `external_gravity_wave` so their init steps write a model-native
    `mesh.nc` and forward steps consume that file for both MPAS-Ocean
    and Omega.

- Bug fixes
  - Correct `fCell`, `fEdge`, and `fVertex` in `seamount` and
    `overflow` so they use horizontal dimensions only.

- Documentation
  - Update developer guide examples and ocean framework docs to
    describe the split mesh/init pattern and the new Omega horizontal
    mesh override.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

Fixes #519
