### PR TITLE
Update to v1.0.0-alpha.4 to fix xarray dataset copy

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - id: skip_check

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Polaris provides infrastructure, test cases and analysis tasks related to the
 ocean, land-ice and sea-ice components of the Exascale Energy Earth System
 Model ([E3SM](https://e3sm.org/)).
 
+Polaris requires Python 3.11 or newer.
+
 Supported models include:
 * [Omega](https://github.com/E3SM-Project/Omega) (in early stages of development)
 * [MPAS-Albany Land Ice (MALI)](https://mpas-dev.github.io/land_ice/land_ice.html)

--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "polaris",
-    "mache_version": "3.5.2",
+    "mache_version": "3.6.0",
     "description": "Deploy polaris environment"
   },
   "arguments": [

--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "polaris",
-    "mache_version": "3.5.0",
+    "mache_version": "3.5.2",
     "description": "Deploy polaris environment"
   },
   "arguments": [

--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "polaris",
-    "mache_version": "3.3.0",
+    "mache_version": "3.5.0",
     "description": "Deploy polaris environment"
   },
   "arguments": [

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -3,7 +3,7 @@
 bootstrap_python = 3.14
 python = 3.14
 geometric_features = 1.6.3
-mache = 3.5.0
+mache = 3.5.2
 mpas_tools = 1.5.0
 otps = 2021.10
 parallelio = 2.6.9

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -3,7 +3,7 @@
 bootstrap_python = 3.14
 python = 3.14
 geometric_features = 1.6.3
-mache = 3.5.2
+mache = 3.6.0
 mpas_tools = 1.5.0
 otps = 2021.10
 parallelio = 2.6.9

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -2,9 +2,9 @@
 [pixi]
 bootstrap_python = 3.14
 python = 3.14
-geometric_features = 1.6.1
-mache = 3.3.0
-mpas_tools = 1.4.0
+geometric_features = 1.6.3
+mache = 3.5.0
+mpas_tools = 1.5.0
 otps = 2021.10
 parallelio = 2.6.9
 

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -47,6 +47,8 @@ As a developer, rerun `./deploy.py` when you check out a new branch or use a
 new worktree. In most cases you do not need to rerun deployment while editing
 existing files in `polaris`, because the package is installed in editable mode.
 
+Polaris requires Python 3.11 or newer.
+
 :::{note}
 Miniforge, Micromamba, and Miniconda are no longer required for Polaris
 deployment. If pixi is not already installed, `./deploy.py` can install it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,9 @@ of Polaris will be kept closely synchronized with the development repositories
 for the components it supports. Release versions will be compatible with
 specific tags of the MPAS components.
 
+Polaris requires Python 3.11 or newer. Python 3.10 is no longer
+supported because `mpas_tools` 1.5.0 and newer do not support it.
+
 Many Polaris tasks are idealized, and are used for things like
 performing convergence tests or regression tests on particular parts of the
 model code.  Other Polaris tasks are "realistic" in the sense that they use

--- a/docs/users_guide/machines/perlmutter.md
+++ b/docs/users_guide/machines/perlmutter.md
@@ -256,7 +256,7 @@ Perlmutter and use it from Jupyter.
 
 ```bash
 module load python
-conda create -n myenv python=3.7 ipykernel <further-packages-to-install>
+conda create -n myenv python=3.14 ipykernel <further-packages-to-install>
 <... installation messages ...>
 source activate myenv
 python -m ipykernel install --user --name myenv --display-name MyEnv

--- a/polaris/tasks/ocean/isomip_plus/topo/scale.py
+++ b/polaris/tasks/ocean/isomip_plus/topo/scale.py
@@ -75,7 +75,7 @@ class TopoScale(Step):
         for index in range(len(dates)):
             date = dates[index]
             scale = scales[index]
-            ds = xr.Dataset(ds_orig)
+            ds = ds_orig.copy()
             ds['xtime'] = date
             for var in ['landIcePressure', 'landIceDraft']:
                 ds[var] = ds_orig[var] * scale

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.0-alpha.3'
+__version__ = '1.0.0-alpha.4'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,9 @@ authors = [
 description = "Testing and analysis for Omega, MPAS-Ocean, MALI and MPAS-Seaice"
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     # these are only for searching/browsing projects on PyPI
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -71,7 +70,7 @@ dev = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 check_untyped_defs = true
 ignore_missing_imports = true
 warn_unused_ignores = true


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR bring in:
* `mache` 3.6.0, which fixes several issues on Frontier and brings in various improvements to deployment
* `mpas_tools` 1.5.0 with a bug fix to copying xarray datasets
* `geometric_features` 1.6.3, required by `mpas_tools` 1.5.0

It drops python 3.10, as `mpas_tools` >=1.5.0 doesn't support this older version of python.

It fixes the same dataset copy issue in the `isomip_plus` tests.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
