### PR TITLE
Set parallel system for all components

### DIFF
--- a/polaris/parallel.py
+++ b/polaris/parallel.py
@@ -1,0 +1,86 @@
+from polaris.config import PolarisConfigParser
+
+
+def set_parallel_systems(tasks, config: PolarisConfigParser):
+    """
+    Set the active parallel system on every component referenced by the task
+    and step graph.
+
+    Parameters
+    ----------
+    tasks : dict of polaris.Task
+        Tasks to scan for referenced components
+
+    config : polaris.config.PolarisConfigParser
+        The config to use in constructing the parallel systems
+    """
+    seen_components: set[int] = set()
+    seen_steps: set[int] = set()
+
+    for task in tasks.values():
+        _set_parallel_system_for_component(
+            task.component, config, seen_components
+        )
+        for step in task.steps.values():
+            _set_parallel_systems_for_step(
+                step, config, seen_components, seen_steps
+            )
+
+
+def _set_parallel_systems_for_step(
+    step, config: PolarisConfigParser, seen_components, seen_steps
+):
+    """
+    Set the active parallel system on a step's component and recursively on
+    the components of any step dependencies.
+
+    Parameters
+    ----------
+    step : polaris.Step
+        The step to scan
+
+    config : polaris.config.PolarisConfigParser
+        The config to use in constructing the parallel systems
+
+    seen_components : set of int
+        The ids of components that have already been initialized
+
+    seen_steps : set of int
+        The ids of steps that have already been visited
+    """
+    step_id = id(step)
+    if step_id in seen_steps:
+        return
+    seen_steps.add(step_id)
+
+    _set_parallel_system_for_component(step.component, config, seen_components)
+
+    for dependency in step.dependencies.values():
+        _set_parallel_systems_for_step(
+            dependency, config, seen_components, seen_steps
+        )
+
+
+def _set_parallel_system_for_component(
+    component, config: PolarisConfigParser, seen_components
+):
+    """
+    Set the active parallel system for a component once.
+
+    Parameters
+    ----------
+    component : polaris.Component
+        The component to initialize
+
+    config : polaris.config.PolarisConfigParser
+        The config to use in constructing the parallel system
+
+    seen_components : set of int
+        The ids of components that have already been initialized
+    """
+    component_id = id(component)
+    if component_id in seen_components:
+        return
+
+    seen_components.add(component_id)
+    component.set_parallel_system(config)

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -13,6 +13,7 @@ from mpas_tools.logging import LoggingContext, check_call
 from polaris import Task
 from polaris.build.omega import detect_omega_build_type
 from polaris.logging import log_function_call, log_method_call
+from polaris.parallel import set_parallel_systems
 from polaris.run import (
     complete_step_run,
     load_dependencies,
@@ -69,7 +70,7 @@ def run_tasks(
     task = next(iter(suite['tasks'].values()))
     component = task.component
     common_config = setup_config(task.base_work_dir, f'{component.name}.cfg')
-    component.set_parallel_system(common_config)
+    set_parallel_systems(suite['tasks'], common_config)
     available_resources = component.get_available_resources()
 
     # start logging to stdout/stderr
@@ -175,7 +176,7 @@ def run_single_step(step_is_subprocess=False, quiet=False):
 
     config = setup_config(step.base_work_dir, step.config.filepath)
     task.config = config
-    step.component.set_parallel_system(config)
+    set_parallel_systems({task.path: task}, config)
     available_resources = step.component.get_available_resources()
 
     mpas_tools.io.default_format = config.get('io', 'format')
@@ -374,8 +375,6 @@ def _log_and_run_task(
 
         config = setup_config(task.base_work_dir, task.config.filepath)
         task.config = config
-        task.component.set_parallel_system(config)
-        available_resources = task.component.get_available_resources()
 
         mpas_tools.io.default_format = config.get('io', 'format')
         mpas_tools.io.default_engine = config.get('io', 'engine')

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -14,6 +14,7 @@ from polaris.constants.pcd import check_pcd_version_matches_branch
 from polaris.io import symlink
 from polaris.job import write_job_script
 from polaris.machines import discover_machine
+from polaris.parallel import set_parallel_systems
 from polaris.tasks import get_components
 
 
@@ -157,7 +158,7 @@ def setup_tasks(
     )
 
     component.configure(basic_config, list(tasks.values()))
-    component.set_parallel_system(basic_config)
+    set_parallel_systems(tasks, basic_config)
 
     provenance.write(
         work_dir,


### PR DESCRIPTION
This is necessary if shared steps belong to a different component than the one for the task they belong to, but they use a parallel command.

This has to happen at both setup and runtime

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
