### PR TITLE
Split horiz. mesh, init. vert. coord. and init. state into separate files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,8 @@ napoleon_use_rtype = False
 # list
 napoleon_use_ivar = True
 
+suppress_warnings = ['autodoc.typehints']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/polaris/ocean/config/model_inputs.yaml
+++ b/polaris/ocean/config/model_inputs.yaml
@@ -1,0 +1,15 @@
+mpas-ocean:
+  streams:
+    mesh:
+      filename_template: {{ horiz_mesh_filename }}
+    input:
+      filename_template: {{ init_filename }}
+
+Omega:
+  IOStreams:
+    HorzMeshIn:
+      Filename: {{ horiz_mesh_filename }}
+    InitialVertCoord:
+      Filename: {{ vert_coord_filename }}
+    InitialState:
+      Filename: {{ init_filename }}

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -31,7 +31,7 @@ class ConvergenceAnalysis(OceanIOStep):
             init : dict of polaris.Steps
                 Keys of the dict correspond to `resolutions`
                 Values of the dict are polaris.Steps, which must have the
-                attribute `path`, the path to `initial_state.nc` of that
+                attribute `path`, the path to `init.nc` of that
                 resolution
             forward : dict of polaris.Steps
                 Keys of the dict correspond to `resolutions`
@@ -94,7 +94,7 @@ class ConvergenceAnalysis(OceanIOStep):
                 init : dict of polaris.Steps
                     Keys of the dict correspond to `refinement_factors`
                     Values of the dict are polaris.Steps, which must have the
-                    attribute `path`, the path to `initial_state.nc` of that
+                    attribute `path`, the path to `init.nc` of that
                     resolution
                 forward : dict of polaris.Steps
                     Keys of the dict correspond to `refinement_factors`
@@ -157,7 +157,7 @@ class ConvergenceAnalysis(OceanIOStep):
             )
             self.add_input_file(
                 filename=f'init_r{refinement_factor:02g}.nc',
-                work_dir_target=f'{init.path}/initial_state.nc',
+                work_dir_target=f'{init.path}/init.nc',
             )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',

--- a/polaris/ocean/convergence/forward.py
+++ b/polaris/ocean/convergence/forward.py
@@ -35,7 +35,6 @@ class ConvergenceForward(OceanModelStep):
         package,
         update_eos=False,
         yaml_filename='forward.yaml',
-        mesh_input_filename='mesh.nc',
         options=None,
         replacements=None,
         graph_target=None,
@@ -67,11 +66,6 @@ class ConvergenceForward(OceanModelStep):
 
         yaml_filename : str, optional
             A YAML file that is a Jinja2 template with model config options
-
-        mesh_input_filename : str, optional
-            The filename of the mesh produced by the ``mesh`` step.  This file
-            will be symlinked into the work directory as ``mesh.nc`` for the
-            ocean model to use.
 
         options : dict, optional
             A nested dictionary of options and value for each ``config_model``
@@ -116,13 +110,13 @@ class ConvergenceForward(OceanModelStep):
                     options=options[config_model], config_model=config_model
                 )
 
