### PR TITLE
Port WOA23 extrapolation from Compass

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -198,6 +198,38 @@
    viz.Viz.run
 ```
 
+### global_ocean
+
+```{eval-rst}
+.. currentmodule:: polaris.tasks.ocean.global_ocean
+
+.. autosummary::
+   :toctree: generated/
+
+   add_global_ocean_tasks
+```
+
+### global_ocean.hydrography.woa23
+
+```{eval-rst}
+.. currentmodule:: polaris.tasks.ocean.global_ocean.hydrography.woa23
+
+.. autosummary::
+   :toctree: generated/
+
+   Woa23
+   get_woa23_topography_step
+   get_woa23_steps
+
+   CombineStep
+   CombineStep.setup
+   CombineStep.run
+
+   ExtrapolateStep
+   ExtrapolateStep.setup
+   ExtrapolateStep.run
+```
+
 ### horiz_press_grad
 
 ```{eval-rst}
@@ -644,4 +676,3 @@
    vertical.ztilde.pressure_and_spec_vol_from_state_at_geom_height
    vertical.ztilde.geom_height_from_pseudo_height
 ```
-

--- a/docs/developers_guide/ocean/tasks/global_ocean.md
+++ b/docs/developers_guide/ocean/tasks/global_ocean.md
@@ -52,8 +52,9 @@ combines January and annual WOA23 temperature and salinity climatologies into
 a single dataset. January values are used where they exist, and annual values
 fill deeper levels where the monthly product is not available.
 
-This step also converts in-situ temperature to potential temperature with
-`gsw`, producing `woa_combined.nc`.
+WOA23 supplies in-situ temperature and practical salinity, so this step uses
+`gsw` to derive conservative temperature and absolute salinity for the
+canonical `woa_combined.nc` product.
 
 ### extrapolate
 

--- a/docs/developers_guide/ocean/tasks/global_ocean.md
+++ b/docs/developers_guide/ocean/tasks/global_ocean.md
@@ -1,0 +1,69 @@
+(dev-ocean-global-ocean)=
+
+# global_ocean
+
+The `global_ocean` tasks in `polaris.tasks.ocean.global_ocean` are intended
+for preprocessing and initialization workflows that are upstream of any
+particular MPAS mesh. The first task category under this framework is
+`hydrography/woa23`, which builds a reusable hydrography product from the
+World Ocean Atlas 2023 on its native 0.25-degree latitude-longitude grid.
+
+(dev-ocean-global-ocean-framework)=
+
+## framework
+
+The shared config options for the WOA23 hydrography task are described in
+{ref}`ocean-global-ocean` in the User's Guide.
+
+The implementation is intentionally organized around reusable Polaris steps
+rather than around the legacy Compass `utility/extrap_woa` multiprocessing
+workflow. One notable design choice is that the task reuses the combined
+topography product from `e3sm/init` rather than taking a raw topography
+filename as a task-specific input.
+
+### cached topography dependency
+
+The helper
+{py:func}`polaris.tasks.ocean.global_ocean.hydrography.woa23.get_woa23_topography_step`
+creates a shared `e3sm/init` {py:class}`polaris.tasks.e3sm.init.topo.combine.step.CombineStep`
+configured for a 0.25-degree lat-lon target grid. The
+{py:class}`polaris.tasks.ocean.global_ocean.hydrography.woa23.task.Woa23`
+task adds this step with a symlink `combine_topo` and prefers to use a cached
+version of its outputs when matching entries are available in the
+`e3sm/init` cache database.
+
+This keeps the expensive topography blending logic in one place and makes the
+ocean hydrography preprocessing task consistent with the broader Polaris
+approach to shared, cacheable preprocessing steps.
+
+(dev-ocean-global-ocean-woa23)=
+
+## hydrography/woa23
+
+The {py:class}`polaris.tasks.ocean.global_ocean.hydrography.woa23.task.Woa23`
+task is the Polaris port of the WOA preprocessing part of the legacy Compass
+workflow.
+
+### combine
+
+The class
+{py:class}`polaris.tasks.ocean.global_ocean.hydrography.woa23.combine.CombineStep`
+combines January and annual WOA23 temperature and salinity climatologies into
+a single dataset. January values are used where they exist, and annual values
+fill deeper levels where the monthly product is not available.
+
+This step also converts in-situ temperature to potential temperature with
+`gsw`, producing `woa_combined.nc`.
+
+### extrapolate
+
+The class
+{py:class}`polaris.tasks.ocean.global_ocean.hydrography.woa23.extrapolate.ExtrapolateStep`
+uses the cached combined-topography product on the WOA grid together with
+`woa_combined.nc` to build a 3D ocean mask and then fill missing WOA values in
+two stages:
+
+1. Horizontal then vertical extrapolation within the ocean mask
+2. Horizontal then vertical extrapolation into land and grounded-ice regions
+
+The final output is `woa23_decav_0.25_jan_extrap.nc`.

--- a/docs/developers_guide/ocean/tasks/index.md
+++ b/docs/developers_guide/ocean/tasks/index.md
@@ -13,6 +13,7 @@ cosine_bell
 customizable_viz
 external_gravity_wave
 geostrophic
+global_ocean
 horiz_press_grad
 divergent_2d
 ice_shelf_2d

--- a/docs/users_guide/ocean/tasks/global_ocean.md
+++ b/docs/users_guide/ocean/tasks/global_ocean.md
@@ -32,10 +32,11 @@ polaris setup -t ocean/global_ocean/hydrography/woa23 ...
 
 The task is organized into three inspectable steps:
 
-1. `combine_topo` reuses a cached `e3sm/init` combined-topography step
-   configured for the WOA23 0.25-degree latitude-longitude grid.
+1. `combine_topo` from the `e3sm/init` component is used to combine topography
+   GEBCO and Bedmap3 datasets on the WOA23 0.25-degree latitude-longitude grid.
 2. `combine` creates `woa_combined.nc` by combining January and annual WOA23
-   fields and converting temperature to potential temperature.
+   in-situ temperature and practical-salinity fields, then deriving
+   conservative temperature and absolute salinity.
 3. `extrapolate` creates the final
    `woa23_decav_0.25_jan_extrap.nc` product.
 

--- a/docs/users_guide/ocean/tasks/global_ocean.md
+++ b/docs/users_guide/ocean/tasks/global_ocean.md
@@ -1,0 +1,83 @@
+(ocean-global-ocean)=
+
+# global_ocean
+
+This category contains ocean preprocessing tasks that are upstream of any
+particular MPAS mesh. The first task builds a reusable World Ocean Atlas 2023
+(WOA23) hydrography product on the native 0.25-degree latitude-longitude grid.
+
+## supported models
+
+This task is model-independent and does not require either MPAS-Ocean or
+Omega to be built.
+
+(ocean-global-ocean-woa23)=
+
+## woa23
+
+This task is the Polaris port of the legacy Compass
+`utility/extrap_woa` workflow. It combines January and annual WOA23
+climatologies, uses a cached `e3sm/init` combined-topography product on the
+WOA grid to define the ocean mask used during preprocessing, and then fills
+missing temperature and salinity values through staged horizontal and vertical
+extrapolation.
+
+The task can be set up with:
+
+```bash
+polaris setup -t ocean/global_ocean/hydrography/woa23 ...
+```
+
+### description
+
+The task is organized into three inspectable steps:
+
+1. `combine_topo` reuses a cached `e3sm/init` combined-topography step
+   configured for the WOA23 0.25-degree latitude-longitude grid.
+2. `combine` creates `woa_combined.nc` by combining January and annual WOA23
+   fields and converting temperature to potential temperature.
+3. `extrapolate` creates the final
+   `woa23_decav_0.25_jan_extrap.nc` product.
+
+This layout is intended to match Polaris shared-step conventions so the WOA23
+preprocessing pipeline can later be reused by mesh-dependent
+`global_ocean` initialization tasks.
+
+### mesh
+
+N/A. This task operates on the native WOA23 latitude-longitude grid rather
+than an MPAS mesh.
+
+### vertical grid
+
+N/A. The task preserves the standard WOA23 depth levels.
+
+### initial conditions
+
+The source fields come from the WOA23 January and annual climatologies in the
+Polaris input database.
+
+### forcing
+
+N/A.
+
+### time step and run duration
+
+N/A.
+
+### config options
+
+```cfg
+# Options related to generating a reusable WOA23 hydrography product
+[woa23]
+
+# the minimum weight sum needed to mark a new cell valid in horizontal
+# extrapolation
+extrap_threshold = 0.01
+```
+
+### cores
+
+The local `combine` and `extrapolate` steps run serially. The
+`combine_topo` step is intended to use the cached `e3sm/init` output because
+regenerating the combined topography product is substantially more expensive.

--- a/docs/users_guide/ocean/tasks/index.md
+++ b/docs/users_guide/ocean/tasks/index.md
@@ -13,6 +13,7 @@ cosine_bell
 customizable_viz
 external_gravity_wave
 geostrophic
+global_ocean
 horiz_press_grad
 divergent_2d
 ice_shelf_2d

--- a/polaris/tasks/ocean/add_tasks.py
+++ b/polaris/tasks/ocean/add_tasks.py
@@ -7,6 +7,7 @@ from polaris.tasks.ocean.external_gravity_wave import (
     add_external_gravity_wave_tasks as add_external_gravity_wave_tasks,
 )
 from polaris.tasks.ocean.geostrophic import add_geostrophic_tasks
+from polaris.tasks.ocean.global_ocean import add_global_ocean_tasks
 from polaris.tasks.ocean.horiz_press_grad import add_horiz_press_grad_tasks
 from polaris.tasks.ocean.ice_shelf_2d import add_ice_shelf_2d_tasks
 from polaris.tasks.ocean.inertial_gravity_wave import (
@@ -55,5 +56,6 @@ def add_ocean_tasks(component):
     add_cosine_bell_tasks(component=component)
     add_external_gravity_wave_tasks(component=component)
     add_geostrophic_tasks(component=component)
+    add_global_ocean_tasks(component=component)
     add_isomip_plus_tasks(component=component, mesh_type='spherical')
     add_sphere_transport_tasks(component=component)

--- a/polaris/tasks/ocean/global_ocean/__init__.py
+++ b/polaris/tasks/ocean/global_ocean/__init__.py
@@ -1,0 +1,15 @@
+from polaris.tasks.ocean.global_ocean.hydrography.woa23 import (
+    Woa23 as Woa23,
+)
+
+
+def add_global_ocean_tasks(component):
+    """
+    Add tasks for global-ocean preprocessing and initialization.
+
+    Parameters
+    ----------
+    component : polaris.tasks.ocean.Ocean
+        The ocean component to which the tasks will be added.
+    """
+    component.add_task(Woa23(component=component))

--- a/polaris/tasks/ocean/global_ocean/hydrography/__init__.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/__init__.py
@@ -1,0 +1,3 @@
+from polaris.tasks.ocean.global_ocean.hydrography.woa23 import (
+    Woa23 as Woa23,
+)

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/__init__.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/__init__.py
@@ -1,0 +1,5 @@
+from .combine import CombineStep as CombineStep
+from .extrapolate import ExtrapolateStep as ExtrapolateStep
+from .steps import get_woa23_steps as get_woa23_steps
+from .steps import get_woa23_topography_step as get_woa23_topography_step
+from .task import Woa23 as Woa23

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/__init__.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/__init__.py
@@ -3,3 +3,4 @@ from .extrapolate import ExtrapolateStep as ExtrapolateStep
 from .steps import get_woa23_steps as get_woa23_steps
 from .steps import get_woa23_topography_step as get_woa23_topography_step
 from .task import Woa23 as Woa23
+from .viz import Woa23VizStep as Woa23VizStep

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/combine.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/combine.py
@@ -1,0 +1,170 @@
+import gsw
+import numpy as np
+import xarray as xr
+from mpas_tools.io import write_netcdf
+
+from polaris import Step
+
+
+class CombineStep(Step):
+    """
+    A step for combining January and annual WOA23 climatologies.
+    """
+
+    def __init__(self, component, subdir):
+        """
+        Create the step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to.
+
+        subdir : str
+            The subdirectory for the step.
+        """
+        super().__init__(
+            component=component,
+            name='combine',
+            subdir=subdir,
+            ntasks=1,
+            min_tasks=1,
+        )
+        self.add_output_file(filename='woa_combined.nc')
+
+    def setup(self):
+        """
+        Set up input files for the step.
+        """
+        super().setup()
+
+        base_url = (
+            'https://www.ncei.noaa.gov/thredds-ocean/fileServer/woa23/DATA'
+        )
+        directories = {
+            'temp': {
+                'ann': 'temperature/netcdf/decav91C0/0.25',
+                'jan': 'temperature/netcdf/decav91C0/0.25',
+            },
+            'salin': {
+                'ann': 'salinity/netcdf/decav91C0/0.25',
+                'jan': 'salinity/netcdf/decav91C0/0.25',
+            },
+        }
+        filenames = {
+            'temp': {
+                'ann': 'woa23_decav91C0_t00_04.nc',
+                'jan': 'woa23_decav91C0_t01_04.nc',
+            },
+            'salin': {
+                'ann': 'woa23_decav91C0_s00_04.nc',
+                'jan': 'woa23_decav91C0_s01_04.nc',
+            },
+        }
+
+        for field in ['temp', 'salin']:
+            for season in ['jan', 'ann']:
+                woa_filename = filenames[field][season]
+                woa_dir = directories[field][season]
+                self.add_input_file(
+                    filename=f'woa_{field}_{season}.nc',
+                    target=woa_filename,
+                    database='initial_condition_database',
+                    url=f'{base_url}/{woa_dir}/{woa_filename}',
+                )
+
+    def run(self):
+        """
+        Combine January and annual climatologies and convert temperature to
+        potential temperature.
+        """
+        logger = self.logger
+        logger.info('Combining January and annual WOA23 climatologies')
+
+        with xr.open_dataset('woa_temp_ann.nc', decode_times=False) as ds_temp:
+            ds_out = xr.Dataset()
+            for var in ['lon', 'lat', 'depth']:
+                ds_out[var] = ds_temp[var]
+                ds_out[f'{var}_bnds'] = ds_temp[f'{var}_bnds']
+
+        var_map = {'temp': 't_an', 'salin': 's_an'}
+        for field, var_name in var_map.items():
+            with xr.open_dataset(
+                f'woa_{field}_ann.nc', decode_times=False
+            ) as ds_ann:
+                ds_ann = ds_ann.isel(time=0, drop=True)
+                with xr.open_dataset(
+                    f'woa_{field}_jan.nc', decode_times=False
+                ) as ds_jan:
+                    ds_jan = ds_jan.isel(time=0, drop=True)
+                    slices = []
+                    for depth_index in range(ds_ann.sizes['depth']):
+                        if depth_index < ds_jan.sizes['depth']:
+                            ds = ds_jan
+                        else:
+                            ds = ds_ann
+                        slices.append(ds[var_name].isel(depth=depth_index))
+
+                    ds_out[var_name] = xr.concat(slices, dim='depth')
+                    ds_out[var_name].attrs = ds_ann[var_name].attrs
+
+        ds_out = self._temp_to_potential_temp(ds_out)
+        write_netcdf(ds_out, 'woa_combined.nc')
+        logger.info('Wrote woa_combined.nc')
+
+    @staticmethod
+    def _temp_to_potential_temp(ds):
+        """
+        Convert WOA in-situ temperature to potential temperature.
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A combined WOA dataset with in-situ temperature and salinity.
+
+        Returns
+        -------
+        ds : xarray.Dataset
+            The dataset with temperature replaced by potential temperature.
+        """
+        dims = ds.t_an.dims
+        slices = []
+        for depth_index in range(ds.sizes['depth']):
+            temp_slice = ds.t_an.isel(depth=depth_index)
+            in_situ_temp = temp_slice.values
+            practical_salinity = ds.s_an.isel(depth=depth_index).values
+            lat = ds.lat.broadcast_like(temp_slice).values
+            lon = ds.lon.broadcast_like(temp_slice).values
+            z = -ds.depth.isel(depth=depth_index).values
+            pressure = gsw.p_from_z(z, lat)
+
+            mask = np.isfinite(in_situ_temp)
+            potential_temp = np.full(in_situ_temp.shape, np.nan)
+            absolute_salinity = gsw.SA_from_SP(
+                practical_salinity[mask],
+                pressure[mask],
+                lon[mask],
+                lat[mask],
+            )
+            potential_temp[mask] = gsw.pt_from_t(
+                absolute_salinity,
+                in_situ_temp[mask],
+                pressure[mask],
+                p_ref=0.0,
+            )
+            slices.append(
+                xr.DataArray(
+                    data=potential_temp,
+                    dims=temp_slice.dims,
+                    attrs=temp_slice.attrs,
+                )
+            )
+
+        ds['pt_an'] = xr.concat(slices, dim='depth').transpose(*dims)
+        ds.pt_an.attrs['standard_name'] = 'sea_water_potential_temperature'
+        ds.pt_an.attrs['long_name'] = (
+            'Objectively analyzed mean fields for '
+            'sea_water_potential_temperature at standard depth levels.'
+        )
+
+        return ds.drop_vars('t_an')

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/combine.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/combine.py
@@ -75,8 +75,8 @@ class CombineStep(Step):
 
     def run(self):
         """
-        Combine January and annual climatologies and convert temperature to
-        potential temperature.
+        Combine January and annual climatologies and derive conservative
+        temperature and absolute salinity.
         """
         logger = self.logger
         logger.info('Combining January and annual WOA23 climatologies')
@@ -108,14 +108,15 @@ class CombineStep(Step):
                     ds_out[var_name] = xr.concat(slices, dim='depth')
                     ds_out[var_name].attrs = ds_ann[var_name].attrs
 
-        ds_out = self._temp_to_potential_temp(ds_out)
+        ds_out = self._to_canonical_teos10(ds_out)
         write_netcdf(ds_out, 'woa_combined.nc')
         logger.info('Wrote woa_combined.nc')
 
     @staticmethod
-    def _temp_to_potential_temp(ds):
+    def _to_canonical_teos10(ds):
         """
-        Convert WOA in-situ temperature to potential temperature.
+        Convert WOA in-situ temperature and practical salinity to canonical
+        conservative temperature and absolute salinity.
 
         Parameters
         ----------
@@ -125,10 +126,11 @@ class CombineStep(Step):
         Returns
         -------
         ds : xarray.Dataset
-            The dataset with temperature replaced by potential temperature.
+            The dataset with conservative temperature and absolute salinity.
         """
         dims = ds.t_an.dims
-        slices = []
+        ct_slices = []
+        sa_slices = []
         for depth_index in range(ds.sizes['depth']):
             temp_slice = ds.t_an.isel(depth=depth_index)
             in_situ_temp = temp_slice.values
@@ -138,33 +140,47 @@ class CombineStep(Step):
             z = -ds.depth.isel(depth=depth_index).values
             pressure = gsw.p_from_z(z, lat)
 
-            mask = np.isfinite(in_situ_temp)
-            potential_temp = np.full(in_situ_temp.shape, np.nan)
-            absolute_salinity = gsw.SA_from_SP(
+            mask = np.isfinite(in_situ_temp) & np.isfinite(practical_salinity)
+            conservative_temp = np.full(in_situ_temp.shape, np.nan)
+            absolute_salinity = np.full(practical_salinity.shape, np.nan)
+            absolute_salinity[mask] = gsw.SA_from_SP(
                 practical_salinity[mask],
                 pressure[mask],
                 lon[mask],
                 lat[mask],
             )
-            potential_temp[mask] = gsw.pt_from_t(
-                absolute_salinity,
+            conservative_temp[mask] = gsw.CT_from_t(
+                absolute_salinity[mask],
                 in_situ_temp[mask],
                 pressure[mask],
-                p_ref=0.0,
             )
-            slices.append(
+            ct_slices.append(
                 xr.DataArray(
-                    data=potential_temp,
+                    data=conservative_temp,
                     dims=temp_slice.dims,
                     attrs=temp_slice.attrs,
                 )
             )
+            sa_slices.append(
+                xr.DataArray(
+                    data=absolute_salinity,
+                    dims=temp_slice.dims,
+                    attrs=ds.s_an.attrs,
+                )
+            )
 
-        ds['pt_an'] = xr.concat(slices, dim='depth').transpose(*dims)
-        ds.pt_an.attrs['standard_name'] = 'sea_water_potential_temperature'
-        ds.pt_an.attrs['long_name'] = (
+        ds['ct_an'] = xr.concat(ct_slices, dim='depth').transpose(*dims)
+        ds.ct_an.attrs['standard_name'] = 'sea_water_conservative_temperature'
+        ds.ct_an.attrs['long_name'] = (
             'Objectively analyzed mean fields for '
-            'sea_water_potential_temperature at standard depth levels.'
+            'sea_water_conservative_temperature at standard depth levels.'
         )
+        ds['sa_an'] = xr.concat(sa_slices, dim='depth').transpose(*dims)
+        ds.sa_an.attrs['standard_name'] = 'sea_water_absolute_salinity'
+        ds.sa_an.attrs['long_name'] = (
+            'Objectively analyzed mean fields for '
+            'sea_water_absolute_salinity at standard depth levels.'
+        )
+        ds.sa_an.attrs['units'] = 'g kg-1'
 
-        return ds.drop_vars('t_an')
+        return ds.drop_vars(['t_an', 's_an'])

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/extrapolate.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/extrapolate.py
@@ -1,0 +1,329 @@
+import numpy as np
+import xarray as xr
+from mpas_tools.io import write_netcdf
+from scipy.signal import convolve2d
+
+from polaris import Step
+
+
+class ExtrapolateStep(Step):
+    """
+    A step for extrapolating WOA23 into missing ocean, land and ice regions.
+    """
+
+    output_filename = 'woa23_decav_0.25_jan_extrap.nc'
+
+    def __init__(self, component, subdir, combine_step, combine_topo_step):
+        """
+        Create the step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to.
+
+        subdir : str
+            The subdirectory for the step.
+
+        combine_step : polaris.Step
+            The step that produces the combined WOA23 dataset.
+
+        combine_topo_step : polaris.Step
+            The cached ``e3sm/init`` step that produces combined topography on
+            the WOA23 grid.
+        """
+        super().__init__(
+            component=component,
+            name='extrapolate',
+            subdir=subdir,
+            ntasks=1,
+            min_tasks=1,
+        )
+        self.combine_step = combine_step
+        self.combine_topo_step = combine_topo_step
+        self.add_output_file(filename=self.output_filename)
+
+    def setup(self):
+        """
+        Set up input files for the step.
+        """
+        super().setup()
+        self.add_input_file(
+            filename='woa.nc',
+            work_dir_target=f'{self.combine_step.path}/woa_combined.nc',
+        )
+        self.add_input_file(
+            filename='topography.nc',
+            work_dir_target=(
+                f'{self.combine_topo_step.path}/'
+                f'{self.combine_topo_step.combined_filename}'
+            ),
+        )
+
+    def run(self):
+        """
+        Extrapolate WOA23 horizontally and vertically in two stages.
+        """
+        logger = self.logger
+        logger.info('Building a 3D ocean mask on the WOA23 grid')
+        self._make_3d_ocean_mask()
+
+        logger.info('Horizontally extrapolating within the ocean mask')
+        self._extrap_horiz(
+            in_filename='woa.nc',
+            out_filename='woa_extrap_ocean_horiz.nc',
+            use_ocean_mask=True,
+        )
+
+        logger.info('Vertically extrapolating within the ocean mask')
+        self._extrap_vert(
+            in_filename='woa_extrap_ocean_horiz.nc',
+            out_filename='woa_extrap_ocean.nc',
+            use_ocean_mask=True,
+        )
+
+        logger.info('Horizontally extrapolating into land and grounded ice')
+        self._extrap_horiz(
+            in_filename='woa_extrap_ocean.nc',
+            out_filename='woa_extrap_horiz.nc',
+            use_ocean_mask=False,
+        )
+
+        logger.info('Vertically extrapolating into land and grounded ice')
+        self._extrap_vert(
+            in_filename='woa_extrap_horiz.nc',
+            out_filename=self.output_filename,
+            use_ocean_mask=False,
+        )
+        logger.info(f'Wrote {self.output_filename}')
+
+    @staticmethod
+    def _make_3d_ocean_mask():
+        """
+        Build a three-dimensional mask of valid ocean cells on the WOA grid.
+        """
+        with xr.open_dataset('topography.nc') as ds_topo:
+            with xr.open_dataset('woa.nc', decode_times=False) as ds_woa:
+                ds_out = xr.Dataset()
+                for var in ['lon', 'lat', 'depth']:
+                    ds_out[var] = ds_woa[var]
+                    ds_out[f'{var}_bnds'] = ds_woa[f'{var}_bnds']
+
+                z_top = -ds_woa.depth_bnds.isel(nbounds=0)
+                ocean_mask_3d = (
+                    (ds_topo.base_elevation <= z_top)
+                    & (ds_topo.ocean_mask >= 0.5)
+                ).transpose('depth', 'lat', 'lon')
+                ds_out['ocean_mask'] = ocean_mask_3d.astype(np.int8)
+
+        write_netcdf(ds_out, 'ocean_mask.nc')
+
+    def _extrap_horiz(self, in_filename, out_filename, use_ocean_mask):
+        """
+        Extrapolate horizontally on each depth level.
+
+        Parameters
+        ----------
+        in_filename : str
+            The input file to read.
+
+        out_filename : str
+            The output file to write.
+
+        use_ocean_mask : bool
+            Whether to restrict filling to the remapped ocean mask.
+        """
+        with xr.open_dataset(in_filename, decode_times=False) as ds:
+            ds_out = ds.load()
+
+        ocean_mask = None
+        if use_ocean_mask:
+            with xr.open_dataset('ocean_mask.nc') as ds_mask:
+                ocean_mask = ds_mask.ocean_mask.values.astype(bool)
+
+        ndepth = ds_out.sizes['depth']
+        for depth_index in range(ndepth):
+            self.logger.info(
+                f'  Horizontal fill for depth {depth_index + 1}/{ndepth}'
+            )
+            level_mask = None
+            if ocean_mask is not None:
+                level_mask = ocean_mask[depth_index, :, :]
+            ds_level = ds_out.isel(depth=depth_index)
+            ds_level = self._extrap_level(
+                ds_level=ds_level,
+                ocean_mask=level_mask,
+                threshold=self.config.getfloat('woa23', 'extrap_threshold'),
+            )
+            for field_name in ['pt_an', 's_an']:
+                ds_out[field_name][depth_index, :, :] = ds_level[field_name]
+
+        write_netcdf(ds_out, out_filename)
+
+    def _extrap_vert(self, in_filename, out_filename, use_ocean_mask):
+        """
+        Extrapolate vertically from shallower depths into deeper missing
+        values.
+
+        Parameters
+        ----------
+        in_filename : str
+            The input file to read.
+
+        out_filename : str
+            The output file to write.
+
+        use_ocean_mask : bool
+            Whether to restrict filling to the remapped ocean mask.
+        """
+        with xr.open_dataset(in_filename, decode_times=False) as ds:
+            ds_out = ds.load()
+
+        ocean_mask = None
+        if use_ocean_mask:
+            with xr.open_dataset('ocean_mask.nc') as ds_mask:
+                ocean_mask = ds_mask.ocean_mask.values.astype(bool)
+
+        ndepth = ds_out.sizes['depth']
+        for field_name in ['pt_an', 's_an']:
+            field = ds_out[field_name].values
+            for depth_index in range(1, ndepth):
+                mask = np.isnan(field[depth_index, :, :])
+                if ocean_mask is not None:
+                    mask = np.logical_and(mask, ocean_mask[depth_index, :, :])
+                field[depth_index, :, :][mask] = field[depth_index - 1, :, :][
+                    mask
+                ]
+
+        write_netcdf(ds_out, out_filename)
+
+    @staticmethod
+    def _extrap_level(ds_level, ocean_mask, threshold):
+        """
+        Extrapolate a single depth level horizontally.
+
+        Parameters
+        ----------
+        ds_level : xarray.Dataset
+            A single-depth WOA dataset.
+
+        ocean_mask : numpy.ndarray or None
+            A Boolean mask for valid ocean cells at this depth.
+
+        threshold : float
+            The minimum valid weight sum needed to mark a new cell valid.
+
+        Returns
+        -------
+        ds_level : xarray.Dataset
+            The filled depth level.
+        """
+        kernel = ExtrapolateStep._get_kernel()
+        field = ds_level.pt_an.values
+
+        valid = np.isfinite(field)
+        orig_mask = valid.copy()
+        if ocean_mask is not None:
+            invalid_after_fill = np.logical_not(
+                np.logical_or(valid, ocean_mask)
+            )
+        else:
+            invalid_after_fill = None
+
+        fields = {
+            field_name: ds_level[field_name].values.copy()
+            for field_name in ['pt_an', 's_an']
+        }
+
+        nlon = field.shape[1]
+        lon_with_halo = np.array(
+            [nlon - 2, nlon - 1] + list(range(nlon)) + [0, 1]
+        )
+        lon_no_halo = list(range(2, nlon + 2))
+
+        prev_fill_count = 0
+        while True:
+            valid_weight_sum = _extrap_with_halo(
+                field=valid.astype(float),
+                kernel=kernel,
+                valid=valid,
+                lon_with_halo=lon_with_halo,
+                lon_no_halo=lon_no_halo,
+            )
+            if invalid_after_fill is not None:
+                valid_weight_sum[invalid_after_fill] = 0.0
+
+            new_valid = valid_weight_sum > threshold
+            fill_mask = np.logical_and(new_valid, np.logical_not(orig_mask))
+            fill_count = int(np.count_nonzero(fill_mask))
+            if fill_count == prev_fill_count:
+                break
+
+            for _field_name, field_values in fields.items():
+                field_extrap = _extrap_with_halo(
+                    field=field_values,
+                    kernel=kernel,
+                    valid=valid,
+                    lon_with_halo=lon_with_halo,
+                    lon_no_halo=lon_no_halo,
+                )
+                field_values[fill_mask] = (
+                    field_extrap[fill_mask] / valid_weight_sum[fill_mask]
+                )
+
+            valid = new_valid
+            prev_fill_count = fill_count
+
+        for field_name, field_values in fields.items():
+            if invalid_after_fill is not None:
+                field_values[invalid_after_fill] = np.nan
+            ds_level[field_name] = (ds_level[field_name].dims, field_values)
+
+        return ds_level
+
+    @staticmethod
+    def _get_kernel():
+        """
+        Build the small averaging kernel used for horizontal extrapolation.
+
+        Returns
+        -------
+        kernel : numpy.ndarray
+            A two-dimensional Gaussian-like averaging kernel.
+        """
+        coordinates = np.arange(-1, 2)
+        x, y = np.meshgrid(coordinates, coordinates)
+        return np.exp(-0.5 * (x**2 + y**2))
+
+
+def _extrap_with_halo(field, kernel, valid, lon_with_halo, lon_no_halo):
+    """
+    Extrapolate a two-dimensional field using a periodic halo in longitude.
+
+    Parameters
+    ----------
+    field : numpy.ndarray
+        The field to extrapolate.
+
+    kernel : numpy.ndarray
+        The horizontal averaging kernel.
+
+    valid : numpy.ndarray
+        A Boolean mask of valid values.
+
+    lon_with_halo : numpy.ndarray
+        Longitude indices including the periodic halo.
+
+    lon_no_halo : list of int
+        Longitude indices excluding the periodic halo.
+
+    Returns
+    -------
+    field_extrap : numpy.ndarray
+        The convolved field without the periodic halo.
+    """
+    masked_field = field.copy()
+    masked_field[np.logical_not(valid)] = 0.0
+    field_with_halo = masked_field[:, lon_with_halo]
+    field_extrap = convolve2d(field_with_halo, kernel, mode='same')
+    return field_extrap[:, lon_no_halo]

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/extrapolate.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/extrapolate.py
@@ -162,7 +162,7 @@ class ExtrapolateStep(Step):
                 ocean_mask=level_mask,
                 threshold=self.config.getfloat('woa23', 'extrap_threshold'),
             )
-            for field_name in ['pt_an', 's_an']:
+            for field_name in ['ct_an', 'sa_an']:
                 ds_out[field_name][depth_index, :, :] = ds_level[field_name]
 
         write_netcdf(ds_out, out_filename)
@@ -192,7 +192,7 @@ class ExtrapolateStep(Step):
                 ocean_mask = ds_mask.ocean_mask.values.astype(bool)
 
         ndepth = ds_out.sizes['depth']
-        for field_name in ['pt_an', 's_an']:
+        for field_name in ['ct_an', 'sa_an']:
             field = ds_out[field_name].values
             for depth_index in range(1, ndepth):
                 mask = np.isnan(field[depth_index, :, :])
@@ -226,7 +226,7 @@ class ExtrapolateStep(Step):
             The filled depth level.
         """
         kernel = ExtrapolateStep._get_kernel()
-        field = ds_level.pt_an.values
+        field = ds_level.ct_an.values
 
         valid = np.isfinite(field)
         orig_mask = valid.copy()
@@ -239,7 +239,7 @@ class ExtrapolateStep(Step):
 
         fields = {
             field_name: ds_level[field_name].values.copy()
-            for field_name in ['pt_an', 's_an']
+            for field_name in ['ct_an', 'sa_an']
         }
 
         nlon = field.shape[1]

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/extrapolate.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/extrapolate.py
@@ -110,13 +110,20 @@ class ExtrapolateStep(Step):
                     ds_out[f'{var}_bnds'] = ds_woa[f'{var}_bnds']
 
                 z_top = -ds_woa.depth_bnds.isel(nbounds=0)
+                ocean_mask = ExtrapolateStep._get_ocean_mask(ds_topo)
                 ocean_mask_3d = (
-                    (ds_topo.base_elevation <= z_top)
-                    & (ds_topo.ocean_mask >= 0.5)
+                    (ds_topo.base_elevation <= z_top) & (ocean_mask >= 0.5)
                 ).transpose('depth', 'lat', 'lon')
                 ds_out['ocean_mask'] = ocean_mask_3d.astype(np.int8)
 
         write_netcdf(ds_out, 'ocean_mask.nc')
+
+    @staticmethod
+    def _get_ocean_mask(ds_topo):
+        """
+        Return the 2D ocean mask from combined topography.
+        """
+        return ds_topo.ocean_mask
 
     def _extrap_horiz(self, in_filename, out_filename, use_ocean_mask):
         """

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
@@ -8,6 +8,7 @@ from polaris.tasks.e3sm.init.topo.combine import (
 
 from .combine import CombineStep
 from .extrapolate import ExtrapolateStep
+from .viz import Woa23VizStep
 
 
 def get_woa23_topography_step():
@@ -75,4 +76,14 @@ def get_woa23_steps(component, combine_topo_step):
         combine_topo_step=combine_topo_step,
     )
 
-    return [combine_step, extrapolate_step], config
+    viz_subdir = os.path.join(subdir, 'viz')
+    viz_step = component.get_or_create_shared_step(
+        step_cls=Woa23VizStep,
+        subdir=viz_subdir,
+        config=config,
+        config_filename=config_filename,
+        extrapolate_step=extrapolate_step,
+        combine_topo_step=combine_topo_step,
+    )
+
+    return [combine_step, extrapolate_step, viz_step], config

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
@@ -1,0 +1,78 @@
+import os
+
+from polaris.config import PolarisConfigParser
+from polaris.tasks.e3sm.init import e3sm_init
+from polaris.tasks.e3sm.init.topo.combine import (
+    get_lat_lon_topo_steps,
+)
+
+from .combine import CombineStep
+from .extrapolate import ExtrapolateStep
+
+
+def get_woa23_topography_step():
+    """
+    Get the cached combined-topography step for the WOA23 target grid.
+
+    Returns
+    -------
+    combine_topo_step : polaris.tasks.e3sm.init.topo.combine.step.CombineStep
+        A shared step from ``e3sm/init`` configured for the WOA23 0.25-degree
+        latitude-longitude grid.
+    """
+    steps, _ = get_lat_lon_topo_steps(
+        component=e3sm_init, resolution=0.25, include_viz=False
+    )
+    return steps[0]
+
+
+def get_woa23_steps(component, combine_topo_step):
+    """
+    Get the shared steps for building the reusable WOA23 hydrography product.
+
+    Parameters
+    ----------
+    component : polaris.tasks.ocean.Ocean
+        The ocean component the steps belong to.
+
+    combine_topo_step : polaris.tasks.e3sm.init.topo.combine.step.CombineStep
+        The cached ``e3sm/init`` step that produces topography on the WOA23
+        grid.
+
+    Returns
+    -------
+    steps : list of polaris.Step
+        Shared steps for combining and extrapolating WOA23 data.
+
+    config : polaris.config.PolarisConfigParser
+        The shared config options for the task and its steps.
+    """
+    subdir = 'global_ocean/hydrography/woa23'
+    config_filename = 'woa23.cfg'
+    config = PolarisConfigParser(
+        filepath=os.path.join(component.name, subdir, config_filename)
+    )
+    config.add_from_package(
+        'polaris.tasks.ocean.global_ocean.hydrography.woa23',
+        config_filename,
+    )
+
+    combine_subdir = os.path.join(subdir, 'combine')
+    combine_step = component.get_or_create_shared_step(
+        step_cls=CombineStep,
+        subdir=combine_subdir,
+        config=config,
+        config_filename=config_filename,
+    )
+
+    extrapolate_subdir = os.path.join(subdir, 'extrapolate')
+    extrapolate_step = component.get_or_create_shared_step(
+        step_cls=ExtrapolateStep,
+        subdir=extrapolate_subdir,
+        config=config,
+        config_filename=config_filename,
+        combine_step=combine_step,
+        combine_topo_step=combine_topo_step,
+    )
+
+    return [combine_step, extrapolate_step], config

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/task.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/task.py
@@ -1,0 +1,50 @@
+import os
+
+from polaris import Task
+from polaris.tasks.ocean.global_ocean.hydrography.woa23.steps import (
+    get_woa23_steps,
+    get_woa23_topography_step,
+)
+
+
+class Woa23(Task):
+    """
+    A task for building a reusable WOA23 hydrography product.
+    """
+
+    def __init__(self, component):
+        """
+        Create the task.
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the task belongs to.
+        """
+        subdir = 'global_ocean/hydrography/woa23'
+        super().__init__(component=component, name='woa23', subdir=subdir)
+
+        self.combine_topo_step = get_woa23_topography_step()
+        steps, config = get_woa23_steps(
+            component=component,
+            combine_topo_step=self.combine_topo_step,
+        )
+        self.set_shared_config(config)
+
+        self.add_step(self.combine_topo_step, symlink='combine_topo')
+        for step in steps:
+            self.add_step(step)
+
+    def configure(self):
+        """
+        Use the cached combined-topography product from ``e3sm/init``.
+        """
+        super().configure()
+        cache_keys = [
+            os.path.join(self.combine_topo_step.path, output)
+            for output in self.combine_topo_step.outputs
+        ]
+        cached_files = self.combine_topo_step.component.cached_files
+        self.combine_topo_step.cached = all(
+            filename in cached_files for filename in cache_keys
+        )

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/task.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/task.py
@@ -33,7 +33,7 @@ class Woa23(Task):
 
         self.add_step(self.combine_topo_step, symlink='combine_topo')
         for step in steps:
-            self.add_step(step)
+            self.add_step(step, run_by_default=step.name != 'viz')
 
     def configure(self):
         """

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/viz.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/viz.py
@@ -1,0 +1,460 @@
+import cmocean  # noqa: F401
+import matplotlib.pyplot as plt
+import numpy as np
+import pyproj
+import xarray as xr
+
+from polaris import Step
+from polaris.viz import plot_global_lat_lon_field, use_mplstyle
+from polaris.viz.spherical import setup_colormap
+
+
+class Woa23VizStep(Step):
+    """
+    A step for visualizing extrapolated WOA23 hydrography.
+    """
+
+    def __init__(self, component, subdir, extrapolate_step, combine_topo_step):
+        """
+        Create the step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to.
+
+        subdir : str
+            The subdirectory for the step.
+
+        extrapolate_step : polaris.Step
+            The step that extrapolates WOA23 hydrography.
+
+        combine_topo_step : polaris.Step
+            The cached ``e3sm/init`` step that produces combined topography on
+            the WOA23 grid.
+        """
+        super().__init__(
+            component=component,
+            name='viz',
+            subdir=subdir,
+            ntasks=1,
+            min_tasks=1,
+        )
+        self.extrapolate_step = extrapolate_step
+        self.combine_topo_step = combine_topo_step
+
+    def setup(self):
+        """
+        Set up input and output files for the step.
+        """
+        super().setup()
+        self.add_input_file(
+            filename='woa.nc',
+            work_dir_target=(
+                f'{self.extrapolate_step.path}/'
+                f'{self.extrapolate_step.output_filename}'
+            ),
+        )
+        self.add_input_file(
+            filename='topography.nc',
+            work_dir_target=(
+                f'{self.combine_topo_step.path}/'
+                f'{self.combine_topo_step.combined_filename}'
+            ),
+        )
+
+        self.outputs = []
+        for depth in self.config.getlist(
+            'woa23', 'horizontal_plot_depths', dtype=float
+        ):
+            depth_tag = self._depth_tag(depth)
+            self.add_output_file(filename=f'pt_an_depth_{depth_tag}.png')
+            self.add_output_file(
+                filename=f'pt_an_depth_{depth_tag}_filled.png'
+            )
+            self.add_output_file(filename=f's_an_depth_{depth_tag}.png')
+            self.add_output_file(filename=f's_an_depth_{depth_tag}_filled.png')
+
+        self.add_output_file(filename='filchner_section.png')
+        self.add_output_file(filename='filchner_section_filled.png')
+        self.add_output_file(filename='ross_section.png')
+        self.add_output_file(filename='ross_section_filled.png')
+
+    def run(self):
+        """
+        Plot horizontal fields at selected depths and two Antarctic transects.
+        """
+        use_mplstyle()
+
+        with xr.open_dataset('woa.nc', decode_times=False) as ds_woa:
+            ds_woa = ds_woa.load()
+        with xr.open_dataset('topography.nc') as ds_topo:
+            ds_topo = ds_topo.load()
+
+        self._plot_horizontal_maps(ds_woa=ds_woa, ds_topo=ds_topo)
+        self._plot_configured_transects(ds_woa=ds_woa, ds_topo=ds_topo)
+
+    def _plot_horizontal_maps(self, ds_woa, ds_topo):
+        logger = self.logger
+        fields = [
+            (
+                'pt_an',
+                'Potential temperature',
+                r'Potential temperature ($^{\circ}$C)',
+                'woa23_viz_temperature',
+            ),
+            (
+                's_an',
+                'Salinity',
+                'Salinity (PSU)',
+                'woa23_viz_salinity',
+            ),
+        ]
+
+        requested_depths = self.config.getlist(
+            'woa23', 'horizontal_plot_depths', dtype=float
+        )
+        depth_values = ds_woa.depth.values
+
+        for requested_depth in requested_depths:
+            depth_index = int(
+                np.abs(depth_values - requested_depth).argmin().item()
+            )
+            actual_depth = float(depth_values[depth_index])
+            depth_tag = self._depth_tag(requested_depth)
+            water_mask = self._get_level_water_mask(
+                ds_topo=ds_topo, depth=actual_depth
+            )
+
+            logger.info(
+                f'Plotting horizontal maps for requested depth '
+                f'{requested_depth:g} m using WOA level {actual_depth:g} m'
+            )
+            for (
+                field_name,
+                field_title,
+                colorbar_label,
+                cmap_section,
+            ) in fields:
+                data = ds_woa[field_name].isel(depth=depth_index).values
+                ocean_title = self._horizontal_title(
+                    field_title=field_title,
+                    requested_depth=requested_depth,
+                    actual_depth=actual_depth,
+                    filled=False,
+                )
+                plot_global_lat_lon_field(
+                    lon=ds_woa.lon.values,
+                    lat=ds_woa.lat.values,
+                    data_array=np.where(water_mask, data, np.nan),
+                    out_filename=f'{field_name}_depth_{depth_tag}.png',
+                    config=self.config,
+                    colormap_section=cmap_section,
+                    title=ocean_title,
+                    colorbar_label=colorbar_label,
+                )
+
+                filled_title = self._horizontal_title(
+                    field_title=field_title,
+                    requested_depth=requested_depth,
+                    actual_depth=actual_depth,
+                    filled=True,
+                )
+                plot_global_lat_lon_field(
+                    lon=ds_woa.lon.values,
+                    lat=ds_woa.lat.values,
+                    data_array=data,
+                    out_filename=f'{field_name}_depth_{depth_tag}_filled.png',
+                    config=self.config,
+                    colormap_section=cmap_section,
+                    title=filled_title,
+                    colorbar_label=colorbar_label,
+                )
+
+    def _plot_configured_transects(self, ds_woa, ds_topo):
+        transects = [
+            (
+                'Filchner Trough',
+                'filchner',
+                'filchner_section.png',
+                'filchner_section_filled.png',
+            ),
+            (
+                'Ross Ice Shelf cavity',
+                'ross',
+                'ross_section.png',
+                'ross_section_filled.png',
+            ),
+        ]
+
+        max_depth = self.config.getfloat('woa23', 'section_max_depth')
+        for transect_name, prefix, out_filename, filled_filename in transects:
+            start_lon = self.config.getfloat('woa23', f'{prefix}_start_lon')
+            start_lat = self.config.getfloat('woa23', f'{prefix}_start_lat')
+            end_lon = self.config.getfloat('woa23', f'{prefix}_end_lon')
+            end_lat = self.config.getfloat('woa23', f'{prefix}_end_lat')
+            self.logger.info(f'Plotting {transect_name} section')
+            self._plot_transect(
+                ds_woa=ds_woa,
+                ds_topo=ds_topo,
+                title=transect_name,
+                start_lon=start_lon,
+                start_lat=start_lat,
+                end_lon=end_lon,
+                end_lat=end_lat,
+                out_filename=out_filename,
+                max_depth=max_depth,
+                filled=False,
+            )
+            self._plot_transect(
+                ds_woa=ds_woa,
+                ds_topo=ds_topo,
+                title=transect_name,
+                start_lon=start_lon,
+                start_lat=start_lat,
+                end_lon=end_lon,
+                end_lat=end_lat,
+                out_filename=filled_filename,
+                max_depth=max_depth,
+                filled=True,
+            )
+
+    def _plot_transect(
+        self,
+        ds_woa,
+        ds_topo,
+        title,
+        start_lon,
+        start_lat,
+        end_lon,
+        end_lat,
+        out_filename,
+        max_depth,
+        filled,
+    ):
+        distance, lon, lat = self._build_transect(
+            start_lon=start_lon,
+            start_lat=start_lat,
+            end_lon=end_lon,
+            end_lat=end_lat,
+        )
+        ds_woa = self._add_periodic_lon(ds_woa)
+        ds_topo = self._add_periodic_lon(ds_topo)
+        coords = {
+            'lat': xr.DataArray(lat, dims=('nPoints',)),
+            'lon': xr.DataArray(lon, dims=('nPoints',)),
+        }
+
+        ds_section = ds_woa[['pt_an', 's_an']].interp(**coords)
+        ds_topo_section = ds_topo[['base_elevation', 'ice_draft']].interp(
+            **coords
+        )
+        ds_topo_section['ocean_mask'] = (
+            ds_topo[['ocean_mask']]
+            .interp(
+                method='nearest',
+                **coords,
+            )
+            .ocean_mask
+        )
+
+        top_depth = np.maximum(-ds_topo_section.ice_draft.values, 0.0)
+        bottom_depth = np.maximum(-ds_topo_section.base_elevation.values, 0.0)
+        ocean_mask = ds_topo_section.ocean_mask.values > 0.5
+        valid_column = np.logical_and(ocean_mask, bottom_depth > top_depth)
+
+        depth = ds_woa.depth.values
+        depth_bounds = self._depth_bounds(ds_woa.depth_bnds.values)
+        distance_bounds = self._distance_bounds(distance)
+        water_mask = (
+            (depth[:, np.newaxis] >= top_depth[np.newaxis, :])
+            & (depth[:, np.newaxis] <= bottom_depth[np.newaxis, :])
+            & valid_column[np.newaxis, :]
+        )
+
+        fields = [
+            (
+                'pt_an',
+                'Potential temperature',
+                r'Potential temperature ($^{\circ}$C)',
+                'woa23_viz_section_temperature',
+            ),
+            (
+                's_an',
+                'Salinity',
+                'Salinity (PSU)',
+                'woa23_viz_section_salinity',
+            ),
+        ]
+
+        fig, axes = plt.subplots(
+            2,
+            1,
+            figsize=(12, 8),
+            sharex=True,
+            constrained_layout=True,
+        )
+
+        max_depth = min(max_depth, float(depth_bounds[-1]))
+        top_depth_plot = np.minimum(top_depth, max_depth)
+        bottom_depth_plot = np.minimum(bottom_depth, max_depth)
+        for ax, (field_name, field_title, colorbar_label, cmap_section) in zip(
+            axes, fields, strict=True
+        ):
+            plot_data = ds_section[field_name].values
+            if not filled:
+                plot_data = np.where(water_mask, plot_data, np.nan)
+            colormap, norm, ticks = setup_colormap(self.config, cmap_section)
+            image = ax.pcolormesh(
+                distance_bounds,
+                depth_bounds,
+                plot_data,
+                cmap=colormap,
+                norm=norm,
+                shading='auto',
+            )
+
+            if not filled:
+                # Grounded ice and land are shown as a light gray
+                # background, floating ice by the cavity roof and the bed
+                # by dark gray fill.
+                ax.fill_between(
+                    distance,
+                    0.0,
+                    max_depth,
+                    where=np.logical_not(valid_column),
+                    color='0.88',
+                    linewidth=0.0,
+                )
+                ax.fill_between(
+                    distance,
+                    0.0,
+                    top_depth_plot,
+                    where=top_depth > 0.0,
+                    color='lightsteelblue',
+                    linewidth=0.0,
+                )
+                ax.fill_between(
+                    distance,
+                    bottom_depth_plot,
+                    max_depth,
+                    where=valid_column,
+                    color='dimgray',
+                    linewidth=0.0,
+                )
+                ax.plot(distance, top_depth_plot, color='k', linewidth=1.0)
+                ax.plot(distance, bottom_depth_plot, color='k', linewidth=1.0)
+            ax.set_ylabel('Depth (m)')
+            ax.set_title(field_title)
+            ax.set_ylim(max_depth, 0.0)
+            colorbar = fig.colorbar(image, ax=ax, pad=0.01)
+            colorbar.set_label(colorbar_label)
+            if ticks is not None:
+                colorbar.set_ticks(ticks)
+                colorbar.set_ticklabels([f'{tick}' for tick in ticks])
+
+        axes[-1].set_xlabel('Distance along transect (km)')
+        fig.suptitle(
+            f'{self._transect_title(title=title, filled=filled)}: '
+            f'({start_lon:.2f}, {start_lat:.2f}) to '
+            f'({end_lon:.2f}, {end_lat:.2f})'
+        )
+        fig.savefig(out_filename, bbox_inches='tight', pad_inches=0.1)
+        plt.close(fig)
+
+    @staticmethod
+    def _depth_tag(depth):
+        depth_str = f'{depth:07.2f}'
+        depth_str = depth_str.replace('.', 'p').replace('-', 'm')
+        return f'{depth_str}m'
+
+    @staticmethod
+    def _horizontal_title(field_title, requested_depth, actual_depth, filled):
+        if np.isclose(requested_depth, actual_depth):
+            title = f'{field_title} at {actual_depth:g} m'
+        else:
+            title = (
+                f'{field_title} near {requested_depth:g} m '
+                f'(WOA level {actual_depth:g} m)'
+            )
+
+        if filled:
+            return f'{title} (filled field)'
+        return f'{title} (ocean only)'
+
+    @staticmethod
+    def _transect_title(title, filled):
+        if filled:
+            return f'{title} (filled field)'
+        return f'{title} (ocean only)'
+
+    @staticmethod
+    def _get_level_water_mask(ds_topo, depth):
+        top_depth = np.maximum(-ds_topo.ice_draft.values, 0.0)
+        bottom_depth = np.maximum(-ds_topo.base_elevation.values, 0.0)
+        ocean_mask = ds_topo.ocean_mask.values > 0.5
+        return (top_depth <= depth) & (bottom_depth >= depth) & ocean_mask
+
+    @staticmethod
+    def _build_transect(start_lon, start_lat, end_lon, end_lat):
+        geod = pyproj.Geod(ellps='WGS84')
+        _, _, total_distance = geod.inv(start_lon, start_lat, end_lon, end_lat)
+        total_distance_km = total_distance * 1.0e-3
+        npoints = int(np.clip(total_distance_km / 10.0, 200, 1000))
+        if npoints < 2:
+            npoints = 2
+
+        if npoints > 2:
+            intermediate = geod.npts(
+                start_lon,
+                start_lat,
+                end_lon,
+                end_lat,
+                npoints - 2,
+            )
+            lon = np.array(
+                [start_lon] + [point[0] for point in intermediate] + [end_lon]
+            )
+            lat = np.array(
+                [start_lat] + [point[1] for point in intermediate] + [end_lat]
+            )
+        else:
+            lon = np.array([start_lon, end_lon])
+            lat = np.array([start_lat, end_lat])
+
+        _, _, segment_distance = geod.inv(lon[:-1], lat[:-1], lon[1:], lat[1:])
+        distance = np.zeros(npoints)
+        distance[1:] = np.cumsum(segment_distance) * 1.0e-3
+        return distance, lon, lat
+
+    @staticmethod
+    def _add_periodic_lon(ds):
+        lon = ds.lon
+        lon_sections = [lon - 360.0, lon, lon + 360.0]
+        lon_periodic = xr.concat(lon_sections, dim='lon')
+
+        periodic = []
+        for offset in [-360.0, 0.0, 360.0]:
+            shifted = ds.assign_coords(lon=ds.lon + offset)
+            periodic.append(shifted)
+
+        ds_periodic = xr.concat(periodic, dim='lon', data_vars='all')
+        ds_periodic = ds_periodic.assign_coords(lon=lon_periodic)
+        return ds_periodic.sortby('lon')
+
+    @staticmethod
+    def _depth_bounds(depth_bounds):
+        lower = depth_bounds[:, 0]
+        upper = depth_bounds[:, 1]
+        return np.concatenate(([lower[0]], upper))
+
+    @staticmethod
+    def _distance_bounds(distance):
+        if distance.size == 1:
+            return np.array([0.0, distance[0]])
+
+        bounds = np.zeros(distance.size + 1)
+        bounds[1:-1] = 0.5 * (distance[:-1] + distance[1:])
+        bounds[0] = 0.0
+        bounds[-1] = distance[-1]
+        return bounds

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/viz.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/viz.py
@@ -266,7 +266,7 @@ class Woa23VizStep(Step):
         valid_column = np.logical_and(ocean_mask, bottom_depth > top_depth)
 
         depth = ds_woa.depth.values
-        depth_bounds = self._depth_bounds(ds_woa.depth_bnds.values)
+        depth_bounds = self._depth_bounds(ds_woa.depth_bnds)
         distance_bounds = self._distance_bounds(distance)
         water_mask = (
             (depth[:, np.newaxis] >= top_depth[np.newaxis, :])
@@ -431,21 +431,39 @@ class Woa23VizStep(Step):
 
     @staticmethod
     def _add_periodic_lon(ds):
-        lon = ds.lon
-        lon_sections = [lon - 360.0, lon, lon + 360.0]
-        lon_periodic = xr.concat(lon_sections, dim='lon')
-
         periodic = []
         for offset in [-360.0, 0.0, 360.0]:
             shifted = ds.assign_coords(lon=ds.lon + offset)
             periodic.append(shifted)
 
-        ds_periodic = xr.concat(periodic, dim='lon', data_vars='all')
-        ds_periodic = ds_periodic.assign_coords(lon=lon_periodic)
+        ds_periodic = xr.concat(
+            periodic,
+            dim='lon',
+            data_vars='minimal',
+            coords='minimal',
+            compat='override',
+        )
         return ds_periodic.sortby('lon')
 
     @staticmethod
     def _depth_bounds(depth_bounds):
+        if isinstance(depth_bounds, xr.DataArray):
+            if {'depth', 'nbounds'}.issubset(depth_bounds.dims):
+                depth_bounds = depth_bounds.transpose('depth', 'nbounds')
+            depth_bounds = depth_bounds.values
+
+        depth_bounds = np.asarray(depth_bounds)
+        if depth_bounds.ndim != 2:
+            raise ValueError('Expected 2D depth bounds array.')
+        if depth_bounds.shape[1] != 2:
+            if depth_bounds.shape[0] == 2:
+                depth_bounds = depth_bounds.T
+            else:
+                raise ValueError(
+                    'Expected depth bounds with shape (depth, 2) or (2, '
+                    'depth).'
+                )
+
         lower = depth_bounds[:, 0]
         upper = depth_bounds[:, 1]
         return np.concatenate(([lower[0]], upper))

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/viz.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/viz.py
@@ -68,12 +68,14 @@ class Woa23VizStep(Step):
             'woa23', 'horizontal_plot_depths', dtype=float
         ):
             depth_tag = self._depth_tag(depth)
-            self.add_output_file(filename=f'pt_an_depth_{depth_tag}.png')
+            self.add_output_file(filename=f'ct_an_depth_{depth_tag}.png')
             self.add_output_file(
-                filename=f'pt_an_depth_{depth_tag}_filled.png'
+                filename=f'ct_an_depth_{depth_tag}_filled.png'
             )
-            self.add_output_file(filename=f's_an_depth_{depth_tag}.png')
-            self.add_output_file(filename=f's_an_depth_{depth_tag}_filled.png')
+            self.add_output_file(filename=f'sa_an_depth_{depth_tag}.png')
+            self.add_output_file(
+                filename=f'sa_an_depth_{depth_tag}_filled.png'
+            )
 
         self.add_output_file(filename='filchner_section.png')
         self.add_output_file(filename='filchner_section_filled.png')
@@ -98,15 +100,15 @@ class Woa23VizStep(Step):
         logger = self.logger
         fields = [
             (
-                'pt_an',
-                'Potential temperature',
-                r'Potential temperature ($^{\circ}$C)',
+                'ct_an',
+                'Conservative temperature',
+                r'Conservative temperature ($^{\circ}$C)',
                 'woa23_viz_temperature',
             ),
             (
-                's_an',
-                'Salinity',
-                'Salinity (PSU)',
+                'sa_an',
+                'Absolute salinity',
+                r'Absolute salinity (g kg$^{-1}$)',
                 'woa23_viz_salinity',
             ),
         ]
@@ -245,7 +247,7 @@ class Woa23VizStep(Step):
             'lon': xr.DataArray(lon, dims=('nPoints',)),
         }
 
-        ds_section = ds_woa[['pt_an', 's_an']].interp(**coords)
+        ds_section = ds_woa[['ct_an', 'sa_an']].interp(**coords)
         ds_topo_section = ds_topo[['base_elevation', 'ice_draft']].interp(
             **coords
         )
@@ -274,15 +276,15 @@ class Woa23VizStep(Step):
 
         fields = [
             (
-                'pt_an',
-                'Potential temperature',
-                r'Potential temperature ($^{\circ}$C)',
+                'ct_an',
+                'Conservative temperature',
+                r'Conservative temperature ($^{\circ}$C)',
                 'woa23_viz_section_temperature',
             ),
             (
-                's_an',
-                'Salinity',
-                'Salinity (PSU)',
+                'sa_an',
+                'Absolute salinity',
+                r'Absolute salinity (g kg$^{-1}$)',
                 'woa23_viz_section_salinity',
             ),
         ]

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/woa23.cfg
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/woa23.cfg
@@ -1,0 +1,6 @@
+# Options related to generating a reusable WOA23 hydrography product
+[woa23]
+
+# the minimum weight sum needed to mark a new cell valid in horizontal
+# extrapolation
+extrap_threshold = 0.01

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/woa23.cfg
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/woa23.cfg
@@ -4,3 +4,48 @@
 # the minimum weight sum needed to mark a new cell valid in horizontal
 # extrapolation
 extrap_threshold = 0.01
+
+# target depths for horizontal plots of the extrapolated product (m)
+horizontal_plot_depths = 0.0, 200.0, 400.0, 600.0, 800.0
+
+# maximum depth to include in section plots (m)
+section_max_depth = 2000.0
+
+# endpoints of a transect through Filchner Trough and into the Filchner
+# ice-shelf cavity
+filchner_start_lon = -46.0
+filchner_start_lat = -71.5
+filchner_end_lon = -38.5
+filchner_end_lat = -81.2
+
+# endpoints of a transect through the Ross Ice Shelf cavity
+ross_start_lon = 176.0
+ross_start_lat = -72.0
+ross_end_lon = -171.0
+ross_end_lat = -84.0
+
+
+[woa23_viz_temperature]
+colormap_name = cmo.thermal
+norm_type = linear
+norm_args = {'vmin': -2.5, 'vmax': 30.0}
+
+
+[woa23_viz_salinity]
+colormap_name = cmo.haline
+norm_type = linear
+norm_args = {'vmin': 32.0, 'vmax': 37.0}
+
+
+[woa23_viz_section_temperature]
+colormap_name = cmo.thermal
+norm_type = linear
+norm_args = {'vmin': -2.5, 'vmax': 1.5}
+colorbar_ticks = -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5
+
+
+[woa23_viz_section_salinity]
+colormap_name = cmo.haline
+norm_type = linear
+norm_args = {'vmin': 34.0, 'vmax': 35.0}
+colorbar_ticks = 34.0, 34.2, 34.4, 34.6, 34.8, 35.0

--- a/tests/ocean/global_ocean/hydrography/woa23/test_combine.py
+++ b/tests/ocean/global_ocean/hydrography/woa23/test_combine.py
@@ -1,0 +1,76 @@
+import gsw
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.tasks.ocean.global_ocean.hydrography.woa23.combine import (
+    CombineStep,
+)
+
+
+def test_to_canonical_teos10():
+    ds = xr.Dataset(
+        data_vars={
+            't_an': (
+                ('depth', 'lat', 'lon'),
+                np.array(
+                    [
+                        [[1.0, 2.0], [3.0, np.nan]],
+                        [[0.5, 1.5], [2.5, 3.5]],
+                    ]
+                ),
+            ),
+            's_an': (
+                ('depth', 'lat', 'lon'),
+                np.array(
+                    [
+                        [[34.5, 34.7], [34.9, 35.1]],
+                        [[34.6, 34.8], [35.0, np.nan]],
+                    ]
+                ),
+            ),
+        },
+        coords={
+            'depth': ('depth', np.array([0.0, 1000.0])),
+            'lat': ('lat', np.array([-45.0, 10.0])),
+            'lon': ('lon', np.array([20.0, 160.0])),
+        },
+    )
+
+    ds_out = CombineStep._to_canonical_teos10(ds)
+
+    assert 't_an' not in ds_out
+    assert 's_an' not in ds_out
+    assert ds_out.ct_an.attrs['standard_name'] == (
+        'sea_water_conservative_temperature'
+    )
+    assert ds_out.sa_an.attrs['standard_name'] == (
+        'sea_water_absolute_salinity'
+    )
+    assert ds_out.sa_an.attrs['units'] == 'g kg-1'
+
+    expected_ct = np.full(ds_out.ct_an.shape, np.nan)
+    expected_sa = np.full(ds_out.sa_an.shape, np.nan)
+    for depth_index, depth in enumerate(ds.depth.values):
+        temp = ds.t_an.isel(depth=depth_index).values
+        practical_salinity = ds.s_an.isel(depth=depth_index).values
+        level = ds.t_an.isel(depth=depth_index)
+        lat = ds.lat.broadcast_like(level).values
+        lon = ds.lon.broadcast_like(level).values
+        pressure = gsw.p_from_z(-depth, lat)
+        mask = np.isfinite(temp) & np.isfinite(practical_salinity)
+
+        expected_sa[depth_index, :, :][mask] = gsw.SA_from_SP(
+            practical_salinity[mask],
+            pressure[mask],
+            lon[mask],
+            lat[mask],
+        )
+        expected_ct[depth_index, :, :][mask] = gsw.CT_from_t(
+            expected_sa[depth_index, :, :][mask],
+            temp[mask],
+            pressure[mask],
+        )
+
+    assert ds_out.ct_an.values == pytest.approx(expected_ct, nan_ok=True)
+    assert ds_out.sa_an.values == pytest.approx(expected_sa, nan_ok=True)

--- a/tests/ocean/global_ocean/hydrography/woa23/test_combine.py
+++ b/tests/ocean/global_ocean/hydrography/woa23/test_combine.py
@@ -6,6 +6,9 @@ import xarray as xr
 from polaris.tasks.ocean.global_ocean.hydrography.woa23.combine import (
     CombineStep,
 )
+from polaris.tasks.ocean.global_ocean.hydrography.woa23.viz import (
+    Woa23VizStep,
+)
 
 
 def test_to_canonical_teos10():
@@ -74,3 +77,55 @@ def test_to_canonical_teos10():
 
     assert ds_out.ct_an.values == pytest.approx(expected_ct, nan_ok=True)
     assert ds_out.sa_an.values == pytest.approx(expected_sa, nan_ok=True)
+
+
+def test_depth_bounds_depth_major():
+    depth_bounds = xr.DataArray(
+        np.array([[0.0, 100.0], [100.0, 300.0], [300.0, 600.0]]),
+        dims=('depth', 'nbounds'),
+    )
+
+    bounds = Woa23VizStep._depth_bounds(depth_bounds)
+
+    assert bounds == pytest.approx([0.0, 100.0, 300.0, 600.0])
+
+
+def test_depth_bounds_bounds_major():
+    depth_bounds = xr.DataArray(
+        np.array([[0.0, 100.0, 300.0], [100.0, 300.0, 600.0]]),
+        dims=('nbounds', 'depth'),
+    )
+
+    bounds = Woa23VizStep._depth_bounds(depth_bounds)
+
+    assert bounds == pytest.approx([0.0, 100.0, 300.0, 600.0])
+
+
+def test_add_periodic_lon_keeps_non_lon_variables_1d():
+    ds = xr.Dataset(
+        data_vars={
+            'ct_an': (
+                ('depth', 'lat', 'lon'),
+                np.arange(12, dtype=float).reshape(2, 2, 3),
+            ),
+            'depth_bnds': (
+                ('depth', 'nbounds'),
+                np.array([[0.0, 100.0], [100.0, 300.0]]),
+            ),
+        },
+        coords={
+            'depth': ('depth', np.array([50.0, 200.0])),
+            'lat': ('lat', np.array([-75.0, -74.0])),
+            'lon': ('lon', np.array([-10.0, 0.0, 10.0])),
+            'nbounds': ('nbounds', np.array([0, 1])),
+        },
+    )
+
+    ds_periodic = Woa23VizStep._add_periodic_lon(ds)
+
+    assert ds_periodic.sizes['lon'] == 9
+    assert ds_periodic.depth_bnds.dims == ('depth', 'nbounds')
+    assert ds_periodic.depth_bnds.values == pytest.approx(ds.depth_bnds.values)
+    assert Woa23VizStep._depth_bounds(ds_periodic.depth_bnds) == pytest.approx(
+        [0.0, 100.0, 300.0]
+    )


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR ports processing of the World Ocean Atlas 2023 (WOA23) dataset from Compass.

First, it combines 2 decadal climatologies together and combines January data at shallower depths with annual data in the deeper ocean (where WOA23 doesn't provide monthly data).  The data are combined on a 0.25 degree grid, the highest resolution available for WOA23.

Then, beginning with a combined topography dataset on the same 0.25 degree lat-lon grid, we extrapolate the WOA23 data first into ice-shelf cavities and open ocean regions, then into land regions and below the bathymetry.

This PR also includes a new `viz` step used to quickly demonstrate that the extrapolation has done what it's supposed to.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
