### PR TITLE
Make provenance find pixi more reliably

### DIFF
--- a/polaris/provenance.py
+++ b/polaris/provenance.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 
@@ -48,11 +49,14 @@ def write(work_dir, tasks, config=None, machine=None, baseline_dir=None):
     else:
         component_git_version = _get_component_git_version(config)
 
-    try:
-        args = ['pixi', 'list']
-        pixi_list = subprocess.check_output(args).decode('utf-8')
-    except subprocess.CalledProcessError:
-        pixi_list = None
+    pixi_list = None
+    pixi_exe = _get_pixi_executable()
+    if pixi_exe is not None:
+        try:
+            args = [pixi_exe, 'list']
+            pixi_list = subprocess.check_output(args).decode('utf-8')
+        except (OSError, subprocess.CalledProcessError):
+            pass
 
     calling_command = ' '.join(sys.argv)
 
@@ -144,6 +148,35 @@ def _get_component_git_version(config):
     os.chdir(cwd)
 
     return component_git_version
+
+
+def _get_pixi_executable():
+    for env_var in (
+        'MACHE_DEPLOY_ACTIVE_PIXI_EXE',
+        'MACHE_DEPLOY_COMPUTE_PIXI_EXE',
+        'PIXI',
+    ):
+        pixi_exe = os.environ.get(env_var)
+        if _is_executable_file(pixi_exe):
+            return pixi_exe
+
+    pixi_exe = shutil.which('pixi')
+    if pixi_exe is not None:
+        return pixi_exe
+
+    default_pixi = os.path.join(
+        os.path.expanduser('~'), '.pixi', 'bin', 'pixi'
+    )
+    if _is_executable_file(default_pixi):
+        return default_pixi
+
+    return None
+
+
+def _is_executable_file(path):
+    return (
+        path is not None and os.path.isfile(path) and os.access(path, os.X_OK)
+    )
 
 
 def _get_system(config):

--- a/tests/test_omega_build_type.py
+++ b/tests/test_omega_build_type.py
@@ -34,6 +34,62 @@ def test_provenance_build_type_falls_back_to_config(tmp_path):
     assert provenance._get_build_type(config) == 'Debug'
 
 
+def test_provenance_write_uses_deploy_pixi_executable(tmp_path, monkeypatch):
+    pixi_exe = _make_executable(tmp_path / 'pixi')
+    monkeypatch.setenv('MACHE_DEPLOY_ACTIVE_PIXI_EXE', str(pixi_exe))
+    monkeypatch.setattr(provenance.sys, 'argv', ['polaris', 'suite'])
+
+    def _check_output(args):
+        if args == ['git', 'describe', '--tags', '--dirty', '--always']:
+            return b'test-version\n'
+        if args == [str(pixi_exe), 'list']:
+            return b'test-package\n'
+        raise AssertionError(f'unexpected command: {args}')
+
+    monkeypatch.setattr(provenance.subprocess, 'check_output', _check_output)
+
+    provenance.write(str(tmp_path / 'work'), tasks={})
+
+    contents = (tmp_path / 'work' / 'provenance').read_text(encoding='utf-8')
+    assert 'pixi list:\n' in contents
+    assert 'test-package\n' in contents
+
+
+def test_provenance_write_skips_pixi_list_when_pixi_missing(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv('MACHE_DEPLOY_ACTIVE_PIXI_EXE', raising=False)
+    monkeypatch.delenv('MACHE_DEPLOY_COMPUTE_PIXI_EXE', raising=False)
+    monkeypatch.delenv('PIXI', raising=False)
+    monkeypatch.setenv('PATH', '')
+    monkeypatch.setenv('HOME', str(tmp_path / 'home'))
+    monkeypatch.setattr(provenance.sys, 'argv', ['polaris', 'suite'])
+
+    def _check_output(args):
+        if args == ['git', 'describe', '--tags', '--dirty', '--always']:
+            return b'test-version\n'
+        raise AssertionError(f'unexpected command: {args}')
+
+    monkeypatch.setattr(provenance.subprocess, 'check_output', _check_output)
+
+    provenance.write(str(tmp_path / 'work'), tasks={})
+
+    contents = (tmp_path / 'work' / 'provenance').read_text(encoding='utf-8')
+    assert 'pixi list:\n' not in contents
+
+
+def test_get_pixi_executable_falls_back_to_home_default(tmp_path, monkeypatch):
+    monkeypatch.delenv('MACHE_DEPLOY_ACTIVE_PIXI_EXE', raising=False)
+    monkeypatch.delenv('MACHE_DEPLOY_COMPUTE_PIXI_EXE', raising=False)
+    monkeypatch.delenv('PIXI', raising=False)
+    monkeypatch.setenv('PATH', '')
+    monkeypatch.setenv('HOME', str(tmp_path))
+
+    pixi_exe = _make_executable(tmp_path / '.pixi' / 'bin' / 'pixi')
+
+    assert provenance._get_pixi_executable() == str(pixi_exe)
+
+
 def _make_omega_build_dir(build_dir, build_type, cache_key='OMEGA_BUILD_TYPE'):
     build_dir.mkdir()
     (build_dir / 'omega_build.sh').write_text('#!/bin/sh\n', encoding='utf-8')
@@ -51,3 +107,10 @@ def _make_config(build_dir, debug):
     config.add_section('build')
     config.set('build', 'debug', str(debug))
     return config
+
+
+def _make_executable(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('#!/bin/sh\n', encoding='utf-8')
+    path.chmod(0o755)
+    return path


### PR DESCRIPTION
It uses environment variables from the load script rather than assuming `pixi` is in the path.

It also doesn't crash if it can't find `pixi`.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