-        self.add_input_file(
-            filename='init.nc', work_dir_target=f'{init.path}/initial_state.nc'
+        self.add_horiz_mesh_input_file(
+            work_dir_target=f'{init.path}/culled_mesh.nc'
         )
-        self.add_input_file(
-            filename='mesh.nc',
-            work_dir_target=f'{mesh.path}/{mesh_input_filename}',
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc'
         )
+        self.add_init_input_file(work_dir_target=f'{init.path}/init.nc')
 
         self.add_output_file(
             filename=output_filename,

--- a/polaris/ocean/coriolis.py
+++ b/polaris/ocean/coriolis.py
@@ -1,0 +1,184 @@
+import numpy as np
+import xarray as xr
+
+from polaris.constants import get_constant
+
+
+def add_beta_plane_coriolis(
+    ds_mesh: xr.Dataset, f0: float, beta: float
+) -> xr.Dataset:
+    """
+    Add beta-plane Coriolis fields to a horizontal mesh dataset.
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        The horizontal mesh dataset to update in place
+
+    f0 : float
+        The Coriolis parameter at ``y=0``
+
+    beta : float
+        The meridional gradient of the Coriolis parameter
+
+    Returns
+    -------
+    xarray.Dataset
+        The updated dataset
+    """
+    return _set_coriolis_fields(
+        ds_mesh,
+        f0 + beta * ds_mesh.yCell,
+        f0 + beta * ds_mesh.yEdge,
+        f0 + beta * ds_mesh.yVertex,
+    )
+
+
+def add_constant_coriolis(
+    ds_mesh: xr.Dataset, coriolis_parameter: float
+) -> xr.Dataset:
+    """
+    Add constant Coriolis fields to a horizontal mesh dataset.
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        The horizontal mesh dataset to update in place
+
+    coriolis_parameter : float
+        The constant Coriolis parameter value
+
+    Returns
+    -------
+    xarray.Dataset
+        The updated dataset
+    """
+    return _set_coriolis_fields(
+        ds_mesh,
+        coriolis_parameter * xr.ones_like(ds_mesh.xCell),
+        coriolis_parameter * xr.ones_like(ds_mesh.xEdge),
+        coriolis_parameter * xr.ones_like(ds_mesh.xVertex),
+    )
+
+
+def add_rotated_sphere_coriolis(
+    ds_mesh: xr.Dataset, alpha: float, omega: float | None = None
+) -> xr.Dataset:
+    """
+    Add Coriolis fields for a sphere rotated by angle ``alpha``.
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        The horizontal mesh dataset to update in place
+
+    alpha : float
+        The rotation angle in radians
+
+    omega : float, optional
+        The angular rotation rate. If not provided, the Earth's angular
+        velocity is used.
+
+    Returns
+    -------
+    xarray.Dataset
+        The updated dataset
+    """
+    if omega is None:
+        omega = get_constant('angular_velocity')
+
+    return _set_coriolis_fields(
+        ds_mesh,
+        _rotated_sphere_coriolis(
+            ds_mesh.lonCell, ds_mesh.latCell, alpha, omega
+        ),
+        _rotated_sphere_coriolis(
+            ds_mesh.lonEdge, ds_mesh.latEdge, alpha, omega
+        ),
+        _rotated_sphere_coriolis(
+            ds_mesh.lonVertex, ds_mesh.latVertex, alpha, omega
+        ),
+    )
+
+
+def add_spherical_coriolis(
+    ds_mesh: xr.Dataset, omega: float | None = None
+) -> xr.Dataset:
+    """
+    Add Coriolis fields for the Earth's rotation axis.
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        The horizontal mesh dataset to update in place
+
+    omega : float, optional
+        The angular rotation rate. If not provided, the Earth's angular
+        velocity is used.
+
+    Returns
+    -------
+    xarray.Dataset
+        The updated dataset
+    """
+    return add_rotated_sphere_coriolis(ds_mesh, alpha=0.0, omega=omega)
+
+
+def add_zero_coriolis(ds_mesh: xr.Dataset) -> xr.Dataset:
+    """
+    Add zero-valued Coriolis fields to a horizontal mesh dataset.
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        The horizontal mesh dataset to update in place
+
+    Returns
+    -------
+    xarray.Dataset
+        The updated dataset
+    """
+    return _set_coriolis_fields(
+        ds_mesh,
+        xr.zeros_like(ds_mesh.xCell),
+        xr.zeros_like(ds_mesh.xEdge),
+        xr.zeros_like(ds_mesh.xVertex),
+    )
+
+
+def _rotated_sphere_coriolis(
+    lon: xr.DataArray, lat: xr.DataArray, alpha: float, omega: float
+) -> xr.DataArray:
+    return (
+        2.0
+        * omega
+        * (
+            -np.cos(lon) * np.cos(lat) * np.sin(alpha)
+            + np.sin(lat) * np.cos(alpha)
+        )
+    )
+
+
+def _set_coriolis_fields(
+    ds_mesh: xr.Dataset,
+    f_cell: xr.DataArray,
+    f_edge: xr.DataArray,
+    f_vertex: xr.DataArray,
+) -> xr.Dataset:
+    ds_mesh['fCell'] = _add_coriolis_attrs(f_cell, 'cell centers')
+    ds_mesh['fEdge'] = _add_coriolis_attrs(f_edge, 'edges')
+    ds_mesh['fVertex'] = _add_coriolis_attrs(f_vertex, 'vertices')
+    return ds_mesh
+
+
+def _add_coriolis_attrs(
+    data_array: xr.DataArray, location: str
+) -> xr.DataArray:
+    data_array.attrs.update(
+        {
+            'long_name': f'Coriolis parameter at {location}',
+            'standard_name': 'coriolis_parameter',
+            'units': 'radians s^-1',
+        }
+    )
+    return data_array

--- a/polaris/ocean/coriolis.py
+++ b/polaris/ocean/coriolis.py
@@ -1,7 +1,49 @@
 import numpy as np
 import xarray as xr
 
+from polaris.config import PolarisConfigParser
 from polaris.constants import get_constant
+
+
+def add_coriolis_to_dataset(
+    config: PolarisConfigParser, ds_mesh: xr.Dataset
+) -> xr.Dataset:
+    """
+    Add Coriolis fields to a mesh dataset based on the ``type`` option
+    in the ``[coriolis]`` config section.
+
+    Parameters
+    ----------
+    config : polaris.config.PolarisConfigParser
+        Configuration object containing ocean parameters.
+
+    ds_mesh : xarray.Dataset
+        The horizontal mesh dataset to update.
+
+    Returns
+    -------
+    xarray.Dataset
+        The updated dataset with ``fCell``, ``fEdge``, and ``fVertex``
+        fields.
+    """
+    section = config['coriolis']
+    coriolis_type = section.get('type').strip()
+    if coriolis_type == 'zero':
+        return add_zero_coriolis(ds_mesh)
+    elif coriolis_type == 'constant':
+        f = section.getfloat('constant_f')
+        return add_constant_coriolis(ds_mesh, f)
+    elif coriolis_type == 'beta_plane':
+        f0 = section.getfloat('beta_plane_f0')
+        beta = section.getfloat('beta_plane_beta')
+        return add_beta_plane_coriolis(ds_mesh, f0, beta)
+    elif coriolis_type == 'spherical':
+        return add_spherical_coriolis(ds_mesh)
+    elif coriolis_type == 'rotated_sphere':
+        alpha = section.getfloat('rotated_sphere_alpha')
+        return add_rotated_sphere_coriolis(ds_mesh, alpha)
+    else:
+        raise ValueError(f'Unsupported Coriolis type: {coriolis_type}')
 
 
 def add_beta_plane_coriolis(

--- a/polaris/ocean/ice_shelf/__init__.py
+++ b/polaris/ocean/ice_shelf/__init__.py
@@ -130,6 +130,7 @@ class IceShelfTask(Task):
                 min_resolution=min_resolution,
                 init_filename=current_init_filename,
                 graph_target=graph_target,
+                mesh_filename=mesh_filename,
                 name=name,
                 package=package,
                 yaml_filename=yaml_filename,

--- a/polaris/ocean/ice_shelf/ssh_forward.py
+++ b/polaris/ocean/ice_shelf/ssh_forward.py
@@ -29,6 +29,7 @@ class SshForward(OceanModelStep):
         init_filename,
         graph_target,
         subdir,
+        mesh_filename,
         name='ssh_forward',
         package=None,
         yaml_filename='ssh_forward.yaml',
@@ -57,6 +58,9 @@ class SshForward(OceanModelStep):
 
         subdir : str
             the subdirectory for the step
+
+        mesh_filename : str
+            the mesh filename (relative to the base work directory)
 
         name : str, optional
             the name of the task
@@ -101,6 +105,7 @@ class SshForward(OceanModelStep):
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
+        self.add_input_file(filename='mesh.nc', work_dir_target=mesh_filename)
         self.add_input_file(filename='init.nc', work_dir_target=init_filename)
         self.add_input_file(
             filename='graph.info', work_dir_target=graph_target

--- a/polaris/ocean/ice_shelf/ssh_forward.yaml
+++ b/polaris/ocean/ice_shelf/ssh_forward.yaml
@@ -15,7 +15,7 @@ mpas-ocean:
     config_check_ssh_consistency: false
   streams:
     mesh:
-      filename_template: init.nc
+      filename_template: mesh.nc
     input:
       filename_template: init.nc
     output:

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -86,55 +86,6 @@ variables:
   pressure: PressureMid
 
 
-horiz_mesh_variables:
-  - indexToCellID
-  - indexToEdgeID
-  - indexToVertexID
-  - cellsOnCell
-  - nEdgesOnCell
-  - edgesOnCell
-  - verticesOnCell
-  - cellsOnEdge
-  - edgesOnEdge
-  - nEdgesOnEdge
-  - verticesOnEdge
-  - cellsOnVertex
-  - edgesOnVertex
-  - xCell
-  - yCell
-  - zCell
-  - latCell
-  - lonCell
-  - xEdge
-  - yEdge
-  - zEdge
-  - latEdge
-  - lonEdge
-  - xVertex
-  - yVertex
-  - zVertex
-  - latVertex
-  - lonVertex
-  - areaCell
-  - meshDensity
-  - areaTriangle
-  - dvEdge
-  - dcEdge
-  - angleEdge
-  - kiteAreasOnVertex
-  - weightsOnEdge
-  - fCell
-  - fEdge
-  - fVertex
-
-vert_coord_variables:
-  - minLevelCell
-  - maxLevelCell
-  - bottomDepth
-  - restingThickness
-  - vertCoordMovementWeights
-
-
 config:
 - section:
     time_management: TimeIntegration

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -12,7 +12,7 @@ dimensions:
   nVertLevelsP1: NVertLayersP1
 
 variables:
-  # mesh
+  # mesh topology
   cellsOnCell: CellsOnCell
   edgesOnCell: EdgesOnCell
   verticesOnCell: VerticesOnCell
@@ -22,11 +22,43 @@ variables:
   cellsOnVertex: CellsOnVertex
   edgesOnVertex: EdgesOnVertex
 
+  # mesh coordinates
+  xCell: XCell
+  yCell: YCell
+  zCell: ZCell
+  latCell: LatCell
+  lonCell: LonCell
+  xEdge: XEdge
+  yEdge: YEdge
+  zEdge: ZEdge
+  latEdge: LatEdge
+  lonEdge: LonEdge
+  xVertex: XVertex
+  yVertex: YVertex
+  zVertex: ZVertex
+  latVertex: LatVertex
+  lonVertex: LonVertex
+  areaCell: AreaCell
+  meshDensity: MeshDensity
+  areaTriangle: AreaTriangle
+  dvEdge: DvEdge
+  dcEdge: DcEdge
+  angleEdge: AngleEdge
+  kiteAreasOnVertex: KiteAreasOnVertex
+  weightsOnEdge: WeightsOnEdge
+
+  # Coriolis
+  fCell: FCell
+  fEdge: FEdge
+  fVertex: FVertex
+
   # vertical coordinate
   minLevelCell: MinLayerCell
   maxLevelCell: MaxLayerCell
   bottomDepth: BottomGeomDepth
   vertCoordMovementWeights: VertCoordMovementWeights
+  # Note: restingThickness in MPAS-Ocean requires conversion to
+  #       RefPseudoThickness in Omega (handled in write_vert_coord_dataset)
 
   # tracers
   temperature: Temperature
@@ -36,8 +68,8 @@ variables:
   tracer3: Debug3
 
   # state
-  # Note: layerThickness in MPAS-Ocean has no Omega equivalent and
-  #       PseudoThickness in Omega has no MPAS-Ocean equivalent
+  # Note: layerThickness in MPAS-Ocean requires conversion to
+  #       PseudoThickness in Omega (handled in write_model_dataset)
   normalVelocity: NormalVelocity
   # Note: vertVelocityTop in MPAS-Ocean has no Omega equivalent and
   #       VerticalPseudoVelocity in Omega has no MPAS-Ocean equivalent
@@ -48,10 +80,59 @@ variables:
   windStressMeridional: WindStressMeridional
   relativeVorticity: RelVortVertex
 
-  # vertical coordinate
+  # vertical coordinate diagnostics
   zMid: GeomZMid
   zInterface: GeomZInterface
   pressure: PressureMid
+
+
+horiz_mesh_variables:
+  - indexToCellID
+  - indexToEdgeID
+  - indexToVertexID
+  - cellsOnCell
+  - nEdgesOnCell
+  - edgesOnCell
+  - verticesOnCell
+  - cellsOnEdge
+  - edgesOnEdge
+  - nEdgesOnEdge
+  - verticesOnEdge
+  - cellsOnVertex
+  - edgesOnVertex
+  - xCell
+  - yCell
+  - zCell
+  - latCell
+  - lonCell
+  - xEdge
+  - yEdge
+  - zEdge
+  - latEdge
+  - lonEdge
+  - xVertex
+  - yVertex
+  - zVertex
+  - latVertex
+  - lonVertex
+  - areaCell
+  - meshDensity
+  - areaTriangle
+  - dvEdge
+  - dcEdge
+  - angleEdge
+  - kiteAreasOnVertex
+  - weightsOnEdge
+  - fCell
+  - fEdge
+  - fVertex
+
+vert_coord_variables:
+  - minLevelCell
+  - maxLevelCell
+  - bottomDepth
+  - restingThickness
+  - vertCoordMovementWeights
 
 
 config:

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -1,5 +1,12 @@
+from typing import TYPE_CHECKING
+
 from polaris import Step
-from polaris.tasks.ocean import Ocean
+
+if TYPE_CHECKING:
+    # Keep Ocean as a type-only import. Importing it at runtime pulls
+    # polaris.tasks.ocean back into polaris.ocean.model while that package is
+    # still importing these step classes, creating a circular import.
+    from polaris.tasks.ocean import Ocean
 
 
 class OceanIOStep(Step):
@@ -7,10 +14,11 @@ class OceanIOStep(Step):
     A step that writes input and/or output files for Omega or MPAS-Ocean
     """
 
-    # make sure component is of type Ocean
-    component: Ocean
+    # make sure component is of type Ocean, using a string to avoid circular
+    # imports
+    component: 'Ocean'
 
-    def __init__(self, component: Ocean, **kwargs):
+    def __init__(self, component: 'Ocean', **kwargs):
         super().__init__(component=component, **kwargs)
 
     def map_to_native_model_vars(self, ds):
@@ -49,6 +57,42 @@ class OceanIOStep(Step):
             Configuration for the task; forwarded to the Ocean component.
         """
         self.component.write_model_dataset(ds, filename, config=config)
+
+    def write_initial_state_dataset(self, ds, filename, config):
+        """
+        Write an initial-state dataset, omitting horizontal mesh fields and
+        (for Omega) vertical coordinate fields.
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A dataset containing MPAS-Ocean variable names
+
+        filename : str
+            The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; forwarded to the Ocean component.
+        """
+        self.component.write_initial_state_dataset(ds, filename, config)
+
+    def write_vert_coord_dataset(self, ds, filename, config):
+        """
+        Write a vertical-coordinate dataset for Omega's ``InitialVertCoord``
+        stream.  No-op for MPAS-Ocean.
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A dataset containing MPAS-Ocean variable names
+
+        filename : str
+            The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; forwarded to the Ocean component.
+        """
+        self.component.write_vert_coord_dataset(ds, filename, config)
 
     def map_from_native_model_vars(self, ds):
         """

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -58,15 +58,16 @@ class OceanIOStep(Step):
         """
         self.component.write_model_dataset(ds, filename, config=config)
 
-    def write_initial_state_dataset(self, ds, filename, config):
+    def write_horiz_mesh_dataset(self, ds, filename, config):
         """
-        Write an initial-state dataset, omitting horizontal mesh fields and
-        (for Omega) vertical coordinate fields.
+        Write a horizontal mesh dataset, validating that all expected mesh
+        variables are present before writing.
 
         Parameters
         ----------
         ds : xarray.Dataset
-            A dataset containing MPAS-Ocean variable names
+            A dataset containing MPAS-Ocean variable names including all
+            horizontal mesh variables
 
         filename : str
             The path for the NetCDF file to write
@@ -74,7 +75,7 @@ class OceanIOStep(Step):
         config : polaris.config.PolarisConfigParser
             Configuration for the task; forwarded to the Ocean component.
         """
-        self.component.write_initial_state_dataset(ds, filename, config)
+        self.component.write_horiz_mesh_dataset(ds, filename, config)
 
     def write_vert_coord_dataset(self, ds, filename, config):
         """
@@ -93,6 +94,24 @@ class OceanIOStep(Step):
             Configuration for the task; forwarded to the Ocean component.
         """
         self.component.write_vert_coord_dataset(ds, filename, config)
+
+    def write_initial_state_dataset(self, ds, filename, config):
+        """
+        Write an initial-state dataset, omitting horizontal mesh fields and
+        (for Omega) vertical coordinate fields.
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A dataset containing MPAS-Ocean variable names
+
+        filename : str
+            The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; forwarded to the Ocean component.
+        """
+        self.component.write_initial_state_dataset(ds, filename, config)
 
     def map_from_native_model_vars(self, ds):
         """

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -21,6 +21,65 @@ class OceanIOStep(Step):
     def __init__(self, component: 'Ocean', **kwargs):
         super().__init__(component=component, **kwargs)
 
+    def add_output_files_for_ocean_model_input(
+        self,
+        horiz_mesh_filename=None,
+        vert_coord_filename=None,
+        init_filename=None,
+        base_mesh_filename=None,
+        graph_filename=None,
+    ):
+        """
+        Register output files that will be consumed by the ocean model as
+        inputs (horizontal mesh, initial condition, and model-specific files).
+
+        Parameters
+        ----------
+        horiz_mesh_filename : str, optional
+            Local filename for the horizontal mesh output; defaults to the
+            ``horiz_mesh_filename`` option in ``[ocean_model_files]``.
+
+        vert_coord_filename : str, optional
+            Local filename for the vertical-coordinate output (Omega only);
+            defaults to the ``vert_coord_filename`` option in
+            ``[ocean_model_files]``.
+
+        init_filename : str, optional
+            Local filename for the initial-state output; defaults to the
+            ``init_filename`` option in ``[ocean_model_files]``.
+
+        base_mesh_filename : str, optional
+            If provided, also register this filename as an output (used when
+            the step writes both a base and a culled mesh, e.g.
+            ``'base_mesh.nc'``).
+
+        graph_filename : str, optional
+            If provided, register this filename as an output for MPAS-Ocean
+            only (e.g. ``'culled_graph.info'``).  Ignored for Omega.
+        """
+        config = self.config
+        model = config.get('ocean', 'model')
+
+        if horiz_mesh_filename is None:
+            horiz_mesh_filename = config.get(
+                'ocean_model_files', 'horiz_mesh_filename'
+            )
+        if vert_coord_filename is None:
+            vert_coord_filename = config.get(
+                'ocean_model_files', 'vert_coord_filename'
+            )
+        if init_filename is None:
+            init_filename = config.get('ocean_model_files', 'init_filename')
+
+        if base_mesh_filename is not None:
+            self.add_output_file(filename=base_mesh_filename)
+        self.add_output_file(filename=horiz_mesh_filename)
+        self.add_output_file(filename=init_filename)
+        if model == 'omega':
+            self.add_output_file(filename=vert_coord_filename)
+        if model == 'mpas-ocean' and graph_filename is not None:
+            self.add_output_file(filename=graph_filename)
+
     def map_to_native_model_vars(self, ds):
         """
         If the model is Omega, rename dimensions and variables in a dataset

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -67,7 +67,7 @@ class OceanModelStep(ModelStep):
 
     def __init__(
         self,
-        component: Ocean,
+        component: 'Ocean',
         name: str,
         subdir: Optional[str] = None,
         indir: Optional[str] = None,

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -1,7 +1,7 @@
 import importlib.resources as imp_res
 import os
 from types import ModuleType
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from ruamel.yaml import YAML
 
@@ -12,7 +12,12 @@ from polaris.ocean.conservation import (
     compute_total_salt,
     compute_total_tracer,
 )
-from polaris.tasks.ocean import Ocean
+
+if TYPE_CHECKING:
+    # Keep Ocean as a type-only import. Importing it at runtime pulls
+    # polaris.tasks.ocean back into polaris.ocean.model while that package is
+    # still importing these step classes, creating a circular import.
+    from polaris.tasks.ocean import Ocean
 
 OptionValue = Union[str, int, float, bool]
 MapSectionKey = Union[str, List[str]]
@@ -48,8 +53,17 @@ class OceanModelStep(ModelStep):
         working directory)
     """
 
-    # make sure component is of type Ocean
-    component: Ocean
+    # a mapping from placeholder filenames to config options used to
+    # determine the actual filenames at runtime
+    _MODEL_INPUT_OPTIONS = {
+        '<<<horiz_mesh>>>': 'horiz_mesh_filename',
+        '<<<vert_coord>>>': 'vert_coord_filename',
+        '<<<init>>>': 'init_filename',
+    }
+
+    # make sure component is of type Ocean, using a string to avoid circular
+    # imports
+    component: 'Ocean'
 
     def __init__(
         self,
@@ -218,6 +232,12 @@ class OceanModelStep(ModelStep):
         if self.update_io_tasks and not at_setup:
             self.update_io_tasks_config(config_model='ocean')
 
+        self.add_yaml_file(
+            'polaris.ocean.config',
+            'model_inputs.yaml',
+            template_replacements=self._get_model_input_replacements(),
+        )
+
         if self.update_eos:
             self.update_namelist_eos()
         if self.config.has_option('ocean', 'write_coeffs_reconstruct'):
@@ -245,6 +265,83 @@ class OceanModelStep(ModelStep):
             self._update_ntasks()
         self._set_gpus_per_task()
         super().constrain_resources(available_cores)
+
+    def add_horiz_mesh_input_file(self, **kwargs) -> None:
+        """
+        Add a horizontal-mesh input file using the configured local filename.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional keyword arguments to pass to
+            :py:meth:`polaris.Step.add_input_file()`
+        """
+        self.add_input_file(filename='<<<horiz_mesh>>>', **kwargs)
+
+    def add_vert_coord_input_file(self, **kwargs) -> None:
+        """
+        Add a vertical-coordinate input file using the configured local
+        filename.  For MPAS-Ocean this entry is silently skipped at runtime
+        (no separate vert_coord file is written).
+
+        Parameters
+        ----------
+        **kwargs
+            Additional keyword arguments to pass to
+            :py:meth:`polaris.Step.add_input_file()`
+        """
+        self.add_input_file(filename='<<<vert_coord>>>', **kwargs)
+
+    def add_init_input_file(self, **kwargs) -> None:
+        """
+        Add an initial-condition input file using the configured local
+        filename.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional keyword arguments to pass to
+            :py:meth:`polaris.Step.add_input_file()`
+        """
+        self.add_input_file(filename='<<<init>>>', **kwargs)
+
+    def get_horiz_mesh_filename(self) -> str:
+        """
+        Get the configured local filename for the horizontal mesh file.
+        """
+        return self._get_model_input_filename('horiz_mesh_filename')
+
+    def get_vert_coord_filename(self) -> str:
+        """
+        Get the configured local filename for the vertical coordinate file.
+        """
+        return self._get_model_input_filename('vert_coord_filename')
+
+    def get_init_filename(self) -> str:
+        """
+        Get the configured local filename for the initial-condition file.
+        """
+        return self._get_model_input_filename('init_filename')
+
+    def process_inputs_and_outputs(self) -> None:
+        """
+        Process the model and any configured model-input placeholders.
+        For MPAS-Ocean, ``<<<vert_coord>>>`` entries are removed because no
+        separate vert coord file is written for that model.
+        """
+        model = self.component.model
+        keep = []
+        for entry in self.input_data:
+            fn = entry['filename']
+            if fn == '<<<vert_coord>>>' and model != 'omega':
+                continue
+            if fn in self._MODEL_INPUT_OPTIONS:
+                entry['filename'] = self._get_model_input_filename(
+                    self._MODEL_INPUT_OPTIONS[fn]
+                )
+            keep.append(entry)
+        self.input_data = keep
+        super().process_inputs_and_outputs()
 
     def compute_cell_count(self) -> Optional[int]:
         """
@@ -429,7 +526,9 @@ class OceanModelStep(ModelStep):
         failed_properties = []
         for filename, properties in self.properties_to_check.items():
             filename = str(filename)
-            mesh_filename = os.path.join(self.work_dir, 'mesh.nc')
+            mesh_filename = os.path.join(
+                self.work_dir, self.get_horiz_mesh_filename()
+            )
             this_filename = os.path.join(self.work_dir, filename)
             ds_mesh = self.component.open_model_dataset(
                 mesh_filename, self.config
@@ -566,6 +665,27 @@ class OceanModelStep(ModelStep):
         self.min_tasks = max(
             1, 4 * round(cell_count / (4 * max_cells_per_core))
         )
+
+    def _get_model_input_filename(self, option: str) -> str:
+        section = 'ocean_model_files'
+        if not self.config.has_section(section):
+            raise ValueError(
+                f'Config section {section} is required to determine model '
+                f'input filenames, but it was not found.'
+            )
+        if not self.config.has_option(section, option):
+            raise ValueError(
+                f'Config option {option} is required to determine model input '
+                f'filenames, but it was not found in section {section}.'
+            )
+        return self.config.get(section, option)
+
+    def _get_model_input_replacements(self) -> Dict[str, str]:
+        return {
+            'horiz_mesh_filename': self.get_horiz_mesh_filename(),
+            'vert_coord_filename': self.get_vert_coord_filename(),
+            'init_filename': self.get_init_filename(),
+        }
 
     def _set_gpus_per_task(self) -> None:
         """

--- a/polaris/ocean/model/variables.yaml
+++ b/polaris/ocean/model/variables.yaml
@@ -1,0 +1,51 @@
+ocean:
+  horiz_mesh_variables:
+    - indexToCellID
+    - indexToEdgeID
+    - indexToVertexID
+    - cellsOnCell
+    - nEdgesOnCell
+    - edgesOnCell
+    - verticesOnCell
+    - cellsOnEdge
+    - edgesOnEdge
+    - nEdgesOnEdge
+    - verticesOnEdge
+    - cellsOnVertex
+    - edgesOnVertex
+    - xCell
+    - yCell
+    - zCell
+    - latCell
+    - lonCell
+    - xEdge
+    - yEdge
+    - zEdge
+    - latEdge
+    - lonEdge
+    - xVertex
+    - yVertex
+    - zVertex
+    - latVertex
+    - lonVertex
+    - areaCell
+    - meshDensity
+    - areaTriangle
+    - dvEdge
+    - dcEdge
+    - angleEdge
+    - kiteAreasOnVertex
+    - weightsOnEdge
+    - fCell
+    - fEdge
+    - fVertex
+  vert_coord_variables:
+    - minLevelCell
+    - maxLevelCell
+    - bottomDepth
+    - restingThickness
+    - vertCoordMovementWeights
+
+mpas-ocean:
+
+Omega:

--- a/polaris/ocean/model/variables.yaml
+++ b/polaris/ocean/model/variables.yaml
@@ -43,9 +43,12 @@ ocean:
     - minLevelCell
     - maxLevelCell
     - bottomDepth
-    - restingThickness
     - vertCoordMovementWeights
 
 mpas-ocean:
+  vert_coord_variables:
+    - restingThickness
 
 Omega:
+  vert_coord_variables:
+    - RefPseudoThickness

--- a/polaris/ocean/ocean.cfg
+++ b/polaris/ocean/ocean.cfg
@@ -48,6 +48,24 @@ init_filename = init.nc
 # the number of iterations of ssh adjustment to perform
 iterations = 10
 
+# Options related to the Coriolis force
+[coriolis]
+
+# Coriolis type: zero, constant, beta_plane, spherical, or rotated_sphere
+type = zero
+
+# Coriolis parameter for the constant (f-plane) type
+constant_f = 1.e-4
+
+# Coriolis parameter at y=0 for the beta_plane type
+beta_plane_f0 = 0.
+
+# Meridional gradient of the Coriolis parameter for the beta_plane type
+beta_plane_beta = 0.
+
+# Rotation angle in radians for the rotated_sphere type
+rotated_sphere_alpha = 0.
+
 # Options related to the vertical grid
 [vertical_grid]
 

--- a/polaris/ocean/ocean.cfg
+++ b/polaris/ocean/ocean.cfg
@@ -33,6 +33,14 @@ goal_cells_per_gpu = 8000
 # few GPUs are available)
 max_cells_per_gpu = 80000
 
+# Local filenames Polaris stages for ocean model inputs. These are setup-time
+# conventions rather than science options. Changing them after setup can break
+# staged inputs and stream filenames.
+[ocean_model_files]
+horiz_mesh_filename = mesh.nc
+vert_coord_filename = vert_coord.nc
+init_filename = init.nc
+
 # Options relate to adjusting the sea-surface height or land-ice pressure
 # below ice shelves to they are dynamically consistent with one another
 [ssh_adjustment]

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -105,9 +105,9 @@ class Ocean(Component):
                     )
                     config.set('build', 'build', 'True', user=True)
 
+        self.model = model
         if model == 'omega':
             self._read_var_map()
-        self.model = model
 
     def map_to_native_model_vars(self, ds):
         """
@@ -163,9 +163,7 @@ class Ocean(Component):
         if model == 'omega':
             assert self.mpaso_to_omega_var_map is not None
             renamed_vars = [
-                v
-                for k, v in self.mpaso_to_omega_var_map.items()
-                if k in var_list
+                self.mpaso_to_omega_var_map.get(v, v) for v in var_list
             ]
         return renamed_vars
 
@@ -210,6 +208,33 @@ class Ocean(Component):
 
         write_netcdf(ds=ds, fileName=filename)
 
+    def write_horiz_mesh_dataset(self, ds, filename, config):
+        """
+        Write a horizontal mesh dataset, validating that all expected mesh
+        variables are present.
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A dataset containing MPAS-Ocean or native model variable names
+            including all horizontal mesh variables
+
+        filename : str
+            The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Not used; retained for API compatibility.
+        """
+        if self.horiz_mesh_vars is None:
+            self._read_variables_yaml()
+        if self.model == 'omega' and self.mpaso_to_omega_var_map is None:
+            self._read_var_map()
+        assert self.horiz_mesh_vars is not None
+        ds = self.map_to_native_model_vars(ds)
+        native_vars = self.map_var_list_to_native_model(self.horiz_mesh_vars)
+        self._check_vars_present(ds, native_vars, 'write_horiz_mesh_dataset')
+        write_netcdf(ds=ds, fileName=filename)
+
     def remove_horiz_mesh_vars(self, ds):
         """
         Remove horizontal mesh variables from a dataset.
@@ -225,13 +250,70 @@ class Ocean(Component):
             The same dataset without horizontal mesh variables
         """
         if self.horiz_mesh_vars is None:
-            self._read_var_map()
+            self._read_variables_yaml()
 
         assert self.horiz_mesh_vars is not None
         drop = [v for v in self.horiz_mesh_vars if v in ds]
         if drop:
             ds = ds.drop_vars(drop)
         return ds
+
+    def write_vert_coord_dataset(self, ds, filename, config):
+        """
+        Write a vertical-coordinate dataset for Omega's ``InitialVertCoord``
+        stream.  This is a no-op for MPAS-Ocean (vertical coordinate fields
+        stay in the initial state file).
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A dataset containing MPAS-Ocean or native model variable names,
+            including the vertical coordinate variables and the
+            temperature/salinity/ssh fields needed for pseudo-thickness
+            conversion.
+
+        filename : str
+            The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; used when converting
+            ``restingThickness`` to ``RefPseudoThickness``.
+        """
+        if self.vert_coord_vars is None:
+            self._read_variables_yaml()
+        if self.model == 'omega' and self.mpaso_to_omega_var_map is None:
+            self._read_var_map()
+        assert self.vert_coord_vars is not None
+
+        native_vars = self.map_var_list_to_native_model(self.vert_coord_vars)
+
+        if self.model != 'omega':
+            self._check_vars_present(
+                ds, native_vars, 'write_vert_coord_dataset'
+            )
+            return
+
+        ds_vc = ds.copy()
+
+        # Convert restingThickness (geometric) to RefPseudoThickness (pseudo)
+        if 'restingThickness' in ds_vc and 'RefPseudoThickness' not in ds_vc:
+            pseudothickness, _ = pseudothickness_from_ds(
+                ds_vc, config=config, src_var_name='restingThickness'
+            )
+            if pseudothickness is not None:
+                # VertCoordInit stream is time-independent; drop Time dim
+                if 'Time' in pseudothickness.dims:
+                    pseudothickness = pseudothickness.isel(Time=0)
+                ds_vc['RefPseudoThickness'] = pseudothickness
+
+        ds_vc = self.map_to_native_model_vars(ds_vc)
+        # native_vars for Omega: [MinLayerCell, MaxLayerCell,
+        #   BottomGeomDepth, VertCoordMovementWeights, RefPseudoThickness]
+        self._check_vars_present(
+            ds_vc, native_vars, 'write_vert_coord_dataset'
+        )
+        ds_vc = ds_vc[native_vars]
+        write_netcdf(ds=ds_vc, fileName=filename)
 
     def remove_vert_coord_vars(self, ds):
         """
@@ -248,7 +330,7 @@ class Ocean(Component):
             The same dataset without vertical coordinate variables
         """
         if self.vert_coord_vars is None:
-            self._read_var_map()
+            self._read_variables_yaml()
 
         assert self.vert_coord_vars is not None
         drop = [v for v in self.vert_coord_vars if v in ds]
@@ -281,57 +363,6 @@ class Ocean(Component):
         if self.model == 'omega':
             ds = self.remove_vert_coord_vars(ds)
         self.write_model_dataset(ds, filename, config)
-
-    def write_vert_coord_dataset(self, ds, filename, config):
-        """
-        Write a vertical-coordinate dataset for Omega's ``InitialVertCoord``
-        stream.  This is a no-op for MPAS-Ocean (vertical coordinate fields
-        stay in the initial state file).
-
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            A dataset containing MPAS-Ocean variable names, including the
-            vertical coordinate variables and the temperature/salinity/ssh
-            fields needed for pseudo-thickness conversion.
-
-        filename : str
-            The path for the NetCDF file to write
-
-        config : polaris.config.PolarisConfigParser
-            Configuration for the task; used when converting
-            ``restingThickness`` to ``RefPseudoThickness``.
-        """
-        if self.model != 'omega':
-            return
-
-        if self.vert_coord_vars is None:
-            self._read_var_map()
-        assert self.vert_coord_vars is not None
-
-        ds_vc = ds.copy()
-
-        # Convert restingThickness (geometric) to RefPseudoThickness (pseudo)
-        if 'restingThickness' in ds_vc and 'RefPseudoThickness' not in ds_vc:
-            pseudothickness, _ = pseudothickness_from_ds(
-                ds_vc, config=config, src_var_name='restingThickness'
-            )
-            if pseudothickness is not None:
-                ds_vc['RefPseudoThickness'] = pseudothickness
-
-        # Collect the vert coord variables (excluding restingThickness since
-        # we have the converted RefPseudoThickness)
-        vc_keep = [
-            v
-            for v in self.vert_coord_vars
-            if v != 'restingThickness' and v in ds_vc
-        ]
-        if 'RefPseudoThickness' in ds_vc:
-            vc_keep.append('RefPseudoThickness')
-
-        ds_vc = ds_vc[vc_keep]
-        ds_vc = self.map_to_native_model_vars(ds_vc)
-        write_netcdf(ds=ds_vc, fileName=filename)
 
     def map_from_native_model_vars(self, ds):
         """
@@ -449,6 +480,17 @@ class Ocean(Component):
         )
         return ds
 
+    def _check_vars_present(self, ds, native_vars, context):
+        """
+        Raise ValueError if any variable in native_vars is absent from ds.
+        """
+        missing = [v for v in native_vars if v not in ds]
+        if missing:
+            raise ValueError(
+                f'{context} requires the following variables that are '
+                'missing from the dataset: ' + ', '.join(missing)
+            )
+
     def _has_ocean_io_model_steps(self, tasks) -> Tuple[bool, bool]:
         """
         Determine if any steps in this component descend from OceanIOStep or
@@ -471,10 +513,38 @@ class Ocean(Component):
 
         return has_ocean_io_steps, has_ocean_model_steps
 
+    def _read_variables_yaml(self):
+        """
+        Read horiz_mesh_vars and vert_coord_vars from variables.yaml
+        """
+        if (
+            self.horiz_mesh_vars is not None
+            and self.vert_coord_vars is not None
+        ):
+            return
+        package = 'polaris.ocean.model'
+        filename = 'variables.yaml'
+        text = imp_res.files(package).joinpath(filename).read_text()
+        yaml_data = YAML(typ='rt')
+        nested_dict = yaml_data.load(text)
+        self.horiz_mesh_vars = nested_dict['ocean']['horiz_mesh_variables']
+        self.vert_coord_vars = list(
+            nested_dict['ocean']['vert_coord_variables']
+        )
+        model_section_map = {'mpas-ocean': 'mpas-ocean', 'omega': 'Omega'}
+        model_key = model_section_map.get(self.model or '')
+        if model_key:
+            extra = nested_dict.get(model_key, {}).get(
+                'vert_coord_variables', []
+            )
+            self.vert_coord_vars.extend(extra)
+
     def _read_var_map(self):
         """
         Read the map from MPAS-Ocean to Omega dimension and variable names
         """
+        if self.mpaso_to_omega_var_map is not None:
+            return
         package = 'polaris.ocean.model'
 
         filename = 'mpaso_to_omega.yaml'
@@ -484,12 +554,7 @@ class Ocean(Component):
         self.mpaso_to_omega_dim_map = nested_dict['dimensions']
         self.mpaso_to_omega_var_map = nested_dict['variables']
 
-        filename = 'variables.yaml'
-        text = imp_res.files(package).joinpath(filename).read_text()
-        yaml_data = YAML(typ='rt')
-        nested_dict = yaml_data.load(text)
-        self.horiz_mesh_vars = nested_dict['ocean']['horiz_mesh_variables']
-        self.vert_coord_vars = nested_dict['ocean']['vert_coord_variables']
+        self._read_variables_yaml()
 
     def _detect_model(self, config) -> str:
         """

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -29,6 +29,14 @@ class Ocean(Component):
 
     mpaso_to_omega_var_map : dict
         A map from MPAS-Ocean variable names to their Omega equivalents
+
+    horiz_mesh_vars : list of str
+        Variables that belong in the horizontal mesh file rather than the
+        initial condition file
+
+    vert_coord_vars : list of str
+        Variables that belong in the vertical coordinate file (Omega only)
+        rather than the initial condition file
     """
 
     def __init__(self):
@@ -39,6 +47,8 @@ class Ocean(Component):
         self.model: Union[None, str] = None
         self.mpaso_to_omega_dim_map: Union[None, Dict[str, str]] = None
         self.mpaso_to_omega_var_map: Union[None, Dict[str, str]] = None
+        self.horiz_mesh_vars: Union[None, list[str]] = None
+        self.vert_coord_vars: Union[None, list[str]] = None
 
     def configure(self, config, tasks):
         """
@@ -200,6 +210,129 @@ class Ocean(Component):
 
         write_netcdf(ds=ds, fileName=filename)
 
+    def remove_horiz_mesh_vars(self, ds):
+        """
+        Remove horizontal mesh variables from a dataset.
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A dataset containing MPAS-Ocean variable names
+
+        Returns
+        -------
+        ds : xarray.Dataset
+            The same dataset without horizontal mesh variables
+        """
+        if self.horiz_mesh_vars is None:
+            self._read_var_map()
+
+        assert self.horiz_mesh_vars is not None
+        drop = [v for v in self.horiz_mesh_vars if v in ds]
+        if drop:
+            ds = ds.drop_vars(drop)
+        return ds
+
+    def remove_vert_coord_vars(self, ds):
+        """
+        Remove vertical coordinate variables from a dataset.
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A dataset containing MPAS-Ocean variable names
+
+        Returns
+        -------
+        ds : xarray.Dataset
+            The same dataset without vertical coordinate variables
+        """
+        if self.vert_coord_vars is None:
+            self._read_var_map()
+
+        assert self.vert_coord_vars is not None
+        drop = [v for v in self.vert_coord_vars if v in ds]
+        if drop:
+            ds = ds.drop_vars(drop)
+        return ds
+
+    def write_initial_state_dataset(self, ds, filename, config):
+        """
+        Write an initial-state dataset, omitting horizontal mesh fields and
+        (for Omega) vertical coordinate fields.
+
+        For MPAS-Ocean the vertical coordinate variables remain in the initial
+        state file.  For Omega they are written separately via
+        :py:meth:`write_vert_coord_dataset`.
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A dataset containing MPAS-Ocean variable names
+
+        filename : str
+            The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; forwarded to
+            :py:meth:`write_model_dataset`.
+        """
+        ds = self.remove_horiz_mesh_vars(ds)
+        if self.model == 'omega':
+            ds = self.remove_vert_coord_vars(ds)
+        self.write_model_dataset(ds, filename, config)
+
+    def write_vert_coord_dataset(self, ds, filename, config):
+        """
+        Write a vertical-coordinate dataset for Omega's ``InitialVertCoord``
+        stream.  This is a no-op for MPAS-Ocean (vertical coordinate fields
+        stay in the initial state file).
+
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            A dataset containing MPAS-Ocean variable names, including the
+            vertical coordinate variables and the temperature/salinity/ssh
+            fields needed for pseudo-thickness conversion.
+
+        filename : str
+            The path for the NetCDF file to write
+
+        config : polaris.config.PolarisConfigParser
+            Configuration for the task; used when converting
+            ``restingThickness`` to ``RefPseudoThickness``.
+        """
+        if self.model != 'omega':
+            return
+
+        if self.vert_coord_vars is None:
+            self._read_var_map()
+        assert self.vert_coord_vars is not None
+
+        ds_vc = ds.copy()
+
+        # Convert restingThickness (geometric) to RefPseudoThickness (pseudo)
+        if 'restingThickness' in ds_vc and 'RefPseudoThickness' not in ds_vc:
+            pseudothickness, _ = pseudothickness_from_ds(
+                ds_vc, config=config, src_var_name='restingThickness'
+            )
+            if pseudothickness is not None:
+                ds_vc['RefPseudoThickness'] = pseudothickness
+
+        # Collect the vert coord variables (excluding restingThickness since
+        # we have the converted RefPseudoThickness)
+        vc_keep = [
+            v
+            for v in self.vert_coord_vars
+            if v != 'restingThickness' and v in ds_vc
+        ]
+        if 'RefPseudoThickness' in ds_vc:
+            vc_keep.append('RefPseudoThickness')
+
+        ds_vc = ds_vc[vc_keep]
+        ds_vc = self.map_to_native_model_vars(ds_vc)
+        write_netcdf(ds=ds_vc, fileName=filename)
+
     def map_from_native_model_vars(self, ds):
         """
         If the model is Omega, rename dimensions and variables in a dataset
@@ -350,6 +483,8 @@ class Ocean(Component):
         nested_dict = yaml_data.load(text)
         self.mpaso_to_omega_dim_map = nested_dict['dimensions']
         self.mpaso_to_omega_var_map = nested_dict['variables']
+        self.horiz_mesh_vars = nested_dict['horiz_mesh_variables']
+        self.vert_coord_vars = nested_dict['vert_coord_variables']
 
     def _detect_model(self, config) -> str:
         """

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -476,15 +476,20 @@ class Ocean(Component):
         Read the map from MPAS-Ocean to Omega dimension and variable names
         """
         package = 'polaris.ocean.model'
+
         filename = 'mpaso_to_omega.yaml'
         text = imp_res.files(package).joinpath(filename).read_text()
-
         yaml_data = YAML(typ='rt')
         nested_dict = yaml_data.load(text)
         self.mpaso_to_omega_dim_map = nested_dict['dimensions']
         self.mpaso_to_omega_var_map = nested_dict['variables']
-        self.horiz_mesh_vars = nested_dict['horiz_mesh_variables']
-        self.vert_coord_vars = nested_dict['vert_coord_variables']
+
+        filename = 'variables.yaml'
+        text = imp_res.files(package).joinpath(filename).read_text()
+        yaml_data = YAML(typ='rt')
+        nested_dict = yaml_data.load(text)
+        self.horiz_mesh_vars = nested_dict['ocean']['horiz_mesh_variables']
+        self.vert_coord_vars = nested_dict['ocean']['vert_coord_variables']
 
     def _detect_model(self, config) -> str:
         """

--- a/polaris/tasks/ocean/baroclinic_channel/baroclinic_channel.cfg
+++ b/polaris/tasks/ocean/baroclinic_channel/baroclinic_channel.cfg
@@ -58,8 +58,15 @@ gradient_width_dist = 40e3
 # Salinity of the water in the entire domain.
 salinity = 35.0
 
-# Coriolis parameter for entire domain.
-coriolis_parameter = -1.2e-4
+
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = constant
+
+# the constant Coriolis parameter
+constant_f = -1.2e-4
 
 
 # config options for the baroclinic channel RPE tasks

--- a/polaris/tasks/ocean/baroclinic_channel/forward.py
+++ b/polaris/tasks/ocean/baroclinic_channel/forward.py
@@ -98,9 +98,9 @@ class Forward(OceanModelStep):
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
-        self.add_input_file(
-            filename='initial_state.nc', target='../../init/initial_state.nc'
-        )
+        self.add_horiz_mesh_input_file(target='../../init/culled_mesh.nc')
+        self.add_vert_coord_input_file(target='../../init/vert_coord.nc')
+        self.add_init_input_file(target='../../init/init.nc')
 
         self.add_yaml_file(
             'polaris.tasks.ocean.baroclinic_channel', 'forward.yaml'

--- a/polaris/tasks/ocean/baroclinic_channel/forward.yaml
+++ b/polaris/tasks/ocean/baroclinic_channel/forward.yaml
@@ -11,10 +11,6 @@ mpas-ocean:
     config_cvmix_background_diffusion: 0.0
     config_cvmix_background_viscosity: 0.0001
   streams:
-    mesh:
-      filename_template: initial_state.nc
-    input:
-      filename_template: initial_state.nc
     restart: {}
     output:
       type: output

--- a/polaris/tasks/ocean/baroclinic_channel/init.py
+++ b/polaris/tasks/ocean/baroclinic_channel/init.py
@@ -1,19 +1,19 @@
 import cmocean  # noqa: F401
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
-from polaris import Step
 from polaris.mesh.planar import compute_planar_hex_nx_ny
 from polaris.mpas import cell_mask_to_edge_mask
+from polaris.ocean.coriolis import add_coriolis_to_dataset
+from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 from polaris.viz import plot_horiz_field
 
 
-class Init(Step):
+class Init(OceanIOStep):
     """
     A step for creating a mesh and initial condition for baroclinic channel
     tasks
@@ -42,11 +42,12 @@ class Init(Step):
         super().__init__(component=component, name='init', indir=indir)
         self.resolution = resolution
 
-        for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info']:
-            self.add_output_file(file)
-        self.add_output_file(
-            'initial_state.nc',
-            validate_vars=['temperature', 'salinity', 'layerThickness'],
+    def setup(self):
+        super().setup()
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
         )
 
     def run(self):
@@ -68,18 +69,6 @@ class Init(Step):
         nx, ny = compute_planar_hex_nx_ny(lx, ly, resolution)
         dc = 1e3 * resolution
 
-        ds_mesh = make_planar_hex_mesh(
-            nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=True
-        )
-        write_netcdf(ds_mesh, 'base_mesh.nc')
-
-        ds_mesh = cull(ds_mesh, logger=logger)
-        ds_mesh = convert(
-            ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
-        )
-        write_netcdf(ds_mesh, 'culled_mesh.nc')
-
-        section = config['baroclinic_channel']
         use_distances = section.getboolean('use_distances')
         gradient_width_dist = section.getfloat('gradient_width_dist')
         gradient_width_frac = section.getfloat('gradient_width_frac')
@@ -87,7 +76,18 @@ class Init(Step):
         surface_temperature = section.getfloat('surface_temperature')
         temperature_difference = section.getfloat('temperature_difference')
         salinity = section.getfloat('salinity')
-        coriolis_parameter = section.getfloat('coriolis_parameter')
+
+        ds_mesh = make_planar_hex_mesh(
+            nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=True
+        )
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
+
+        ds_mesh = cull(ds_mesh, logger=logger)
+        ds_mesh = convert(
+            ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
+        )
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()
         x_cell = ds.xCell
@@ -168,15 +168,16 @@ class Init(Step):
         ds['temperature'] = temperature
         ds['salinity'] = salinity * xr.ones_like(temperature)
         ds['normalVelocity'] = normal_velocity
-        ds['fCell'] = coriolis_parameter * xr.ones_like(x_cell)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
 
         ds.attrs['nx'] = nx
         ds.attrs['ny'] = ny
         ds.attrs['dc'] = dc
 
-        write_netcdf(ds, 'initial_state.nc')
+        # temperature and salinity must be set before this call:
+        # write_vert_coord_dataset converts restingThickness to
+        # RefPseudoThickness via pseudothickness_from_ds, which requires T/S
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)
 
         cell_mask = ds.maxLevelCell >= 1
         edge_mask = cell_mask_to_edge_mask(ds, cell_mask)

--- a/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
+++ b/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
@@ -43,9 +43,7 @@ class Analysis(Step):
             filename='mesh.nc', target='../../init/culled_mesh.nc'
         )
 
-        self.add_input_file(
-            filename='init.nc', target='../../init/initial_state.nc'
-        )
+        self.add_input_file(target='../../init/init.nc')
 
         for nu in nus:
             self.add_input_file(

--- a/polaris/tasks/ocean/baroclinic_channel/viz.py
+++ b/polaris/tasks/ocean/baroclinic_channel/viz.py
@@ -29,9 +29,7 @@ class Viz(Step):
         self.add_input_file(
             filename='mesh.nc', target='../../init/culled_mesh.nc'
         )
-        self.add_input_file(
-            filename='init.nc', target='../../init/initial_state.nc'
-        )
+        self.add_input_file(filename='init.nc', target='../../init/init.nc')
         self.add_input_file(
             filename='output.nc', target='../forward/output.nc'
         )

--- a/polaris/tasks/ocean/barotropic_channel/barotropic_channel.cfg
+++ b/polaris/tasks/ocean/barotropic_channel/barotropic_channel.cfg
@@ -37,3 +37,10 @@ resolution = 10.
 horizontal_viscosity = 1.e-2
 
 bottom_drag = 1.e2
+
+
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = zero

--- a/polaris/tasks/ocean/barotropic_channel/forward.py
+++ b/polaris/tasks/ocean/barotropic_channel/forward.py
@@ -78,10 +78,9 @@ class Forward(OceanModelStep):
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
-        self.add_input_file(
-            filename='init.nc',
-            target='../init/initial_state.nc',
-        )
+        self.add_horiz_mesh_input_file(target='../init/culled_mesh.nc')
+        self.add_vert_coord_input_file(target='../init/vert_coord.nc')
+        self.add_init_input_file(target='../init/init.nc')
 
         self.add_input_file(
             filename='forcing.nc',
@@ -96,16 +95,6 @@ class Forward(OceanModelStep):
                 'temperature',
             ],
         )
-
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
 
     def dynamic_model_config(self, at_setup):
         super().dynamic_model_config(at_setup=at_setup)

--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -40,10 +40,6 @@ mpas-ocean:
   debug:
     config_disable_vel_coriolis: true
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     restart:
       output_interval: 0000_01:00:00
     forcing:
@@ -84,7 +80,6 @@ Omega:
   IOStreams:
     InitialVertCoord:
       UsePointerFile: false
-      Filename: init.nc
       Mode: read
       Precision: double
       Freq: 1
@@ -94,7 +89,6 @@ Omega:
         - InitVertCoord
     InitialState:
       UsePointerFile: false
-      Filename: init.nc
       Mode: read
       Precision: double
       Freq: 1

--- a/polaris/tasks/ocean/barotropic_channel/init.py
+++ b/polaris/tasks/ocean/barotropic_channel/init.py
@@ -1,10 +1,10 @@
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
@@ -32,17 +32,14 @@ class Init(OceanIOStep):
         """
         super().__init__(component=component, name='init', indir=indir)
 
-        for file in [
-            'base_mesh.nc',
-            'culled_mesh.nc',
-            'culled_graph.info',
-            'forcing.nc',
-        ]:
-            self.add_output_file(file)
-        self.add_output_file(
-            'initial_state.nc',
-            validate_vars=['temperature', 'salinity', 'layerThickness'],
+    def setup(self):
+        super().setup()
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
         )
+        self.add_output_file(filename='forcing.nc')
 
     def run(self):
         """
@@ -70,13 +67,14 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=True
         )
-        write_netcdf(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        write_netcdf(ds_mesh, 'culled_mesh.nc')
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()
 
@@ -88,21 +86,21 @@ class Init(OceanIOStep):
         ds['bottomDepth'] = bottom_depth * frac
         ds['ssh'] = xr.zeros_like(ds.xCell)
         init_vertical_coord(config, ds)
-
         cell_field = xr.ones_like(ds.xCell)
         cell_field, _ = xr.broadcast(cell_field, ds.refBottomDepth)
         ds['temperature'] = cell_field.expand_dims(dim='Time', axis=0)
         ds['salinity'] = 35.0 * cell_field.expand_dims(dim='Time', axis=0)
+        # temperature and salinity must be set before this call:
+        # write_vert_coord_dataset converts restingThickness to
+        # RefPseudoThickness via pseudothickness_from_ds, which requires T/S
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
         normal_velocity = u * np.cos(ds_mesh.angleEdge) + v * np.sin(
             ds_mesh.angleEdge
         )
         normal_velocity, _ = xr.broadcast(normal_velocity, ds.refBottomDepth)
         normal_velocity = normal_velocity.transpose('nEdges', 'nVertLevels')
         ds['normalVelocity'] = normal_velocity.expand_dims(dim='Time', axis=0)
-        ds['fCell'] = xr.zeros_like(ds.xCell)
-        ds['fEdge'] = xr.zeros_like(ds.xEdge)
-        ds['fVertex'] = xr.zeros_like(ds.xVertex)
-        self.write_model_dataset(ds, 'initial_state.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)
 
         # set the wind stress forcing
         ds_forcing = xr.Dataset()

--- a/polaris/tasks/ocean/barotropic_channel/viz.py
+++ b/polaris/tasks/ocean/barotropic_channel/viz.py
@@ -28,9 +28,7 @@ class Viz(OceanIOStep):
         self.add_input_file(
             filename='mesh.nc', target='../init/culled_mesh.nc'
         )
-        self.add_input_file(
-            filename='init.nc', target='../init/initial_state.nc'
-        )
+        self.add_input_file(filename='init.nc', target='../init/init.nc')
         self.add_input_file(
             filename='output.nc', target='../forward/output.nc'
         )

--- a/polaris/tasks/ocean/barotropic_gyre/barotropic_gyre.cfg
+++ b/polaris/tasks/ocean/barotropic_gyre/barotropic_gyre.cfg
@@ -21,6 +21,17 @@ beta = 1.0e-10
 # Duration of forward step if run_time_steps not given [years]
 run_duration = 2.
 
+
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = beta_plane
+
+# meridional gradient of the Coriolis parameter
+beta_plane_beta = 1.0e-10
+
+
 [barotropic_gyre_munk_free-slip]
 
 # Horizontal visocity [m2 s-1]

--- a/polaris/tasks/ocean/barotropic_gyre/forward.py
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.py
@@ -100,10 +100,9 @@ class Forward(OceanModelStep):
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
-        self.add_input_file(
-            filename='mesh.nc', target='../init/culled_mesh.nc'
-        )
-        self.add_input_file(filename='init.nc', target='../init/init.nc')
+        self.add_horiz_mesh_input_file(target='../init/culled_mesh.nc')
+        self.add_vert_coord_input_file(target='../init/vert_coord.nc')
+        self.add_init_input_file(target='../init/init.nc')
 
         self.add_output_file(
             filename='output.nc',
@@ -265,14 +264,9 @@ class Forward(OceanModelStep):
         )
 
     def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
         super().setup()
         model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
         if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
             self.add_input_file(
                 target='coeffs.nc',
                 filename='coeffs.nc',

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -35,10 +35,6 @@ mpas-ocean:
     config_disable_tr_all_tend: true
 
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     forcing:
       filename_template: init.nc
       input_interval: initial_only
@@ -69,11 +65,9 @@ Omega:
     FluxThicknessType: Center
   IOStreams:
     InitialVertCoord:
-      Filename: init.nc
       Mode: read
     InitialState:
       UsePointerFile: false
-      Filename: init.nc
       Mode: read
       Contents:
       - State

--- a/polaris/tasks/ocean/barotropic_gyre/init.py
+++ b/polaris/tasks/ocean/barotropic_gyre/init.py
@@ -4,6 +4,7 @@ from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 from polaris.viz import plot_horiz_field
@@ -48,20 +49,17 @@ class Init(OceanIOStep):
             The type of boundary condition (default is 'free-slip')
         """
         super().__init__(component=component, name=name, indir=indir)
-
-        for file in [
-            'base_mesh.nc',
-            'culled_mesh.nc',
-            'culled_graph.info',
-        ]:
-            self.add_output_file(file)
         self.name = name
         self.test_name = test_name
         self.boundary_condition = boundary_condition
-        self.add_output_file('init.nc', validate_vars=['layerThickness'])
 
     def setup(self):
         super().setup()
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
+        )
 
     def run(self):
         """
@@ -87,7 +85,6 @@ class Init(OceanIOStep):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         # vertical coordinate parameters
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
@@ -96,7 +93,9 @@ class Init(OceanIOStep):
             f'barotropic_gyre_{self.test_name}_{self.boundary_condition}',
             'f_0',
         )
-        beta = config.getfloat('barotropic_gyre', 'beta')
+        config.set('coriolis', 'beta_plane_f0', str(f0))
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
         # surface (wind) forcing parameters
         tau_0 = config.getfloat('barotropic_gyre', 'tau_0')
 
@@ -111,10 +110,11 @@ class Init(OceanIOStep):
         init_vertical_coord(config, ds)
         ds['temperature'] = 20.0 * xr.ones_like(ds.zMid)
         ds['salinity'] = 35.0 * xr.ones_like(ds.zMid)
+        # temperature and salinity must be set before this call:
+        # write_vert_coord_dataset converts restingThickness to
+        # RefPseudoThickness via pseudothickness_from_ds, which requires T/S
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
 
-        # set the coriolis values
-        for loc in ['Cell', 'Edge', 'Vertex']:
-            ds[f'f{loc}'] = f0 + beta * ds[f'y{loc}']
         ds.attrs['nx'] = nx
         ds.attrs['ny'] = ny
         ds.attrs['dc'] = dc
@@ -142,7 +142,7 @@ class Init(OceanIOStep):
         )
 
         # write the initial condition file
-        self.write_model_dataset(ds, 'init.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)
 
         cell_mask = ds.maxLevelCell >= 1
 

--- a/polaris/tasks/ocean/cosine_bell/cosine_bell.cfg
+++ b/polaris/tasks/ocean/cosine_bell/cosine_bell.cfg
@@ -52,6 +52,13 @@ run_duration = ${cosine_bell:vel_pd}
 output_interval = ${cosine_bell:vel_pd}
 
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = zero
+
+
 # options for cosine bell convergence test case
 [cosine_bell]
 

--- a/polaris/tasks/ocean/cosine_bell/forward.py
+++ b/polaris/tasks/ocean/cosine_bell/forward.py
@@ -1,4 +1,3 @@
-from polaris.mesh.base import parse_mesh_filepath
 from polaris.ocean.convergence.spherical import SphericalConvergenceForward
 
 
@@ -64,7 +63,6 @@ class Forward(SphericalConvergenceForward):
             init=init,
             package=package,
             yaml_filename='forward.yaml',
-            mesh_input_filename='base_mesh.nc',
             output_filename='output.nc',
             validate_vars=validate_vars,
             check_properties=['mass conservation', 'tracer conservation'],
@@ -77,14 +75,11 @@ class Forward(SphericalConvergenceForward):
         self.mesh_path = mesh.path
 
     def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
         super().setup()
+        from polaris.mesh.base import parse_mesh_filepath
+
         model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
         if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
             component, database, mesh_name = parse_mesh_filepath(
                 self.mesh_path
             )

--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -45,10 +45,6 @@ mpas-ocean:
   AM_mixedLayerDepths:
     config_AM_mixedLayerDepths_enable: false
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     restart:
       output_interval: 0030_00:00:00
     output:
@@ -81,10 +77,7 @@ Omega:
     TracerHyperDiffTendencyEnable : false
     PressureGradTendencyEnable : false
   IOStreams:
-    InitialVertCoord:
-      Filename: init.nc
     InitialState:
-      Filename: init.nc
       Contents:
         - State
         - Tracers

--- a/polaris/tasks/ocean/cosine_bell/init.py
+++ b/polaris/tasks/ocean/cosine_bell/init.py
@@ -3,6 +3,7 @@ import xarray as xr
 from mpas_tools.transects import lon_lat_to_cartesian
 from mpas_tools.vector import Vector
 
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
@@ -37,7 +38,11 @@ class Init(OceanIOStep):
             work_dir_target=f'{base_mesh.path}/base_mesh.nc',
         )
 
-        self.add_output_file(filename='initial_state.nc')
+    def setup(self):
+        super().setup()
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+        )
 
     def run(self):
         """
@@ -64,17 +69,23 @@ class Init(OceanIOStep):
         lonCell = ds_mesh.lonCell
         sphere_radius = ds_mesh.sphere_radius
 
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
+
         ds = ds_mesh.copy()
 
         ds['bottomDepth'] = bottom_depth * xr.ones_like(latCell)
         ds['ssh'] = xr.zeros_like(latCell)
 
         init_vertical_coord(config, ds)
-
         temperature_array = temperature * xr.ones_like(ds_mesh.latCell)
         temperature_array, _ = xr.broadcast(temperature_array, ds.refZMid)
         ds['temperature'] = temperature_array.expand_dims(dim='Time', axis=0)
         ds['salinity'] = salinity * xr.ones_like(ds.temperature)
+        # temperature and salinity must be set before this call:
+        # write_vert_coord_dataset converts restingThickness to
+        # RefPseudoThickness via pseudothickness_from_ds, which requires T/S
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
 
         x_center, y_center, z_center = lon_lat_to_cartesian(
             lon_center, lat_center, sphere_radius, degrees=False
@@ -108,11 +119,7 @@ class Init(OceanIOStep):
         velocity_array, _ = xr.broadcast(velocity, ds.refZMid)
         ds['normalVelocity'] = velocity_array.expand_dims(dim='Time', axis=0)
 
-        ds['fCell'] = xr.zeros_like(ds_mesh.xCell)
-        ds['fEdge'] = xr.zeros_like(ds_mesh.xEdge)
-        ds['fVertex'] = xr.zeros_like(ds_mesh.xVertex)
-
-        self.write_model_dataset(ds, 'initial_state.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)
 
 
 def cosine_bell(max_value, ri, r):

--- a/polaris/tasks/ocean/cosine_bell/restart/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/restart/forward.yaml
@@ -19,8 +19,6 @@ mpas-ocean:
 
 Omega:
   IOStreams:
-    InitialVertCoord:
-      Filename: init.nc
     InitialState:
       FreqUnits: {{ init_freq_units }}
     RestartRead:

--- a/polaris/tasks/ocean/cosine_bell/viz.py
+++ b/polaris/tasks/ocean/cosine_bell/viz.py
@@ -50,7 +50,7 @@ class Viz(OceanIOStep):
         )
         self.add_input_file(
             filename='initial_state.nc',
-            work_dir_target=f'{init.path}/initial_state.nc',
+            work_dir_target=f'{init.path}/init.nc',
         )
         self.add_input_file(
             filename='output.nc', work_dir_target=f'{forward.path}/output.nc'

--- a/polaris/tasks/ocean/external_gravity_wave/analysis.py
+++ b/polaris/tasks/ocean/external_gravity_wave/analysis.py
@@ -56,7 +56,7 @@ class Analysis(ConvergenceAnalysis):
         )
         self.add_input_file(
             filename=f'init_r{ref_solution_factor:02g}.nc',
-            work_dir_target=f'{init.path}/initial_state.nc',
+            work_dir_target=f'{init.path}/init.nc',
         )
         self.add_input_file(
             filename=f'output_r{ref_solution_factor:02g}.nc',

--- a/polaris/tasks/ocean/external_gravity_wave/external_gravity_wave.cfg
+++ b/polaris/tasks/ocean/external_gravity_wave/external_gravity_wave.cfg
@@ -57,6 +57,13 @@ run_duration = 48.
 output_interval = ${convergence_forward:run_duration}
 
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = zero
+
+
 # options for external gravity wave convergence test case
 [external_gravity_wave]
 

--- a/polaris/tasks/ocean/external_gravity_wave/forward.py
+++ b/polaris/tasks/ocean/external_gravity_wave/forward.py
@@ -175,10 +175,13 @@ class ReferenceForward(OceanModelStep):
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
-        self.add_input_file(
-            filename='init.nc',
-            work_dir_target=f'{init.path}/initial_state.nc',
+        self.add_horiz_mesh_input_file(
+            work_dir_target=f'{init.path}/culled_mesh.nc'
         )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc'
+        )
+        self.add_init_input_file(work_dir_target=f'{init.path}/init.nc')
 
         if dt_type == 'local':
             self.add_yaml_file(
@@ -272,11 +275,4 @@ class ReferenceForward(OceanModelStep):
         )
 
     def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
         super().setup()
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')

--- a/polaris/tasks/ocean/external_gravity_wave/forward.py
+++ b/polaris/tasks/ocean/external_gravity_wave/forward.py
@@ -67,7 +67,6 @@ class Forward(SphericalConvergenceForward):
             init=init,
             package=package,
             yaml_filename='forward.yaml',
-            mesh_input_filename='base_mesh.nc',
             output_filename='output.nc',
             validate_vars=validate_vars,
             graph_target=graph_target,

--- a/polaris/tasks/ocean/external_gravity_wave/forward.yaml
+++ b/polaris/tasks/ocean/external_gravity_wave/forward.yaml
@@ -41,10 +41,6 @@ mpas-ocean:
   AM_mixedLayerDepths:
     config_AM_mixedLayerDepths_enable: false
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     restart:
       output_interval: 0030_00:00:00
     output:

--- a/polaris/tasks/ocean/external_gravity_wave/init.py
+++ b/polaris/tasks/ocean/external_gravity_wave/init.py
@@ -1,6 +1,7 @@
 import numpy as np
 import xarray as xr
 
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
@@ -41,7 +42,11 @@ class Init(OceanIOStep):
             work_dir_target=f'{base_mesh.path}/graph.info',
         )
 
-        self.add_output_file(filename='initial_state.nc')
+    def setup(self):
+        super().setup()
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+        )
 
     def run(self):
         """
@@ -63,17 +68,23 @@ class Init(OceanIOStep):
         latEdge = ds_mesh.latEdge
         lonCell = ds_mesh.lonCell
 
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
+
         ds = ds_mesh.copy()
 
         ds['bottomDepth'] = bottom_depth * xr.ones_like(latCell)
         ds['ssh'] = xr.zeros_like(latCell)
 
         init_vertical_coord(config, ds)
-
         temperature_array = temperature * xr.ones_like(latCell)
         temperature_array, _ = xr.broadcast(temperature_array, ds.refZMid)
         ds['temperature'] = temperature_array.expand_dims(dim='Time', axis=0)
         ds['salinity'] = salinity * xr.ones_like(ds.temperature)
+        # temperature and salinity must be set before this call:
+        # write_vert_coord_dataset converts restingThickness to
+        # RefPseudoThickness via pseudothickness_from_ds, which requires T/S
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
 
         # Initialize layer thickness
         gaussian_bump_value = gaussian_bump(
@@ -89,11 +100,7 @@ class Init(OceanIOStep):
         velocity_array, _ = xr.broadcast(velocity, ds.refZMid)
         ds['normalVelocity'] = velocity_array.expand_dims(dim='Time', axis=0)
 
-        ds['fCell'] = xr.zeros_like(ds_mesh.xCell)
-        ds['fEdge'] = xr.zeros_like(ds_mesh.xEdge)
-        ds['fVertex'] = xr.zeros_like(ds_mesh.xVertex)
-
-        self.write_model_dataset(ds, 'initial_state.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)
 
 
 def gaussian_bump(lat_center, lon_center, latCell, lonCell):

--- a/polaris/tasks/ocean/external_gravity_wave/lts_regions.py
+++ b/polaris/tasks/ocean/external_gravity_wave/lts_regions.py
@@ -17,7 +17,7 @@ class LTSRegions(Step):
 
     Attributes
     ----------
-    initial_state_step :
+    init_step :
         polaris.ocean.tasks.external_gravity_wave.init.Init
         The initial step containing input files to this step
     """
@@ -42,7 +42,7 @@ class LTSRegions(Step):
         """
         super().__init__(component, name=name, subdir=subdir)
 
-        for file in ['graph.info', 'initial_state.nc']:
+        for file in ['graph.info', 'init.nc']:
             self.add_output_file(filename=file)
 
         self.init_step = init_step
@@ -56,15 +56,28 @@ class LTSRegions(Step):
 
         init_step = self.init_step
 
+        # Pass-through symlinks so forward step can find mesh/vert_coord
         self.add_input_file(
-            filename='init.nc',
-            work_dir_target=f'{init_step.path}/initial_state.nc',
+            filename='culled_mesh.nc',
+            work_dir_target=f'{init_step.path}/culled_mesh.nc',
+        )
+
+        self.add_input_file(
+            filename='init_in.nc',
+            work_dir_target=f'{init_step.path}/init.nc',
         )
 
         self.add_input_file(
             filename='pre_lts_graph.info',
             work_dir_target=f'{init_step.path}/graph.info',
         )
+
+        model = self.config.get('ocean', 'model')
+        if model == 'omega':
+            self.add_input_file(
+                filename='vert_coord.nc',
+                work_dir_target=f'{init_step.path}/vert_coord.nc',
+            )
 
     def run(self):
         """
@@ -78,7 +91,8 @@ class LTSRegions(Step):
 
         use_progress_bar = self.log_filename is None
         label_mesh(
-            mesh='init.nc',
+            mesh='culled_mesh.nc',
+            init='init_in.nc',
             graph_info='pre_lts_graph.info',
             num_interface=2,
             num_interface_adjacent=10,
@@ -92,6 +106,7 @@ class LTSRegions(Step):
 
 def label_mesh(
     mesh,
+    init,
     graph_info,
     num_interface,  # noqa: C901
     num_interface_adjacent,
@@ -134,11 +149,11 @@ def label_mesh(
 
     logger.info('Creating lts_mesh...')
 
-    # open mesh nc file to be copied
+    # copy the init file and add LTSRegion to it
 
-    ds_msh = xr.open_dataset(mesh)
+    ds_msh = xr.open_dataset(init)
     ds_ltsmsh = ds_msh.copy(deep=True)
-    ltsmsh_name = 'initial_state.nc'
+    ltsmsh_name = 'init.nc'
     write_netcdf(ds_ltsmsh, ltsmsh_name)
     mshnc = nc.Dataset(ltsmsh_name, 'a', format='NETCDF4_64BIT_OFFSET')
 

--- a/polaris/tasks/ocean/geostrophic/forward.py
+++ b/polaris/tasks/ocean/geostrophic/forward.py
@@ -59,7 +59,6 @@ class Forward(SphericalConvergenceForward):
             init=init,
             package=package,
             yaml_filename='forward.yaml',
-            mesh_input_filename='base_mesh.nc',
             output_filename='output.nc',
             validate_vars=validate_vars,
             graph_target=f'{mesh.path}/graph.info',

--- a/polaris/tasks/ocean/geostrophic/forward.yaml
+++ b/polaris/tasks/ocean/geostrophic/forward.yaml
@@ -27,10 +27,6 @@ mpas-ocean:
     config_AM_globalStats_compute_on_startup: true
     config_AM_globalStats_write_on_startup: true
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     restart: {}
     output:
       type: output

--- a/polaris/tasks/ocean/geostrophic/geostrophic.cfg
+++ b/polaris/tasks/ocean/geostrophic/geostrophic.cfg
@@ -33,6 +33,16 @@ time_integrator = RK4
 rk4_dt_per_km = 2.0
 
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = rotated_sphere
+
+# rotation angle in radians for the rotated_sphere type
+rotated_sphere_alpha = 0.0
+
+
 # options for geostrophic convergence test case
 [geostrophic]
 

--- a/polaris/tasks/ocean/geostrophic/init.py
+++ b/polaris/tasks/ocean/geostrophic/init.py
@@ -1,16 +1,14 @@
-import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
 
-from polaris import Step
-from polaris.constants import get_constant
+from polaris.ocean.coriolis import add_coriolis_to_dataset
+from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 from polaris.tasks.ocean.geostrophic.exact_solution import (
     compute_exact_solution,
 )
 
 
-class Init(Step):
+class Init(OceanIOStep):
     """
     A step for an initial condition for for the geostrophic test case
     """
@@ -45,15 +43,19 @@ class Init(Step):
             work_dir_target=f'{base_mesh.path}/graph.info',
         )
 
-        self.add_output_file(
-            filename='initial_state.nc',
-            validate_vars=[
-                'temperature',
-                'salinity',
-                'layerThickness',
-                'normalVelocity',
-            ],
-        )
+    def setup(self):
+        super().setup()
+        self.add_output_file(filename='culled_mesh.nc')
+        validate_vars = [
+            'temperature',
+            'salinity',
+            'layerThickness',
+            'normalVelocity',
+        ]
+        self.add_output_file(filename='init.nc', validate_vars=validate_vars)
+        model = self.config.get('ocean', 'model')
+        if model == 'omega':
+            self.add_output_file(filename='vert_coord.nc')
 
     def run(self):
         """
@@ -74,18 +76,15 @@ class Init(Step):
             alpha, vel_period, gh_0, mesh_filename
         )
 
-        omega = get_constant('angular_velocity')
-
         section = config['vertical_grid']
         bottom_depth = section.getfloat('bottom_depth')
 
         ds_mesh = xr.open_dataset('mesh.nc')
         latCell = ds_mesh.latCell
-        lonCell = ds_mesh.lonCell
-        latEdge = ds_mesh.latEdge
-        lonEdge = ds_mesh.lonEdge
-        latVertex = ds_mesh.latVertex
-        lonVertex = ds_mesh.lonVertex
+
+        config.set('coriolis', 'rotated_sphere_alpha', str(alpha))
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()
 
@@ -93,7 +92,6 @@ class Init(Step):
         ds['ssh'] = -ds.bottomDepth + h
 
         init_vertical_coord(config, ds)
-
         temperature_array = temperature * xr.ones_like(ds_mesh.latCell)
         temperature_array, _ = xr.broadcast(temperature_array, ds.refZMid)
         salinity_array = salinity * xr.ones_like(temperature_array)
@@ -103,25 +101,13 @@ class Init(Step):
         ds['temperature'] = temperature_array.expand_dims(dim='Time', axis=0)
         ds['salinity'] = salinity_array.expand_dims(dim='Time', axis=0)
         ds['normalVelocity'] = normalVelocity.expand_dims(dim='Time', axis=0)
-
-        ds['fCell'] = _coriolis(lonCell, latCell, alpha, omega)
-        ds['fEdge'] = _coriolis(lonEdge, latEdge, alpha, omega)
-        ds['fVertex'] = _coriolis(lonVertex, latVertex, alpha, omega)
+        # temperature and salinity must be set before this call:
+        # write_vert_coord_dataset converts restingThickness to
+        # RefPseudoThickness via pseudothickness_from_ds, which requires T/S
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
 
         # for visualization
         ds['velocityZonal'] = u_cell.broadcast_like(ds.temperature)
         ds['velocityMeridional'] = v_cell.broadcast_like(ds.temperature)
 
-        write_netcdf(ds, 'initial_state.nc')
-
-
-def _coriolis(lon, lat, alpha, omega):
-    f = (
-        2
-        * omega
-        * (
-            -np.cos(lon) * np.cos(lat) * np.sin(alpha)
-            + np.sin(lat) * np.cos(alpha)
-        )
-    )
-    return f
+        self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/geostrophic/viz.py
+++ b/polaris/tasks/ocean/geostrophic/viz.py
@@ -51,7 +51,7 @@ class Viz(Step):
         )
         self.add_input_file(
             filename='initial_state.nc',
-            work_dir_target=f'{init.path}/initial_state.nc',
+            work_dir_target=f'{init.path}/init.nc',
         )
         self.add_input_file(
             filename='output.nc', work_dir_target=f'{forward.path}/output.nc'

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -68,6 +68,7 @@ class Analysis(OceanIOStep):
             work_dir_target=f'{reference.path}/reference_solution.nc',
         )
 
+        model = self.config.get('ocean', 'model')
         init_steps = self.dependencies_dict['init']
         forward_steps = self.dependencies_dict['forward']
         for resolution in horiz_resolutions:
@@ -75,12 +76,21 @@ class Analysis(OceanIOStep):
             forward = forward_steps[resolution]
             self.add_input_file(
                 filename=f'init_r{resolution:02g}.nc',
-                work_dir_target=f'{init.path}/initial_state.nc',
+                work_dir_target=f'{init.path}/init.nc',
             )
             self.add_input_file(
                 filename=f'output_r{resolution:02g}.nc',
                 work_dir_target=f'{forward.path}/output.nc',
             )
+            self.add_input_file(
+                filename=f'culled_mesh_r{resolution:02g}.nc',
+                work_dir_target=f'{init.path}/culled_mesh.nc',
+            )
+            if model == 'omega':
+                self.add_input_file(
+                    filename=f'vert_coord_r{resolution:02g}.nc',
+                    work_dir_target=f'{init.path}/vert_coord.nc',
+                )
 
     def run(self):
         """
@@ -145,6 +155,7 @@ class Analysis(OceanIOStep):
         ref_hpga = ds_ref.HPGAInter.isel(Time=0).values
         ref_valid_grad_mask = ds_ref.ValidGradInterMask.isel(Time=0).values
 
+        model = self.config.get('ocean', 'model')
         ref_errors = []
         py_errors = []
 
@@ -152,13 +163,16 @@ class Analysis(OceanIOStep):
             ds_init = self.open_model_dataset(
                 f'init_r{resolution:02g}.nc', self.config
             )
+            ds_mesh = self.open_model_dataset(
+                f'culled_mesh_r{resolution:02g}.nc', self.config
+            )
             ds_out = self.open_model_dataset(
                 f'output_r{resolution:02g}.nc',
                 self.config,
                 decode_times=False,
             )
 
-            edge_index, cells_on_edge = _get_internal_edge(ds_init)
+            edge_index, cells_on_edge = _get_internal_edge(ds_mesh)
             cell0, cell1 = cells_on_edge
 
             z_tilde_forward = _get_forward_z_tilde_edge_mid(
@@ -173,9 +187,17 @@ class Analysis(OceanIOStep):
             # maxLevelCell is one-based (Fortran indexing), convert to
             # zero-based and use the shallowest valid bottom among the two
             # cells that bound the internal edge.
-            max_level_cells = ds_init.maxLevelCell.isel(
-                nCells=[cell0, cell1]
-            ).values.astype(int)
+            if model == 'omega':
+                ds_vc = self.open_model_dataset(
+                    f'vert_coord_r{resolution:02g}.nc', self.config
+                )
+                max_level_cells = ds_vc.maxLevelCell.isel(
+                    nCells=[cell0, cell1]
+                ).values.astype(int)
+            else:
+                max_level_cells = ds_init.maxLevelCell.isel(
+                    nCells=[cell0, cell1]
+                ).values.astype(int)
             max_level_index = int(np.min(max_level_cells) - 1)
             if max_level_index < 0:
                 raise ValueError(
@@ -326,15 +348,15 @@ class Analysis(OceanIOStep):
             )
 
 
-def _get_internal_edge(ds_init: xr.Dataset) -> tuple[int, tuple[int, int]]:
+def _get_internal_edge(ds_mesh: xr.Dataset) -> tuple[int, tuple[int, int]]:
     """
     Determine the edge that connects the two valid cells in the two-column
     mesh.
     """
-    if 'cellsOnEdge' not in ds_init:
-        raise ValueError('cellsOnEdge is required in initial_state.nc')
+    if 'cellsOnEdge' not in ds_mesh:
+        raise ValueError('cellsOnEdge is required in culled_mesh.nc')
 
-    cells_on_edge = ds_init.cellsOnEdge.values.astype(int)
+    cells_on_edge = ds_mesh.cellsOnEdge.values.astype(int)
     if cells_on_edge.ndim != 2 or cells_on_edge.shape[1] != 2:
         raise ValueError('cellsOnEdge must have shape (nEdges, 2).')
 

--- a/polaris/tasks/ocean/horiz_press_grad/forward.py
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.py
@@ -9,7 +9,7 @@ class Forward(OceanModelStep):
     acceleration) along with other diagnostics.
     """
 
-    def __init__(self, component, horiz_res, indir):
+    def __init__(self, component, horiz_res, init, indir):
         """
         Create the step
 
@@ -20,6 +20,9 @@ class Forward(OceanModelStep):
 
         horiz_res : float
             The horizontal resolution in km
+
+        init : polaris.tasks.ocean.horiz_press_grad.init.Init
+            The init step for this resolution
 
         indir : str
             The subdirectory that the task belongs to, that this step will
@@ -36,18 +39,13 @@ class Forward(OceanModelStep):
             openmp_threads=1,
         )
 
-        init_dir = f'init_{resolution_to_string(horiz_res)}'
-        self.add_input_file(
-            filename='initial_state.nc',
-            target=f'../{init_dir}/initial_state.nc',
+        self.add_horiz_mesh_input_file(
+            work_dir_target=f'{init.path}/culled_mesh.nc'
         )
-        self.add_input_file(
-            filename='mesh.nc',
-            target=f'../{init_dir}/culled_mesh.nc',
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc'
         )
-
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        self.add_input_file(filename='OmegaMesh.nc', target='initial_state.nc')
+        self.add_init_input_file(work_dir_target=f'{init.path}/init.nc')
 
         validate_vars = ['NormalVelocityTend']
         self.add_output_file('output.nc', validate_vars=validate_vars)

--- a/polaris/tasks/ocean/horiz_press_grad/forward.yaml
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.yaml
@@ -19,11 +19,6 @@ Omega:
     ManufacturedSolutionTendency: false
     PressureGradTendencyEnable: true
   IOStreams:
-    InitialVertCoord:
-      Filename: initial_state.nc
-    InitialState:
-      UsePointerFile: false
-      Filename: initial_state.nc
     History:
       Filename: output.nc
       Freq: 1

--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -23,6 +23,13 @@ model = mpas-ocean
 eos_type = teos-10
 
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = zero
+
+
 # config options for horizontal pressure gradient testcases
 [horiz_press_grad]
 

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -4,6 +4,7 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.eos import compute_specvol
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical.ztilde import (
@@ -57,11 +58,12 @@ class Init(OceanIOStep):
         self.vert_res = vert_res
         name = f'init_{resolution_to_string(horiz_res)}'
         super().__init__(component=component, name=name, indir=indir)
-        for file in [
-            'culled_mesh.nc',
-            'initial_state.nc',
-        ]:
-            self.add_output_file(file)
+
+    def setup(self):
+        super().setup()
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+        )
 
     def run(self):
         """
@@ -121,7 +123,8 @@ class Init(OceanIOStep):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        write_netcdf(ds_mesh, 'culled_mesh.nc')
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ncells = ds_mesh.sizes['nCells']
         if ncells != 2:
@@ -368,14 +371,11 @@ class Init(OceanIOStep):
                 'units': 'm s-1',
             },
         )
-        ds['fCell'] = xr.zeros_like(ds_mesh.xCell)
-        ds['fEdge'] = xr.zeros_like(ds_mesh.xEdge)
-        ds['fVertex'] = xr.zeros_like(ds_mesh.xVertex)
-
         ds.attrs['nx'] = nx
         ds.attrs['ny'] = ny
         ds.attrs['dc'] = dc
-        self.write_model_dataset(ds, 'initial_state.nc', config)
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)
 
     def _compute_montgomery_and_hpga(
         self,

--- a/polaris/tasks/ocean/horiz_press_grad/task.py
+++ b/polaris/tasks/ocean/horiz_press_grad/task.py
@@ -109,6 +109,7 @@ class HorizPressGradTask(Task):
             forward_step = Forward(
                 component=self.component,
                 horiz_res=horiz_res,
+                init=init_steps[horiz_res],
                 indir=self.subdir,
             )
             self.add_step(forward_step)

--- a/polaris/tasks/ocean/ice_shelf_2d/default/__init__.py
+++ b/polaris/tasks/ocean/ice_shelf_2d/default/__init__.py
@@ -90,7 +90,7 @@ class Default(IceShelfTask):
         last_adjust_step = self.setup_ssh_adjustment_steps(
             mesh_filename=f'{init.path}/culled_mesh.nc',
             graph_target=f'{init.path}/culled_graph.info',
-            init_filename=f'{init.path}/output.nc',
+            init_filename=f'{init.path}/init.nc',
             config=config,
             config_filename='ice_shelf_2d.cfg',
             ForwardStep=SshForward,

--- a/polaris/tasks/ocean/ice_shelf_2d/forward.py
+++ b/polaris/tasks/ocean/ice_shelf_2d/forward.py
@@ -96,9 +96,13 @@ class Forward(OceanModelStep):
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
-        self.add_input_file(
-            filename='init.nc', work_dir_target=f'{init.path}/output.nc'
+        self.add_horiz_mesh_input_file(
+            work_dir_target=f'{mesh.path}/culled_mesh.nc'
         )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{mesh.path}/vert_coord.nc'
+        )
+        self.add_init_input_file(work_dir_target=f'{init.path}/output.nc')
 
         self.add_output_file(
             filename='output.nc',

--- a/polaris/tasks/ocean/ice_shelf_2d/forward.yaml
+++ b/polaris/tasks/ocean/ice_shelf_2d/forward.yaml
@@ -35,10 +35,6 @@ mpas-ocean:
     config_use_frazil_ice_formation: true
     config_frazil_maximum_depth: 2000.0
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     restart:
       output_interval: 0000_00:00:01
       filename_template: ../forward/restarts/restart.$Y-$M-$D_$h.$m.$s.nc

--- a/polaris/tasks/ocean/ice_shelf_2d/ice_shelf_2d.cfg
+++ b/polaris/tasks/ocean/ice_shelf_2d/ice_shelf_2d.cfg
@@ -37,6 +37,16 @@ split_dt_per_km = 10
 # Time step in seconds as a function of resolution
 btr_dt_per_km = 2.5
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = constant
+
+# the constant Coriolis parameter
+constant_f = 0.
+
+
 # config options for 2D ice-shelf testcases
 [ice_shelf_2d]
 
@@ -57,9 +67,6 @@ surface_salinity = 34.5
 
 # Salinity of the water in the entire domain
 bottom_salinity = 34.7
-
-# Coriolis parameter
-coriolis_parameter = 0.
 
 # GL location in y in km
 y1 = 30.0

--- a/polaris/tasks/ocean/ice_shelf_2d/init.py
+++ b/polaris/tasks/ocean/ice_shelf_2d/init.py
@@ -4,13 +4,14 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
-from polaris import Step
 from polaris.constants import get_constant
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.coriolis import add_coriolis_to_dataset
+from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
 
-class Init(Step):
+class Init(OceanIOStep):
     """
     A step for creating a mesh and initial condition for ice shelf 2-d tasks
 
@@ -38,12 +39,17 @@ class Init(Step):
         super().__init__(component=component, name='init', indir=indir)
         self.resolution = resolution
 
+    def setup(self):
+        super().setup()
         for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info']:
             self.add_output_file(file)
         self.add_output_file(
-            'output.nc',
+            'init.nc',
             validate_vars=['temperature', 'salinity', 'layerThickness'],
         )
+        model = self.config.get('ocean', 'model')
+        if model == 'omega':
+            self.add_output_file('vert_coord.nc')
 
     def run(self):
         """
@@ -74,16 +80,18 @@ class Init(Step):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        write_netcdf(ds_mesh, 'culled_mesh.nc')
-
-        ds = ds_mesh.copy()
 
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
         section = config['ice_shelf_2d']
+
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
+
+        ds = ds_mesh.copy()
+
         temperature = section.getfloat('temperature')
         surface_salinity = section.getfloat('surface_salinity')
         bottom_salinity = section.getfloat('bottom_salinity')
-        coriolis_parameter = section.getfloat('coriolis_parameter')
 
         # points 1 and 2 are where angles on ice shelf are located.
         # point 3 is at the surface.
@@ -95,7 +103,6 @@ class Init(Step):
         d2 = section.getfloat('y2_water_column_thickness')
         d3 = bottom_depth
 
-        x_cell = ds.xCell
         y_cell = ds.yCell
         ds['bottomDepth'] = bottom_depth * xr.ones_like(ds.xCell)
 
@@ -113,6 +120,16 @@ class Init(Step):
         ds['ssh'] = -bottom_depth + column_thickness
 
         init_vertical_coord(config, ds)
+        salinity = surface_salinity + (
+            (bottom_salinity - surface_salinity) * (ds.zMid / (-bottom_depth))
+        )
+        salinity, _ = xr.broadcast(salinity, ds.layerThickness)
+        ds['salinity'] = salinity.transpose('Time', 'nCells', 'nVertLevels')
+        ds['temperature'] = temperature * xr.ones_like(ds.salinity)
+        # temperature and salinity must be set before this call:
+        # write_vert_coord_dataset converts restingThickness to
+        # RefPseudoThickness via pseudothickness_from_ds, which requires T/S
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
 
         modify_mask = xr.where(y_cell < y3, 1, 0).expand_dims(
             dim='Time', axis=0
@@ -130,14 +147,6 @@ class Init(Step):
             ref_density=ref_density,
         )
 
-        salinity = surface_salinity + (
-            (bottom_salinity - surface_salinity) * (ds.zMid / (-bottom_depth))
-        )
-        salinity, _ = xr.broadcast(salinity, ds.layerThickness)
-        ds['salinity'] = salinity.transpose('Time', 'nCells', 'nVertLevels')
-
-        ds['temperature'] = temperature * xr.ones_like(ds.salinity)
-
         normal_velocity = xr.zeros_like(ds_mesh.xEdge)
         normal_velocity, _ = xr.broadcast(normal_velocity, ds.refBottomDepth)
         normal_velocity = normal_velocity.transpose('nEdges', 'nVertLevels')
@@ -151,9 +160,6 @@ class Init(Step):
         ds[mask_variable] = mask
 
         ds['normalVelocity'] = normal_velocity
-        ds['fCell'] = coriolis_parameter * xr.ones_like(x_cell)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
         ds['modifyLandIcePressureMask'] = modify_mask
         ds['landIceFraction'] = landIceFraction
         ds['landIceFloatingFraction'] = landIceFloatingFraction
@@ -166,7 +172,7 @@ class Init(Step):
         ds.attrs['ny'] = ny
         ds.attrs['dc'] = dc
 
-        write_netcdf(ds, 'output.nc')
+        self.write_initial_state_dataset(ds, 'init.nc', config)
 
         # Generate the tidal forcing dataset whether it is used or not
         ds_forcing = xr.Dataset()

--- a/polaris/tasks/ocean/inertial_gravity_wave/analysis.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/analysis.py
@@ -74,8 +74,8 @@ class Analysis(ConvergenceAnalysis):
         solution : xarray.DataArray
             The exact solution as derived from the initial condition
         """
-        init = xr.open_dataset(f'init_r{refinement_factor:02g}.nc')
-        exact = ExactSolution(init, self.config)
+        ds_mesh = xr.open_dataset(f'mesh_r{refinement_factor:02g}.nc')
+        exact = ExactSolution(ds_mesh, self.config)
         if field_name != 'ssh':
             raise ValueError(f'{field_name} is not currently supported')
         return exact.ssh(time)

--- a/polaris/tasks/ocean/inertial_gravity_wave/exact_solution.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/exact_solution.py
@@ -60,8 +60,8 @@ class ExactSolution:
         self.yEdge = ds.yEdge
 
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
+        self.f0 = config.getfloat('coriolis', 'constant_f')
         section = config['inertial_gravity_wave']
-        self.f0 = section.getfloat('coriolis_parameter')
         self.eta0 = section.getfloat('ssh_amplitude')
         lx = section.getfloat('lx')
         npx = section.getfloat('n_wavelengths_x')

--- a/polaris/tasks/ocean/inertial_gravity_wave/forward.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/forward.py
@@ -62,7 +62,6 @@ class Forward(ConvergenceForward):
             init=init,
             package='polaris.tasks.ocean.inertial_gravity_wave',
             yaml_filename='forward.yaml',
-            mesh_input_filename='culled_mesh.nc',
             graph_target=f'{init.path}/culled_graph.info',
             output_filename='output.nc',
             validate_vars=['layerThickness', 'normalVelocity'],

--- a/polaris/tasks/ocean/inertial_gravity_wave/forward.yaml
+++ b/polaris/tasks/ocean/inertial_gravity_wave/forward.yaml
@@ -16,10 +16,6 @@ mpas-ocean:
     config_disable_vel_hmix: true
     config_disable_tr_all_tend: true
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     restart: {}
     output:
       type: output

--- a/polaris/tasks/ocean/inertial_gravity_wave/inertial_gravity_wave.cfg
+++ b/polaris/tasks/ocean/inertial_gravity_wave/inertial_gravity_wave.cfg
@@ -1,11 +1,18 @@
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = constant
+
+# the constant Coriolis parameter
+constant_f = 1e-4
+
+
 # config options for inertial gravity wave testcases
 [inertial_gravity_wave]
 
 # The size of the domain in km in the x direction, (size in y direction = sqrt(3)/2*lx)
 lx = 10000
-
-# The Corilois parameter (constant)
-coriolis_parameter = 1e-4
 
 # Amplitude of the ssh initial condition
 ssh_amplitude = 1.0

--- a/polaris/tasks/ocean/inertial_gravity_wave/init.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/init.py
@@ -4,8 +4,9 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
-from polaris import Step
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.coriolis import add_coriolis_to_dataset
+from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 from polaris.resolution import resolution_to_string
 from polaris.tasks.ocean.inertial_gravity_wave.exact_solution import (
@@ -13,7 +14,7 @@ from polaris.tasks.ocean.inertial_gravity_wave.exact_solution import (
 )
 
 
-class Init(Step):
+class Init(OceanIOStep):
     """
     A step for creating a mesh and initial condition for the
     inertial gravity wave test cases
@@ -44,12 +45,14 @@ class Init(Step):
             component=component, name=f'init_{mesh_name}', subdir=subdir
         )
         self.resolution = resolution
-        for filename in [
-            'culled_mesh.nc',
-            'initial_state.nc',
-            'culled_graph.info',
-        ]:
-            self.add_output_file(filename=filename)
+
+    def setup(self):
+        super().setup()
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
+        )
 
     def run(self):
         """
@@ -63,7 +66,6 @@ class Init(Step):
 
         lx = section.getfloat('lx')
         ly = np.sqrt(3.0) / 2.0 * lx
-        f0 = section.getfloat('coriolis_parameter')
 
         nx, ny = compute_planar_hex_nx_ny(lx, ly, resolution)
         dc = 1e3 * resolution
@@ -77,7 +79,8 @@ class Init(Step):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        write_netcdf(ds_mesh, 'culled_mesh.nc')
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
 
@@ -87,10 +90,7 @@ class Init(Step):
         ds['bottomDepth'] = bottom_depth * xr.ones_like(ds_mesh.xCell)
 
         init_vertical_coord(config, ds)
-
-        ds['fCell'] = f0 * xr.ones_like(ds_mesh.xCell)
-        ds['fEdge'] = f0 * xr.ones_like(ds_mesh.xEdge)
-        ds['fVertex'] = f0 * xr.ones_like(ds_mesh.xVertex)
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
 
         exact_solution = ExactSolution(ds, config)
 
@@ -111,4 +111,4 @@ class Init(Step):
         normal_velocity = normal_velocity.expand_dims(dim='Time', axis=0)
         ds['normalVelocity'] = normal_velocity
 
-        write_netcdf(ds, 'initial_state.nc')
+        self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/inertial_gravity_wave/viz.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/viz.py
@@ -113,7 +113,7 @@ class Viz(Step):
             )
             self.add_input_file(
                 filename=f'init_r{refinement_factor:02g}.nc',
-                work_dir_target=f'{init.path}/initial_state.nc',
+                work_dir_target=f'{init.path}/init.nc',
             )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',

--- a/polaris/tasks/ocean/internal_wave/forward.py
+++ b/polaris/tasks/ocean/internal_wave/forward.py
@@ -86,10 +86,13 @@ class Forward(OceanModelStep):
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
-        self.add_input_file(
-            filename='initial_state.nc',
-            work_dir_target=f'{init.path}/initial_state.nc',
+        self.add_horiz_mesh_input_file(
+            work_dir_target=f'{init.path}/culled_mesh.nc'
         )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc'
+        )
+        self.add_init_input_file(work_dir_target=f'{init.path}/init.nc')
 
         self.add_yaml_file('polaris.tasks.ocean.internal_wave', 'forward.yaml')
 

--- a/polaris/tasks/ocean/internal_wave/forward.yaml
+++ b/polaris/tasks/ocean/internal_wave/forward.yaml
@@ -18,10 +18,6 @@ mpas-ocean:
   split_explicit_ts:
     config_btr_dt: 00:00:15
   streams:
-    mesh:
-      filename_template: initial_state.nc
-    input:
-      filename_template: initial_state.nc
     restart: {}
     output:
       type: output

--- a/polaris/tasks/ocean/internal_wave/init.py
+++ b/polaris/tasks/ocean/internal_wave/init.py
@@ -1,16 +1,16 @@
-import cmocean  # noqa: F401
 import numpy as np
 import xarray as xr
 from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
-from polaris import Step
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.coriolis import add_coriolis_to_dataset
+from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
 
-class Init(Step):
+class Init(OceanIOStep):
     """
     A step for creating a mesh and initial condition for internal wave test
     cases
@@ -30,12 +30,17 @@ class Init(Step):
         """
         super().__init__(component=component, name='init', indir=indir)
 
+    def setup(self):
+        super().setup()
         for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info']:
             self.add_output_file(file)
         self.add_output_file(
-            'initial_state.nc',
+            'init.nc',
             validate_vars=['temperature', 'salinity', 'layerThickness'],
         )
+        model = self.config.get('ocean', 'model')
+        if model == 'omega':
+            self.add_output_file('vert_coord.nc')
 
     def run(self):
         """
@@ -55,7 +60,6 @@ class Init(Step):
         surface_temperature = section.getfloat('surface_temperature')
         temperature_difference = section.getfloat('temperature_difference')
         salinity = section.getfloat('salinity')
-        coriolis_parameter = section.getfloat('coriolis_parameter')
 
         section = config['vertical_grid']
         vert_levels = section.getint('vert_levels')
@@ -72,7 +76,8 @@ class Init(Step):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        write_netcdf(ds_mesh, 'culled_mesh.nc')
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()
 
@@ -126,12 +131,10 @@ class Init(Step):
         ds['temperature'] = temperature
         ds['salinity'] = salinity * xr.ones_like(temperature)
         ds['normalVelocity'] = normal_velocity
-        ds['fCell'] = coriolis_parameter * xr.ones_like(y_cell)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
 
         ds.attrs['nx'] = nx
         ds.attrs['ny'] = ny
         ds.attrs['dc'] = dc
 
-        write_netcdf(ds, 'initial_state.nc')
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/internal_wave/internal_wave.cfg
+++ b/polaris/tasks/ocean/internal_wave/internal_wave.cfg
@@ -19,6 +19,16 @@ partial_cell_type = None
 # The minimum fraction of a layer for partial cells
 min_pc_fraction = 0.1
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = constant
+
+# the constant Coriolis parameter
+constant_f = 0.0
+
+
 # config options for internal wave test cases
 [internal_wave]
 
@@ -54,9 +64,6 @@ amplitude_width_dist = 50e3
 
 # Salinity of the water in the entire domain.
 salinity = 35.0
-
-# Coriolis parameter for the entire domain
-coriolis_parameter = 0.0
 
 # isopycnal displacement = 125.0 Isopycnal configuration not implemented
 

--- a/polaris/tasks/ocean/internal_wave/rpe/analysis.py
+++ b/polaris/tasks/ocean/internal_wave/rpe/analysis.py
@@ -41,9 +41,7 @@ class Analysis(Step):
             filename='mesh.nc', target='../../../init/culled_mesh.nc'
         )
 
-        self.add_input_file(
-            filename='init.nc', target='../../../init/initial_state.nc'
-        )
+        self.add_input_file(filename='init.nc', target='../../../init/init.nc')
 
         for nu in nus:
             self.add_input_file(

--- a/polaris/tasks/ocean/internal_wave/viz.py
+++ b/polaris/tasks/ocean/internal_wave/viz.py
@@ -24,9 +24,7 @@ class Viz(Step):
         self.add_input_file(
             filename='mesh.nc', target='../../../init/culled_mesh.nc'
         )
-        self.add_input_file(
-            filename='init.nc', target='../../../init/initial_state.nc'
-        )
+        self.add_input_file(filename='init.nc', target='../../../init/init.nc')
         self.add_input_file(
             filename='output.nc', target='../forward/output.nc'
         )

--- a/polaris/tasks/ocean/manufactured_solution/analysis.py
+++ b/polaris/tasks/ocean/manufactured_solution/analysis.py
@@ -67,10 +67,10 @@ class Analysis(ConvergenceAnalysis):
         solution : xarray.DataArray
             The exact solution as derived from the initial condition
         """
-        init = self.open_model_dataset(
-            f'init_r{refinement_factor:02g}.nc', self.config
+        mesh = self.open_model_dataset(
+            f'mesh_r{refinement_factor:02g}.nc', self.config
         )
-        exact = ExactSolution(self.config, init)
+        exact = ExactSolution(self.config, mesh)
         if field_name != 'ssh':
             raise ValueError(f'{field_name} is not currently supported')
         return exact.ssh(time)

--- a/polaris/tasks/ocean/manufactured_solution/forward.py
+++ b/polaris/tasks/ocean/manufactured_solution/forward.py
@@ -93,21 +93,13 @@ class Forward(ConvergenceForward):
         self.del4 = del4
 
     def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
         super().setup()
-        config = self.config
-        model = config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
-            mesh_name = self.init.path.split('/')[-1]
-            self.add_input_file(
-                target=f'{mesh_name}_coeffs.nc',
-                filename='coeffs.nc',
-                database='manufactured_solution',
-            )
+        mesh_name = self.init.path.split('/')[-1]
+        self.add_input_file(
+            target=f'{mesh_name}_coeffs.nc',
+            filename='coeffs.nc',
+            database='manufactured_solution',
+        )
 
     def compute_cell_count(self):
         """

--- a/polaris/tasks/ocean/manufactured_solution/forward.py
+++ b/polaris/tasks/ocean/manufactured_solution/forward.py
@@ -83,7 +83,6 @@ class Forward(ConvergenceForward):
             refinement=refinement,
             package='polaris.tasks.ocean.manufactured_solution',
             yaml_filename='forward.yaml',
-            mesh_input_filename='culled_mesh.nc',
             graph_target=f'{init.path}/culled_graph.info',
             output_filename='output.nc',
             validate_vars=['layerThickness', 'normalVelocity'],

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -22,10 +22,6 @@ mpas-ocean:
     config_disable_vel_vmix: true
     config_disable_tr_all_tend: true
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     restart: {}
     output:
       type: output
@@ -48,8 +44,6 @@ Omega:
     ManufacturedSolutionTendency: true
     PressureGradTendencyEnable : false
   IOStreams:
-    InitialVertCoord:
-      Filename: init.nc
     InitialState:
       UsePointerFile: false
       Filename: init.nc

--- a/polaris/tasks/ocean/manufactured_solution/init.py
+++ b/polaris/tasks/ocean/manufactured_solution/init.py
@@ -4,6 +4,7 @@ from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 from polaris.tasks.ocean.manufactured_solution.exact_solution import (
@@ -42,12 +43,11 @@ class Init(OceanIOStep):
 
     def setup(self):
         super().setup()
-        output_filenames = ['culled_mesh.nc', 'initial_state.nc']
-        model = self.config.get('ocean', 'model')
-        if model == 'mpas-ocean':
-            output_filenames.append('culled_graph.info')
-        for filename in output_filenames:
-            self.add_output_file(filename=filename)
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
+        )
 
     def run(self):
         """
@@ -61,7 +61,6 @@ class Init(OceanIOStep):
 
         lx = section.getfloat('lx')
         ly = np.sqrt(3.0) / 2.0 * lx
-        coriolis_parameter = section.getfloat('coriolis_parameter')
 
         nx, ny = compute_planar_hex_nx_ny(lx, ly, resolution)
         dc = 1e3 * resolution
@@ -75,7 +74,8 @@ class Init(OceanIOStep):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
 
@@ -85,10 +85,6 @@ class Init(OceanIOStep):
         ds['bottomDepth'] = bottom_depth * xr.ones_like(ds_mesh.xCell)
 
         init_vertical_coord(config, ds)
-
-        ds['fCell'] = coriolis_parameter * xr.ones_like(ds_mesh.xCell)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
 
         # Evaluate the exact solution at time=0
         exact_solution = ExactSolution(config, ds)
@@ -112,4 +108,5 @@ class Init(OceanIOStep):
         ds['temperature'] = xr.zeros_like(layer_thickness)
         ds['salinity'] = xr.ones_like(layer_thickness)
 
-        self.write_model_dataset(ds, 'initial_state.nc', config)
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/manufactured_solution/manufactured_solution.cfg
+++ b/polaris/tasks/ocean/manufactured_solution/manufactured_solution.cfg
@@ -1,3 +1,13 @@
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = constant
+
+# the constant Coriolis parameter
+constant_f = 1.0e-4
+
+
 [ocean]
 # the number of cells per core to aim for
 goal_cells_per_core = 200
@@ -11,9 +21,6 @@ max_cells_per_core = 4500
 
 # the size of the domain in km in the x and y directions
 lx = 10000.0
-
-# the coriolis parameter
-coriolis_parameter = 1.0e-4
 
 # the amplitude of the sea surface height perturbation
 ssh_amplitude = 1.0

--- a/polaris/tasks/ocean/manufactured_solution/viz.py
+++ b/polaris/tasks/ocean/manufactured_solution/viz.py
@@ -112,7 +112,7 @@ class Viz(OceanIOStep):
             )
             self.add_input_file(
                 filename=f'init_r{refinement_factor:02g}.nc',
-                work_dir_target=f'{init.path}/initial_state.nc',
+                work_dir_target=f'{init.path}/init.nc',
             )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -61,7 +61,7 @@ class Viz(OceanIOStep):
         )
         self.add_input_file(
             filename='init.nc',
-            work_dir_target=f'{init.path}/initial_state.nc',
+            work_dir_target=f'{init.path}/init.nc',
         )
         self.add_input_file(
             filename='output.nc',

--- a/polaris/tasks/ocean/merry_go_round/forward.py
+++ b/polaris/tasks/ocean/merry_go_round/forward.py
@@ -68,7 +68,6 @@ class Forward(ConvergenceForward):
             refinement=refinement,
             package='polaris.tasks.ocean.merry_go_round',
             yaml_filename='forward.yaml',
-            mesh_input_filename='culled_mesh.nc',
             graph_target=f'{init.path}/culled_graph.info',
             output_filename='output.nc',
             validate_vars=validate_vars,

--- a/polaris/tasks/ocean/merry_go_round/forward.py
+++ b/polaris/tasks/ocean/merry_go_round/forward.py
@@ -77,20 +77,12 @@ class Forward(ConvergenceForward):
         self.mesh_name = init.path.split('/')[-1]
 
     def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
         super().setup()
-        config = self.config
-        model = config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
-            self.add_input_file(
-                target=f'{self.mesh_name}_coeffs.nc',
-                filename='coeffs.nc',
-                database='merry_go_round',
-            )
+        self.add_input_file(
+            target=f'{self.mesh_name}_coeffs.nc',
+            filename='coeffs.nc',
+            database='merry_go_round',
+        )
 
     def dynamic_model_config(self, at_setup):
         """

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -53,10 +53,6 @@ mpas-ocean:
   AM_mixedLayerDepths:
     config_AM_mixedLayerDepths_enable: false
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     restart: {}
     output:
       type: output
@@ -91,7 +87,6 @@ Omega:
   IOStreams:
     InitialVertCoord:
       UsePointerFile: false
-      Filename: OmegaMesh.nc
       Mode: read
       Precision: double
       Freq: 1
@@ -104,7 +99,6 @@ Omega:
     # "OnStartup" to "never" so that the initial state file is not read.
     InitialState:
       UsePointerFile: false
-      Filename: OmegaMesh.nc
       Mode: read
       Precision: double
       Freq: 1

--- a/polaris/tasks/ocean/merry_go_round/init.py
+++ b/polaris/tasks/ocean/merry_go_round/init.py
@@ -4,6 +4,7 @@ from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
@@ -38,13 +39,11 @@ class Init(OceanIOStep):
 
     def setup(self):
         super().setup()
-        output_filenames = ['culled_mesh.nc', 'initial_state.nc']
-        model = self.config.get('ocean', 'model')
-        if model == 'mpas-ocean':
-            output_filenames.append('culled_graph.info')
-
-        for file in output_filenames:
-            self.add_output_file(file)
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
+        )
 
     def run(self):
         """
@@ -89,16 +88,13 @@ class Init(OceanIOStep):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()
 
         ds['ssh'] = xr.zeros_like(ds.xCell)
         ds['bottomDepth'] = bottom_depth * xr.ones_like(ds.xCell)
-
-        ds['fCell'] = xr.zeros_like(ds.xCell)
-        ds['fEdge'] = xr.zeros_like(ds.xEdge)
-        ds['fVertex'] = xr.zeros_like(ds.xVertex)
 
         config.set('vertical_grid', 'vert_levels', str(nz))
         init_vertical_coord(config, ds)
@@ -171,4 +167,5 @@ class Init(OceanIOStep):
         ds['tracer2'] = tracer2_background * xr.ones_like(temperature)
         ds['tracer3'] = tracer3_background * xr.ones_like(temperature)
 
-        self.write_model_dataset(ds, 'initial_state.nc', config=config)
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/merry_go_round/merry_go_round.cfg
+++ b/polaris/tasks/ocean/merry_go_round/merry_go_round.cfg
@@ -19,6 +19,13 @@ partial_cell_type = None
 # The minimum fraction of a layer for partial cells
 min_pc_fraction = 0.1
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = zero
+
+
 # config options for merry-go-round testcases
 [merry_go_round]
 

--- a/polaris/tasks/ocean/merry_go_round/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/viz.py
@@ -111,7 +111,7 @@ class Viz(OceanIOStep):
             )
             self.add_input_file(
                 filename=f'init_r{refinement_factor:02g}.nc',
-                work_dir_target=f'{init.path}/initial_state.nc',
+                work_dir_target=f'{init.path}/init.nc',
             )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -91,10 +91,13 @@ class Forward(OceanModelStep):
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
-        self.add_input_file(
-            filename='initial_state.nc',
-            work_dir_target=f'{init.path}/init.nc',
+        self.add_horiz_mesh_input_file(
+            work_dir_target=f'{init.path}/culled_mesh.nc'
         )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc'
+        )
+        self.add_init_input_file(work_dir_target=f'{init.path}/init.nc')
 
         self.add_output_file(
             filename='output.nc',
@@ -104,19 +107,6 @@ class Forward(OceanModelStep):
                 'temperature',
             ],
         )
-
-    def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
-        super().setup()
-        config = self.config
-        model = config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
-        if model == 'omega':
-            self.add_input_file(
-                filename='OmegaMesh.nc', target='initial_state.nc'
-            )
 
     def dynamic_model_config(self, at_setup):
         super().dynamic_model_config(at_setup=at_setup)

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -30,10 +30,6 @@ mpas-ocean:
   split_explicit_ts:
     config_btr_dt: {{ btr_dt }}
   streams:
-    mesh:
-      filename_template: initial_state.nc
-    input:
-      filename_template: initial_state.nc
     restart:
       output_interval: 0010_00:00:00
     output:
@@ -58,19 +54,7 @@ Omega:
   Tracers:
     Base: [Temperature, Salinity]
   IOStreams:
-    InitialVertCoord:
-      UsePointerFile: false
-      Filename: initial_state.nc
-      Mode: read
-      Precision: double
-      Freq: 1
-      FreqUnits: OnStartup
-      UseStartEnd: false
-      Contents:
-        - InitVertCoord
     InitialState:
-      UsePointerFile: false
-      Filename: initial_state.nc
       Mode: read
       Precision: double
       Freq: 1

--- a/polaris/tasks/ocean/overflow/init.py
+++ b/polaris/tasks/ocean/overflow/init.py
@@ -4,6 +4,7 @@ from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.eos import compute_density
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
@@ -33,12 +34,11 @@ class Init(OceanIOStep):
 
     def setup(self):
         super().setup()
-        output_filenames = ['base_mesh.nc', 'culled_mesh.nc', 'init.nc']
-        model = self.config.get('ocean', 'model')
-        if model == 'mpas-ocean':
-            output_filenames.append('culled_graph.info')
-        for filename in output_filenames:
-            self.add_output_file(filename=filename)
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
+        )
 
     def run(self):
         """
@@ -63,7 +63,8 @@ class Init(OceanIOStep):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         max_bottom_depth = section.getfloat('max_bottom_depth')
         shelf_depth = section.getfloat('shelf_depth')
@@ -124,10 +125,5 @@ class Init(OceanIOStep):
             np.zeros([1, ds.sizes['nEdges'], ds.sizes['nVertLevels']]),
         )
 
-        # Coriolis parameter is zero
-        ds['fCell'] = xr.zeros_like(ds.xCell)
-        ds['fEdge'] = xr.zeros_like(ds.xEdge)
-        ds['fVertex'] = xr.zeros_like(ds.xVertex)
-
-        # finalize and write file
-        self.write_model_dataset(ds, 'init.nc', config)
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/overflow/overflow.cfg
+++ b/polaris/tasks/ocean/overflow/overflow.cfg
@@ -16,6 +16,13 @@ coord_type = z-star
 # Whether to use "partial" or "full", or "None" to not alter the topography
 partial_cell_type = None
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = zero
+
+
 # Options related to the overflow case
 [overflow]
 

--- a/polaris/tasks/ocean/seamount/forward.py
+++ b/polaris/tasks/ocean/seamount/forward.py
@@ -91,10 +91,13 @@ class Forward(OceanModelStep):
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
-        self.add_input_file(
-            filename='initial_state.nc',
-            work_dir_target=f'{init.path}/init.nc',
+        self.add_horiz_mesh_input_file(
+            work_dir_target=f'{init.path}/culled_mesh.nc'
         )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc'
+        )
+        self.add_init_input_file(work_dir_target=f'{init.path}/init.nc')
 
         self.add_output_file(
             filename='output.nc',

--- a/polaris/tasks/ocean/seamount/forward.yaml
+++ b/polaris/tasks/ocean/seamount/forward.yaml
@@ -19,10 +19,6 @@ mpas-ocean:
   split_explicit_ts:
     config_btr_dt: {{ btr_dt }}
   streams:
-    mesh:
-      filename_template: initial_state.nc
-    input:
-      filename_template: initial_state.nc
     restart:
       output_interval: 0010_00:00:00
     output:

--- a/polaris/tasks/ocean/seamount/init.py
+++ b/polaris/tasks/ocean/seamount/init.py
@@ -4,6 +4,7 @@ from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.mesh.planar import compute_planar_hex_nx_ny
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
@@ -32,12 +33,11 @@ class Init(OceanIOStep):
 
     def setup(self):
         super().setup()
-        output_filenames = ['base_mesh.nc', 'culled_mesh.nc', 'init.nc']
-        model = self.config.get('ocean', 'model')
-        if model == 'mpas-ocean':
-            output_filenames.append('culled_graph.info')
-        for filename in output_filenames:
-            self.add_output_file(filename=filename)
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
+        )
 
     def run(self):
         """
@@ -62,7 +62,8 @@ class Init(OceanIOStep):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        self.write_model_dataset(ds_mesh, 'culled_mesh.nc', config)
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         # from overflow. Delete when not needed.
         max_bottom_depth = section.getfloat('max_bottom_depth')
@@ -94,7 +95,6 @@ class Init(OceanIOStep):
         seamount_height = section.getfloat('seamount_height')
         seamount_width = section.getfloat('seamount_width')
         constant_salinity = section.getfloat('constant_salinity')
-        coriolis_parameter = section.getfloat('coriolis_parameter')
 
         ds = ds_mesh.copy()
 
@@ -149,18 +149,9 @@ class Init(OceanIOStep):
             ),
             np.zeros([1, ds.sizes['nEdges'], ds.sizes['nVertLevels']]),
         )
-        ds['fCell'] = coriolis_parameter * xr.ones_like(ds.xCell)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds.xVertex)
-
-        # this was in internal wave but not overflow. Is it needed?
         ds.attrs['nx'] = nx
         ds.attrs['ny'] = ny
         ds.attrs['dc'] = dc
 
-        # finalize and write file
-        self.write_model_dataset(ds, 'init.nc', config)
-        # May not be needed.
-
-
-# from internal wave:write_netcdf(ds, 'initial_state.nc')
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/seamount/seamount.cfg
+++ b/polaris/tasks/ocean/seamount/seamount.cfg
@@ -16,6 +16,16 @@ coord_type = sigma
 # Whether to use "partial" or "full", or "None" to not alter the topography
 partial_cell_type = None
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = constant
+
+# the constant Coriolis parameter
+constant_f = -1.0e-4
+
+
 # Options related to the seamount case
 [seamount]
 
@@ -67,9 +77,6 @@ seamount_width = 40.0e3
 
 # Salinity of the water in the entire domain (PSU)
 constant_salinity = 35.0
-
-# Coriolis parameter for entire domain (s^{-1})
-coriolis_parameter = -1.0e-4
 
 [seamount_default]
 

--- a/polaris/tasks/ocean/single_column/ekman/analysis.py
+++ b/polaris/tasks/ocean/single_column/ekman/analysis.py
@@ -30,7 +30,7 @@ class Analysis(Step):
         """
         super().__init__(component=component, name='analysis', indir=indir)
         self.add_input_file(
-            filename='init.nc', target='../forward/initial_state.nc'
+            filename='mesh.nc', target='../init/culled_mesh.nc'
         )
         self.add_input_file(
             filename='output.nc', target='../forward/output.nc'
@@ -44,13 +44,13 @@ class Analysis(Step):
         use_mplstyle()
 
         config = self.config
-        f = config.getfloat('single_column', 'coriolis_parameter')
+        f = config.getfloat('coriolis', 'constant_f')
         bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
         tau_x = config.getfloat('single_column_forcing', 'wind_stress_zonal')
         nu = config.getfloat('single_column_ekman', 'vertical_viscosity')
         tol = config.getfloat('single_column_ekman', 'L2_error_norm_max')
 
-        ds_mesh = xr.load_dataset('init.nc')
+        ds_mesh = xr.load_dataset('mesh.nc')
         ds = xr.load_dataset('output.nc')
         t_index = ds.sizes['Time'] - 1
         t = ds.daysSinceStartOfSim[t_index]

--- a/polaris/tasks/ocean/single_column/ekman/ekman.cfg
+++ b/polaris/tasks/ocean/single_column/ekman/ekman.cfg
@@ -36,9 +36,6 @@ salinity_gradient_interior = 0.0
 # Depth of the salinity mixed layer
 mixed_layer_depth_salinity = 0.0
 
-# coriolis parameter
-coriolis_parameter = 1.0e-4
-
 # config options for forcing single column testcases
 [single_column_forcing]
 

--- a/polaris/tasks/ocean/single_column/ekman/forward.yaml
+++ b/polaris/tasks/ocean/single_column/ekman/forward.yaml
@@ -24,10 +24,6 @@ mpas-ocean:
     config_use_activeTracers_surface_restoring: false
     config_use_activeTracers_interior_restoring: false
   streams:
-    mesh:
-      filename_template: initial_state.nc
-    input:
-      filename_template: initial_state.nc
     restart: {}
     KPP_testing: {}
     mixedLayerDepthsOutput:

--- a/polaris/tasks/ocean/single_column/forward.py
+++ b/polaris/tasks/ocean/single_column/forward.py
@@ -75,9 +75,9 @@ class Forward(OceanModelStep):
 
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
 
-        self.add_input_file(
-            filename='initial_state.nc', target='../init/initial_state.nc'
-        )
+        self.add_horiz_mesh_input_file(target='../init/culled_mesh.nc')
+        self.add_vert_coord_input_file(target='../init/vert_coord.nc')
+        self.add_init_input_file(target='../init/init.nc')
         self.add_input_file(filename='forcing.nc', target='../init/forcing.nc')
         self.add_input_file(
             filename='graph.info', target='../init/culled_graph.info'

--- a/polaris/tasks/ocean/single_column/forward.yaml
+++ b/polaris/tasks/ocean/single_column/forward.yaml
@@ -14,10 +14,6 @@ mpas-ocean:
     config_use_activeTracers_surface_restoring: true
     config_use_activeTracers_interior_restoring: true
   streams:
-    mesh:
-      filename_template: initial_state.nc
-    input:
-      filename_template: initial_state.nc
     restart: {}
     mixedLayerDepthsOutput:
       contents:

--- a/polaris/tasks/ocean/single_column/inertial/analysis.py
+++ b/polaris/tasks/ocean/single_column/inertial/analysis.py
@@ -44,7 +44,7 @@ class Analysis(Step):
         use_mplstyle()
 
         config = self.config
-        f = config.getfloat('single_column', 'coriolis_parameter')
+        f = config.getfloat('coriolis', 'constant_f')
         tol = config.getfloat(
             'single_column_inertial', 'period_tolerance_fraction'
         )

--- a/polaris/tasks/ocean/single_column/init.py
+++ b/polaris/tasks/ocean/single_column/init.py
@@ -4,11 +4,12 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
-from polaris import Step
+from polaris.ocean.coriolis import add_coriolis_to_dataset
+from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 
 
-class Init(Step):
+class Init(OceanIOStep):
     """
     A step for creating a mesh and initial condition for single column
     test cases
@@ -32,14 +33,15 @@ class Init(Step):
         """
         super().__init__(component=component, name='init', indir=indir)
         self.ideal_age = ideal_age
-        for file in [
-            'base_mesh.nc',
-            'culled_mesh.nc',
-            'culled_graph.info',
-            'initial_state.nc',
-            'forcing.nc',
-        ]:
-            self.add_output_file(file)
+
+    def setup(self):
+        super().setup()
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
+        )
+        self.add_output_file(filename='forcing.nc')
 
     def run(self):
         """
@@ -61,7 +63,8 @@ class Init(Step):
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger
         )
-        write_netcdf(ds_mesh, 'culled_mesh.nc')
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()
         x_cell = ds_mesh.xCell
@@ -97,7 +100,6 @@ class Init(Step):
         mixed_layer_depth_salinity = section.getfloat(
             'mixed_layer_depth_salinity'
         )
-        coriolis_parameter = section.getfloat('coriolis_parameter')
         u = section.getfloat('zonal_velocity')
         v = section.getfloat('meridional_velocity')
 
@@ -146,14 +148,13 @@ class Init(Step):
         ds['temperature'] = temperature
         ds['salinity'] = salinity
         ds['normalVelocity'] = normal_velocity
-        ds['fCell'] = coriolis_parameter * xr.ones_like(x_cell)
-        ds['fEdge'] = coriolis_parameter * xr.ones_like(ds_mesh.xEdge)
-        ds['fVertex'] = coriolis_parameter * xr.ones_like(ds_mesh.xVertex)
 
         ds.attrs['nx'] = nx
         ds.attrs['ny'] = ny
         ds.attrs['dc'] = dc
-        write_netcdf(ds, 'initial_state.nc')
+
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)
 
         # create forcing stream
         ds_forcing = xr.Dataset()

--- a/polaris/tasks/ocean/single_column/single_column.cfg
+++ b/polaris/tasks/ocean/single_column/single_column.cfg
@@ -19,6 +19,16 @@ partial_cell_type = None
 # The minimum fraction of a layer for partial cells
 min_pc_fraction = 0.1
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = constant
+
+# the constant Coriolis parameter
+constant_f = 1.0e-4
+
+
 # config options for single column testcases
 [single_column]
 
@@ -58,9 +68,6 @@ salinity_gradient_interior = 0.0
 
 # Depth of the salinity mixed layer
 mixed_layer_depth_salinity = 0.0
-
-# coriolis parameter
-coriolis_parameter = 1.0e-4
 
 # Initial zonal velocity
 zonal_velocity = 0.0

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -30,7 +30,7 @@ class Viz(Step):
         super().__init__(component=component, name='viz', indir=indir)
         self.ideal_age = ideal_age
         self.add_input_file(
-            filename='initial_state.nc', target='../init/initial_state.nc'
+            filename='initial_state.nc', target='../init/init.nc'
         )
         self.add_input_file(
             filename='output.nc', target='../forward/output.nc'

--- a/polaris/tasks/ocean/sphere_transport/filament_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/filament_analysis.py
@@ -76,7 +76,7 @@ class FilamentAnalysis(OceanIOStep):
             )
             self.add_input_file(
                 filename=f'init_r{refinement_factor:02g}.nc',
-                work_dir_target=f'{init.path}/initial_state.nc',
+                work_dir_target=f'{init.path}/init.nc',
             )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',

--- a/polaris/tasks/ocean/sphere_transport/forward.py
+++ b/polaris/tasks/ocean/sphere_transport/forward.py
@@ -87,14 +87,9 @@ class Forward(SphericalConvergenceForward):
         self.mesh_path = base_mesh.path
 
     def setup(self):
-        """
-        TEMP: symlink initial condition to name hard-coded in Omega
-        """
         super().setup()
         model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer hard-codes this file
         if model == 'omega':
-            self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
             component, database, mesh_name = parse_mesh_filepath(
                 self.mesh_path
             )

--- a/polaris/tasks/ocean/sphere_transport/forward.py
+++ b/polaris/tasks/ocean/sphere_transport/forward.py
@@ -75,7 +75,6 @@ class Forward(SphericalConvergenceForward):
             init=init,
             package=package,
             yaml_filename='forward.yaml',
-            mesh_input_filename='base_mesh.nc',
             output_filename='output.nc',
             validate_vars=validate_vars,
             check_properties=['mass conservation', 'tracer conservation'],

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -40,10 +40,6 @@ mpas-ocean:
   tracer_forcing_debugTracers:
     config_use_debugTracers: true
   streams:
-    mesh:
-      filename_template: init.nc
-    input:
-      filename_template: init.nc
     restart:
       output_interval: 0030_00:00:00
     output:
@@ -80,10 +76,7 @@ Omega:
     TracerHyperDiffTendencyEnable : false
     PressureGradTendencyEnable : false
   IOStreams:
-    InitialVertCoord:
-      Filename: init.nc
     InitialState:
-      Filename: init.nc
       Contents:
         - State
         - Tracers

--- a/polaris/tasks/ocean/sphere_transport/init.py
+++ b/polaris/tasks/ocean/sphere_transport/init.py
@@ -2,6 +2,7 @@ import numpy as np
 import xarray as xr
 
 from polaris.constants import get_constant
+from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
 from polaris.tasks.ocean.sphere_transport.resources.flow_types import (
@@ -59,7 +60,11 @@ class Init(OceanIOStep):
             work_dir_target=f'{base_mesh.path}/graph.info',
         )
 
-        self.add_output_file(filename='initial_state.nc')
+    def setup(self):
+        super().setup()
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+        )
 
     def run(self):
         """
@@ -83,6 +88,9 @@ class Init(OceanIOStep):
         latEdge = ds_mesh.latEdge
         lonCell = ds_mesh.lonCell
         lonEdge = ds_mesh.lonEdge
+
+        ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()
 
@@ -212,8 +220,5 @@ class Init(OceanIOStep):
             dim='Time', axis=0
         )
 
