### PR TITLE
Turn off HPG term in tests that do not require it

### DIFF
--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -60,6 +60,7 @@ Omega:
     TracerHorzAdvTendencyEnable : false
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
+    PressureGradTendencyEnable : false
   Advection:
     FluxThicknessType: Center
   IOStreams:

--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -79,6 +79,7 @@ Omega:
     TracerHorzAdvTendencyEnable : true
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
+    PressureGradTendencyEnable : false
   IOStreams:
     InitialVertCoord:
       Filename: init.nc

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -44,6 +44,7 @@ Omega:
     VelHyperDiffTendencyEnable: false
     UseCustomTendency: true
     ManufacturedSolutionTendency: true
+    PressureGradTendencyEnable : false
   IOStreams:
     InitialVertCoord:
       Filename: init.nc

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -71,6 +71,7 @@ Omega:
     TracerHorzAdvTendencyEnable : true
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
+    PressureGradTendencyEnable : false
   IOStreams:
     InitialVertCoord:
       Filename: init.nc


### PR DESCRIPTION
This PR turns off the horizontal pressure gradient term for tests where it is not required in the omega_pr suite.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes
