### PR TITLE
Remove nVertLevels from Coriolis variables in overflow test case

### DIFF
--- a/polaris/tasks/ocean/overflow/init.py
+++ b/polaris/tasks/ocean/overflow/init.py
@@ -126,25 +126,16 @@ class Init(OceanIOStep):
 
         # Coriolis parameter is zero
         ds['fCell'] = (
-            (
-                'nCells',
-                'nVertLevels',
-            ),
-            np.zeros([ds.sizes['nCells'], ds.sizes['nVertLevels']]),
+            ('nCells',),
+            np.zeros([ds.sizes['nCells']]),
         )
         ds['fEdge'] = (
-            (
-                'nEdges',
-                'nVertLevels',
-            ),
-            np.zeros([ds.sizes['nEdges'], ds.sizes['nVertLevels']]),
+            ('nEdges',),
+            np.zeros([ds.sizes['nEdges']]),
         )
         ds['fVertex'] = (
-            (
-                'nVertices',
-                'nVertLevels',
-            ),
-            np.zeros([ds.sizes['nVertices'], ds.sizes['nVertLevels']]),
+            ('nVertices',),
+            np.zeros([ds.sizes['nVertices']]),
         )
 
         # finalize and write file

--- a/polaris/tasks/ocean/overflow/init.py
+++ b/polaris/tasks/ocean/overflow/init.py
@@ -125,18 +125,9 @@ class Init(OceanIOStep):
         )
 
         # Coriolis parameter is zero
-        ds['fCell'] = (
-            ('nCells',),
-            np.zeros([ds.sizes['nCells']]),
-        )
-        ds['fEdge'] = (
-            ('nEdges',),
-            np.zeros([ds.sizes['nEdges']]),
-        )
-        ds['fVertex'] = (
-            ('nVertices',),
-            np.zeros([ds.sizes['nVertices']]),
-        )
+        ds['fCell'] = xr.zeros_like(ds.xCell)
+        ds['fEdge'] = xr.zeros_like(ds.xEdge)
+        ds['fVertex'] = xr.zeros_like(ds.xVertex)
 
         # finalize and write file
         self.write_model_dataset(ds, 'init.nc')

--- a/polaris/tasks/ocean/seamount/init.py
+++ b/polaris/tasks/ocean/seamount/init.py
@@ -149,9 +149,9 @@ class Init(OceanIOStep):
             ),
             np.zeros([1, ds.sizes['nEdges'], ds.sizes['nVertLevels']]),
         )
-        ds['fCell'] = coriolis_parameter * xr.ones_like(temperature)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
+        ds['fCell'] = coriolis_parameter * xr.ones_like(ds.xCell)
+        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds.xEdge)
+        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds.xVertex)
 
         # this was in internal wave but not overflow. Is it needed?
         ds.attrs['nx'] = nx


### PR DESCRIPTION
Before this fix, the Coriolis variables fCell, fEdge, and fVertex included a vertical dimension. This did not cause an error for MPAS-Ocean, but does for Omega. A vertical dimension is not needed, so it was removed. 