-        ds['fCell'] = xr.zeros_like(ds_mesh.xCell)
-        ds['fEdge'] = xr.zeros_like(ds_mesh.xEdge)
-        ds['fVertex'] = xr.zeros_like(ds_mesh.xVertex)
-
-        self.write_model_dataset(ds, 'initial_state.nc', config)
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
@@ -85,7 +85,7 @@ class MixingAnalysis(OceanIOStep):
             )
             self.add_input_file(
                 filename=f'init_r{refinement_factor:02g}.nc',
-                work_dir_target=f'{init.path}/initial_state.nc',
+                work_dir_target=f'{init.path}/init.nc',
             )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',

--- a/polaris/tasks/ocean/sphere_transport/sphere_transport.cfg
+++ b/polaris/tasks/ocean/sphere_transport/sphere_transport.cfg
@@ -49,6 +49,13 @@ run_duration = ${sphere_transport:vel_pd}
 output_interval = 24.0
 
 
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = zero
+
+
 # options for all sphere transport test cases
 [sphere_transport]
 

--- a/polaris/tasks/ocean/sphere_transport/viz.py
+++ b/polaris/tasks/ocean/sphere_transport/viz.py
@@ -52,7 +52,7 @@ class Viz(OceanIOStep):
         )
         self.add_input_file(
             filename='initial_state.nc',
-            work_dir_target=f'{init.path}/initial_state.nc',
+            work_dir_target=f'{init.path}/init.nc',
         )
         self.add_input_file(
             filename='output.nc', work_dir_target=f'{forward.path}/output.nc'

--- a/tests/ocean/test_mesh_init_split.py
+++ b/tests/ocean/test_mesh_init_split.py
@@ -119,7 +119,11 @@ def test_write_vert_coord_dataset_noop_for_mpas_ocean(tmp_path):
 
     ds = xr.Dataset(
         data_vars=dict(
+            minLevelCell=('nCells', [0, 0]),
+            maxLevelCell=('nCells', [0, 0]),
             bottomDepth=('nCells', [100.0, 200.0]),
+            restingThickness=(('nCells', 'nVertLevels'), [[50.0], [100.0]]),
+            vertCoordMovementWeights=('nVertLevels', [1.0]),
         )
     )
 
@@ -127,6 +131,93 @@ def test_write_vert_coord_dataset_noop_for_mpas_ocean(tmp_path):
     component.write_vert_coord_dataset(ds, str(filename), config)
 
     assert not filename.exists()
+
+
+@pytest.mark.parametrize(
+    'model,missing_var',
+    [
+        ('mpas-ocean', 'restingThickness'),
+        ('omega', 'RefPseudoThickness'),
+    ],
+)
+def test_write_vert_coord_dataset_raises_on_missing_vars(
+    tmp_path, model, missing_var
+):
+    component = Ocean()
+    component.model = model
+    component._read_var_map()
+
+    config = MagicMock()
+
+    # omit the model-specific thickness var and vertCoordMovementWeights
+    ds = xr.Dataset(
+        data_vars=dict(
+            minLevelCell=('nCells', [0, 0]),
+            maxLevelCell=('nCells', [0, 0]),
+            bottomDepth=('nCells', [100.0, 200.0]),
+        )
+    )
+
+    filename = tmp_path / 'vert_coord.nc'
+    with pytest.raises(ValueError, match=missing_var):
+        component.write_vert_coord_dataset(ds, str(filename), config)
+
+
+def _make_horiz_mesh_ds(component):
+    """Build a minimal dataset with all horiz_mesh_vars as dummy data."""
+    return xr.Dataset(
+        data_vars={
+            v: ('nCells', [0.0, 1.0]) for v in component.horiz_mesh_vars
+        }
+    )
+
+
+def test_write_horiz_mesh_dataset_raises_on_missing_vars(tmp_path):
+    component = Ocean()
+    component.model = 'mpas-ocean'
+    component._read_var_map()
+
+    config = MagicMock()
+
+    # dataset is missing most horiz_mesh_vars
+    ds = xr.Dataset(data_vars=dict(xCell=('nCells', [0.0, 1.0])))
+
+    filename = tmp_path / 'mesh.nc'
+    with pytest.raises(ValueError, match='indexToCellID'):
+        component.write_horiz_mesh_dataset(ds, str(filename), config)
+
+
+def test_write_horiz_mesh_dataset_writes_mpas_ocean(tmp_path):
+    component = Ocean()
+    component.model = 'mpas-ocean'
+    component._read_var_map()
+
+    config = MagicMock()
+    ds = _make_horiz_mesh_ds(component)
+
+    filename = tmp_path / 'mesh.nc'
+    component.write_horiz_mesh_dataset(ds, str(filename), config)
+
+    ds_out = xr.open_dataset(filename)
+    assert 'xCell' in ds_out
+    assert 'fCell' in ds_out
+
+
+def test_write_horiz_mesh_dataset_writes_omega(tmp_path):
+    component = Ocean()
+    component.model = 'omega'
+    component._read_var_map()
+
+    config = MagicMock()
+    ds = _make_horiz_mesh_ds(component)
+
+    filename = tmp_path / 'mesh.nc'
+    component.write_horiz_mesh_dataset(ds, str(filename), config)
+
+    ds_out = xr.open_dataset(filename)
+    assert 'XCell' in ds_out
+    assert 'FCell' in ds_out
+    assert 'xCell' not in ds_out
 
 
 def test_process_inputs_and_outputs_resolves_model_input_filenames(

--- a/tests/ocean/test_mesh_init_split.py
+++ b/tests/ocean/test_mesh_init_split.py
@@ -1,0 +1,240 @@
+import importlib
+from configparser import ConfigParser
+from unittest.mock import MagicMock
+
+import pytest
+import xarray as xr
+
+from polaris.model_step import ModelStep
+from polaris.ocean.model import OceanIOStep, OceanModelStep
+from polaris.tasks.ocean import Ocean
+from polaris.yaml import PolarisYaml
+
+
+def _make_config(
+    horiz_mesh_filename='mesh.nc',
+    vert_coord_filename='vert_coord.nc',
+    init_filename='init.nc',
+):
+    config = ConfigParser()
+    config.add_section('ocean_model_files')
+    config.set('ocean_model_files', 'horiz_mesh_filename', horiz_mesh_filename)
+    config.set('ocean_model_files', 'vert_coord_filename', vert_coord_filename)
+    config.set('ocean_model_files', 'init_filename', init_filename)
+    return config
+
+
+def test_write_initial_state_dataset_omega_drops_horiz_mesh_vars(tmp_path):
+    component = Ocean()
+    component.model = 'omega'
+    component._read_var_map()
+
+    config = MagicMock()
+
+    ds = xr.Dataset(
+        data_vars=dict(
+            xCell=('nCells', [0.0, 1.0]),
+            fCell=('nCells', [1.0, 2.0]),
+            temperature=(('nCells', 'nVertLevels'), [[3.0], [4.0]]),
+            salinity=(('nCells', 'nVertLevels'), [[35.0], [35.0]]),
+        )
+    )
+
+    filename = tmp_path / 'initial_state.nc'
+    component.write_initial_state_dataset(ds, str(filename), config)
+
+    ds_out = xr.open_dataset(filename)
+    assert 'Temperature' in ds_out
+    assert 'temperature' not in ds_out
+    assert 'XCell' not in ds_out
+    assert 'FCell' not in ds_out
+
+
+def test_write_initial_state_dataset_omega_drops_vert_coord_vars(tmp_path):
+    component = Ocean()
+    component.model = 'omega'
+    component._read_var_map()
+
+    config = MagicMock()
+
+    ds = xr.Dataset(
+        data_vars=dict(
+            temperature=(('nCells', 'nVertLevels'), [[3.0], [4.0]]),
+            salinity=(('nCells', 'nVertLevels'), [[35.0], [35.0]]),
+            minLevelCell=('nCells', [0, 0]),
+            maxLevelCell=('nCells', [0, 0]),
+            bottomDepth=('nCells', [100.0, 200.0]),
+            vertCoordMovementWeights=('nVertLevels', [1.0]),
+        )
+    )
+
+    filename = tmp_path / 'initial_state.nc'
+    component.write_initial_state_dataset(ds, str(filename), config)
+
+    ds_out = xr.open_dataset(filename)
+    assert 'Temperature' in ds_out
+    assert 'MinLayerCell' not in ds_out
+    assert 'MaxLayerCell' not in ds_out
+    assert 'BottomGeomDepth' not in ds_out
+    assert 'VertCoordMovementWeights' not in ds_out
+
+
+def test_write_initial_state_dataset_mpas_ocean_keeps_vert_coord_vars(
+    tmp_path,
+):
+    component = Ocean()
+    component.model = 'mpas-ocean'
+    component._read_var_map()
+
+    config = MagicMock()
+
+    ds = xr.Dataset(
+        data_vars=dict(
+            temperature=(('nCells', 'nVertLevels'), [[3.0], [4.0]]),
+            salinity=(('nCells', 'nVertLevels'), [[35.0], [35.0]]),
+            minLevelCell=('nCells', [0, 0]),
+            maxLevelCell=('nCells', [0, 0]),
+            bottomDepth=('nCells', [100.0, 200.0]),
+            vertCoordMovementWeights=('nVertLevels', [1.0]),
+        )
+    )
+
+    filename = tmp_path / 'initial_state.nc'
+    component.write_initial_state_dataset(ds, str(filename), config)
+
+    ds_out = xr.open_dataset(filename)
+    assert 'temperature' in ds_out
+    assert 'minLevelCell' in ds_out
+    assert 'maxLevelCell' in ds_out
+    assert 'bottomDepth' in ds_out
+    assert 'vertCoordMovementWeights' in ds_out
+
+
+def test_write_vert_coord_dataset_noop_for_mpas_ocean(tmp_path):
+    component = Ocean()
+    component.model = 'mpas-ocean'
+    component._read_var_map()
+
+    config = MagicMock()
+
+    ds = xr.Dataset(
+        data_vars=dict(
+            bottomDepth=('nCells', [100.0, 200.0]),
+        )
+    )
+
+    filename = tmp_path / 'vert_coord.nc'
+    component.write_vert_coord_dataset(ds, str(filename), config)
+
+    assert not filename.exists()
+
+
+def test_process_inputs_and_outputs_resolves_model_input_filenames(
+    monkeypatch,
+):
+    component = Ocean()
+    component.model = 'omega'
+    step = OceanModelStep(
+        component=component,
+        name='forward',
+        ntasks=1,
+        min_tasks=1,
+    )
+
+    step.config = _make_config(
+        horiz_mesh_filename='custom_mesh.nc',
+        vert_coord_filename='custom_vc.nc',
+        init_filename='custom_init.nc',
+    )
+
+    step.add_horiz_mesh_input_file(work_dir_target='mesh_target.nc')
+    step.add_vert_coord_input_file(work_dir_target='vc_target.nc')
+    step.add_init_input_file(work_dir_target='init_target.nc')
+
+    monkeypatch.setattr(
+        ModelStep, 'process_inputs_and_outputs', lambda _: None
+    )
+
+    step.process_inputs_and_outputs()
+
+    input_data = {
+        entry['work_dir_target']: entry['filename']
+        for entry in step.input_data
+        if entry.get('work_dir_target') is not None
+    }
+    assert input_data['mesh_target.nc'] == 'custom_mesh.nc'
+    assert input_data['vc_target.nc'] == 'custom_vc.nc'
+    assert input_data['init_target.nc'] == 'custom_init.nc'
+
+
+def test_vert_coord_placeholder_skipped_for_mpas_ocean(monkeypatch):
+    component = Ocean()
+    component.model = 'mpas-ocean'
+    step = OceanModelStep(
+        component=component,
+        name='forward',
+        ntasks=1,
+        min_tasks=1,
+    )
+
+    step.config = _make_config()
+    step.add_vert_coord_input_file(work_dir_target='vc_target.nc')
+
+    monkeypatch.setattr(
+        ModelStep, 'process_inputs_and_outputs', lambda _: None
+    )
+
+    step.process_inputs_and_outputs()
+
+    filenames = [entry['filename'] for entry in step.input_data]
+    assert 'vert_coord.nc' not in filenames
+    assert '<<<vert_coord>>>' not in filenames
+
+
+def test_dynamic_model_config_uses_model_input_filename_replacements():
+    component = Ocean()
+    step = OceanModelStep(
+        component=component,
+        name='forward',
+        ntasks=1,
+        min_tasks=1,
+    )
+
+    step.config = _make_config(
+        horiz_mesh_filename='custom_mesh.nc',
+        vert_coord_filename='custom_vc.nc',
+        init_filename='custom_init.nc',
+    )
+
+    step.dynamic_model_config(at_setup=True)
+
+    entry = step.model_config_data[0]
+    yaml = PolarisYaml.read(
+        filename=entry['yaml'],
+        package=entry['package'],
+        replacements=entry['replacements'],
+        model='Omega',
+        streams_section='IOStreams',
+    )
+    assert yaml.streams['HorzMeshIn']['Filename'] == 'custom_mesh.nc'
+    assert yaml.streams['InitialVertCoord']['Filename'] == 'custom_vc.nc'
+    assert yaml.streams['InitialState']['Filename'] == 'custom_init.nc'
+
+
+@pytest.mark.parametrize(
+    'module_name',
+    [
+        'polaris.tasks.ocean.baroclinic_channel.init',
+        'polaris.tasks.ocean.barotropic_channel.init',
+        'polaris.tasks.ocean.geostrophic.init',
+        'polaris.tasks.ocean.ice_shelf_2d.init',
+        'polaris.tasks.ocean.inertial_gravity_wave.init',
+        'polaris.tasks.ocean.internal_wave.init',
+        'polaris.tasks.ocean.single_column.init',
+    ],
+)
+def test_init_steps_with_ocean_model_io_descend_from_ocean_io_step(
+    module_name,
+):
+    module = importlib.import_module(module_name)
+    assert issubclass(module.Init, OceanIOStep)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

## Summary

This PR refactors Polaris ocean tasks to stage the horizontal mesh and initial-state files separately, rather than relying on a single combined input file. It also makes the runtime horizontal mesh the canonical home for the Coriolis fields `fCell`, `fEdge`, and `fVertex`, which are required by both MPAS-Ocean and newer Omega workflows.

This work is needed to support the `HorzMeshIn` stream https://github.com/E3SM-Project/Omega/pull/382, where the horizontal mesh filename can be configured independently and must include the expected mesh-side Coriolis fields.

The Omega submodule update brings in:
* https://github.com/E3SM-Project/Omega/pull/382
* https://github.com/E3SM-Project/Omega/pull/421
* E3SM/master at [a3999e](https://github.com/E3SM-Project/E3SM/commit/a3999e3d2801a56ebd9bae6fa701372c066c6f1b)

## What Changed

- added framework support for staging separate mesh and init files in `OceanModelStep`
- added helpers for writing initial-state files without horizontal mesh variables
- expanded MPAS-Omega variable mapping for horizontal mesh and Coriolis fields
- added a shared Coriolis helper module for populating `fCell`, `fEdge`, and `fVertex` on mesh datasets
- updated affected task families so Coriolis fields are written to the runtime mesh file (`base_mesh.nc`, `culled_mesh.nc`, or `lts_mesh.nc`, depending on the task) instead of existing only on the in-memory initial-state dataset
- updated affected task families to link the correct mesh file explicitly instead of relying on `OmegaMesh.nc`
- promoted remaining relevant init steps to `OceanIOStep`
- added tests for filename replacement, split mesh/init behavior, and Coriolis mesh-field helpers
- updated the generated API docs, user guide, and developer guide

## Omega Motivation

With https://github.com/E3SM-Project/Omega/pull/382, Omega can now read the horizontal mesh from a configurable NetCDF file via `HorzMeshIn`. This PR updates Polaris so it can take advantage of that capability by:

- staging the horizontal mesh separately from the initial state
- mapping MPAS-Ocean horizontal mesh variable names to the corresponding Omega names
- ensuring the runtime mesh contains `fCell`, `fEdge`, and `fVertex`, which Omega expects as horizontal-mesh inputs
- removing old symlink workarounds that depended on the hard-coded `OmegaMesh.nc` filename

## Coriolis Motivation

Both MPAS-Ocean and Omega expect `fCell`, `fEdge`, and `fVertex` to be present on the horizontal mesh. In Polaris, tasks previously added these fields to the initial condition.  However, with the new approach of splitting the horizontal-mesh variables from the initial condition, they need to live in the horizontal mesh and not the initial condition.

This PR fixes that by moving these fields to the mesh file used in forward runs. The implementation preserves each task's existing Coriolis semantics, including:

- zero Coriolis cases
- constant `f`-plane cases
- `beta`-plane cases
- rotated-sphere Coriolis cases

## Notes

The refactor preserves each task's existing choice of mesh source (e.g. `base_mesh.nc` vs. `culled_mesh.nc` vs. `lts_mesh.nc`), so periodic vs. non-periodic mesh selection remains task-specific and is not changed by this PR.

The Coriolis update also preserves each task's existing Coriolis definition; this PR changes where those fields are written, not the physics each task uses.

Omega still defaults `HorzMeshIn`, `InitialVertCoord`, and `InitialState` to `OmegaMesh.nc` in `Default.yml`, and several Omega tests/docs still assume that filename. Polaris now overrides the filenames explicitly, but broader Omega testing (especially CTests) may still benefit from exercising truly separate mesh and init files. It probably makes sense to make this split when we rename `LayerThickness` to `PseudoThickness`, since new meshes and initial conditions will be needed in any case.

## Validation

- added and ran targeted mesh/init split tests
- added and ran targeted tests for the Coriolis helper functions
- ran `pre-commit` on the changed files

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
