### PR TITLE
Update submodule and tests with constant EOS type

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -595,6 +595,7 @@
    compute_density
    compute_specvol
 
+   constant.compute_constant_density
    linear.compute_linear_density
    teos10.compute_specvol
 ```

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -224,12 +224,15 @@ The high-level APIs are {py:func}`polaris.ocean.eos.compute_density()` and
 {py:func}`polaris.ocean.eos.compute_specvol()`.  These functions dispatch
 based on `eos_type` in the `[ocean]` config section.
 
+- `eos_type = constant` uses the linear EOS and calls
+  {py:func}`polaris.ocean.eos.constant.compute_constant_density()`.
 - `eos_type = linear` uses the linear EOS and calls
   {py:func}`polaris.ocean.eos.linear.compute_linear_density()`.
 - `eos_type = teos-10` uses TEOS-10 and calls
   {py:func}`polaris.ocean.eos.teos10.compute_specvol()`, with density computed
   as the inverse of specific volume.
 
+The constant EOS density is set by the config option `eos_constant_rhoref`.
 The linear EOS coefficients and reference values are set with ocean config
 options such as `eos_linear_alpha`, `eos_linear_beta`, `eos_linear_rhoref`,
 `eos_linear_Tref`, and `eos_linear_Sref`.  TEOS-10 requires pressure to be

--- a/docs/users_guide/ocean/tasks/barotropic_gyre.md
+++ b/docs/users_guide/ocean/tasks/barotropic_gyre.md
@@ -79,8 +79,7 @@ min_pc_fraction = 0.1
 
 ## initial conditions
 
-The initial condition is at rest. Since the test case is barotropic, only a
-reference density is provided with the config option `rho_0`. A beta-plane
+The initial condition is at rest. A beta-plane
 is indicated by the coriolis parameter and determined by the config options
 `f_0` and `beta`.
 
@@ -122,9 +121,6 @@ tau_0 = 0.1
 
 # Horizontal gradient in coriolis parameter [s-1 m-1]
 beta = 1.0e-10
-
-# homogenous fluid density [kg m-3]
-rho_0 = 1000
 
 # Duration of forward step if run_time_steps not given [years]
 run_duration = 2.

--- a/polaris/ocean/convergence/forward.py
+++ b/polaris/ocean/convergence/forward.py
@@ -33,6 +33,7 @@ class ConvergenceForward(OceanModelStep):
         mesh,
         init,
         package,
+        update_eos=False,
         yaml_filename='forward.yaml',
         mesh_input_filename='mesh.nc',
         options=None,
@@ -94,6 +95,7 @@ class ConvergenceForward(OceanModelStep):
             component=component,
             name=name,
             subdir=subdir,
+            update_eos=update_eos,
             openmp_threads=1,
             graph_target=graph_target,
         )

--- a/polaris/ocean/eos/__init__.py
+++ b/polaris/ocean/eos/__init__.py
@@ -9,10 +9,10 @@ from .teos10 import compute_specvol as compute_teos10_specvol
 
 def compute_density(
     config: PolarisConfigParser,
-    temperature: xr.DataArray,
-    salinity: xr.DataArray,
-    pressure: xr.DataArray | None = None,
-) -> xr.DataArray:
+    temperature: xr.DataArray | float,
+    salinity: xr.DataArray | float,
+    pressure: xr.DataArray | float | None = None,
+) -> xr.DataArray | float:
     """
     Compute the density of seawater based on the equation of state specified
     in the configuration.
@@ -52,17 +52,18 @@ def compute_density(
         )
     else:
         raise ValueError(f'Unsupported equation of state type: {eos_type}')
-    density.attrs['units'] = 'kg m-3'
-    density.attrs['long_name'] = 'density'
+    if isinstance(density, xr.DataArray):
+        density.attrs['units'] = 'kg m-3'
+        density.attrs['long_name'] = 'density'
     return density
 
 
 def compute_specvol(
     config: PolarisConfigParser,
-    temperature: xr.DataArray,
-    salinity: xr.DataArray,
-    pressure: xr.DataArray | None = None,
-) -> xr.DataArray:
+    temperature: xr.DataArray | float,
+    salinity: xr.DataArray | float,
+    pressure: xr.DataArray | float | None = None,
+) -> xr.DataArray | float:
     """
     Compute the specific volume of seawater based on the equation of state
     specified in the configuration.
@@ -100,6 +101,7 @@ def compute_specvol(
         )
     else:
         raise ValueError(f'Unsupported equation of state type: {eos_type}')
-    specvol.attrs['units'] = 'm3 kg-1'
-    specvol.attrs['long_name'] = 'specific volume'
+    if isinstance(specvol, xr.DataArray):
+        specvol.attrs['units'] = 'm3 kg-1'
+        specvol.attrs['long_name'] = 'specific volume'
     return specvol

--- a/polaris/ocean/eos/__init__.py
+++ b/polaris/ocean/eos/__init__.py
@@ -2,6 +2,7 @@ import xarray as xr
 
 from polaris.config import PolarisConfigParser
 
+from .constant import compute_constant_density
 from .linear import compute_linear_density
 from .teos10 import compute_specvol as compute_teos10_specvol
 
@@ -36,7 +37,9 @@ def compute_density(
         Computed density (in-situ or reference) of the seawater.
     """
     eos_type = config.get('ocean', 'eos_type')
-    if eos_type == 'linear':
+    if eos_type == 'constant':
+        density = compute_constant_density(config, temperature)
+    elif eos_type == 'linear':
         density = compute_linear_density(config, temperature, salinity)
     elif eos_type == 'teos-10':
         if pressure is None:

--- a/polaris/ocean/eos/constant.cfg
+++ b/polaris/ocean/eos/constant.cfg
@@ -1,0 +1,22 @@
+[ocean]
+
+# Equation of state type, defaults to mpas-ocean default
+eos_type = constant
+
+# Equation of state constant term, defaults to PCD seawater_density_reference
+eos_constant_rhoref = {{ eos_constant_rhoref }}
+
+# Equation of state -drho/dT, defaults to mpas-ocean default
+eos_linear_alpha = 0.
+
+# Equation of state drho/dS, defaults to mpas-ocean default
+eos_linear_beta = 0.
+
+# Equation of state constant term, designed to match mpas-ocean's default reference density
+eos_linear_rhoref = ${ocean:eos_constant_rhoref}
+
+# Equation of state reference temperature, defaults to omega default
+eos_linear_Tref = 0.
+
+# Equation of state reference salinity, defaults to omega default
+eos_linear_Sref = 0.

--- a/polaris/ocean/eos/constant.py
+++ b/polaris/ocean/eos/constant.py
@@ -6,7 +6,7 @@ from polaris.config import PolarisConfigParser
 def compute_constant_density(
     config: PolarisConfigParser,
     temperature: xr.DataArray,
-) -> xr.DataArray:
+) -> xr.DataArray or float:
     """
     Compute the density of seawater based on the constant equation of state
     with the value specified in the configuration.

--- a/polaris/ocean/eos/constant.py
+++ b/polaris/ocean/eos/constant.py
@@ -1,0 +1,40 @@
+import xarray as xr
+
+from polaris.config import PolarisConfigParser
+
+
+def compute_constant_density(
+    config: PolarisConfigParser,
+    temperature: xr.DataArray,
+    salinity: xr.DataArray,
+) -> xr.DataArray:
+    """
+    Compute the density of seawater based on the constant equation of state
+    with the value specified in the configuration.
+
+    Parameters
+    ----------
+    config : polaris.config.PolarisConfigParser
+        Configuration object containing ocean parameters.
+
+    temperature : float or xarray.DataArray
+        Temperature of the seawater.
+
+    salinity : float or xarray.DataArray
+        Salinity of the seawater.
+
+    Returns
+    -------
+    density : float or xarray.DataArray
+        Computed density of the seawater.
+    """
+    section = config['ocean']
+    rhoref = section.getfloat('eos_rhoref')
+    assert rhoref is not None, (
+        'eos_rho_ref must be specified in the config options for eos type '
+        'constant.'
+    )
+    # Return density of same type and size as temperature
+    # (needs to work for both float and xarray DataArray)
+    density = rhoref * (temperature / temperature)
+    return density

--- a/polaris/ocean/eos/constant.py
+++ b/polaris/ocean/eos/constant.py
@@ -6,7 +6,6 @@ from polaris.config import PolarisConfigParser
 def compute_constant_density(
     config: PolarisConfigParser,
     temperature: xr.DataArray,
-    salinity: xr.DataArray,
 ) -> xr.DataArray:
     """
     Compute the density of seawater based on the constant equation of state
@@ -18,10 +17,7 @@ def compute_constant_density(
         Configuration object containing ocean parameters.
 
     temperature : float or xarray.DataArray
-        Temperature of the seawater.
-
-    salinity : float or xarray.DataArray
-        Salinity of the seawater.
+        Temperature of the seawater used to set density type and size.
 
     Returns
     -------

--- a/polaris/ocean/eos/constant.py
+++ b/polaris/ocean/eos/constant.py
@@ -32,5 +32,8 @@ def compute_constant_density(
     )
     # Return density of same type and size as temperature
     # (needs to work for both float and xarray DataArray)
-    density = rhoref * (temperature / temperature)
+    if isinstance(temperature, xr.DataArray):
+        density = rhoref * xr.ones_like(temperature)
+    else:
+        density = rhoref
     return density

--- a/polaris/ocean/eos/constant.py
+++ b/polaris/ocean/eos/constant.py
@@ -5,8 +5,8 @@ from polaris.config import PolarisConfigParser
 
 def compute_constant_density(
     config: PolarisConfigParser,
-    temperature: xr.DataArray,
-) -> xr.DataArray or float:
+    temperature: xr.DataArray | float,
+) -> xr.DataArray | float:
     """
     Compute the density of seawater based on the constant equation of state
     with the value specified in the configuration.

--- a/polaris/ocean/eos/linear.cfg
+++ b/polaris/ocean/eos/linear.cfg
@@ -1,0 +1,23 @@
+[ocean]
+
+# Equation of state type, defaults to mpas-ocean default
+eos_type = linear
+
+# Equation of state constant term, defaults to PCD seawater_density_reference
+eos_constant_rhoref = {{ eos_constant_rhoref }}
+
+# Equation of state -drho/dT, defaults to mpas-ocean default
+eos_linear_alpha = 0.2
+
+# Equation of state drho/dS, defaults to mpas-ocean default
+eos_linear_beta = 0.8
+
+# Equation of state constant term, designed to match mpas-ocean's default linear EOS
+# 1000.0 + 0.2 * 5.0 - 0.8 * 35 = 973.0
+eos_linear_rhoref = 973.0
+
+# Equation of state reference temperature, defaults to omega default
+eos_linear_Tref = 0.
+
+# Equation of state reference salinity, defaults to omega default
+eos_linear_Sref = 0.

--- a/polaris/ocean/eos/linear.py
+++ b/polaris/ocean/eos/linear.py
@@ -5,9 +5,9 @@ from polaris.config import PolarisConfigParser
 
 def compute_linear_density(
     config: PolarisConfigParser,
-    temperature: xr.DataArray,
-    salinity: xr.DataArray,
-) -> xr.DataArray:
+    temperature: xr.DataArray | float,
+    salinity: xr.DataArray | float,
+) -> xr.DataArray | float:
     """
     Compute the density of seawater based on the the linear equation of state
     with coefficients specified in the configuration. The distinction between

--- a/polaris/ocean/eos/teos10.py
+++ b/polaris/ocean/eos/teos10.py
@@ -3,55 +3,118 @@ import xarray as xr
 
 
 def compute_specvol(
-    sa: xr.DataArray, ct: xr.DataArray, p: xr.DataArray
-) -> xr.DataArray:
+    sa: xr.DataArray | float,
+    ct: xr.DataArray | float,
+    p: xr.DataArray | float,
+) -> xr.DataArray | float:
     """
     Compute specific volume from co-located p, CT and SA.
 
     Notes
     -----
-    - This function converts inputs to NumPy arrays and calls
-        ``gsw.specvol`` directly for performance. Inputs must fit in
-        memory.
+    - For xarray inputs, this function converts inputs to NumPy arrays
+        and calls ``gsw.specvol`` directly for performance. Inputs must
+        fit in memory.
 
     - Any parallelization should be handled by the caller (e.g., splitting
         over outer dimensions and calling this function per chunk).
 
     Parameters
     ----------
-    sa : xarray.DataArray
+    sa : float or xarray.DataArray
         Absolute Salinity at the same points as p and ct.
 
-    ct : xarray.DataArray
+    ct : float or xarray.DataArray
         Conservative Temperature at the same points as p and sa.
 
-    p : xarray.DataArray
+    p : float or xarray.DataArray
         Sea pressure in Pascals (Pa) at the same points as ct and sa.
 
     Returns
     -------
-    xarray.DataArray
-        Specific volume with the same dims/coords as ct and sa (m^3/kg).
+    float or xarray.DataArray
+        Specific volume with the same dims/coords as the input arrays
+        (m^3/kg), or a scalar if all inputs are scalar.
     """
 
-    # Check sizes/dims match exactly
-    if not (p.sizes == ct.sizes == sa.sizes):
-        raise ValueError(
-            'p, ct and sa must have identical dimensions and sizes; '
-            f'got p={p.sizes}, ct={ct.sizes}, sa={sa.sizes}'
-        )
+    if not any(isinstance(value, xr.DataArray) for value in (p, ct, sa)):
+        p_dbar = p / 1.0e4
+        specvol = gsw.specvol(sa, ct, p_dbar)
+        return float(specvol)
 
-    # Ensure coordinates align identically (names and labels)
-    p, ct, sa = xr.align(p, ct, sa, join='exact')
+    p, ct, sa = _align_data_arrays(p=p, ct=ct, sa=sa)
+    template = _get_template_data_array(p=p, ct=ct, sa=sa)
 
     # Convert to NumPy and call gsw directly for performance
-    p_dbar = (p / 1.0e4).to_numpy()
-    ct_np = ct.to_numpy()
-    sa_np = sa.to_numpy()
+    p_dbar = _to_numpy(p) / 1.0e4
+    ct_np = _to_numpy(ct)
+    sa_np = _to_numpy(sa)
     specvol_np = gsw.specvol(sa_np, ct_np, p_dbar)
 
     specvol = xr.DataArray(
-        specvol_np, dims=ct.dims, coords=ct.coords, name='specvol'
+        specvol_np,
+        dims=template.dims,
+        coords=template.coords,
+        name='specvol',
     )
 
     return specvol
+
+
+def _align_data_arrays(
+    p: xr.DataArray | float,
+    ct: xr.DataArray | float,
+    sa: xr.DataArray | float,
+) -> tuple[xr.DataArray | float, xr.DataArray | float, xr.DataArray | float]:
+    data_arrays = [
+        value for value in (p, ct, sa) if isinstance(value, xr.DataArray)
+    ]
+
+    if len(data_arrays) <= 1:
+        return p, ct, sa
+
+    dims = [data_array.dims for data_array in data_arrays]
+    sizes = [data_array.sizes for data_array in data_arrays]
+    if any(dim != dims[0] for dim in dims) or any(
+        size != sizes[0] for size in sizes
+    ):
+        raise ValueError(
+            'DataArray inputs must have identical dimensions and sizes; '
+            f'got p={_sizes_str(p)}, ct={_sizes_str(ct)}, sa={_sizes_str(sa)}'
+        )
+
+    aligned = iter(xr.align(*data_arrays, join='exact'))
+    if isinstance(p, xr.DataArray):
+        p = next(aligned)
+    if isinstance(ct, xr.DataArray):
+        ct = next(aligned)
+    if isinstance(sa, xr.DataArray):
+        sa = next(aligned)
+
+    return p, ct, sa
+
+
+def _get_template_data_array(
+    p: xr.DataArray | float,
+    ct: xr.DataArray | float,
+    sa: xr.DataArray | float,
+) -> xr.DataArray:
+    for value in (ct, sa, p):
+        if isinstance(value, xr.DataArray):
+            return value
+
+    raise ValueError('At least one input must be an xarray.DataArray.')
+
+
+def _to_numpy(value: xr.DataArray | float):
+    if isinstance(value, xr.DataArray):
+        return value.to_numpy()
+
+    return value
+
+
+def _sizes_str(value: xr.DataArray | float) -> str:
+    if isinstance(value, xr.DataArray):
+        return str(value.sizes)
+
+    return 'scalar'

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -395,9 +395,24 @@ class OceanModelStep(ModelStep):
             'config_eos_linear_alpha': eos_linear_alpha,
             'config_eos_linear_beta': eos_linear_beta,
             'config_eos_linear_densityref': eos_linear_rhoref,
-            'config_eos_linear_Tref': eos_linear_Tref,
-            'config_eos_linear_Sref': eos_linear_Sref,
         }
+        model = config.get('ocean', 'model')
+        if model == 'mpas-ocean':
+            if eos_type.lower() == 'constant':
+                eos_type = 'linear'
+            replacements.update(
+                {
+                    'config_eos_type': eos_type,
+                    'config_eos_linear_Tref': eos_linear_Tref,
+                    'config_eos_linear_Sref': eos_linear_Sref,
+                }
+            )
+        else:
+            if eos_linear_Tref != 0.0 or eos_linear_Sref != 0.0:
+                raise ValueError(
+                    'Nonzero Tref and Sref are not supported for Omega '
+                    'model since they do not affect the linear EOS'
+                )
 
         self.add_model_config_options(
             options=replacements, config_model='ocean'

--- a/polaris/ocean/ocean.cfg
+++ b/polaris/ocean/ocean.cfg
@@ -33,25 +33,6 @@ goal_cells_per_gpu = 8000
 # few GPUs are available)
 max_cells_per_gpu = 80000
 
-# Equation of state type, defaults to mpas-ocean default
-eos_type = linear
-
-# Equation of state -drho/dT, defaults to mpas-ocean default
-eos_linear_alpha = 0.2
-
-# Equation of state drho/dS, defaults to mpas-ocean default
-eos_linear_beta = 0.8
-
-# Equation of state constant term, designed to match mpas-ocean's default linear EOS
-# 1000.0 + 0.2 * 5.0 - 0.8 * 35 = 973.0
-eos_linear_rhoref = 973.0
-
-# Equation of state reference temperature, defaults to omega default
-eos_linear_Tref = 0.
-
-# Equation of state reference salinity, defaults to omega default
-eos_linear_Sref = 0.
-
 # Options relate to adjusting the sea-surface height or land-ice pressure
 # below ice shelves to they are dynamically consistent with one another
 [ssh_adjustment]

--- a/polaris/tasks/ocean/barotropic_channel/__init__.py
+++ b/polaris/tasks/ocean/barotropic_channel/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 from polaris.config import PolarisConfigParser as PolarisConfigParser
+from polaris.constants import get_constant
 from polaris.tasks.ocean.barotropic_channel.default import Default as Default
 
 
@@ -18,8 +19,17 @@ def add_barotropic_channel_tasks(component):
         component.name, 'planar', group_name, config_filename
     )
     config = PolarisConfigParser(filepath=filepath)
+    config.add_from_package('polaris.ocean.eos', 'constant.cfg')
     config.add_from_package(
         f'polaris.tasks.ocean.{group_name}', config_filename
+    )
+    # Set rhoref to the PCD value only at setup so that if the
+    # user wants to run with a different value by changing the cfg
+    # before runtime, they can
+    config.set(
+        'ocean',
+        'eos_constant_rhoref',
+        value=f'{get_constant("seawater_density_reference"):02g}',
     )
     default = Default(component=component)
     default.set_shared_config(config, link=config_filename)

--- a/polaris/tasks/ocean/barotropic_channel/forward.py
+++ b/polaris/tasks/ocean/barotropic_channel/forward.py
@@ -69,6 +69,7 @@ class Forward(OceanModelStep):
             indir=indir,
             ntasks=ntasks,
             min_tasks=min_tasks,
+            update_eos=True,
             openmp_threads=openmp_threads,
             graph_target=graph_target,
         )

--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -141,6 +141,7 @@ Omega:
       Contents:
       - AuxiliaryState
       - State
+      - Eos
       - SshCell
       FileFreq: 9999
       FileFreqUnits: years

--- a/polaris/tasks/ocean/barotropic_gyre/__init__.py
+++ b/polaris/tasks/ocean/barotropic_gyre/__init__.py
@@ -7,6 +7,7 @@ from polaris import (
     Task as Task,
 )
 from polaris.config import PolarisConfigParser as PolarisConfigParser
+from polaris.constants import get_constant
 from polaris.tasks.ocean.barotropic_gyre.analysis import Analysis as Analysis
 from polaris.tasks.ocean.barotropic_gyre.forward import Forward as Forward
 from polaris.tasks.ocean.barotropic_gyre.init import Init as Init
@@ -29,6 +30,14 @@ def add_barotropic_gyre_tasks(component):
     )
     config.add_from_package(
         f'polaris.tasks.ocean.{group_name}', config_filename
+    )
+    # Set rhoref to the PCD value only at setup so that if the
+    # user wants to run with a different value by changing the cfg
+    # before runtime, they can
+    config.set(
+        'ocean',
+        'eos_constant_rhoref',
+        value=f'{get_constant('seawater_density_reference'):02g}'
     )
 
     for boundary_condition in ['free-slip', 'no-slip']:

--- a/polaris/tasks/ocean/barotropic_gyre/__init__.py
+++ b/polaris/tasks/ocean/barotropic_gyre/__init__.py
@@ -25,9 +25,7 @@ def add_barotropic_gyre_tasks(component):
     config_filename = f'{group_name}.cfg'
     config_filepath = os.path.join(component.name, group_dir, config_filename)
     config = PolarisConfigParser(filepath=config_filepath)
-    config.add_from_package(
-        f'polaris.ocean.eos', 'constant.cfg'
-    )
+    config.add_from_package('polaris.ocean.eos', 'constant.cfg')
     config.add_from_package(
         f'polaris.tasks.ocean.{group_name}', config_filename
     )
@@ -37,7 +35,7 @@ def add_barotropic_gyre_tasks(component):
     config.set(
         'ocean',
         'eos_constant_rhoref',
-        value=f'{get_constant('seawater_density_reference'):02g}'
+        value=f'{get_constant("seawater_density_reference"):02g}',
     )
 
     for boundary_condition in ['free-slip', 'no-slip']:

--- a/polaris/tasks/ocean/barotropic_gyre/__init__.py
+++ b/polaris/tasks/ocean/barotropic_gyre/__init__.py
@@ -25,6 +25,9 @@ def add_barotropic_gyre_tasks(component):
     config_filepath = os.path.join(component.name, group_dir, config_filename)
     config = PolarisConfigParser(filepath=config_filepath)
     config.add_from_package(
+        f'polaris.ocean.eos', 'constant.cfg'
+    )
+    config.add_from_package(
         f'polaris.tasks.ocean.{group_name}', config_filename
     )
 

--- a/polaris/tasks/ocean/barotropic_gyre/barotropic_gyre.cfg
+++ b/polaris/tasks/ocean/barotropic_gyre/barotropic_gyre.cfg
@@ -18,9 +18,6 @@ tau_0 = 0.1
 # Horizontal gradient in coriolis parameter [s-1 m-1]
 beta = 1.0e-10
 
-# homogenous fluid density [kg m-3]
-rho_0 = 1000
-
 # Duration of forward step if run_time_steps not given [years]
 run_duration = 2.
 

--- a/polaris/tasks/ocean/barotropic_gyre/forward.py
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.py
@@ -162,7 +162,6 @@ class Forward(OceanModelStep):
             )
         else:
             nu = 0.0
-        rho_0 = config.getfloat('barotropic_gyre', 'rho_0')
         # beta = df/dy where f is coriolis parameter
         beta = config.getfloat('barotropic_gyre', 'beta')
 
@@ -205,12 +204,6 @@ class Forward(OceanModelStep):
                 f'maximum value is {nu_max} or decrease the time step'
             )
 
-        model = config.get('ocean', 'model')
-        options = {'config_dt': dt_str, 'config_density0': rho_0}
-        self.add_model_config_options(
-            options=options, config_model='mpas-ocean'
-        )
-
         if self.run_time_steps is not None:
             output_interval_units = 'Seconds'
             run_duration = ceil(self.run_time_steps * dt)
@@ -239,10 +232,12 @@ class Forward(OceanModelStep):
 
         # slip_factor_dict = {'no-slip': 0.0, 'free-slip': 1.0}  # noqa: E501 Uncomment this when free-slip BCs are supported
         time_integrator = config.get('barotropic_gyre', 'time_integrator')
-        time_integrator_map = dict([('RK4', 'RungeKutta4')])
+        if time_integrator.lower() == 'rk4':
+            dt_str = dt_btr_str
+        time_integrator_map = dict([('rk4', 'RungeKutta4')])
         if model == 'omega':
-            if time_integrator in time_integrator_map.keys():
-                time_integrator = time_integrator_map[time_integrator]
+            if time_integrator.lower() in time_integrator_map.keys():
+                time_integrator = time_integrator_map[time_integrator.lower()]
             else:
                 print(
                     'Warning: mapping from time integrator '

--- a/polaris/tasks/ocean/barotropic_gyre/forward.py
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.py
@@ -92,6 +92,7 @@ class Forward(OceanModelStep):
             indir=indir,
             ntasks=ntasks,
             min_tasks=min_tasks,
+            update_eos=True,
             openmp_threads=openmp_threads,
             graph_target=graph_target,
         )

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -89,6 +89,7 @@ Omega:
       Contents:
       - AuxiliaryState
       - State
+      - Eos
       - SshCell
       FileFreq: 9999
       FileFreqUnits: years

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -18,10 +18,14 @@ ocean:
 mpas-ocean:
   run_modes:
     config_ocean_run_mode: forward
+  io:
+    config_write_output_on_startup: false
   decomposition:
     config_block_decomp_file_prefix: graph.info.part.
   advection:
     config_thickness_flux_type: constant
+  split_explicit_ts:
+    config_btr_dt: {{ dt_btr }}
 #  lateral_walls:  # Uncomment this section when free-slip BC are supported
 #    config_wall_slip_factor: {{ slip_factor }}
   debug:

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -92,3 +92,15 @@ Omega:
       - SshCell
       FileFreq: 9999
       FileFreqUnits: years
+    RestartWrite:
+      UsePointerFile: true
+      PointerFilename: ocn.pointer
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Mode: write
+      IfExists: replace
+      Precision: double
+      Freq: 3
+      FreqUnits: months
+      UseStartEnd: false
+      Contents:
+        - Restart

--- a/polaris/tasks/ocean/barotropic_gyre/init.py
+++ b/polaris/tasks/ocean/barotropic_gyre/init.py
@@ -109,6 +109,8 @@ class Init(OceanIOStep):
 
         # use polaris framework functions to initialize the vertical coordinate
         init_vertical_coord(config, ds)
+        ds['temperature'] = 20.0 * xr.ones_like(ds.zMid)
+        ds['salinity'] = 35.0 * xr.ones_like(ds.zMid)
 
         # set the coriolis values
         for loc in ['Cell', 'Edge', 'Vertex']:

--- a/polaris/tasks/ocean/cosine_bell/__init__.py
+++ b/polaris/tasks/ocean/cosine_bell/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict as Dict
 
 from polaris import Step, Task
 from polaris.config import PolarisConfigParser as PolarisConfigParser
+from polaris.constants import get_constant
 from polaris.mesh.base import add_spherical_base_mesh_step
 from polaris.ocean.convergence import (
     get_resolution_for_task as get_resolution_for_task,
@@ -31,6 +32,7 @@ def add_cosine_bell_tasks(component):
             f'{component.name}/spherical/{prefix}/cosine_bell/cosine_bell.cfg'
         )
         config = PolarisConfigParser(filepath=filepath)
+        config.add_from_package('polaris.ocean.eos', 'constant.cfg')
         config.add_from_package('polaris.ocean.convergence', 'convergence.cfg')
         config.add_from_package(
             'polaris.ocean.convergence.spherical', 'spherical.cfg'
@@ -161,6 +163,14 @@ class CosineBell(Task):
         else:
             option = 'refinement_factors_space'
 
+        # Set rhoref to the PCD value only at setup so that if the
+        # user wants to run with a different value by changing the cfg
+        # before runtime, they can
+        config.set(
+            'ocean',
+            'eos_constant_rhoref',
+            value=f'{get_constant("seawater_density_reference"):02g}',
+        )
         _set_convergence_configs(config, prefix)
 
         refinement_factors = config.getlist('convergence', option, dtype=float)

--- a/polaris/tasks/ocean/cosine_bell/forward.py
+++ b/polaris/tasks/ocean/cosine_bell/forward.py
@@ -68,6 +68,7 @@ class Forward(SphericalConvergenceForward):
             output_filename='output.nc',
             validate_vars=validate_vars,
             check_properties=['mass conservation', 'tracer conservation'],
+            update_eos=True,
             graph_target=f'{mesh.path}/graph.info',
             refinement_factor=refinement_factor,
             refinement=refinement,

--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -100,3 +100,4 @@ Omega:
         - Tracers
         - LayerThickness
         - NormalVelocity
+        - Eos

--- a/polaris/tasks/ocean/geostrophic/__init__.py
+++ b/polaris/tasks/ocean/geostrophic/__init__.py
@@ -8,6 +8,7 @@ from polaris import (
     Task as Task,
 )
 from polaris.config import PolarisConfigParser as PolarisConfigParser
+from polaris.constants import get_constant
 from polaris.mesh.base import add_spherical_base_mesh_step
 from polaris.ocean.convergence import (
     get_resolution_for_task as get_resolution_for_task,
@@ -34,12 +35,21 @@ def add_geostrophic_tasks(component):
             f'{component.name}/spherical/{prefix}/geostrophic/geostrophic.cfg'
         )
         config = PolarisConfigParser(filepath=filepath)
+        config.add_from_package('polaris.ocean.eos', 'constant.cfg')
         config.add_from_package('polaris.ocean.convergence', 'convergence.cfg')
         config.add_from_package(
             'polaris.ocean.convergence.spherical', 'spherical.cfg'
         )
         config.add_from_package(
             'polaris.tasks.ocean.geostrophic', 'geostrophic.cfg'
+        )
+        # Set rhoref to the PCD value only at setup so that if the
+        # user wants to run with a different value by changing the cfg
+        # before runtime, they can
+        config.set(
+            'ocean',
+            'eos_constant_rhoref',
+            value=f'{get_constant("seawater_density_reference"):02g}',
         )
 
         for refinement in ['space', 'time', 'both']:

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -39,6 +39,8 @@ mpas-ocean:
       - ssh
 
 Omega:
+  Eos:
+    EosType: constant
   Tendencies:
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false
@@ -65,4 +67,5 @@ Omega:
       Contents:
       - NormalVelocity
       - LayerThickness
+      - Eos
       - SshCell

--- a/polaris/tasks/ocean/overflow/__init__.py
+++ b/polaris/tasks/ocean/overflow/__init__.py
@@ -19,6 +19,7 @@ def add_overflow_tasks(component):
     config = PolarisConfigParser(
         filepath=os.path.join(component.name, taskdir, config_filename)
     )
+    config.add_from_package('polaris.ocean.eos', 'linear.cfg')
     config.add_from_package('polaris.tasks.ocean.overflow', config_filename)
 
     init_step = Init(component=component, name='init', indir=taskdir)

--- a/polaris/tasks/ocean/sphere_transport/__init__.py
+++ b/polaris/tasks/ocean/sphere_transport/__init__.py
@@ -9,6 +9,7 @@ from polaris import (
     Task as Task,
 )
 from polaris.config import PolarisConfigParser as PolarisConfigParser
+from polaris.constants import get_constant
 from polaris.mesh.base import add_spherical_base_mesh_step
 from polaris.ocean.convergence import (
     get_resolution_for_task as get_resolution_for_task,
@@ -54,6 +55,7 @@ def add_sphere_transport_tasks(component):
                 f'{case_name}.cfg',
             )
             config = PolarisConfigParser(filepath=filepath)
+            config.add_from_package('polaris.ocean.eos', 'constant.cfg')
             config.add_from_package(
                 'polaris.ocean.convergence', 'convergence.cfg'
             )
@@ -63,6 +65,14 @@ def add_sphere_transport_tasks(component):
             package = 'polaris.tasks.ocean.sphere_transport'
             config.add_from_package(package, 'sphere_transport.cfg')
             config.add_from_package(package, f'{case_name}.cfg')
+            # Set rhoref to the PCD value only at setup so that if the
+            # user wants to run with a different value by changing the cfg
+            # before runtime, they can
+            config.set(
+                'ocean',
+                'eos_constant_rhoref',
+                value=f'{get_constant("seawater_density_reference"):02g}',
+            )
             for include_viz in [False, True]:
                 component.add_task(
                     SphereTransport(

--- a/polaris/tasks/ocean/sphere_transport/forward.py
+++ b/polaris/tasks/ocean/sphere_transport/forward.py
@@ -75,6 +75,7 @@ class Forward(SphericalConvergenceForward):
             validate_vars=validate_vars,
             check_properties=['mass conservation', 'tracer conservation'],
             options=namelist_options,
+            update_eos=True,
             graph_target=f'{base_mesh.path}/graph.info',
             refinement_factor=refinement_factor,
             refinement=refinement,

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -92,3 +92,4 @@ Omega:
         - Tracers
         - LayerThickness
         - NormalVelocity
+        - Eos


### PR DESCRIPTION
This PR adds the constant EOS type to the polaris framework, updates the Omega submodule so that the constant EOS type is available, and uses the constant EOS type for Omega-supported barotropic tests.

Checklist
* [N/A] User's Guide has been updated
* [X] Developer's Guide has been updated
* [X] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes
* [N/A] New tests have been added to a test suite
