### PR TITLE
Add river-network preprocessing for the unified MPAS mesh

### DIFF
--- a/docs/developers_guide/mesh/api.md
+++ b/docs/developers_guide/mesh/api.md
@@ -48,3 +48,30 @@
    VizCoastlineStep.setup
    VizCoastlineStep.run
 ```
+
+### Unified River Tasks
+
+```{eval-rst}
+.. currentmodule:: polaris.tasks.mesh.spherical.unified.river
+
+.. autosummary::
+   :toctree: generated/
+
+   SimplifyRiverNetworkStep
+   SimplifyRiverNetworkStep.setup
+   SimplifyRiverNetworkStep.run
+   simplify_river_network_feature_collection
+   RasterizeRiverLatLonStep
+   RasterizeRiverLatLonStep.setup
+   RasterizeRiverLatLonStep.run
+   build_river_network_dataset
+   ClipRiverNetworkStep
+   ClipRiverNetworkStep.setup
+   ClipRiverNetworkStep.run
+   get_unified_mesh_river_steps
+   VizRiverStep
+   VizRiverStep.setup
+   VizRiverStep.run
+   UnifiedRiverNetworkTask
+   add_river_tasks
+```

--- a/docs/developers_guide/mesh/tasks/index.md
+++ b/docs/developers_guide/mesh/tasks/index.md
@@ -23,4 +23,5 @@ than implemented separately inside each consumer.
 :titlesonly: true
 
 unified/coastline
+unified/river
 ```

--- a/docs/developers_guide/mesh/tasks/unified/river.md
+++ b/docs/developers_guide/mesh/tasks/unified/river.md
@@ -127,14 +127,26 @@ base-mesh consumers.
 Its `run()` method reads the simplified river network and coastline products,
 then conditions the retained geometry for direct base-mesh use by:
 
-- clipping segments inland of the selected coastline by the configured clip
-  distance;
-- simplifying clipped geometry and removing degenerate or too-short pieces;
+- densifying each river line at the coastline-grid scale before evaluating the
+  selected coastline signed-distance field;
+- clipping only the line portions that fall inside the configured coastal
+  exclusion band, with threshold-crossing points interpolated along each
+  sampled line interval;
+- preserving all valid inland pieces, including multiple pieces from one
+  HydroRIVERS feature when the line exits and re-enters the exclusion band;
+- simplifying clipped geometry and falling back to the unsimplified clipped
+  piece if simplification would make it degenerate;
+- removing only degenerate pieces with fewer than two distinct points;
 - regenerating a diagnostic lat-lon mask product from the conditioned river
   geometry.
 
 This step writes `clipped_river_network.geojson` and
 `clipped_river_network.nc`.
+
+The `min_segment_length_m` helper argument and
+`base_mesh_min_segment_length_km` config option are retained for compatibility,
+but they no longer prune valid inland river geometry. This avoids artificial
+gaps far inland from the coastline.
 
 ### `viz.py`
 
@@ -199,7 +211,9 @@ Unit tests in `tests/mesh/spherical/unified/test_river.py` currently cover:
   retention, and cycle detection;
 - HydroRIVERS archive unpacking and shapefile-to-GeoJSON conversion helpers;
 - target-grid river-channel raster contracts;
-- coastline-aware base-mesh conditioning helpers and shared-step factories;
+- coastline-aware base-mesh conditioning helpers, including local clipping,
+  re-entry through the exclusion band, densification before signed-distance
+  sampling, preservation of short inland pieces, and shared-step factories;
 - and task registration for all named unified meshes.
 
 There is not yet a full task-level integration test that runs the end-to-end

--- a/docs/developers_guide/mesh/tasks/unified/river.md
+++ b/docs/developers_guide/mesh/tasks/unified/river.md
@@ -74,21 +74,22 @@ task families:
 
 `SimplifyRiverNetworkStep.setup()` registers the HydroRIVERS archive as an input
 file through `add_input_file()` using the public URL from `river_network.cfg`.
-`SimplifyRiverNetworkStep.run()` unpacks the archive, converts the shapefile to
-GeoJSON, simplifies the source network, and writes:
+`SimplifyRiverNetworkStep.run()` unpacks the archive, simplifies the source
+network, and writes:
 
-- `source_river_network.geojson`
 - `simplified_river_network.geojson`
-- `retained_outlets.geojson`
 
 The public helper
 {py:func}`polaris.tasks.mesh.spherical.unified.river.simplify_river_network_feature_collection`
 contains the source-level retention logic. It builds canonical segments,
-validates downstream topology, filters outlet candidates, and traverses
-retained basins while preserving main stems and significant tributaries.
+validates downstream topology, and traverses upstream from all retained
+HydroRIVERS terminal segments while preserving main stems and significant
+tributaries. The resulting segment metadata keeps `outlet_hyriv_id` as
+basin-root provenance for future catchment grouping, but the step does not
+write separate outlet products.
 
 The tributary-selection logic compares each non-primary tributary's drainage
-area against the **basin outlet's** drainage area (not the primary upstream
+area against the **terminal root's** drainage area (not the primary upstream
 tributary's area), matching the reference point used by the standalone
 implementation. Strahler stream-order-1 headwater tributaries skip the
 drainage-area check entirely and proceed directly to the distance-based
@@ -100,19 +101,18 @@ public API.
 
 ### `rasterize.py`
 
-`RasterizeRiverLatLonStep.setup()` links the simplified source products and the
+`RasterizeRiverLatLonStep.setup()` links the simplified source product and the
 selected coastline NetCDF file. `RasterizeRiverLatLonStep.run()` reads those
 inputs, calls
 {py:func}`polaris.tasks.mesh.spherical.unified.river.build_river_network_dataset`,
 and writes:
 
 - `river_network.nc`
-- `river_outlets.geojson`
 
 `build_river_network_dataset()` is the public target-grid helper. It rasterizes
-river channels, snaps ocean outlets against coastline ocean cells, snaps inland
-sinks to land cells, and writes a clean mask split between channels, all
-outlets, ocean outlets, and inland sinks.
+river channels and writes `river_channel_mask` on the shared lat-lon grid.
+Outlet snapping and coastline reconciliation are deferred until after an MPAS
+base mesh exists.
 
 ### `clip.py`
 
@@ -126,17 +126,17 @@ then conditions the retained geometry for direct base-mesh use by:
 - clipping segments inland of the selected coastline by the configured clip
   distance;
 - simplifying clipped geometry and removing degenerate or too-short pieces;
-- dropping outlets that do not remain inland after clipping; and
 - regenerating a diagnostic lat-lon mask product from the conditioned river
   geometry.
 
-This step writes `clipped_river_network.geojson`, `clipped_outlets.geojson`,
-and `clipped_river_network.nc`.
+This step writes `clipped_river_network.geojson` and
+`clipped_river_network.nc`.
 
 ### `viz.py`
 
 `VizRiverStep` is a pure diagnostic consumer of the shared source, coastline,
-and lat-lon river products. It writes `river_network_overview.png` and
+lat-lon river, and clipped river products. It writes
+`river_network_overlay.png`, `rasterized_river_network.png`, and
 `debug_summary.txt`, and keeps visualization logic out of the numerical steps.
 
 ## Configuration plumbing
@@ -150,7 +150,7 @@ combines:
 - the selected named-mesh config file.
 
 `SimplifyRiverNetworkStep` consumes `[river_network]` options and, when
-`drainage_area_threshold` or `outlet_distance_tolerance` is set to the sentinel
+`drainage_area_threshold` or `branch_distance_tolerance` is set to the sentinel
 value `-1`, reads `land_background_km` and `river_channel_km` from
 `[sizing_field]` to derive the threshold values automatically.
 
@@ -189,10 +189,10 @@ without breaking downstream callers.
 
 Unit tests in `tests/mesh/spherical/unified/test_river.py` currently cover:
 
-- source-level outlet filtering, deep main-stem traversal, tributary
+- source-level terminal-root traversal, deep main-stem traversal, tributary
   retention, and cycle detection;
 - HydroRIVERS archive unpacking and shapefile-to-GeoJSON conversion helpers;
-- target-grid raster and snapped-outlet contracts;
+- target-grid river-channel raster contracts;
 - coastline-aware base-mesh conditioning helpers and shared-step factories;
 - and task registration for all named unified meshes.
 

--- a/docs/developers_guide/mesh/tasks/unified/river.md
+++ b/docs/developers_guide/mesh/tasks/unified/river.md
@@ -85,8 +85,9 @@ contains the source-level retention logic. It builds canonical segments,
 validates downstream topology, and traverses upstream from all retained
 HydroRIVERS terminal segments while preserving main stems and significant
 tributaries. The resulting segment metadata keeps `outlet_hyriv_id` as
-basin-root provenance for future catchment grouping, but the step does not
-write separate outlet products.
+basin-root provenance for future catchment grouping, and adds
+`outlet_drainage_area` and `river_network_rank` so individual networks can be
+selected from the single GeoJSON output without default per-network files.
 
 The tributary-selection logic compares each non-primary tributary's drainage
 area against the **terminal root's** drainage area (not the primary upstream
@@ -97,7 +98,10 @@ fallback, consistent with the standalone's more aggressive headwater pruning.
 
 The internal `RiverSegment` dataclass is the canonical representation used by
 the simplification helpers. It is intentionally not exported as part of the
-public API.
+public API. `read_river_segments_from_feature_collection()` and
+`river_segments_to_feature_collection()` preserve `outlet_hyriv_id`,
+`outlet_drainage_area`, and `river_network_rank` during GeoJSON round trips,
+and `ClipRiverNetworkStep` carries these fields through coastline conditioning.
 
 ### `rasterize.py`
 
@@ -154,13 +158,15 @@ combines:
 value `-1`, reads `land_background_km` and `river_channel_km` from
 `[sizing_field]` to derive the threshold values automatically.
 
-`RasterizeRiverLatLonStep` consumes `[river_rasterize]` options and also reads the
-selected `unified_mesh` settings such as `mesh_name`, `resolution_latlon`,
-and `coastline_convention`.
+`RasterizeRiverLatLonStep` consumes `[river_rasterize]` options and also reads
+the selected `unified_mesh` settings such as `mesh_name` and
+`resolution_latlon`.
+It reads `antarctic_boundary_convention` from `[spherical_mesh]` when selecting
+the coastline product.
 
 `ClipRiverNetworkStep` consumes `[river_network]` and `unified_mesh`
-settings, and currently reads the Antarctic coastline convention from the
-`[spherical_mesh]` section when selecting the coastline product for clipping.
+settings, and also reads `antarctic_boundary_convention` from
+`[spherical_mesh]` when selecting the coastline product for clipping.
 
 `VizRiverStep` consumes `[viz_river_network].dpi`.
 

--- a/docs/developers_guide/mesh/tasks/unified/river.md
+++ b/docs/developers_guide/mesh/tasks/unified/river.md
@@ -1,0 +1,201 @@
+(dev-mesh-unified-river)=
+
+# River-Network Steps and Tasks
+
+This section of the Developer's guide covers the code for the unified-mesh
+river workflow. The {ref}`users-mesh-unified-river` section describes the
+user-facing behavior, configuration options, algorithms, and output products.
+
+The `polaris.tasks.mesh.spherical.unified.river` package separates the river
+workflow into source-level simplification, target-grid rasterization, optional
+diagnostics, and downstream base-mesh conditioning. The package makes available
+functions that return a dict of shared steps and thin task wrappers so the same
+implementation can be reused by standalone inspection tasks and by downstream
+unified-mesh tasks.
+
+## Available tasks
+
+The helper
+{py:func}`polaris.tasks.mesh.spherical.unified.river.add_river_tasks`
+registers one standalone task for each mesh name in
+`polaris.mesh.spherical.unified.UNIFIED_MESH_NAMES`:
+
+- {py:class}`polaris.tasks.mesh.spherical.unified.river.UnifiedRiverNetworkTask` at
+  `mesh/spherical/unified/<mesh_name>/river/task`.
+
+{py:func}`polaris.tasks.mesh.add_tasks.add_mesh_tasks` wires these tasks into
+the `mesh` component after the generic base-mesh tasks (see
+{ref}`dev-mesh-base-mesh-task`) and the shared coastline tasks (see
+{ref}`dev-mesh-unified-coastline`).
+
+## Task structure and shared steps
+
+`UnifiedRiverNetworkTask` layers shared dependencies in a fixed order:
+
+1. It requests the shared lat-lon topography step (see
+   {ref}`dev-e3sm-init-topo-combine-tasks`) from
+   {py:func}`polaris.tasks.e3sm.init.topo.combine.steps.get_lat_lon_topo_steps`
+   and exposes it as `combine_topo`.
+2. It requests the shared coastline steps (see {ref}`dev-mesh-unified-coastline`)
+   from
+   {py:func}`polaris.tasks.mesh.spherical.unified.coastline.get_unified_mesh_coastline_steps`
+   and exposes them as `coastline_compute` and the optional
+   `viz_coastline_compute`.
+3. It requests the full set of shared river steps from
+   {py:func}`polaris.tasks.mesh.spherical.unified.river.get_unified_mesh_river_steps`
+   and exposes {py:class}`polaris.tasks.mesh.spherical.unified.river.SimplifyRiverNetworkStep`
+   as `river_simplify`,
+   {py:class}`polaris.tasks.mesh.spherical.unified.river.RasterizeRiverLatLonStep`
+   as `river_rasterize`,
+   {py:class}`polaris.tasks.mesh.spherical.unified.river.VizRiverStep` as
+   `viz_river_network`, and
+   {py:class}`polaris.tasks.mesh.spherical.unified.river.ClipRiverNetworkStep`
+   as `river_clip`.
+
+This ordering keeps the river implementation dependent only on the explicit
+products it consumes: simplified HydroRIVERS geometry and the selected
+coastline dataset.
+
+The shared-step factory in `steps.py` is the main extension point for other
+task families:
+
+- {py:func}`polaris.tasks.mesh.spherical.unified.river.get_unified_mesh_river_steps`
+  builds or reuses the full chain of shared river steps —
+  {py:class}`polaris.tasks.mesh.spherical.unified.river.SimplifyRiverNetworkStep`,
+  {py:class}`polaris.tasks.mesh.spherical.unified.river.RasterizeRiverLatLonStep`,
+  optional {py:class}`polaris.tasks.mesh.spherical.unified.river.VizRiverStep`,
+  and {py:class}`polaris.tasks.mesh.spherical.unified.river.ClipRiverNetworkStep`
+  — returning them as a dict keyed by step name along with the lat-lon mesh
+  config.
+
+## Implementation map
+
+### `simplify.py`
+
+`SimplifyRiverNetworkStep.setup()` registers the HydroRIVERS archive as an input
+file through `add_input_file()` using the public URL from `river_network.cfg`.
+`SimplifyRiverNetworkStep.run()` unpacks the archive, converts the shapefile to
+GeoJSON, simplifies the source network, and writes:
+
+- `source_river_network.geojson`
+- `simplified_river_network.geojson`
+- `retained_outlets.geojson`
+
+The public helper
+{py:func}`polaris.tasks.mesh.spherical.unified.river.simplify_river_network_feature_collection`
+contains the source-level retention logic. It builds canonical segments,
+validates downstream topology, filters outlet candidates, and traverses
+retained basins while preserving main stems and significant tributaries.
+
+The tributary-selection logic compares each non-primary tributary's drainage
+area against the **basin outlet's** drainage area (not the primary upstream
+tributary's area), matching the reference point used by the standalone
+implementation. Strahler stream-order-1 headwater tributaries skip the
+drainage-area check entirely and proceed directly to the distance-based
+fallback, consistent with the standalone's more aggressive headwater pruning.
+
+The internal `RiverSegment` dataclass is the canonical representation used by
+the simplification helpers. It is intentionally not exported as part of the
+public API.
+
+### `rasterize.py`
+
+`RasterizeRiverLatLonStep.setup()` links the simplified source products and the
+selected coastline NetCDF file. `RasterizeRiverLatLonStep.run()` reads those
+inputs, calls
+{py:func}`polaris.tasks.mesh.spherical.unified.river.build_river_network_dataset`,
+and writes:
+
+- `river_network.nc`
+- `river_outlets.geojson`
+
+`build_river_network_dataset()` is the public target-grid helper. It rasterizes
+river channels, snaps ocean outlets against coastline ocean cells, snaps inland
+sinks to land cells, and writes a clean mask split between channels, all
+outlets, ocean outlets, and inland sinks.
+
+### `clip.py`
+
+`ClipRiverNetworkStep` is produced through `get_unified_mesh_river_steps()`
+and is included in `UnifiedRiverNetworkTask` as well as downstream unified
+base-mesh consumers.
+
+Its `run()` method reads the simplified river network and coastline products,
+then conditions the retained geometry for direct base-mesh use by:
+
+- clipping segments inland of the selected coastline by the configured clip
+  distance;
+- simplifying clipped geometry and removing degenerate or too-short pieces;
+- dropping outlets that do not remain inland after clipping; and
+- regenerating a diagnostic lat-lon mask product from the conditioned river
+  geometry.
+
+This step writes `clipped_river_network.geojson`, `clipped_outlets.geojson`,
+and `clipped_river_network.nc`.
+
+### `viz.py`
+
+`VizRiverStep` is a pure diagnostic consumer of the shared source, coastline,
+and lat-lon river products. It writes `river_network_overview.png` and
+`debug_summary.txt`, and keeps visualization logic out of the numerical steps.
+
+## Configuration plumbing
+
+All shared river steps use mesh-specific configs built through
+`polaris.mesh.spherical.unified.get_unified_mesh_config()`. That loader
+combines:
+
+- the generic `unified_mesh.cfg` defaults;
+- the shared `river_network.cfg` file; and
+- the selected named-mesh config file.
+
+`SimplifyRiverNetworkStep` consumes `[river_network]` options and, when
+`drainage_area_threshold` or `outlet_distance_tolerance` is set to the sentinel
+value `-1`, reads `land_background_km` and `river_channel_km` from
+`[sizing_field]` to derive the threshold values automatically.
+
+`RasterizeRiverLatLonStep` consumes `[river_rasterize]` options and also reads the
+selected `unified_mesh` settings such as `mesh_name`, `resolution_latlon`,
+and `coastline_convention`.
+
+`ClipRiverNetworkStep` consumes `[river_network]` and `unified_mesh`
+settings, and currently reads the Antarctic coastline convention from the
+`[spherical_mesh]` section when selecting the coastline product for clipping.
+
+`VizRiverStep` consumes `[viz_river_network].dpi`.
+
+## Extension points
+
+Common extension paths for future development are:
+
+- adding a new named unified mesh by creating a new config file under
+  `polaris.mesh.spherical.unified`; task registration discovers mesh names
+  from those config files automatically;
+- extending source-level metadata or retention rules in
+  `simplify_river_network_feature_collection()` and the associated GeoJSON
+  property builders;
+- extending the target-grid output contract in
+  `build_river_network_dataset()` and the visualization step; and
+- adjusting downstream coastline-aware conditioning in
+  `ClipRiverNetworkStep` without creating a separate river-processing
+  code path for base meshes.
+
+The public API in this package is intentionally narrow: task wrappers,
+shared-step factories, step classes, and the two reusable dataset-building
+helpers. Most geometry and graph utilities remain private so they can evolve
+without breaking downstream callers.
+
+## Test coverage
+
+Unit tests in `tests/mesh/spherical/unified/test_river.py` currently cover:
+
+- source-level outlet filtering, deep main-stem traversal, tributary
+  retention, and cycle detection;
+- HydroRIVERS archive unpacking and shapefile-to-GeoJSON conversion helpers;
+- target-grid raster and snapped-outlet contracts;
+- coastline-aware base-mesh conditioning helpers and shared-step factories;
+- and task registration for all named unified meshes.
+
+There is not yet a full task-level integration test that runs the end-to-end
+river workflow on real HydroRIVERS data inside the documentation build or unit
+test suite.

--- a/docs/users_guide/mesh/tasks/index.md
+++ b/docs/users_guide/mesh/tasks/index.md
@@ -44,4 +44,5 @@ and river information independently.
 :titlesonly: true
 
 unified/coastline
+unified/river
 ```

--- a/docs/users_guide/mesh/tasks/unified/coastline.md
+++ b/docs/users_guide/mesh/tasks/unified/coastline.md
@@ -5,11 +5,12 @@
 The `mesh/spherical/unified/coastline` tasks build coastline masks and
 signed-distance fields from the shared combined-topography products on
 latitude-longitude grids. These tasks are intended for inspecting and caching
-coastline products that later unified-mesh workflows
-can reuse.
+coastline products that later unified-mesh workflows (such as
+{ref}`users-mesh-unified-river`) can reuse.
 
 Current coastline products are derived only from the combined topography
-fields produced by the `e3sm/init/topo/combine` workflow.
+fields produced by the `e3sm/init/topo/combine` workflow (see
+{ref}`e3sm-init-topo-tasks`).
 
 ## Available tasks
 

--- a/docs/users_guide/mesh/tasks/unified/river.md
+++ b/docs/users_guide/mesh/tasks/unified/river.md
@@ -226,30 +226,28 @@ simplification:
 - `base_mesh_clip_distance_km`: inland clip distance in km applied when
   preparing base-mesh river products. The coastline dataset stores a
   signed-distance field that is negative inland and positive over the
-  ocean. River-segment coordinates that lie within this distance of the
-  coastline — or seaward of it — are trimmed away, removing the
-  near-shore portions of river segments that would potentially affect
-  resolution too close to the ocean-sea ice portion of the base mesh
-  and thus could result in smaller-than-acceptable cells in the culled
-  ocean-sea ice mesh. Linear interpolation is used to
-  find the exact crossing point along each segment edge. Increase this
-  value to push the clip boundary farther inland; reduce it to preserve
-  more of each river's lower reach.
+  ocean. The clip operation is local to each river line: Polaris densifies the
+  line at the coastline-grid scale, samples the signed-distance field, and
+  trims only the portions that lie within this distance of the coastline or
+  seaward of it. Inland portions of the same HydroRIVERS feature are preserved,
+  even when clipping splits one feature into multiple pieces. Linear
+  interpolation is used to find the crossing point along each sampled line
+  interval. Increase this value to push the clip boundary farther inland;
+  reduce it to preserve more of each river's lower reach.
 - `base_mesh_simplify_tolerance_km`: Douglas-Peucker simplification
   tolerance in km applied to each clipped segment. The tolerance is
   converted to degrees using the equatorial approximation
   (km ÷ 111), so the default 2 km corresponds to roughly 0.018°.
   Simplification reduces vertex count while preserving overall river
   shape, making the geometry more suitable for mesh-generation tools that
-  operate at coarser scales. Increasing this value produces simpler,
-  smoother geometry; decreasing it preserves finer bends at the cost of
-  higher vertex count.
-- `base_mesh_min_segment_length_km`: minimum arc-length in km that a
-  segment must have after clipping and simplification in order to be
-  retained. Clipping near the coastline often leaves short stubs that
-  are numerically harmless but visually noisy; this threshold discards
-  them. Arc-length is computed along the sphere using the haversine
-  formula.
+  operate at coarser scales. If simplification would collapse a valid clipped
+  piece into a degenerate geometry, Polaris keeps the unsimplified piece
+  instead. Increasing this value produces simpler, smoother geometry;
+  decreasing it preserves finer bends at the cost of higher vertex count.
+- `base_mesh_min_segment_length_km`: deprecated for river clipping. This
+  option is retained for configuration compatibility, but valid inland clipped
+  river pieces are no longer discarded based on length. Polaris drops only
+  degenerate geometries with fewer than two distinct points.
 The `[river_rasterize]` section controls the target-grid products:
 
 - `channel_subsegment_fraction`: fraction of one target-grid cell used to set
@@ -265,9 +263,19 @@ The `[viz_river_network]` section currently contains:
 
 `river_network_overlay.png` overlays the simplified and clipped river networks
 on the selected coastline background, with a global view and a CONUS inset.
+The simplified network is drawn faintly under the clipped network so gaps in
+the clipped product can be distinguished from plotting order. The clipped
+network should match the simplified network except where geometry falls inside
+the configured coastal exclusion band.
+
 `rasterized_river_network.png` shows the channel mask on the shared lat-lon
-grid. `debug_summary.txt` records counts of simplified segments, clipped
-segments, and rasterized channel cells.
+grid. For high-resolution grids, the plot uses max aggregation for display so
+one-cell-wide river channels remain visible in the PNG; this aggregation does
+not change `river_network.nc`.
+
+`debug_summary.txt` records counts of simplified and clipped features, unique
+retained and dropped `hyriv_id` values, total simplified and clipped lengths,
+and rasterized channel cells.
 
 The lat-lon NetCDF product also records target-grid metadata such as
 `target_grid_resolution_degrees` and `channel_buffer_m`.

--- a/docs/users_guide/mesh/tasks/unified/river.md
+++ b/docs/users_guide/mesh/tasks/unified/river.md
@@ -4,8 +4,7 @@
 
 The unified-mesh river-network tasks simplify HydroRIVERS source data,
 build target-grid channel masks, and prepare clipped base-mesh geometry that
-downstream sizing-field and base-mesh workflows (see
-{ref}`users-mesh-unified-sizing-field` and {ref}`mesh-base-mesh-task`) can
+downstream sizing-field and base-mesh workflows can
 consume directly.
 
 The standalone task runs the full river workflow in one place: source

--- a/docs/users_guide/mesh/tasks/unified/river.md
+++ b/docs/users_guide/mesh/tasks/unified/river.md
@@ -53,8 +53,35 @@ The source-level workflow follows a staged simplification strategy:
 5. It identifies terminal basin roots from segments with `next_down == 0`.
 6. It traverses upstream from each terminal root to keep main stems and
    significant tributaries, preserving basin connectivity and confluence
-   structure. The retained segment metadata includes `outlet_hyriv_id` as
-   basin-root provenance for later catchment grouping.
+   structure. The retained segment metadata includes `outlet_hyriv_id`,
+   `outlet_drainage_area`, and `river_network_rank` for later catchment
+   grouping.
+
+The `river_simplify` step is not a line-geometry simplification step in the
+Douglas-Peucker sense. It is a graph simplification step: it keeps or prunes
+whole HydroRIVERS segments while preserving the retained `next_down`
+relationships. The algorithm builds an upstream adjacency map from the
+HydroRIVERS `next_down` field, validates that the retained graph is acyclic,
+and then traverses every terminal basin root. At each confluence, the upstream
+segment with the largest drainage area is kept as the primary branch. Other
+upstream branches are kept when they are large enough relative to that
+confluence's primary branch, or when they are farther than
+`branch_distance_tolerance` from the already-retained basin skeleton.
+
+This differs from the greedy reverse-search simplification in the standalone
+[`mpas_land_mesh`](https://github.com/changliao1025/mpas_land_mesh) reference
+workflow that is the inspiration for the Polaris implementation. The standalone
+workflow reconstructs one
+basin at a time with `pyrivergraph`, rebuilds stream segments and stream order,
+then mutates a per-basin R-tree of retained flowlines as it recursively searches
+upstream from each outlet. Nearby candidates are accepted, rejected, or in some
+cases replace smaller already-retained branches as that greedy search proceeds.
+Polaris instead uses the HydroRIVERS `next_down` topology directly, processes
+terminal basins independently, and applies a deterministic confluence-local
+selection rule without removing retained segments later in the traversal. This
+makes the implementation simpler to test and parallelize while preserving the
+same intent: retain the dominant main stems and significant, geographically
+separated tributaries at the mesh scale.
 
 The lat-lon workflow then turns the simplified network into target-grid
 products:
@@ -70,7 +97,13 @@ The source task writes:
 
 - `simplified_river_network.geojson`, the retained river segments and their
   basin-root metadata, with networks sorted largest-first by terminal-root
-  drainage area.
+  drainage area. Each feature includes:
+  - `outlet_hyriv_id`, the HydroRIVERS ID of the terminal-root segment for
+    that river network;
+  - `outlet_drainage_area`, the terminal-root drainage area in square meters;
+    and
+  - `river_network_rank`, a 1-based rank with `1` denoting the largest
+    retained river network for the current task configuration.
 
 The lat-lon task writes:
 
@@ -88,11 +121,55 @@ also writes:
 These clipped products are intended for the unified base-mesh workflow rather
 than the standalone inspection tasks.
 
+## Selecting individual river networks
+
+`simplified_river_network.geojson` contains all retained river networks in one
+GeoJSON feature collection. To inspect or export one network at a time, filter
+features by `river_network_rank` or by the stable `outlet_hyriv_id`.
+
+For example, this snippet writes the largest retained network to its own
+GeoJSON file:
+
+```python
+import json
+
+rank = 1
+
+with open('simplified_river_network.geojson', encoding='utf-8') as infile:
+    river_fc = json.load(infile)
+
+features = [
+    feature
+    for feature in river_fc['features']
+    if feature['properties']['river_network_rank'] == rank
+]
+
+network_fc = dict(
+    type='FeatureCollection',
+    features=features,
+    metadata=river_fc.get('metadata', {}),
+)
+
+with open(
+    f'river_network_rank_{rank:04d}.geojson',
+    'w',
+    encoding='utf-8',
+) as outfile:
+    json.dump(network_fc, outfile, indent=2, sort_keys=True)
+```
+
+To export the N largest networks as one combined file, use
+`feature['properties']['river_network_rank'] <= n`. To create one file per
+network, loop over the desired ranks and update the output filename in the
+example above.
+
 ## Configuration
 
 Each task links the shared `river_network.cfg` file and inherits the selected
-mesh's `unified_mesh` settings, including the target-grid resolution and
-coastline convention (see {ref}`users-mesh-unified-coastline`).
+mesh's `unified_mesh` settings, including the target-grid resolution. It also
+uses the shared `[spherical_mesh]` setting
+`antarctic_boundary_convention` when selecting the coastline product (see
+{ref}`users-mesh-unified-coastline`).
 
 The `[sizing_field]` section in each per-mesh config provides the resolution
 parameters used to auto-derive thresholds:
@@ -115,13 +192,17 @@ simplification:
 - `drainage_area_threshold`: minimum drainage area in square meters for
   retaining a source segment. The default value of `-1` signals
   auto-derivation from the `[sizing_field]` land resolution:
-  `drainage_area_threshold = land_background_km² × 1×10⁸ m²`
-  (100 grid cells at land resolution). For example, the 30 km ocean /
-  10 km land mesh uses `1.0×10¹⁰ m²` and the 240 km mesh uses
-  `5.76×10¹²  m²`. Override this in a per-mesh config to fix the
+  `drainage_area_threshold = land_background_km² ×`
+  `drainage_area_multiplier × 1×10⁶ m²`. For example, with the default
+  multiplier of 100, the 30 km ocean / 10 km land mesh uses
+  `1.0×10¹⁰ m²`; with its per-mesh multiplier of 10, the 240 km mesh uses
+  `5.76×10¹¹ m²`. Override this in a per-mesh config to fix the
   threshold explicitly. Reducing this value retains finer tributaries at
   the cost of a much larger, denser network; increasing it produces a
   sparser network containing only the largest river systems.
+- `drainage_area_multiplier`: number of land-grid-cell areas that must drain
+  to a point for auto-derived channel retention. This option is only used
+  when `drainage_area_threshold = -1`.
 - `branch_distance_tolerance`: geographic fallback distance used during
   upstream traversal. The default value of `-1` signals auto-derivation from
   the `[sizing_field]` river-channel resolution:
@@ -133,16 +214,16 @@ simplification:
   value, preserving geographically isolated branches that would otherwise
   be pruned on drainage-area grounds alone.
 - `tributary_area_ratio`: minimum ratio of tributary drainage area to
-  terminal-root drainage area for retaining a nearby tributary. At each
+  the primary branch drainage area at the current confluence. At each
   confluence, the upstream branch with the largest drainage area is
   always retained as the main stem. Each additional upstream branch is
   retained if its drainage area is at least this fraction of the
-  **terminal root's** drainage area. Strahler stream-order-1 headwater
-  tributaries skip this area check entirely and go straight to the
-  distance-based fallback (see `branch_distance_tolerance` above).
-  Branches that fail both tests are pruned. Lowering this ratio retains
-  more tributaries; raising it prunes all but the most significant
-  branches.
+  primary branch's drainage area. Branches that fail this area test are
+  still retained if they are far enough from the already-retained basin
+  skeleton to satisfy the distance-based fallback (see
+  `branch_distance_tolerance` above). Branches that fail both tests are
+  pruned. Lowering this ratio retains more tributaries; raising it prunes
+  all but the most significant branches.
 - `base_mesh_clip_distance_km`: inland clip distance in km applied when
   preparing base-mesh river products. The coastline dataset stores a
   signed-distance field that is negative inland and positive over the

--- a/docs/users_guide/mesh/tasks/unified/river.md
+++ b/docs/users_guide/mesh/tasks/unified/river.md
@@ -3,14 +3,14 @@
 # River-network tasks
 
 The unified-mesh river-network tasks simplify HydroRIVERS source data,
-reconcile retained outlets with the selected coastline product, and build
-target-grid masks and clipped base-mesh geometry that downstream
-sizing-field and base-mesh workflows (see {ref}`users-mesh-unified-sizing-field`
-and {ref}`mesh-base-mesh-task`) can consume directly.
+build target-grid channel masks, and prepare clipped base-mesh geometry that
+downstream sizing-field and base-mesh workflows (see
+{ref}`users-mesh-unified-sizing-field` and {ref}`mesh-base-mesh-task`) can
+consume directly.
 
 The standalone task runs the full river workflow in one place: source
-simplification, coastline-aware outlet snapping, target-grid rasterization,
-coastline-clipped base-mesh geometry, and diagnostic plots.
+simplification, target-grid channel rasterization, coastline-clipped base-mesh
+geometry, and diagnostic plots.
 
 The downstream sizing-field and base-mesh workflows reuse these same shared
 steps without re-running them.
@@ -32,8 +32,8 @@ The task work directory contains symlinks to:
 
 - `river_simplify`, the shared source-level step that downloads and
   simplifies HydroRIVERS;
-- `river_rasterize`, the shared lat-lon step that writes raster and outlet
-  products;
+- `river_rasterize`, the shared lat-lon step that writes the channel raster
+  product;
 - `river_clip`, the shared base-mesh conditioning step that clips river
   geometry to the coastline;
 - `viz_river_network`, a diagnostic step that writes an overview plot and
@@ -45,63 +45,45 @@ The task work directory contains symlinks to:
 
 The source-level workflow follows a staged simplification strategy:
 
-1. It downloads the HydroRIVERS archive and converts the shapefile into
-   `source_river_network.geojson`.
+1. It downloads the HydroRIVERS archive and reads the shapefile.
 2. It canonicalizes source features into one segment per `hyriv_id` when the
    source contains multiple geometries for the same river segment.
 3. It filters segments by `drainage_area_threshold`.
 4. It validates that the retained `next_down` graph is acyclic.
-5. It identifies outlet candidates from segments with `next_down == 0`, then
-   keeps large, well-separated ocean outlets while retaining explicit inland
-   sinks.
-6. It traverses upstream from each retained outlet to keep main stems and
+5. It identifies terminal basin roots from segments with `next_down == 0`.
+6. It traverses upstream from each terminal root to keep main stems and
    significant tributaries, preserving basin connectivity and confluence
-   structure.
+   structure. The retained segment metadata includes `outlet_hyriv_id` as
+   basin-root provenance for later catchment grouping.
 
 The lat-lon workflow then turns the simplified network into target-grid
 products:
 
-1. It samples the retained river lines densely enough to rasterize them onto
-   the chosen latitude-longitude grid.
-2. It snaps ocean outlets to nearby ocean cells from `coastline.nc` when a
-   match is available within `outlet_match_tolerance`.
-3. It snaps inland sinks to the nearest land cell derived from the coastline
-   `ocean_mask`.
-4. It writes separate masks for channels, all outlets, ocean outlets, and
-   inland sinks instead of overloading one raster with mixed semantics.
-
-If an ocean outlet cannot be matched to ocean within tolerance, it is still
-snapped to the nearest grid cell, but its `matched_to_ocean` flag remains
-`false` and the snapping distance is recorded for diagnostics.
+It samples the retained river lines densely enough to rasterize them onto the
+chosen latitude-longitude grid, then writes a river-channel mask. Outlet
+snapping and coastline reconciliation are deferred until after an MPAS base
+mesh exists.
 
 ## Outputs
 
 The source task writes:
 
-- `source_river_network.geojson`, the direct conversion of the HydroRIVERS
-  shapefile;
 - `simplified_river_network.geojson`, the retained river segments and their
-  basin and outlet metadata, with networks sorted largest-first by outlet
-  drainage area; and
-- `retained_outlets.geojson`, one feature per retained ocean outlet or inland
-  sink.
+  basin-root metadata, with networks sorted largest-first by terminal-root
+  drainage area.
 
 The lat-lon task writes:
 
-- `river_network.nc`, containing `river_channel_mask`, `river_outlet_mask`,
-  `river_ocean_outlet_mask`, and `river_inland_sink_mask`;
-- `river_outlets.geojson`, containing source and snapped outlet coordinates,
-  snapped grid indices, snapping distance, and `matched_to_ocean`; and
-- `river_network_overview.png` and `debug_summary.txt` from the visualization
-  step.
+- `river_network.nc`, containing `river_channel_mask`;
+- `river_network_overlay.png`, `rasterized_river_network.png`, and
+  `debug_summary.txt` from the visualization step.
 
 The downstream shared base-mesh river step (see {ref}`mesh-base-mesh-task`)
 also writes:
 
 - `clipped_river_network.geojson`, with networks sorted largest-first by
-  outlet drainage area;
-- `clipped_outlets.geojson`;
-- and `clipped_river_network.nc`.
+  terminal-root drainage area;
+- `clipped_river_network.nc`.
 
 These clipped products are intended for the unified base-mesh workflow rather
 than the standalone inspection tasks.
@@ -118,7 +100,7 @@ parameters used to auto-derive thresholds:
 - `land_background_km`: background land cell width in km. Used to compute
   `drainage_area_threshold` when that option is set to `-1`.
 - `river_channel_km`: target cell width along river channels in km. Used to
-  compute `outlet_distance_tolerance` when that option is set to `-1`.
+  compute `branch_distance_tolerance` when that option is set to `-1`.
 
 The `[river_network]` section controls HydroRIVERS access and source-level
 simplification:
@@ -140,31 +122,24 @@ simplification:
   threshold explicitly. Reducing this value retains finer tributaries at
   the cost of a much larger, denser network; increasing it produces a
   sparser network containing only the largest river systems.
-- `outlet_distance_tolerance`: minimum great-circle spacing in meters
-  between retained non-endorheic (ocean) outlets, and also a geographic
-  fallback distance used during upstream traversal. The default value of
-  `-1` signals auto-derivation from the `[sizing_field]` river-channel
-  resolution: `outlet_distance_tolerance = river_channel_km × 1000 m`.
-  During the outlet-selection pass, candidates are ranked from largest to
-  smallest drainage area and added greedily; any candidate whose endpoint
-  falls within this distance of an already-retained ocean outlet is
-  skipped, preventing many closely spaced outlets from being kept in the
-  same delta or estuary. Inland sinks are exempt from this check and are
-  always retained regardless of their proximity to other inland sinks.
-  The same tolerance is reused during upstream traversal as a fallback:
+- `branch_distance_tolerance`: geographic fallback distance used during
+  upstream traversal. The default value of `-1` signals auto-derivation from
+  the `[sizing_field]` river-channel resolution:
+  `branch_distance_tolerance = river_channel_km × 1000 m`. During upstream
+  traversal,
   a tributary that is too small to satisfy `tributary_area_ratio` is
   still retained if the minimum great-circle distance from any point on
   that tributary to any already-retained basin segment exceeds this
   value, preserving geographically isolated branches that would otherwise
   be pruned on drainage-area grounds alone.
 - `tributary_area_ratio`: minimum ratio of tributary drainage area to
-  basin-outlet drainage area for retaining a nearby tributary. At each
+  terminal-root drainage area for retaining a nearby tributary. At each
   confluence, the upstream branch with the largest drainage area is
   always retained as the main stem. Each additional upstream branch is
   retained if its drainage area is at least this fraction of the
-  **basin outlet's** drainage area. Strahler stream-order-1 headwater
+  **terminal root's** drainage area. Strahler stream-order-1 headwater
   tributaries skip this area check entirely and go straight to the
-  distance-based fallback (see `outlet_distance_tolerance` above).
+  distance-based fallback (see `branch_distance_tolerance` above).
   Branches that fail both tests are pruned. Lowering this ratio retains
   more tributaries; raising it prunes all but the most significant
   branches.
@@ -195,22 +170,8 @@ simplification:
   are numerically harmless but visually noisy; this threshold discards
   them. Arc-length is computed along the sphere using the haversine
   formula.
-- `base_mesh_preserve_outlet_stub_km`: optional minimum stub length in
-  km to preserve for outlet segments that would otherwise be fully
-  removed by clipping. When an outlet segment's entire length lies within
-  `base_mesh_clip_distance_km` of the coastline and would normally be
-  dropped, a stub is reconstructed from the clip boundary back to the
-  outlet endpoint. If that stub is at least this long it is kept,
-  ensuring the outlet location remains present in the clipped product;
-  otherwise the segment is still discarded. The default value of 0.0
-  disables stub preservation entirely. Set this to a small positive value
-  (e.g., 1–5 km) when outlet positions must be retained in the clipped
-  product even when most of the segment has been removed.
-
 The `[river_rasterize]` section controls the target-grid products:
 
-- `outlet_match_tolerance`: maximum snapping distance in meters when matching
-  an ocean outlet to a coastline ocean cell.
 - `channel_subsegment_fraction`: fraction of one target-grid cell used to set
   line-sampling density during rasterization.
 - `channel_buffer_km`: optional physical buffer around sampled river-channel
@@ -222,16 +183,14 @@ The `[viz_river_network]` section currently contains:
 
 ## Diagnostics and expected behavior
 
-`river_network_overview.png` overlays the simplified river network and snapped
-outlets on the selected coastline background, with a global view and a CONUS
-inset. `debug_summary.txt` records counts of retained segments, retained
-outlets, matched and unmatched ocean outlets, inland sinks, and raster cells
-flagged in each mask.
+`river_network_overlay.png` overlays the simplified and clipped river networks
+on the selected coastline background, with a global view and a CONUS inset.
+`rasterized_river_network.png` shows the channel mask on the shared lat-lon
+grid. `debug_summary.txt` records counts of simplified segments, clipped
+segments, and rasterized channel cells.
 
 The lat-lon NetCDF product also records target-grid metadata such as
-`target_grid_resolution_degrees`, `outlet_match_tolerance_m`,
-`channel_buffer_m`, `matched_ocean_outlets`, and
-`unmatched_ocean_outlets`.
+`target_grid_resolution_degrees` and `channel_buffer_m`.
 
 ## Running a task
 

--- a/docs/users_guide/mesh/tasks/unified/river.md
+++ b/docs/users_guide/mesh/tasks/unified/river.md
@@ -1,0 +1,247 @@
+(users-mesh-unified-river)=
+
+# River-network tasks
+
+The unified-mesh river-network tasks simplify HydroRIVERS source data,
+reconcile retained outlets with the selected coastline product, and build
+target-grid masks and clipped base-mesh geometry that downstream
+sizing-field and base-mesh workflows (see {ref}`users-mesh-unified-sizing-field`
+and {ref}`mesh-base-mesh-task`) can consume directly.
+
+The standalone task runs the full river workflow in one place: source
+simplification, coastline-aware outlet snapping, target-grid rasterization,
+coastline-clipped base-mesh geometry, and diagnostic plots.
+
+The downstream sizing-field and base-mesh workflows reuse these same shared
+steps without re-running them.
+
+## Available tasks
+
+Polaris registers one standalone river task for each named unified mesh:
+
+- `mesh/spherical/unified/<mesh_name>/river/task`
+
+Supported `mesh_name` values are:
+
+- `u.oi240.lr240`
+- `u.oi30.lr10`
+- `u.oi6to18.lr6to10`
+- `u.oi.so12to30.lr10`
+
+The task work directory contains symlinks to:
+
+- `river_simplify`, the shared source-level step that downloads and
+  simplifies HydroRIVERS;
+- `river_rasterize`, the shared lat-lon step that writes raster and outlet
+  products;
+- `river_clip`, the shared base-mesh conditioning step that clips river
+  geometry to the coastline;
+- `viz_river_network`, a diagnostic step that writes an overview plot and
+  summary text file; and
+- the upstream coastline and topography-combine shared steps
+  (see {ref}`users-mesh-unified-coastline`).
+
+## How the river network is derived
+
+The source-level workflow follows a staged simplification strategy:
+
+1. It downloads the HydroRIVERS archive and converts the shapefile into
+   `source_river_network.geojson`.
+2. It canonicalizes source features into one segment per `hyriv_id` when the
+   source contains multiple geometries for the same river segment.
+3. It filters segments by `drainage_area_threshold`.
+4. It validates that the retained `next_down` graph is acyclic.
+5. It identifies outlet candidates from segments with `next_down == 0`, then
+   keeps large, well-separated ocean outlets while retaining explicit inland
+   sinks.
+6. It traverses upstream from each retained outlet to keep main stems and
+   significant tributaries, preserving basin connectivity and confluence
+   structure.
+
+The lat-lon workflow then turns the simplified network into target-grid
+products:
+
+1. It samples the retained river lines densely enough to rasterize them onto
+   the chosen latitude-longitude grid.
+2. It snaps ocean outlets to nearby ocean cells from `coastline.nc` when a
+   match is available within `outlet_match_tolerance`.
+3. It snaps inland sinks to the nearest land cell derived from the coastline
+   `ocean_mask`.
+4. It writes separate masks for channels, all outlets, ocean outlets, and
+   inland sinks instead of overloading one raster with mixed semantics.
+
+If an ocean outlet cannot be matched to ocean within tolerance, it is still
+snapped to the nearest grid cell, but its `matched_to_ocean` flag remains
+`false` and the snapping distance is recorded for diagnostics.
+
+## Outputs
+
+The source task writes:
+
+- `source_river_network.geojson`, the direct conversion of the HydroRIVERS
+  shapefile;
+- `simplified_river_network.geojson`, the retained river segments and their
+  basin and outlet metadata, with networks sorted largest-first by outlet
+  drainage area; and
+- `retained_outlets.geojson`, one feature per retained ocean outlet or inland
+  sink.
+
+The lat-lon task writes:
+
+- `river_network.nc`, containing `river_channel_mask`, `river_outlet_mask`,
+  `river_ocean_outlet_mask`, and `river_inland_sink_mask`;
+- `river_outlets.geojson`, containing source and snapped outlet coordinates,
+  snapped grid indices, snapping distance, and `matched_to_ocean`; and
+- `river_network_overview.png` and `debug_summary.txt` from the visualization
+  step.
+
+The downstream shared base-mesh river step (see {ref}`mesh-base-mesh-task`)
+also writes:
+
+- `clipped_river_network.geojson`, with networks sorted largest-first by
+  outlet drainage area;
+- `clipped_outlets.geojson`;
+- and `clipped_river_network.nc`.
+
+These clipped products are intended for the unified base-mesh workflow rather
+than the standalone inspection tasks.
+
+## Configuration
+
+Each task links the shared `river_network.cfg` file and inherits the selected
+mesh's `unified_mesh` settings, including the target-grid resolution and
+coastline convention (see {ref}`users-mesh-unified-coastline`).
+
+The `[sizing_field]` section in each per-mesh config provides the resolution
+parameters used to auto-derive thresholds:
+
+- `land_background_km`: background land cell width in km. Used to compute
+  `drainage_area_threshold` when that option is set to `-1`.
+- `river_channel_km`: target cell width along river channels in km. Used to
+  compute `outlet_distance_tolerance` when that option is set to `-1`.
+
+The `[river_network]` section controls HydroRIVERS access and source-level
+simplification:
+
+- `hydrorivers_url`: the public HydroRIVERS archive URL.
+- `hydrorivers_archive_filename`: local filename used for the downloaded
+  archive.
+- `hydrorivers_shp_directory`: expected directory name after unpacking the
+  archive.
+- `hydrorivers_shp_filename`: HydroRIVERS shapefile basename inside the
+  unpacked archive.
+- `drainage_area_threshold`: minimum drainage area in square meters for
+  retaining a source segment. The default value of `-1` signals
+  auto-derivation from the `[sizing_field]` land resolution:
+  `drainage_area_threshold = land_background_km² × 1×10⁸ m²`
+  (100 grid cells at land resolution). For example, the 30 km ocean /
+  10 km land mesh uses `1.0×10¹⁰ m²` and the 240 km mesh uses
+  `5.76×10¹²  m²`. Override this in a per-mesh config to fix the
+  threshold explicitly. Reducing this value retains finer tributaries at
+  the cost of a much larger, denser network; increasing it produces a
+  sparser network containing only the largest river systems.
+- `outlet_distance_tolerance`: minimum great-circle spacing in meters
+  between retained non-endorheic (ocean) outlets, and also a geographic
+  fallback distance used during upstream traversal. The default value of
+  `-1` signals auto-derivation from the `[sizing_field]` river-channel
+  resolution: `outlet_distance_tolerance = river_channel_km × 1000 m`.
+  During the outlet-selection pass, candidates are ranked from largest to
+  smallest drainage area and added greedily; any candidate whose endpoint
+  falls within this distance of an already-retained ocean outlet is
+  skipped, preventing many closely spaced outlets from being kept in the
+  same delta or estuary. Inland sinks are exempt from this check and are
+  always retained regardless of their proximity to other inland sinks.
+  The same tolerance is reused during upstream traversal as a fallback:
+  a tributary that is too small to satisfy `tributary_area_ratio` is
+  still retained if the minimum great-circle distance from any point on
+  that tributary to any already-retained basin segment exceeds this
+  value, preserving geographically isolated branches that would otherwise
+  be pruned on drainage-area grounds alone.
+- `tributary_area_ratio`: minimum ratio of tributary drainage area to
+  basin-outlet drainage area for retaining a nearby tributary. At each
+  confluence, the upstream branch with the largest drainage area is
+  always retained as the main stem. Each additional upstream branch is
+  retained if its drainage area is at least this fraction of the
+  **basin outlet's** drainage area. Strahler stream-order-1 headwater
+  tributaries skip this area check entirely and go straight to the
+  distance-based fallback (see `outlet_distance_tolerance` above).
+  Branches that fail both tests are pruned. Lowering this ratio retains
+  more tributaries; raising it prunes all but the most significant
+  branches.
+- `base_mesh_clip_distance_km`: inland clip distance in km applied when
+  preparing base-mesh river products. The coastline dataset stores a
+  signed-distance field that is negative inland and positive over the
+  ocean. River-segment coordinates that lie within this distance of the
+  coastline — or seaward of it — are trimmed away, removing the
+  near-shore portions of river segments that would potentially affect
+  resolution too close to the ocean-sea ice portion of the base mesh
+  and thus could result in smaller-than-acceptable cells in the culled
+  ocean-sea ice mesh. Linear interpolation is used to
+  find the exact crossing point along each segment edge. Increase this
+  value to push the clip boundary farther inland; reduce it to preserve
+  more of each river's lower reach.
+- `base_mesh_simplify_tolerance_km`: Douglas-Peucker simplification
+  tolerance in km applied to each clipped segment. The tolerance is
+  converted to degrees using the equatorial approximation
+  (km ÷ 111), so the default 2 km corresponds to roughly 0.018°.
+  Simplification reduces vertex count while preserving overall river
+  shape, making the geometry more suitable for mesh-generation tools that
+  operate at coarser scales. Increasing this value produces simpler,
+  smoother geometry; decreasing it preserves finer bends at the cost of
+  higher vertex count.
+- `base_mesh_min_segment_length_km`: minimum arc-length in km that a
+  segment must have after clipping and simplification in order to be
+  retained. Clipping near the coastline often leaves short stubs that
+  are numerically harmless but visually noisy; this threshold discards
+  them. Arc-length is computed along the sphere using the haversine
+  formula.
+- `base_mesh_preserve_outlet_stub_km`: optional minimum stub length in
+  km to preserve for outlet segments that would otherwise be fully
+  removed by clipping. When an outlet segment's entire length lies within
+  `base_mesh_clip_distance_km` of the coastline and would normally be
+  dropped, a stub is reconstructed from the clip boundary back to the
+  outlet endpoint. If that stub is at least this long it is kept,
+  ensuring the outlet location remains present in the clipped product;
+  otherwise the segment is still discarded. The default value of 0.0
+  disables stub preservation entirely. Set this to a small positive value
+  (e.g., 1–5 km) when outlet positions must be retained in the clipped
+  product even when most of the segment has been removed.
+
+The `[river_rasterize]` section controls the target-grid products:
+
+- `outlet_match_tolerance`: maximum snapping distance in meters when matching
+  an ocean outlet to a coastline ocean cell.
+- `channel_subsegment_fraction`: fraction of one target-grid cell used to set
+  line-sampling density during rasterization.
+- `channel_buffer_km`: optional physical buffer around sampled river-channel
+  points. A value of `0` preserves one-cell-wide rasterization.
+
+The `[viz_river_network]` section currently contains:
+
+- `dpi`: output resolution for the river diagnostic plot.
+
+## Diagnostics and expected behavior
+
+`river_network_overview.png` overlays the simplified river network and snapped
+outlets on the selected coastline background, with a global view and a CONUS
+inset. `debug_summary.txt` records counts of retained segments, retained
+outlets, matched and unmatched ocean outlets, inland sinks, and raster cells
+flagged in each mask.
+
+The lat-lon NetCDF product also records target-grid metadata such as
+`target_grid_resolution_degrees`, `outlet_match_tolerance_m`,
+`channel_buffer_m`, `matched_ocean_outlets`, and
+`unmatched_ocean_outlets`.
+
+## Running a task
+
+To run the full river-network workflow for one named unified mesh:
+
+```bash
+polaris setup -t \
+    mesh/spherical/unified/u.oi30.lr10/river/task \
+    -w river_30km
+```
+
+The work directory contains symlinks to the shared river, topography, and
+coastline steps, along with the shared `river_network.cfg` file.

--- a/polaris/archive.py
+++ b/polaris/archive.py
@@ -3,6 +3,20 @@ import shutil
 import zipfile
 
 
+def extract_zip_subdir(zip_filename, member_prefix, out_dir='.'):
+    with zipfile.ZipFile(zip_filename) as archive:
+        member_names = _find_zip_subdir_members(archive, member_prefix)
+        for member_name in member_names:
+            member_path = pathlib.PurePosixPath(member_name)
+            out_filename = pathlib.Path(out_dir).joinpath(*member_path.parts)
+            out_filename.parent.mkdir(parents=True, exist_ok=True)
+            with (
+                archive.open(member_name) as src,
+                open(out_filename, 'wb') as dst,
+            ):
+                shutil.copyfileobj(src, dst)
+
+
 def extract_zip_member(zip_filename, member_name, out_filename):
     with zipfile.ZipFile(zip_filename) as archive:
         member_name = find_zip_member(archive, member_name)
@@ -27,3 +41,19 @@ def find_zip_member(archive, member_name):
         f'Could not find ZIP member {member_name!r} in archive '
         f'{archive.filename!r}'
     )
+
+
+def _find_zip_subdir_members(archive, member_prefix):
+    prefix = pathlib.PurePosixPath(member_prefix).as_posix().rstrip('/')
+    prefix = f'{prefix}/'
+    matches = [
+        name
+        for name in archive.namelist()
+        if name.startswith(prefix) and not name.endswith('/')
+    ]
+    if len(matches) == 0:
+        raise ValueError(
+            f'Could not find ZIP subdirectory {member_prefix!r} in archive '
+            f'{archive.filename!r}'
+        )
+    return matches

--- a/polaris/mesh/spherical/unified/__init__.py
+++ b/polaris/mesh/spherical/unified/__init__.py
@@ -1,3 +1,12 @@
+from polaris.mesh.spherical.unified.configs import (
+    RIVER_CONFIG_FILENAME as RIVER_CONFIG_FILENAME,
+)
+from polaris.mesh.spherical.unified.configs import (
+    UNIFIED_MESH_NAMES as UNIFIED_MESH_NAMES,
+)
+from polaris.mesh.spherical.unified.configs import (
+    get_unified_mesh_config as get_unified_mesh_config,
+)
 from polaris.mesh.spherical.unified.resolutions import (
     LAT_LON_TARGET_GRID_RESOLUTIONS as LAT_LON_TARGET_GRID_RESOLUTIONS,
 )

--- a/polaris/mesh/spherical/unified/configs.py
+++ b/polaris/mesh/spherical/unified/configs.py
@@ -1,0 +1,73 @@
+import importlib.resources as imp_res
+import os
+
+from polaris.config import PolarisConfigParser
+
+PACKAGE = 'polaris.mesh.spherical.unified'
+RIVER_CONFIG_PACKAGE = 'polaris.mesh.spherical.unified.river'
+RIVER_CONFIG_FILENAME = 'river_network.cfg'
+DEFAULT_CONFIG_FILENAME = 'unified_mesh.cfg'
+
+
+def _discover_mesh_names():
+    """
+    Discover unified-mesh names from config files in the package.
+    """
+    package_files = imp_res.files(PACKAGE)
+    mesh_names = []
+    for resource in package_files.iterdir():
+        if not resource.is_file() or not resource.name.endswith('.cfg'):
+            continue
+        if resource.name == DEFAULT_CONFIG_FILENAME:
+            continue
+
+        config = PolarisConfigParser()
+        config.add_from_package(PACKAGE, resource.name)
+        config.combine()
+        combined = config.combined
+        assert combined is not None
+        if not combined.has_section('unified_mesh'):
+            continue
+
+        mesh_name = combined.get('unified_mesh', 'mesh_name')
+        expected_name = os.path.splitext(resource.name)[0]
+        if mesh_name != expected_name:
+            raise ValueError(
+                f'Unified-mesh config {resource.name!r} declares '
+                f'mesh_name={mesh_name!r}, expected {expected_name!r}.'
+            )
+
+        mesh_names.append(mesh_name)
+
+    return tuple(sorted(mesh_names))
+
+
+UNIFIED_MESH_NAMES = _discover_mesh_names()
+
+
+def get_unified_mesh_config(mesh_name, filepath=None):
+    """
+    Load default, generic river and per-mesh unified-mesh configs.
+    """
+    config_filename = _get_mesh_config_filename(mesh_name)
+    config = PolarisConfigParser(filepath=filepath)
+    config.add_from_package(PACKAGE, DEFAULT_CONFIG_FILENAME)
+    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+    config.add_from_package(RIVER_CONFIG_PACKAGE, RIVER_CONFIG_FILENAME)
+    config.add_from_package(PACKAGE, config_filename)
+    config.combine()
+    return config
+
+
+def _get_mesh_config_filename(mesh_name):
+    """
+    Get the config filename for one named unified mesh.
+    """
+    if mesh_name not in UNIFIED_MESH_NAMES:
+        valid_mesh_names = ', '.join(UNIFIED_MESH_NAMES)
+        raise ValueError(
+            f'Unexpected unified mesh {mesh_name!r}. Valid mesh names '
+            f'are: {valid_mesh_names}'
+        )
+
+    return f'{mesh_name}.cfg'

--- a/polaris/mesh/spherical/unified/river/distance.py
+++ b/polaris/mesh/spherical/unified/river/distance.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from polaris.constants import get_constant
+
+EARTH_RADIUS = get_constant('mean_radius')
+
+
+def haversine_distance(lon_a, lat_a, lon_b, lat_b):
+    """
+    Compute great-circle distance in meters.
+
+    Parameters
+    ----------
+    lon_a : float or array-like
+        Longitude of the first point(s) in degrees.
+    lat_a : float or array-like
+        Latitude of the first point(s) in degrees.
+    lon_b : float or array-like
+        Longitude of the second point(s) in degrees.
+    lat_b : float or array-like
+        Latitude of the second point(s) in degrees.
+
+    Returns
+    -------
+    float or array-like
+        Great-circle distance(s) in meters.
+    """
+    lon_a = np.deg2rad(lon_a)
+    lat_a = np.deg2rad(lat_a)
+    lon_b = np.deg2rad(lon_b)
+    lat_b = np.deg2rad(lat_b)
+    delta_lon = lon_b - lon_a
+    delta_lat = lat_b - lat_a
+    haversine = (
+        np.sin(delta_lat / 2.0) ** 2
+        + np.cos(lat_a) * np.cos(lat_b) * np.sin(delta_lon / 2.0) ** 2
+    )
+    return 2.0 * EARTH_RADIUS * np.arcsin(np.sqrt(haversine))

--- a/polaris/mesh/spherical/unified/river/geojson.py
+++ b/polaris/mesh/spherical/unified/river/geojson.py
@@ -1,0 +1,35 @@
+import json
+
+
+def read_geojson(filename):
+    """
+    Read a GeoJSON file into a dictionary.
+
+    Parameters
+    ----------
+    filename : str
+        The path to the GeoJSON file
+
+    Returns
+    -------
+    feature_collection : dict
+        The GeoJSON feature collection as a dictionary
+    """
+    with open(filename, 'r', encoding='utf-8') as infile:
+        return json.load(infile)
+
+
+def write_geojson(feature_collection, filename):
+    """
+    Write a GeoJSON feature collection.
+
+    Parameters
+    ----------
+    feature_collection : dict
+        The GeoJSON feature collection as a dictionary
+
+    filename : str
+        The path to the output GeoJSON file
+    """
+    with open(filename, 'w', encoding='utf-8') as outfile:
+        json.dump(feature_collection, outfile, indent=2, sort_keys=True)

--- a/polaris/mesh/spherical/unified/river/river_network.cfg
+++ b/polaris/mesh/spherical/unified/river/river_network.cfg
@@ -1,0 +1,60 @@
+[river_network]
+# public HydroRIVERS archive URL
+hydrorivers_url = https://data.hydrosheds.org/file/HydroRIVERS/HydroRIVERS_v10_shp.zip
+
+# local filename for the downloaded HydroRIVERS archive
+hydrorivers_archive_filename = HydroRIVERS_v10_shp.zip
+
+# shapefile directory expected after unpacking the archive
+hydrorivers_shp_directory = HydroRIVERS_v10_shp
+
+# HydroRIVERS shapefile basename within the unpacked archive
+hydrorivers_shp_filename = HydroRIVERS_v10.shp
+
+# minimum drainage area to retain in the simplified network (m^2).
+# Set to -1 to auto-derive from the sizing-field land resolution and
+# drainage_area_multiplier:
+#   drainage_area_threshold = land_background_km^2 * drainage_area_multiplier * 1e6
+drainage_area_threshold = -1
+
+# number of land-grid cells whose combined area must drain to a point to form
+# a channel.  Use ~100 for high-resolution land meshes and ~10 for coarse ones.
+drainage_area_multiplier = 100
+
+# minimum separation between retained non-endorheic outlets (m).
+# Set to -1 to auto-derive from the sizing-field river-channel resolution:
+#   outlet_distance_tolerance = river_channel_km * 1000.0
+outlet_distance_tolerance = -1
+
+# minimum tributary-to-main-stem drainage-area ratio for retaining a nearby
+# tributary at a confluence
+tributary_area_ratio = 0.05
+
+# inland clip distance for base-mesh river products (km)
+base_mesh_clip_distance_km = 20.0
+
+# geometry simplification tolerance for base-mesh river products (km)
+base_mesh_simplify_tolerance_km = 2.0
+
+# minimum retained segment length after base-mesh clipping (km)
+base_mesh_min_segment_length_km = 2.0
+
+# optional minimum outlet stub length to preserve after clipping (km)
+base_mesh_preserve_outlet_stub_km = 0.0
+
+
+[river_rasterize]
+# maximum distance allowed when matching an ocean outlet to a coastline cell
+outlet_match_tolerance = 50000.0
+
+# fraction of a grid cell used when sampling lines for rasterization
+channel_subsegment_fraction = 0.5
+
+# physical buffer radius around river channels for the lat-lon channel mask;
+# 0 preserves single-cell line rasterization
+channel_buffer_km = 0.0
+
+
+[viz_river_network]
+# output resolution for diagnostic plots
+dpi = 200

--- a/polaris/mesh/spherical/unified/river/river_network.cfg
+++ b/polaris/mesh/spherical/unified/river/river_network.cfg
@@ -21,10 +21,10 @@ drainage_area_threshold = -1
 # a channel.  Use ~100 for high-resolution land meshes and ~10 for coarse ones.
 drainage_area_multiplier = 100
 
-# minimum separation between retained non-endorheic outlets (m).
+# minimum distance between retained nearby upstream branches (m).
 # Set to -1 to auto-derive from the sizing-field river-channel resolution:
-#   outlet_distance_tolerance = river_channel_km * 1000.0
-outlet_distance_tolerance = -1
+#   branch_distance_tolerance = river_channel_km * 1000.0
+branch_distance_tolerance = -1
 
 # minimum tributary-to-main-stem drainage-area ratio for retaining a nearby
 # tributary at a confluence
@@ -39,14 +39,8 @@ base_mesh_simplify_tolerance_km = 2.0
 # minimum retained segment length after base-mesh clipping (km)
 base_mesh_min_segment_length_km = 2.0
 
-# optional minimum outlet stub length to preserve after clipping (km)
-base_mesh_preserve_outlet_stub_km = 0.0
-
 
 [river_rasterize]
-# maximum distance allowed when matching an ocean outlet to a coastline cell
-outlet_match_tolerance = 50000.0
-
 # fraction of a grid cell used when sampling lines for rasterization
 channel_subsegment_fraction = 0.5
 

--- a/polaris/mesh/spherical/unified/u.oi.so12to30.lr10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi.so12to30.lr10.cfg
@@ -1,0 +1,34 @@
+[unified_mesh]
+# name of this unified mesh; must match the config filename
+mesh_name = u.oi.so12to30.lr10
+
+# shared lat-lon target-grid resolution for coastline, river and sizing-field
+# masks (degrees)
+resolution_latlon = 0.0625
+
+[river_network]
+# inland clip distance used for base-mesh river products (km)
+base_mesh_clip_distance_km = 60.0
+
+# geometry simplification tolerance used for base-mesh river products (km)
+base_mesh_simplify_tolerance_km = 5.0
+
+# minimum retained segment length after base-mesh clipping (km)
+base_mesh_min_segment_length_km = 5.0
+
+[river_lat_lon]
+# maximum distance allowed when matching an ocean outlet to a coastline cell
+outlet_match_tolerance = 50000.0
+
+# physical buffer radius around river channels for the lat-lon channel mask;
+# 0 preserves single-cell line rasterization
+# We use twice the river resolution
+channel_buffer_km = 20.0
+
+[sizing_field]
+# background land cell width (km); used to derive drainage_area_threshold
+land_background_km = 10.0
+
+# target cell width (km) along rasterized river channels; used to derive
+# outlet_distance_tolerance
+river_channel_km = 10.0

--- a/polaris/mesh/spherical/unified/u.oi.so12to30.lr10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi.so12to30.lr10.cfg
@@ -17,9 +17,6 @@ base_mesh_simplify_tolerance_km = 5.0
 base_mesh_min_segment_length_km = 5.0
 
 [river_lat_lon]
-# maximum distance allowed when matching an ocean outlet to a coastline cell
-outlet_match_tolerance = 50000.0
-
 # physical buffer radius around river channels for the lat-lon channel mask;
 # 0 preserves single-cell line rasterization
 # We use twice the river resolution

--- a/polaris/mesh/spherical/unified/u.oi240.lr240.cfg
+++ b/polaris/mesh/spherical/unified/u.oi240.lr240.cfg
@@ -1,0 +1,39 @@
+[unified_mesh]
+# name of this unified mesh; must match the config filename
+mesh_name = u.oi240.lr240
+
+# shared lat-lon target-grid resolution for coastline, river and sizing-field
+# masks (degrees)
+resolution_latlon = 0.25
+
+[river_network]
+# at 240 km resolution, 10 cells is sufficient to identify a channel
+drainage_area_multiplier = 10
+
+# inland clip distance used for base-mesh river products (km)
+base_mesh_clip_distance_km = 480.0
+
+# geometry simplification tolerance used for base-mesh river products (km)
+# finer than 1/2 river resolution so river network isn't over-simplified
+base_mesh_simplify_tolerance_km = 30.0
+
+# minimum retained segment length after base-mesh clipping (km)
+# finer than 1/2 river resolution so river network isn't over-simplified
+base_mesh_min_segment_length_km = 30.0
+
+[river_lat_lon]
+# maximum distance allowed when matching an ocean outlet to a coastline cell
+outlet_match_tolerance = 50000.0
+
+# physical buffer radius around river channels for the lat-lon channel mask;
+# 0 preserves single-cell line rasterization
+# We use twice the river resolution
+channel_buffer_km = 480.0
+
+[sizing_field]
+# background land cell width (km); used to derive drainage_area_threshold
+land_background_km = 240.0
+
+# target cell width (km) along rasterized river channels; used to derive
+# outlet_distance_tolerance
+river_channel_km = 240.0

--- a/polaris/mesh/spherical/unified/u.oi240.lr240.cfg
+++ b/polaris/mesh/spherical/unified/u.oi240.lr240.cfg
@@ -7,8 +7,9 @@ mesh_name = u.oi240.lr240
 resolution_latlon = 0.25
 
 [river_network]
-# at 240 km resolution, 10 cells is sufficient to identify a channel
-drainage_area_multiplier = 10
+# 240 km is so coarse that we need to ramp down the multiplier so we
+# retain at least a few river networks
+drainage_area_multiplier = 3.0
 
 # inland clip distance used for base-mesh river products (km)
 base_mesh_clip_distance_km = 480.0
@@ -25,7 +26,7 @@ base_mesh_min_segment_length_km = 30.0
 # physical buffer radius around river channels for the lat-lon channel mask;
 # 0 preserves single-cell line rasterization
 # We use twice the river resolution
-channel_buffer_km = 480.0
+channel_buffer_km = 360.0
 
 [sizing_field]
 # background land cell width (km); used to derive drainage_area_threshold

--- a/polaris/mesh/spherical/unified/u.oi240.lr240.cfg
+++ b/polaris/mesh/spherical/unified/u.oi240.lr240.cfg
@@ -22,9 +22,6 @@ base_mesh_simplify_tolerance_km = 30.0
 base_mesh_min_segment_length_km = 30.0
 
 [river_lat_lon]
-# maximum distance allowed when matching an ocean outlet to a coastline cell
-outlet_match_tolerance = 50000.0
-
 # physical buffer radius around river channels for the lat-lon channel mask;
 # 0 preserves single-cell line rasterization
 # We use twice the river resolution

--- a/polaris/mesh/spherical/unified/u.oi30.lr10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi30.lr10.cfg
@@ -1,0 +1,34 @@
+[unified_mesh]
+# name of this unified mesh; must match the config filename
+mesh_name = u.oi30.lr10
+
+# shared lat-lon target-grid resolution for coastline, river and sizing-field
+# masks (degrees)
+resolution_latlon = 0.125
+
+[river_network]
+# inland clip distance used for base-mesh river products (km)
+base_mesh_clip_distance_km = 60.0
+
+# geometry simplification tolerance used for base-mesh river products (km)
+base_mesh_simplify_tolerance_km = 5.0
+
+# minimum retained segment length after base-mesh clipping (km)
+base_mesh_min_segment_length_km = 5.0
+
+[river_lat_lon]
+# maximum distance allowed when matching an ocean outlet to a coastline cell
+outlet_match_tolerance = 50000.0
+
+# physical buffer radius around river channels for the lat-lon channel mask;
+# 0 preserves single-cell line rasterization
+# We use twice the river resolution
+channel_buffer_km = 20.0
+
+[sizing_field]
+# background land cell width (km); used to derive drainage_area_threshold
+land_background_km = 10.0
+
+# target cell width (km) along rasterized river channels; used to derive
+# outlet_distance_tolerance
+river_channel_km = 10.0

--- a/polaris/mesh/spherical/unified/u.oi30.lr10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi30.lr10.cfg
@@ -17,9 +17,6 @@ base_mesh_simplify_tolerance_km = 5.0
 base_mesh_min_segment_length_km = 5.0
 
 [river_lat_lon]
-# maximum distance allowed when matching an ocean outlet to a coastline cell
-outlet_match_tolerance = 50000.0
-
 # physical buffer radius around river channels for the lat-lon channel mask;
 # 0 preserves single-cell line rasterization
 # We use twice the river resolution

--- a/polaris/mesh/spherical/unified/u.oi6to18.lr6to10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi6to18.lr6to10.cfg
@@ -17,9 +17,6 @@ base_mesh_simplify_tolerance_km = 3.0
 base_mesh_min_segment_length_km = 3.0
 
 [river_lat_lon]
-# maximum distance allowed when matching an ocean outlet to a coastline cell
-outlet_match_tolerance = 25000.0
-
 # physical buffer radius around river channels for the lat-lon channel mask;
 # 0 preserves single-cell line rasterization
 # We use twice the river resolution

--- a/polaris/mesh/spherical/unified/u.oi6to18.lr6to10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi6to18.lr6to10.cfg
@@ -1,0 +1,34 @@
+[unified_mesh]
+# name of this unified mesh; must match the config filename
+mesh_name = u.oi6to18.lr6to10
+
+# shared lat-lon target-grid resolution for coastline, river and sizing-field
+# masks (degrees)
+resolution_latlon = 0.03125
+
+[river_network]
+# inland clip distance used for base-mesh river products (km)
+base_mesh_clip_distance_km = 36.0
+
+# geometry simplification tolerance used for base-mesh river products (km)
+base_mesh_simplify_tolerance_km = 3.0
+
+# minimum retained segment length after base-mesh clipping (km)
+base_mesh_min_segment_length_km = 3.0
+
+[river_lat_lon]
+# maximum distance allowed when matching an ocean outlet to a coastline cell
+outlet_match_tolerance = 25000.0
+
+# physical buffer radius around river channels for the lat-lon channel mask;
+# 0 preserves single-cell line rasterization
+# We use twice the river resolution
+channel_buffer_km = 12.0
+
+[sizing_field]
+# background land cell width (km); used to derive drainage_area_threshold
+land_background_km = 10.0
+
+# target cell width (km) along rasterized river channels; used to derive
+# outlet_distance_tolerance
+river_channel_km = 6.0

--- a/polaris/mesh/spherical/unified/unified_mesh.cfg
+++ b/polaris/mesh/spherical/unified/unified_mesh.cfg
@@ -1,0 +1,1 @@
+[unified_mesh]

--- a/polaris/tasks/mesh/add_tasks.py
+++ b/polaris/tasks/mesh/add_tasks.py
@@ -2,6 +2,7 @@ from polaris.tasks.mesh.base import add_base_mesh_tasks
 from polaris.tasks.mesh.spherical.unified.coastline import (
     add_coastline_tasks,
 )
+from polaris.tasks.mesh.spherical.unified.river import add_river_tasks
 
 
 def add_mesh_tasks(component):
@@ -14,3 +15,4 @@ def add_mesh_tasks(component):
     # add tasks alphabetically
     add_base_mesh_tasks(component=component)
     add_coastline_tasks(component=component)
+    add_river_tasks(component=component)

--- a/polaris/tasks/mesh/spherical/unified/river/__init__.py
+++ b/polaris/tasks/mesh/spherical/unified/river/__init__.py
@@ -1,0 +1,33 @@
+from polaris.tasks.mesh.spherical.unified.river.clip import (
+    ClipRiverNetworkStep,
+)
+from polaris.tasks.mesh.spherical.unified.river.rasterize import (
+    RasterizeRiverLatLonStep,
+    build_river_network_dataset,
+)
+from polaris.tasks.mesh.spherical.unified.river.simplify import (
+    SimplifyRiverNetworkStep,
+    simplify_river_network_feature_collection,
+)
+from polaris.tasks.mesh.spherical.unified.river.steps import (
+    get_unified_mesh_river_steps,
+)
+from polaris.tasks.mesh.spherical.unified.river.task import (
+    UnifiedRiverNetworkTask,
+)
+from polaris.tasks.mesh.spherical.unified.river.tasks import (
+    add_river_tasks,
+)
+from polaris.tasks.mesh.spherical.unified.river.viz import VizRiverStep
+
+__all__ = [
+    'RasterizeRiverLatLonStep',
+    'ClipRiverNetworkStep',
+    'SimplifyRiverNetworkStep',
+    'VizRiverStep',
+    'UnifiedRiverNetworkTask',
+    'add_river_tasks',
+    'build_river_network_dataset',
+    'get_unified_mesh_river_steps',
+    'simplify_river_network_feature_collection',
+]

--- a/polaris/tasks/mesh/spherical/unified/river/clip.py
+++ b/polaris/tasks/mesh/spherical/unified/river/clip.py
@@ -245,6 +245,8 @@ def _conditioned_segment_from_geometry(segment, geometry):
         endorheic=segment.endorheic,
         river_name=segment.river_name,
         outlet_hyriv_id=segment.outlet_hyriv_id,
+        outlet_drainage_area=segment.outlet_drainage_area,
+        river_network_rank=segment.river_network_rank,
     )
 
 

--- a/polaris/tasks/mesh/spherical/unified/river/clip.py
+++ b/polaris/tasks/mesh/spherical/unified/river/clip.py
@@ -5,9 +5,6 @@ import xarray as xr
 from mpas_tools.mesh.interpolation import interp_bilin
 from shapely.geometry import LineString
 
-from polaris.mesh.spherical.unified.river.distance import (
-    haversine_distance,
-)
 from polaris.mesh.spherical.unified.river.geojson import (
     read_geojson,
     write_geojson,
@@ -165,7 +162,8 @@ def condition_base_mesh_river_segments(
         in degrees
 
     min_segment_length_m : float
-        Minimum retained segment length after simplification, in meters
+        Deprecated. Valid inland geometry is retained regardless of length;
+        only degenerate geometries are dropped.
 
     Returns
     -------
@@ -179,9 +177,14 @@ def condition_base_mesh_river_segments(
     lat = ds_coastline.lat.values.astype(float)
     signed_distance = ds_coastline.signed_distance.values.astype(float)
     threshold_m = -float(clip_distance_m)
+    max_spacing_deg = _get_sample_spacing_deg(lon=lon, lat=lat)
 
     all_coords = [
-        np.asarray(seg.geometry.coords, dtype=float) for seg in segments
+        _densify_line_coords(
+            coords=np.asarray(seg.geometry.coords, dtype=float),
+            max_spacing_deg=max_spacing_deg,
+        )
+        for seg in segments
     ]
     seg_sizes = [len(c) for c in all_coords]
     if seg_sizes:
@@ -209,9 +212,9 @@ def condition_base_mesh_river_segments(
             simplified = geometry.simplify(
                 simplify_tolerance_deg, preserve_topology=False
             )
-            cleaned = _clean_conditioned_geometry(
-                simplified, min_segment_length_m
-            )
+            cleaned = _clean_conditioned_geometry(simplified)
+            if cleaned is None:
+                cleaned = _clean_conditioned_geometry(geometry)
             if cleaned is None:
                 continue
             clipped_segments.append(
@@ -259,9 +262,9 @@ def _get_outlet_hyriv_id(segment):
     return segment.outlet_hyriv_id
 
 
-def _clean_conditioned_geometry(geometry, min_segment_length_m):
+def _clean_conditioned_geometry(geometry):
     """
-    Drop degenerate or too-short conditioned geometries.
+    Drop degenerate conditioned geometries.
     """
     if not isinstance(geometry, LineString):
         return None
@@ -279,10 +282,54 @@ def _clean_conditioned_geometry(geometry, min_segment_length_m):
         return None
 
     cleaned = LineString(np.asarray(deduped))
-    if _line_string_length_m(cleaned) < min_segment_length_m:
-        return None
-
     return cleaned
+
+
+def _get_sample_spacing_deg(lon, lat):
+    """
+    Get a clipping sample spacing from the coastline grid.
+    """
+    spacings = []
+    if lon.size > 1:
+        lon_spacing = np.abs(np.diff(lon))
+        lon_spacing = lon_spacing[lon_spacing > 0.0]
+        if lon_spacing.size > 0:
+            spacings.append(float(np.median(lon_spacing)))
+    if lat.size > 1:
+        lat_spacing = np.abs(np.diff(lat))
+        lat_spacing = lat_spacing[lat_spacing > 0.0]
+        if lat_spacing.size > 0:
+            spacings.append(float(np.median(lat_spacing)))
+    if len(spacings) == 0:
+        return 1.0
+    return min(spacings)
+
+
+def _densify_line_coords(coords, max_spacing_deg):
+    """
+    Densify a line so coastline-distance clipping is geometry-local.
+    """
+    if coords.shape[0] < 2:
+        return coords
+
+    dense_coords = [coords[0]]
+    for start, end in zip(coords[:-1], coords[1:], strict=True):
+        delta_lon = _wrapped_longitude_difference(end[0] - start[0])
+        delta_lat = end[1] - start[1]
+        segment_extent = max(abs(delta_lon), abs(delta_lat))
+        n_steps = max(1, int(np.ceil(segment_extent / max_spacing_deg)))
+        for index in range(1, n_steps + 1):
+            fraction = index / n_steps
+            point = np.array(
+                [
+                    _wrap_longitude(start[0] + fraction * delta_lon),
+                    start[1] + fraction * delta_lat,
+                ],
+                dtype=float,
+            )
+            _append_point_if_distinct(dense_coords, point)
+
+    return np.vstack(dense_coords)
 
 
 def _clip_line_string_with_distances(
@@ -351,20 +398,6 @@ def _clip_coords_by_threshold(coords, point_signed_distance, threshold_m):
         clipped_lines.append(np.vstack(current_points))
 
     return clipped_lines
-
-
-def _line_string_length_m(geometry):
-    coords = np.asarray(geometry.coords, dtype=float)
-    if coords.shape[0] < 2:
-        return 0.0
-
-    segment_lengths = haversine_distance(
-        coords[:-1, 0],
-        coords[:-1, 1],
-        coords[1:, 0],
-        coords[1:, 1],
-    )
-    return float(np.sum(segment_lengths))
 
 
 def _km_to_equatorial_degrees(distance_km):
@@ -450,3 +483,17 @@ def _append_point_if_distinct(points, point):
     point = np.asarray(point, dtype=np.float64)
     if len(points) == 0 or not np.allclose(points[-1], point):
         points.append(point)
+
+
+def _wrapped_longitude_difference(delta_lon):
+    """
+    Wrap a longitude difference into the [-180, 180) interval.
+    """
+    return (delta_lon + 180.0) % 360.0 - 180.0
+
+
+def _wrap_longitude(lon):
+    """
+    Wrap a longitude into the [-180, 180) interval.
+    """
+    return _wrapped_longitude_difference(lon)

--- a/polaris/tasks/mesh/spherical/unified/river/clip.py
+++ b/polaris/tasks/mesh/spherical/unified/river/clip.py
@@ -1,5 +1,4 @@
 import os
-from typing import Any
 
 import numpy as np
 import xarray as xr
@@ -57,7 +56,6 @@ class ClipRiverNetworkStep(Step):
         self.simplify_step = simplify_step
         self.coastline_step = coastline_step
         self.clipped_filename = 'clipped_river_network.geojson'
-        self.clipped_outlets_filename = 'clipped_outlets.geojson'
         self.masks_filename = 'clipped_river_network.nc'
 
     def setup(self):
@@ -74,12 +72,6 @@ class ClipRiverNetworkStep(Step):
             ),
         )
         self.add_input_file(
-            filename='retained_outlets.geojson',
-            work_dir_target=os.path.join(
-                self.simplify_step.path, self.simplify_step.outlets_filename
-            ),
-        )
-        self.add_input_file(
             filename='coastline.nc',
             work_dir_target=os.path.join(
                 self.coastline_step.path,
@@ -87,7 +79,6 @@ class ClipRiverNetworkStep(Step):
             ),
         )
         self.add_output_file(filename=self.clipped_filename)
-        self.add_output_file(filename=self.clipped_outlets_filename)
         self.add_output_file(filename=self.masks_filename)
 
     def run(self):
@@ -96,7 +87,6 @@ class ClipRiverNetworkStep(Step):
         """
         section = self.config['river_network']
         river_fc = read_geojson('simplified_river_network.geojson')
-        outlet_fc = read_geojson('retained_outlets.geojson')
         with xr.open_dataset('coastline.nc') as ds_coastline:
             segments = read_river_segments_from_feature_collection(river_fc)
             clipped_segments = condition_base_mesh_river_segments(
@@ -109,25 +99,13 @@ class ClipRiverNetworkStep(Step):
                 ),
                 min_segment_length_m=1.0e3
                 * section.getfloat('base_mesh_min_segment_length_km'),
-                preserve_outlet_stub_m=1.0e3
-                * section.getfloat('base_mesh_preserve_outlet_stub_km'),
             )
             clipped_fc = river_segments_to_feature_collection(clipped_segments)
-            clipped_outlets_fc = clip_outlet_feature_collection(
-                outlet_feature_collection=outlet_fc,
-                ds_coastline=ds_coastline,
-                clip_distance_m=1.0e3
-                * section.getfloat('base_mesh_clip_distance_km'),
-            )
-            ds_river, _ = build_river_network_dataset(
+            ds_river = build_river_network_dataset(
                 river_feature_collection=clipped_fc,
-                outlet_feature_collection=clipped_outlets_fc,
                 ds_coastline=ds_coastline,
                 resolution=self.config.getfloat(
                     'unified_mesh', 'resolution_latlon'
-                ),
-                outlet_match_tolerance=self.config['river_rasterize'].getfloat(
-                    'outlet_match_tolerance'
                 ),
                 channel_subsegment_fraction=self.config[
                     'river_rasterize'
@@ -152,15 +130,10 @@ class ClipRiverNetworkStep(Step):
             min_segment_length_km=section.getfloat(
                 'base_mesh_min_segment_length_km'
             ),
-            preserve_outlet_stub_km=section.getfloat(
-                'base_mesh_preserve_outlet_stub_km'
-            ),
         )
         clipped_fc['metadata'] = metadata
-        clipped_outlets_fc['metadata'] = dict(metadata)
         ds_river.attrs.update(metadata)
         write_geojson(clipped_fc, self.clipped_filename)
-        write_geojson(clipped_outlets_fc, self.clipped_outlets_filename)
         ds_river.to_netcdf(self.masks_filename)
 
 
@@ -170,7 +143,6 @@ def condition_base_mesh_river_segments(
     clip_distance_m,
     simplify_tolerance_deg,
     min_segment_length_m,
-    preserve_outlet_stub_m=0.0,
 ):
     """
     Clip, simplify, and clean river segments for base-mesh use.
@@ -194,11 +166,6 @@ def condition_base_mesh_river_segments(
 
     min_segment_length_m : float
         Minimum retained segment length after simplification, in meters
-
-    preserve_outlet_stub_m : float, optional
-        If positive, a stub of at least this length is kept for outlet
-        segments that would otherwise be fully clipped, preserving the
-        outlet location
 
     Returns
     -------
@@ -237,7 +204,6 @@ def condition_base_mesh_river_segments(
             coords=coords,
             point_signed_distance=point_signed_distance,
             threshold_m=threshold_m,
-            preserve_outlet_stub_m=preserve_outlet_stub_m,
         )
         for geometry in clipped_geometries:
             simplified = geometry.simplify(
@@ -260,7 +226,7 @@ def condition_base_mesh_river_segments(
     return sorted(
         clipped_segments,
         key=lambda segment: (
-            -outlet_area_by_id.get(segment.outlet_hyriv_id, 0.0),
+            -outlet_area_by_id.get(_get_outlet_hyriv_id(segment), 0.0),
             -segment.drainage_area,
             segment.hyriv_id,
             tuple(segment.geometry.coords[-1]),
@@ -268,67 +234,7 @@ def condition_base_mesh_river_segments(
     )
 
 
-def clip_outlet_feature_collection(
-    outlet_feature_collection,
-    ds_coastline,
-    clip_distance_m,
-) -> dict[str, Any]:
-    """
-    Retain only outlets that remain inland after base-mesh clipping.
-
-    Parameters
-    ----------
-    outlet_feature_collection : dict
-        A GeoJSON feature collection of outlet points
-
-    ds_coastline : xarray.Dataset
-        Coastline dataset with ``signed_distance``, ``lon``, and ``lat``
-        variables
-
-    clip_distance_m : float
-        Distance inland from the coastline beyond which outlets are
-        removed, in meters
-
-    Returns
-    -------
-    dict
-        A GeoJSON feature collection containing only the outlets whose
-        signed distance remains within the clipping threshold
-    """
-    lon = ds_coastline.lon.values.astype(float)
-    lat = ds_coastline.lat.values.astype(float)
-    signed_distance = ds_coastline.signed_distance.values.astype(float)
-    threshold_m = -float(clip_distance_m)
-    all_features = outlet_feature_collection['features']
-
-    if not all_features:
-        return dict(type='FeatureCollection', features=[])
-
-    coords = np.array(
-        [feature['geometry']['coordinates'] for feature in all_features],
-        dtype=float,
-    )
-    distances = _interpolate_signed_distance(
-        coords=coords,
-        lon=lon,
-        lat=lat,
-        signed_distance=signed_distance,
-    )
-    features = [
-        feature
-        for feature, dist in zip(all_features, distances, strict=True)
-        if dist <= threshold_m
-    ]
-    return dict(type='FeatureCollection', features=features)
-
-
 def _conditioned_segment_from_geometry(segment, geometry):
-    outlet_type = segment.outlet_type
-    outlet_hyriv_id = segment.outlet_hyriv_id
-    if geometry.coords[-1] != segment.geometry.coords[-1]:
-        outlet_type = None
-        outlet_hyriv_id = None
-
     return RiverSegment(
         geometry=geometry,
         hyriv_id=segment.hyriv_id,
@@ -338,9 +244,17 @@ def _conditioned_segment_from_geometry(segment, geometry):
         next_down=segment.next_down,
         endorheic=segment.endorheic,
         river_name=segment.river_name,
-        outlet_type=outlet_type,
-        outlet_hyriv_id=outlet_hyriv_id,
+        outlet_hyriv_id=segment.outlet_hyriv_id,
     )
+
+
+def _get_outlet_hyriv_id(segment):
+    """
+    Get a sortable basin-root identifier for a river segment.
+    """
+    if segment.outlet_hyriv_id is None:
+        return 0
+    return segment.outlet_hyriv_id
 
 
 def _clean_conditioned_geometry(geometry, min_segment_length_m):
@@ -373,52 +287,14 @@ def _clip_line_string_with_distances(
     coords,
     point_signed_distance,
     threshold_m,
-    preserve_outlet_stub_m,
 ):
     clipped_coords = _clip_coords_by_threshold(
         coords=coords,
         point_signed_distance=point_signed_distance,
         threshold_m=threshold_m,
     )
-    if len(clipped_coords) == 0 and preserve_outlet_stub_m > 0.0:
-        stub = _build_outlet_stub(
-            coords=coords,
-            point_signed_distance=point_signed_distance,
-            threshold_m=threshold_m,
-            preserve_outlet_stub_m=preserve_outlet_stub_m,
-        )
-        if stub is not None:
-            clipped_coords = [stub]
 
     return [LineString(line) for line in clipped_coords if len(line) >= 2]
-
-
-def _build_outlet_stub(
-    coords,
-    point_signed_distance,
-    threshold_m,
-    preserve_outlet_stub_m,
-):
-    for start_index in range(coords.shape[0] - 1, 0, -1):
-        start_point = coords[start_index - 1]
-        end_point = coords[start_index]
-        start_distance = float(point_signed_distance[start_index - 1])
-        end_distance = float(point_signed_distance[start_index])
-        if start_distance <= threshold_m or end_distance <= threshold_m:
-            continue
-
-        crossing = _interpolate_threshold_crossing(
-            start_point=start_point,
-            end_point=end_point,
-            start_distance=start_distance,
-            end_distance=end_distance,
-            threshold_m=threshold_m,
-        )
-        stub = LineString([crossing, end_point])
-        if _line_string_length_m(stub) >= preserve_outlet_stub_m:
-            return np.vstack([crossing, end_point])
-
-    return None
 
 
 def _clip_coords_by_threshold(coords, point_signed_distance, threshold_m):

--- a/polaris/tasks/mesh/spherical/unified/river/clip.py
+++ b/polaris/tasks/mesh/spherical/unified/river/clip.py
@@ -1,0 +1,574 @@
+import os
+from typing import Any
+
+import numpy as np
+import xarray as xr
+from mpas_tools.mesh.interpolation import interp_bilin
+from shapely.geometry import LineString
+
+from polaris.mesh.spherical.unified.river.distance import (
+    haversine_distance,
+)
+from polaris.mesh.spherical.unified.river.geojson import (
+    read_geojson,
+    write_geojson,
+)
+from polaris.step import Step
+from polaris.tasks.mesh.spherical.unified.river.rasterize import (
+    build_river_network_dataset,
+)
+from polaris.tasks.mesh.spherical.unified.river.simplify import (
+    RiverSegment,
+    read_river_segments_from_feature_collection,
+    river_segments_to_feature_collection,
+)
+
+
+class ClipRiverNetworkStep(Step):
+    """
+    Prepare clipped river products for base-mesh consumers.
+    """
+
+    def __init__(self, component, simplify_step, coastline_step, subdir):
+        """
+        Create a new step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        simplify_step : polaris.tasks.mesh.spherical.unified.river.simplify.SimplifyRiverNetworkStep
+            The shared simplify river network step
+
+        coastline_step : polaris.Step
+            The shared coastline step
+
+        subdir : str
+            The subdirectory within the component's work directory
+        """  # noqa: E501
+        super().__init__(
+            component=component,
+            name='river_clip',
+            subdir=subdir,
+            cpus_per_task=1,
+            min_cpus_per_task=1,
+        )
+        self.simplify_step = simplify_step
+        self.coastline_step = coastline_step
+        self.clipped_filename = 'clipped_river_network.geojson'
+        self.clipped_outlets_filename = 'clipped_outlets.geojson'
+        self.masks_filename = 'clipped_river_network.nc'
+
+    def setup(self):
+        """
+        Link simplified river and coastline products and declare outputs.
+        """
+        convention = self.config.get(
+            'spherical_mesh', 'antarctic_boundary_convention'
+        )
+        self.add_input_file(
+            filename='simplified_river_network.geojson',
+            work_dir_target=os.path.join(
+                self.simplify_step.path, self.simplify_step.simplified_filename
+            ),
+        )
+        self.add_input_file(
+            filename='retained_outlets.geojson',
+            work_dir_target=os.path.join(
+                self.simplify_step.path, self.simplify_step.outlets_filename
+            ),
+        )
+        self.add_input_file(
+            filename='coastline.nc',
+            work_dir_target=os.path.join(
+                self.coastline_step.path,
+                self.coastline_step.output_filenames[convention],
+            ),
+        )
+        self.add_output_file(filename=self.clipped_filename)
+        self.add_output_file(filename=self.clipped_outlets_filename)
+        self.add_output_file(filename=self.masks_filename)
+
+    def run(self):
+        """
+        Clip and simplify the retained river network for base-mesh use.
+        """
+        section = self.config['river_network']
+        river_fc = read_geojson('simplified_river_network.geojson')
+        outlet_fc = read_geojson('retained_outlets.geojson')
+        with xr.open_dataset('coastline.nc') as ds_coastline:
+            segments = read_river_segments_from_feature_collection(river_fc)
+            clipped_segments = condition_base_mesh_river_segments(
+                segments=segments,
+                ds_coastline=ds_coastline,
+                clip_distance_m=1.0e3
+                * section.getfloat('base_mesh_clip_distance_km'),
+                simplify_tolerance_deg=_km_to_equatorial_degrees(
+                    section.getfloat('base_mesh_simplify_tolerance_km')
+                ),
+                min_segment_length_m=1.0e3
+                * section.getfloat('base_mesh_min_segment_length_km'),
+                preserve_outlet_stub_m=1.0e3
+                * section.getfloat('base_mesh_preserve_outlet_stub_km'),
+            )
+            clipped_fc = river_segments_to_feature_collection(clipped_segments)
+            clipped_outlets_fc = clip_outlet_feature_collection(
+                outlet_feature_collection=outlet_fc,
+                ds_coastline=ds_coastline,
+                clip_distance_m=1.0e3
+                * section.getfloat('base_mesh_clip_distance_km'),
+            )
+            ds_river, _ = build_river_network_dataset(
+                river_feature_collection=clipped_fc,
+                outlet_feature_collection=clipped_outlets_fc,
+                ds_coastline=ds_coastline,
+                resolution=self.config.getfloat(
+                    'unified_mesh', 'resolution_latlon'
+                ),
+                outlet_match_tolerance=self.config['river_rasterize'].getfloat(
+                    'outlet_match_tolerance'
+                ),
+                channel_subsegment_fraction=self.config[
+                    'river_rasterize'
+                ].getfloat('channel_subsegment_fraction'),
+                channel_buffer_km=self.config['river_rasterize'].getfloat(
+                    'channel_buffer_km'
+                ),
+            )
+
+        metadata = dict(
+            mesh_name=self.config.get('unified_mesh', 'mesh_name'),
+            resolution_latlon=self.config.getfloat(
+                'unified_mesh', 'resolution_latlon'
+            ),
+            source_river_step=self.simplify_step.subdir,
+            source_coastline_step=self.coastline_step.subdir,
+            clip_distance_m=1.0e3
+            * section.getfloat('base_mesh_clip_distance_km'),
+            simplify_tolerance_km=section.getfloat(
+                'base_mesh_simplify_tolerance_km'
+            ),
+            min_segment_length_km=section.getfloat(
+                'base_mesh_min_segment_length_km'
+            ),
+            preserve_outlet_stub_km=section.getfloat(
+                'base_mesh_preserve_outlet_stub_km'
+            ),
+        )
+        clipped_fc['metadata'] = metadata
+        clipped_outlets_fc['metadata'] = dict(metadata)
+        ds_river.attrs.update(metadata)
+        write_geojson(clipped_fc, self.clipped_filename)
+        write_geojson(clipped_outlets_fc, self.clipped_outlets_filename)
+        ds_river.to_netcdf(self.masks_filename)
+
+
+def condition_base_mesh_river_segments(
+    segments,
+    ds_coastline,
+    clip_distance_m,
+    simplify_tolerance_deg,
+    min_segment_length_m,
+    preserve_outlet_stub_m=0.0,
+):
+    """
+    Clip, simplify, and clean river segments for base-mesh use.
+
+    Parameters
+    ----------
+    segments : list of RiverSegment
+        River segments to condition
+
+    ds_coastline : xarray.Dataset
+        Coastline dataset with ``signed_distance``, ``lon``, and ``lat``
+        variables
+
+    clip_distance_m : float
+        Distance inland from the coastline at which segments are clipped,
+        in meters; segment portions seaward of this boundary are removed
+
+    simplify_tolerance_deg : float
+        Douglas-Peucker simplification tolerance applied after clipping,
+        in degrees
+
+    min_segment_length_m : float
+        Minimum retained segment length after simplification, in meters
+
+    preserve_outlet_stub_m : float, optional
+        If positive, a stub of at least this length is kept for outlet
+        segments that would otherwise be fully clipped, preserving the
+        outlet location
+
+    Returns
+    -------
+    list of RiverSegment
+        Conditioned segments sorted by network size (outlet drainage area,
+        largest first), then by segment drainage area and HydroRIVERS
+        identifier within each network
+    """
+    clipped_segments: list[RiverSegment] = []
+    lon = ds_coastline.lon.values.astype(float)
+    lat = ds_coastline.lat.values.astype(float)
+    signed_distance = ds_coastline.signed_distance.values.astype(float)
+    threshold_m = -float(clip_distance_m)
+
+    all_coords = [
+        np.asarray(seg.geometry.coords, dtype=float) for seg in segments
+    ]
+    seg_sizes = [len(c) for c in all_coords]
+    if seg_sizes:
+        all_distances = _interpolate_signed_distance(
+            coords=np.vstack(all_coords),
+            lon=lon,
+            lat=lat,
+            signed_distance=signed_distance,
+        )
+        per_segment_distances = np.split(
+            all_distances, np.cumsum(seg_sizes)[:-1]
+        )
+    else:
+        per_segment_distances = []
+
+    for segment, coords, point_signed_distance in zip(
+        segments, all_coords, per_segment_distances, strict=True
+    ):
+        clipped_geometries = _clip_line_string_with_distances(
+            coords=coords,
+            point_signed_distance=point_signed_distance,
+            threshold_m=threshold_m,
+            preserve_outlet_stub_m=preserve_outlet_stub_m,
+        )
+        for geometry in clipped_geometries:
+            simplified = geometry.simplify(
+                simplify_tolerance_deg, preserve_topology=False
+            )
+            cleaned = _clean_conditioned_geometry(
+                simplified, min_segment_length_m
+            )
+            if cleaned is None:
+                continue
+            clipped_segments.append(
+                _conditioned_segment_from_geometry(segment, cleaned)
+            )
+
+    outlet_area_by_id = {
+        s.outlet_hyriv_id: s.drainage_area
+        for s in segments
+        if s.outlet_hyriv_id is not None and s.hyriv_id == s.outlet_hyriv_id
+    }
+    return sorted(
+        clipped_segments,
+        key=lambda segment: (
+            -outlet_area_by_id.get(segment.outlet_hyriv_id, 0.0),
+            -segment.drainage_area,
+            segment.hyriv_id,
+            tuple(segment.geometry.coords[-1]),
+        ),
+    )
+
+
+def clip_outlet_feature_collection(
+    outlet_feature_collection,
+    ds_coastline,
+    clip_distance_m,
+) -> dict[str, Any]:
+    """
+    Retain only outlets that remain inland after base-mesh clipping.
+
+    Parameters
+    ----------
+    outlet_feature_collection : dict
+        A GeoJSON feature collection of outlet points
+
+    ds_coastline : xarray.Dataset
+        Coastline dataset with ``signed_distance``, ``lon``, and ``lat``
+        variables
+
+    clip_distance_m : float
+        Distance inland from the coastline beyond which outlets are
+        removed, in meters
+
+    Returns
+    -------
+    dict
+        A GeoJSON feature collection containing only the outlets whose
+        signed distance remains within the clipping threshold
+    """
+    lon = ds_coastline.lon.values.astype(float)
+    lat = ds_coastline.lat.values.astype(float)
+    signed_distance = ds_coastline.signed_distance.values.astype(float)
+    threshold_m = -float(clip_distance_m)
+    all_features = outlet_feature_collection['features']
+
+    if not all_features:
+        return dict(type='FeatureCollection', features=[])
+
+    coords = np.array(
+        [feature['geometry']['coordinates'] for feature in all_features],
+        dtype=float,
+    )
+    distances = _interpolate_signed_distance(
+        coords=coords,
+        lon=lon,
+        lat=lat,
+        signed_distance=signed_distance,
+    )
+    features = [
+        feature
+        for feature, dist in zip(all_features, distances, strict=True)
+        if dist <= threshold_m
+    ]
+    return dict(type='FeatureCollection', features=features)
+
+
+def _conditioned_segment_from_geometry(segment, geometry):
+    outlet_type = segment.outlet_type
+    outlet_hyriv_id = segment.outlet_hyriv_id
+    if geometry.coords[-1] != segment.geometry.coords[-1]:
+        outlet_type = None
+        outlet_hyriv_id = None
+
+    return RiverSegment(
+        geometry=geometry,
+        hyriv_id=segment.hyriv_id,
+        main_riv=segment.main_riv,
+        ord_stra=segment.ord_stra,
+        drainage_area=segment.drainage_area,
+        next_down=segment.next_down,
+        endorheic=segment.endorheic,
+        river_name=segment.river_name,
+        outlet_type=outlet_type,
+        outlet_hyriv_id=outlet_hyriv_id,
+    )
+
+
+def _clean_conditioned_geometry(geometry, min_segment_length_m):
+    """
+    Drop degenerate or too-short conditioned geometries.
+    """
+    if not isinstance(geometry, LineString):
+        return None
+
+    coords = np.asarray(geometry.coords, dtype=float)
+    if coords.shape[0] < 2:
+        return None
+
+    deduped = [coords[0]]
+    for point in coords[1:]:
+        if not np.allclose(deduped[-1], point):
+            deduped.append(point)
+
+    if len(deduped) < 2:
+        return None
+
+    cleaned = LineString(np.asarray(deduped))
+    if _line_string_length_m(cleaned) < min_segment_length_m:
+        return None
+
+    return cleaned
+
+
+def _clip_line_string_with_distances(
+    coords,
+    point_signed_distance,
+    threshold_m,
+    preserve_outlet_stub_m,
+):
+    clipped_coords = _clip_coords_by_threshold(
+        coords=coords,
+        point_signed_distance=point_signed_distance,
+        threshold_m=threshold_m,
+    )
+    if len(clipped_coords) == 0 and preserve_outlet_stub_m > 0.0:
+        stub = _build_outlet_stub(
+            coords=coords,
+            point_signed_distance=point_signed_distance,
+            threshold_m=threshold_m,
+            preserve_outlet_stub_m=preserve_outlet_stub_m,
+        )
+        if stub is not None:
+            clipped_coords = [stub]
+
+    return [LineString(line) for line in clipped_coords if len(line) >= 2]
+
+
+def _build_outlet_stub(
+    coords,
+    point_signed_distance,
+    threshold_m,
+    preserve_outlet_stub_m,
+):
+    for start_index in range(coords.shape[0] - 1, 0, -1):
+        start_point = coords[start_index - 1]
+        end_point = coords[start_index]
+        start_distance = float(point_signed_distance[start_index - 1])
+        end_distance = float(point_signed_distance[start_index])
+        if start_distance <= threshold_m or end_distance <= threshold_m:
+            continue
+
+        crossing = _interpolate_threshold_crossing(
+            start_point=start_point,
+            end_point=end_point,
+            start_distance=start_distance,
+            end_distance=end_distance,
+            threshold_m=threshold_m,
+        )
+        stub = LineString([crossing, end_point])
+        if _line_string_length_m(stub) >= preserve_outlet_stub_m:
+            return np.vstack([crossing, end_point])
+
+    return None
+
+
+def _clip_coords_by_threshold(coords, point_signed_distance, threshold_m):
+    clipped_lines: list[np.ndarray] = []
+    current_points: list[np.ndarray] = []
+
+    for start_index in range(coords.shape[0] - 1):
+        start_point = coords[start_index]
+        end_point = coords[start_index + 1]
+        start_distance = float(point_signed_distance[start_index])
+        end_distance = float(point_signed_distance[start_index + 1])
+        start_valid = start_distance <= threshold_m
+        end_valid = end_distance <= threshold_m
+
+        if start_valid and not current_points:
+            _append_point_if_distinct(current_points, start_point)
+
+        if start_valid and end_valid:
+            _append_point_if_distinct(current_points, end_point)
+            continue
+
+        if start_valid and not end_valid:
+            _append_point_if_distinct(
+                current_points,
+                _interpolate_threshold_crossing(
+                    start_point=start_point,
+                    end_point=end_point,
+                    start_distance=start_distance,
+                    end_distance=end_distance,
+                    threshold_m=threshold_m,
+                ),
+            )
+            if len(current_points) >= 2:
+                clipped_lines.append(np.vstack(current_points))
+            current_points = []
+            continue
+
+        if not start_valid and end_valid:
+            _append_point_if_distinct(
+                current_points,
+                _interpolate_threshold_crossing(
+                    start_point=start_point,
+                    end_point=end_point,
+                    start_distance=start_distance,
+                    end_distance=end_distance,
+                    threshold_m=threshold_m,
+                ),
+            )
+            _append_point_if_distinct(current_points, end_point)
+
+    if len(current_points) >= 2:
+        clipped_lines.append(np.vstack(current_points))
+
+    return clipped_lines
+
+
+def _line_string_length_m(geometry):
+    coords = np.asarray(geometry.coords, dtype=float)
+    if coords.shape[0] < 2:
+        return 0.0
+
+    segment_lengths = haversine_distance(
+        coords[:-1, 0],
+        coords[:-1, 1],
+        coords[1:, 0],
+        coords[1:, 1],
+    )
+    return float(np.sum(segment_lengths))
+
+
+def _km_to_equatorial_degrees(distance_km):
+    return float(distance_km) / 111.0
+
+
+def _interpolate_signed_distance(coords, lon, lat, signed_distance):
+    sample_lon = np.asarray(coords[:, 0], dtype=float)
+    interp_lon, interp_field, sample_lon = (
+        _prepare_periodic_longitude_interpolation(
+            lon=lon,
+            field=signed_distance,
+            sample_lon=sample_lon,
+        )
+    )
+    sample_lat = np.asarray(coords[:, 1], dtype=float)
+    return interp_bilin(
+        x=interp_lon,
+        y=lat,
+        field=interp_field,
+        xCell=sample_lon,
+        yCell=sample_lat,
+    )
+
+
+def _prepare_periodic_longitude_interpolation(lon, field, sample_lon):
+    lon = np.asarray(lon, dtype=float)
+    field = np.asarray(field)
+    sample_lon = np.asarray(sample_lon, dtype=float)
+
+    if lon.ndim != 1 or lon.size < 2:
+        return lon, field, sample_lon
+
+    lon_spacing = np.diff(lon)
+    if not np.all(lon_spacing > 0.0):
+        return lon, field, sample_lon
+
+    spacing = float(np.median(lon_spacing))
+    includes_periodic_endpoint = np.isclose(
+        lon[-1] - lon[0], 360.0, atol=spacing * 0.5
+    )
+    omits_periodic_endpoint = np.isclose(
+        lon[-1] - lon[0] + spacing, 360.0, atol=spacing * 0.5
+    )
+
+    if not includes_periodic_endpoint and not omits_periodic_endpoint:
+        return lon, field, sample_lon
+
+    original_sample_lon = sample_lon.copy()
+    sample_lon = lon[0] + np.mod(sample_lon - lon[0], 360.0)
+
+    if includes_periodic_endpoint:
+        wrap_mask = np.isclose(sample_lon, lon[0]) & (
+            original_sample_lon > lon[-1]
+        )
+        sample_lon[wrap_mask] = lon[-1]
+        return lon, field, sample_lon
+
+    lon = np.append(lon, lon[0] + 360.0)
+    field = np.concatenate([field, field[:, :1]], axis=1)
+    return lon, field, sample_lon
+
+
+def _interpolate_threshold_crossing(
+    start_point,
+    end_point,
+    start_distance,
+    end_distance,
+    threshold_m,
+):
+    if np.isclose(end_distance, start_distance):
+        fraction = 0.5
+    else:
+        fraction = (threshold_m - start_distance) / (
+            end_distance - start_distance
+        )
+
+    fraction = float(np.clip(fraction, 0.0, 1.0))
+    return start_point + fraction * (end_point - start_point)
+
+
+def _append_point_if_distinct(points, point):
+    point = np.asarray(point, dtype=np.float64)
+    if len(points) == 0 or not np.allclose(points[-1], point):
+        points.append(point)

--- a/polaris/tasks/mesh/spherical/unified/river/rasterize.py
+++ b/polaris/tasks/mesh/spherical/unified/river/rasterize.py
@@ -2,15 +2,12 @@ import os
 
 import numpy as np
 import xarray as xr
-from scipy.spatial import cKDTree
-from shapely.geometry import Point, mapping, shape
 
 from polaris.mesh.spherical.unified.river.distance import (
     haversine_distance,
 )
 from polaris.mesh.spherical.unified.river.geojson import (
     read_geojson,
-    write_geojson,
 )
 from polaris.step import Step
 from polaris.tasks.mesh.spherical.unified.river.simplify import (
@@ -52,7 +49,6 @@ class RasterizeRiverLatLonStep(Step):
         self.simplify_step = simplify_step
         self.coastline_step = coastline_step
         self.masks_filename = 'river_network.nc'
-        self.outlets_filename = 'river_outlets.geojson'
 
     def setup(self):
         """
@@ -68,12 +64,6 @@ class RasterizeRiverLatLonStep(Step):
             ),
         )
         self.add_input_file(
-            filename='retained_outlets.geojson',
-            work_dir_target=os.path.join(
-                self.simplify_step.path, self.simplify_step.outlets_filename
-            ),
-        )
-        self.add_input_file(
             filename='coastline.nc',
             work_dir_target=os.path.join(
                 self.coastline_step.path,
@@ -81,24 +71,20 @@ class RasterizeRiverLatLonStep(Step):
             ),
         )
         self.add_output_file(filename=self.masks_filename)
-        self.add_output_file(filename=self.outlets_filename)
 
     def run(self):
         """
-        Build target-grid river masks and snapped outlet diagnostics.
+        Build the target-grid river-channel mask.
         """
         section = self.config['river_rasterize']
         river_fc = read_geojson('simplified_river_network.geojson')
-        outlet_fc = read_geojson('retained_outlets.geojson')
         ds_coastline = xr.open_dataset('coastline.nc')
-        ds_river, snapped_outlets = build_river_network_dataset(
+        ds_river = build_river_network_dataset(
             river_feature_collection=river_fc,
-            outlet_feature_collection=outlet_fc,
             ds_coastline=ds_coastline,
             resolution=self.config.getfloat(
                 'unified_mesh', 'resolution_latlon'
             ),
-            outlet_match_tolerance=section.getfloat('outlet_match_tolerance'),
             channel_subsegment_fraction=section.getfloat(
                 'channel_subsegment_fraction'
             ),
@@ -113,15 +99,12 @@ class RasterizeRiverLatLonStep(Step):
             'spherical_mesh', 'antarctic_boundary_convention'
         )
         ds_river.to_netcdf(self.masks_filename)
-        write_geojson(snapped_outlets, self.outlets_filename)
 
 
 def build_river_network_dataset(
     river_feature_collection,
-    outlet_feature_collection,
     ds_coastline,
     resolution,
-    outlet_match_tolerance,
     channel_subsegment_fraction=0.5,
     channel_buffer_km=0.0,
 ):
@@ -133,20 +116,11 @@ def build_river_network_dataset(
     river_feature_collection : dict
         A GeoJSON feature collection of simplified river line segments
 
-    outlet_feature_collection : dict
-        A GeoJSON feature collection of outlet points
-
     ds_coastline : xarray.Dataset
-        Coastline dataset with ``lat``, ``lon``, and ``ocean_mask``
-        variables
+        Coastline dataset with ``lat`` and ``lon`` variables
 
     resolution : float
         The target grid resolution in degrees
-
-    outlet_match_tolerance : float
-        Maximum distance in meters within which an ocean outlet is
-        snapped to the nearest ocean cell; outlets beyond this distance
-        fall back to the nearest grid cell
 
     channel_subsegment_fraction : float, optional
         Fraction of the target resolution used as the maximum
@@ -160,13 +134,7 @@ def build_river_network_dataset(
     Returns
     -------
     ds_river : xarray.Dataset
-        Dataset with ``river_channel_mask``, ``river_outlet_mask``,
-        ``river_ocean_outlet_mask``, and ``river_inland_sink_mask``
-        on the target lat-lon grid
-
-    snapped_outlets : dict
-        A GeoJSON feature collection of snapped outlet points with
-        diagnostic snapping properties
+        Dataset with ``river_channel_mask`` on the target lat-lon grid
     """
     river_segments = read_river_segments_from_feature_collection(
         river_feature_collection
@@ -176,9 +144,6 @@ def build_river_network_dataset(
     shape_2d = (lat.size, lon.size)
 
     river_channel_mask = np.zeros(shape_2d, dtype=np.int8)
-    river_outlet_mask = np.zeros(shape_2d, dtype=np.int8)
-    river_ocean_outlet_mask = np.zeros(shape_2d, dtype=np.int8)
-    river_inland_sink_mask = np.zeros(shape_2d, dtype=np.int8)
     channel_buffer_m = channel_buffer_km * 1.0e3
 
     for segment in river_segments:
@@ -197,77 +162,6 @@ def build_river_network_dataset(
                 buffer_m=channel_buffer_m,
             )
 
-    snapped_features = []
-    ocean_outlets = 0
-    unmatched_ocean_outlets = 0
-    ocean_mask = _mask_from_dataset(ds_coastline, 'ocean_mask')
-    land_mask = _get_land_mask(ds_coastline)
-    ocean_kdtree, ocean_indices_arr = _build_cell_kdtree(ocean_mask, lon, lat)
-    land_kdtree, land_indices_arr = _build_cell_kdtree(land_mask, lon, lat)
-    for feature in outlet_feature_collection['features']:
-        properties = dict(feature['properties'])
-        source_point = shape(feature['geometry'])
-        source_lon = float(source_point.x)
-        source_lat = float(source_point.y)
-        outlet_type = properties['outlet_type']
-        if outlet_type == 'ocean':
-            ocean_outlets += 1
-            (
-                lat_index,
-                lon_index,
-                snapped_lon,
-                snapped_lat,
-                matched_to_ocean,
-                snapping_distance,
-            ) = _match_ocean_outlet(
-                source_lon=source_lon,
-                source_lat=source_lat,
-                lon=lon,
-                lat=lat,
-                ocean_kdtree=ocean_kdtree,
-                ocean_indices_arr=ocean_indices_arr,
-                outlet_match_tolerance=outlet_match_tolerance,
-            )
-            if not matched_to_ocean:
-                unmatched_ocean_outlets += 1
-            river_ocean_outlet_mask[lat_index, lon_index] = 1
-        else:
-            (
-                lat_index,
-                lon_index,
-                snapped_lon,
-                snapped_lat,
-                snapping_distance,
-            ) = _match_land_point(
-                source_lon=source_lon,
-                source_lat=source_lat,
-                lon=lon,
-                lat=lat,
-                land_kdtree=land_kdtree,
-                land_indices_arr=land_indices_arr,
-            )
-            matched_to_ocean = False
-            river_inland_sink_mask[lat_index, lon_index] = 1
-
-        river_outlet_mask[lat_index, lon_index] = 1
-        properties.update(
-            source_lon=source_lon,
-            source_lat=source_lat,
-            snapped_lon=snapped_lon,
-            snapped_lat=snapped_lat,
-            snapped_lat_index=int(lat_index),
-            snapped_lon_index=int(lon_index),
-            snapping_distance_m=snapping_distance,
-            matched_to_ocean=matched_to_ocean,
-        )
-        snapped_features.append(
-            dict(
-                type='Feature',
-                properties=properties,
-                geometry=mapping(Point(snapped_lon, snapped_lat)),
-            )
-        )
-
     ds_river = xr.Dataset(
         coords=dict(lat=ds_coastline.lat, lon=ds_coastline.lon)
     )
@@ -275,88 +169,17 @@ def build_river_network_dataset(
     ds_river['river_channel_mask'] = xr.DataArray(
         river_channel_mask, dims=dims
     )
-    ds_river['river_outlet_mask'] = xr.DataArray(river_outlet_mask, dims=dims)
-    ds_river['river_ocean_outlet_mask'] = xr.DataArray(
-        river_ocean_outlet_mask, dims=dims
-    )
-    ds_river['river_inland_sink_mask'] = xr.DataArray(
-        river_inland_sink_mask, dims=dims
-    )
     ds_river.attrs.update(
         dict(
             target_grid='lat_lon',
             target_grid_resolution_degrees=resolution,
-            outlet_match_tolerance_m=outlet_match_tolerance,
             channel_buffer_m=channel_buffer_m,
-            unmatched_ocean_outlets=unmatched_ocean_outlets,
-            matched_ocean_outlets=ocean_outlets - unmatched_ocean_outlets,
         )
     )
     ds_river['river_channel_mask'].attrs['long_name'] = (
         'Lat-lon mask for retained river channels'
     )
-    ds_river['river_outlet_mask'].attrs['long_name'] = (
-        'Lat-lon mask for all retained river outlets and inland sinks'
-    )
-    ds_river['river_ocean_outlet_mask'].attrs['long_name'] = (
-        'Lat-lon mask for retained ocean-draining river outlets'
-    )
-    ds_river['river_inland_sink_mask'].attrs['long_name'] = (
-        'Lat-lon mask for retained inland sinks'
-    )
-
-    snapped_outlets = dict(
-        type='FeatureCollection',
-        features=snapped_features,
-        metadata=dict(
-            mesh_name=ds_river.attrs.get('mesh_name'),
-            target_grid='lat_lon',
-            target_grid_resolution_degrees=resolution,
-            outlet_match_tolerance_m=outlet_match_tolerance,
-            channel_buffer_m=channel_buffer_m,
-            unmatched_ocean_outlets=unmatched_ocean_outlets,
-        ),
-    )
-    return ds_river, snapped_outlets
-
-
-def _mask_from_dataset(ds_coastline, variable_name):
-    """
-    Read an integer mask from a coastline dataset if available.
-    """
-    if variable_name not in ds_coastline:
-        return None
-    return ds_coastline[variable_name].values.astype(bool)
-
-
-def _get_land_mask(ds_coastline):
-    """
-    Derive the land mask from ocean_mask.
-    """
-    return np.logical_not(ds_coastline.ocean_mask.values.astype(bool))
-
-
-def _build_cell_kdtree(mask, lon, lat):
-    """
-    Build a 3-D spherical KD-tree from grid cells where mask is True.
-
-    Converts lon/lat to unit-sphere Cartesian coordinates so that the
-    nearest neighbour in Euclidean 3-D space equals the nearest neighbour
-    by great-circle distance.  Returns (None, None) when the mask is empty.
-    """
-    if mask is None or not np.any(mask):
-        return None, None
-    indices = np.argwhere(mask)
-    cell_lon_rad = np.deg2rad(lon[indices[:, 1]])
-    cell_lat_rad = np.deg2rad(lat[indices[:, 0]])
-    xyz = np.column_stack(
-        [
-            np.cos(cell_lat_rad) * np.cos(cell_lon_rad),
-            np.cos(cell_lat_rad) * np.sin(cell_lon_rad),
-            np.sin(cell_lat_rad),
-        ]
-    )
-    return cKDTree(xyz), indices
+    return ds_river
 
 
 def _sample_line(geometry, resolution, subsegment_fraction):
@@ -467,119 +290,6 @@ def _coordinate_window(value, coord, delta, periodic=False):
     start = max(0, center - half_width)
     stop = min(coord.size, center + half_width + 1)
     return np.arange(start, stop, dtype=int)
-
-
-def _match_ocean_outlet(
-    source_lon,
-    source_lat,
-    lon,
-    lat,
-    ocean_kdtree,
-    ocean_indices_arr,
-    outlet_match_tolerance,
-):
-    """
-    Match an ocean outlet to the nearest ocean cell.
-    """
-    if ocean_kdtree is not None:
-        lon_rad = np.deg2rad(source_lon)
-        lat_rad = np.deg2rad(source_lat)
-        source_xyz = [
-            np.cos(lat_rad) * np.cos(lon_rad),
-            np.cos(lat_rad) * np.sin(lon_rad),
-            np.sin(lat_rad),
-        ]
-        _, tree_idx = ocean_kdtree.query(source_xyz)
-        lat_index = int(ocean_indices_arr[tree_idx, 0])
-        lon_index = int(ocean_indices_arr[tree_idx, 1])
-        snapped_lon = float(lon[lon_index])
-        snapped_lat = float(lat[lat_index])
-        snapping_distance = float(
-            haversine_distance(
-                source_lon, source_lat, snapped_lon, snapped_lat
-            )
-        )
-        matched_to_ocean = snapping_distance <= outlet_match_tolerance
-        if matched_to_ocean:
-            return (
-                lat_index,
-                lon_index,
-                snapped_lon,
-                snapped_lat,
-                True,
-                snapping_distance,
-            )
-
-    lat_index, lon_index = _nearest_grid_index(
-        sample_lon=source_lon,
-        sample_lat=source_lat,
-        lon=lon,
-        lat=lat,
-    )
-    snapped_lon = float(lon[lon_index])
-    snapped_lat = float(lat[lat_index])
-    snapping_distance = float(
-        haversine_distance(source_lon, source_lat, snapped_lon, snapped_lat)
-    )
-    return (
-        lat_index,
-        lon_index,
-        snapped_lon,
-        snapped_lat,
-        False,
-        snapping_distance,
-    )
-
-
-def _match_land_point(
-    source_lon,
-    source_lat,
-    lon,
-    lat,
-    land_kdtree,
-    land_indices_arr,
-):
-    """
-    Match an inland sink to the nearest land cell.
-    """
-    if land_kdtree is not None:
-        lon_rad = np.deg2rad(source_lon)
-        lat_rad = np.deg2rad(source_lat)
-        source_xyz = [
-            np.cos(lat_rad) * np.cos(lon_rad),
-            np.cos(lat_rad) * np.sin(lon_rad),
-            np.sin(lat_rad),
-        ]
-        _, tree_idx = land_kdtree.query(source_xyz)
-        lat_index = int(land_indices_arr[tree_idx, 0])
-        lon_index = int(land_indices_arr[tree_idx, 1])
-        snapped_lon = float(lon[lon_index])
-        snapped_lat = float(lat[lat_index])
-        snapping_distance = float(
-            haversine_distance(
-                source_lon, source_lat, snapped_lon, snapped_lat
-            )
-        )
-        return (
-            lat_index,
-            lon_index,
-            snapped_lon,
-            snapped_lat,
-            snapping_distance,
-        )
-
-    lat_index, lon_index = _nearest_grid_index(
-        sample_lon=source_lon,
-        sample_lat=source_lat,
-        lon=lon,
-        lat=lat,
-    )
-    snapped_lon = float(lon[lon_index])
-    snapped_lat = float(lat[lat_index])
-    snapping_distance = float(
-        haversine_distance(source_lon, source_lat, snapped_lon, snapped_lat)
-    )
-    return lat_index, lon_index, snapped_lon, snapped_lat, snapping_distance
 
 
 def _wrapped_longitude_difference(delta_lon):

--- a/polaris/tasks/mesh/spherical/unified/river/rasterize.py
+++ b/polaris/tasks/mesh/spherical/unified/river/rasterize.py
@@ -1,0 +1,596 @@
+import os
+
+import numpy as np
+import xarray as xr
+from scipy.spatial import cKDTree
+from shapely.geometry import Point, mapping, shape
+
+from polaris.mesh.spherical.unified.river.distance import (
+    haversine_distance,
+)
+from polaris.mesh.spherical.unified.river.geojson import (
+    read_geojson,
+    write_geojson,
+)
+from polaris.step import Step
+from polaris.tasks.mesh.spherical.unified.river.simplify import (
+    EARTH_RADIUS,
+    read_river_segments_from_feature_collection,
+)
+
+
+class RasterizeRiverLatLonStep(Step):
+    """
+    Rasterize a simplified river network onto a shared lat-lon target grid.
+    """
+
+    def __init__(self, component, simplify_step, coastline_step, subdir):
+        """
+        Create a new step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        simplify_step : polaris.tasks.mesh.spherical.unified.river.simplify.SimplifyRiverNetworkStep
+            The shared simplify river network step
+
+        coastline_step : polaris.Step
+            The shared coastline step
+
+        subdir : str
+            The subdirectory within the component's work directory
+        """  # noqa: E501
+        super().__init__(
+            component=component,
+            name='river_rasterize',
+            subdir=subdir,
+            cpus_per_task=1,
+            min_cpus_per_task=1,
+        )
+        self.simplify_step = simplify_step
+        self.coastline_step = coastline_step
+        self.masks_filename = 'river_network.nc'
+        self.outlets_filename = 'river_outlets.geojson'
+
+    def setup(self):
+        """
+        Link shared source and coastline inputs and declare outputs.
+        """
+        convention = self.config.get(
+            'spherical_mesh', 'antarctic_boundary_convention'
+        )
+        self.add_input_file(
+            filename='simplified_river_network.geojson',
+            work_dir_target=os.path.join(
+                self.simplify_step.path, self.simplify_step.simplified_filename
+            ),
+        )
+        self.add_input_file(
+            filename='retained_outlets.geojson',
+            work_dir_target=os.path.join(
+                self.simplify_step.path, self.simplify_step.outlets_filename
+            ),
+        )
+        self.add_input_file(
+            filename='coastline.nc',
+            work_dir_target=os.path.join(
+                self.coastline_step.path,
+                self.coastline_step.output_filenames[convention],
+            ),
+        )
+        self.add_output_file(filename=self.masks_filename)
+        self.add_output_file(filename=self.outlets_filename)
+
+    def run(self):
+        """
+        Build target-grid river masks and snapped outlet diagnostics.
+        """
+        section = self.config['river_rasterize']
+        river_fc = read_geojson('simplified_river_network.geojson')
+        outlet_fc = read_geojson('retained_outlets.geojson')
+        ds_coastline = xr.open_dataset('coastline.nc')
+        ds_river, snapped_outlets = build_river_network_dataset(
+            river_feature_collection=river_fc,
+            outlet_feature_collection=outlet_fc,
+            ds_coastline=ds_coastline,
+            resolution=self.config.getfloat(
+                'unified_mesh', 'resolution_latlon'
+            ),
+            outlet_match_tolerance=section.getfloat('outlet_match_tolerance'),
+            channel_subsegment_fraction=section.getfloat(
+                'channel_subsegment_fraction'
+            ),
+            channel_buffer_km=section.getfloat('channel_buffer_km'),
+        )
+        ds_river.attrs['source_river_step'] = self.simplify_step.subdir
+        ds_river.attrs['source_coastline_step'] = self.coastline_step.subdir
+        ds_river.attrs['mesh_name'] = self.config.get(
+            'unified_mesh', 'mesh_name'
+        )
+        ds_river.attrs['antarctic_boundary_convention'] = self.config.get(
+            'spherical_mesh', 'antarctic_boundary_convention'
+        )
+        ds_river.to_netcdf(self.masks_filename)
+        write_geojson(snapped_outlets, self.outlets_filename)
+
+
+def build_river_network_dataset(
+    river_feature_collection,
+    outlet_feature_collection,
+    ds_coastline,
+    resolution,
+    outlet_match_tolerance,
+    channel_subsegment_fraction=0.5,
+    channel_buffer_km=0.0,
+):
+    """
+    Rasterize a simplified river network onto a regular lat-lon grid.
+
+    Parameters
+    ----------
+    river_feature_collection : dict
+        A GeoJSON feature collection of simplified river line segments
+
+    outlet_feature_collection : dict
+        A GeoJSON feature collection of outlet points
+
+    ds_coastline : xarray.Dataset
+        Coastline dataset with ``lat``, ``lon``, and ``ocean_mask``
+        variables
+
+    resolution : float
+        The target grid resolution in degrees
+
+    outlet_match_tolerance : float
+        Maximum distance in meters within which an ocean outlet is
+        snapped to the nearest ocean cell; outlets beyond this distance
+        fall back to the nearest grid cell
+
+    channel_subsegment_fraction : float, optional
+        Fraction of the target resolution used as the maximum
+        inter-sample spacing when densifying river channels for
+        rasterization
+
+    channel_buffer_km : float, optional
+        Physical buffer radius in kilometres around each sampled channel
+        point within which additional grid cells are marked
+
+    Returns
+    -------
+    ds_river : xarray.Dataset
+        Dataset with ``river_channel_mask``, ``river_outlet_mask``,
+        ``river_ocean_outlet_mask``, and ``river_inland_sink_mask``
+        on the target lat-lon grid
+
+    snapped_outlets : dict
+        A GeoJSON feature collection of snapped outlet points with
+        diagnostic snapping properties
+    """
+    river_segments = read_river_segments_from_feature_collection(
+        river_feature_collection
+    )
+    lat = ds_coastline.lat.values
+    lon = ds_coastline.lon.values
+    shape_2d = (lat.size, lon.size)
+
+    river_channel_mask = np.zeros(shape_2d, dtype=np.int8)
+    river_outlet_mask = np.zeros(shape_2d, dtype=np.int8)
+    river_ocean_outlet_mask = np.zeros(shape_2d, dtype=np.int8)
+    river_inland_sink_mask = np.zeros(shape_2d, dtype=np.int8)
+    channel_buffer_m = channel_buffer_km * 1.0e3
+
+    for segment in river_segments:
+        sample_points = _sample_line(
+            segment.geometry,
+            resolution=resolution,
+            subsegment_fraction=channel_subsegment_fraction,
+        )
+        for sample_lon, sample_lat in sample_points:
+            _mark_channel_sample(
+                mask=river_channel_mask,
+                sample_lon=sample_lon,
+                sample_lat=sample_lat,
+                lon=lon,
+                lat=lat,
+                buffer_m=channel_buffer_m,
+            )
+
+    snapped_features = []
+    ocean_outlets = 0
+    unmatched_ocean_outlets = 0
+    ocean_mask = _mask_from_dataset(ds_coastline, 'ocean_mask')
+    land_mask = _get_land_mask(ds_coastline)
+    ocean_kdtree, ocean_indices_arr = _build_cell_kdtree(ocean_mask, lon, lat)
+    land_kdtree, land_indices_arr = _build_cell_kdtree(land_mask, lon, lat)
+    for feature in outlet_feature_collection['features']:
+        properties = dict(feature['properties'])
+        source_point = shape(feature['geometry'])
+        source_lon = float(source_point.x)
+        source_lat = float(source_point.y)
+        outlet_type = properties['outlet_type']
+        if outlet_type == 'ocean':
+            ocean_outlets += 1
+            (
+                lat_index,
+                lon_index,
+                snapped_lon,
+                snapped_lat,
+                matched_to_ocean,
+                snapping_distance,
+            ) = _match_ocean_outlet(
+                source_lon=source_lon,
+                source_lat=source_lat,
+                lon=lon,
+                lat=lat,
+                ocean_kdtree=ocean_kdtree,
+                ocean_indices_arr=ocean_indices_arr,
+                outlet_match_tolerance=outlet_match_tolerance,
+            )
+            if not matched_to_ocean:
+                unmatched_ocean_outlets += 1
+            river_ocean_outlet_mask[lat_index, lon_index] = 1
+        else:
+            (
+                lat_index,
+                lon_index,
+                snapped_lon,
+                snapped_lat,
+                snapping_distance,
+            ) = _match_land_point(
+                source_lon=source_lon,
+                source_lat=source_lat,
+                lon=lon,
+                lat=lat,
+                land_kdtree=land_kdtree,
+                land_indices_arr=land_indices_arr,
+            )
+            matched_to_ocean = False
+            river_inland_sink_mask[lat_index, lon_index] = 1
+
+        river_outlet_mask[lat_index, lon_index] = 1
+        properties.update(
+            source_lon=source_lon,
+            source_lat=source_lat,
+            snapped_lon=snapped_lon,
+            snapped_lat=snapped_lat,
+            snapped_lat_index=int(lat_index),
+            snapped_lon_index=int(lon_index),
+            snapping_distance_m=snapping_distance,
+            matched_to_ocean=matched_to_ocean,
+        )
+        snapped_features.append(
+            dict(
+                type='Feature',
+                properties=properties,
+                geometry=mapping(Point(snapped_lon, snapped_lat)),
+            )
+        )
+
+    ds_river = xr.Dataset(
+        coords=dict(lat=ds_coastline.lat, lon=ds_coastline.lon)
+    )
+    dims = ('lat', 'lon')
+    ds_river['river_channel_mask'] = xr.DataArray(
+        river_channel_mask, dims=dims
+    )
+    ds_river['river_outlet_mask'] = xr.DataArray(river_outlet_mask, dims=dims)
+    ds_river['river_ocean_outlet_mask'] = xr.DataArray(
+        river_ocean_outlet_mask, dims=dims
+    )
+    ds_river['river_inland_sink_mask'] = xr.DataArray(
+        river_inland_sink_mask, dims=dims
+    )
+    ds_river.attrs.update(
+        dict(
+            target_grid='lat_lon',
+            target_grid_resolution_degrees=resolution,
+            outlet_match_tolerance_m=outlet_match_tolerance,
+            channel_buffer_m=channel_buffer_m,
+            unmatched_ocean_outlets=unmatched_ocean_outlets,
+            matched_ocean_outlets=ocean_outlets - unmatched_ocean_outlets,
+        )
+    )
+    ds_river['river_channel_mask'].attrs['long_name'] = (
+        'Lat-lon mask for retained river channels'
+    )
+    ds_river['river_outlet_mask'].attrs['long_name'] = (
+        'Lat-lon mask for all retained river outlets and inland sinks'
+    )
+    ds_river['river_ocean_outlet_mask'].attrs['long_name'] = (
+        'Lat-lon mask for retained ocean-draining river outlets'
+    )
+    ds_river['river_inland_sink_mask'].attrs['long_name'] = (
+        'Lat-lon mask for retained inland sinks'
+    )
+
+    snapped_outlets = dict(
+        type='FeatureCollection',
+        features=snapped_features,
+        metadata=dict(
+            mesh_name=ds_river.attrs.get('mesh_name'),
+            target_grid='lat_lon',
+            target_grid_resolution_degrees=resolution,
+            outlet_match_tolerance_m=outlet_match_tolerance,
+            channel_buffer_m=channel_buffer_m,
+            unmatched_ocean_outlets=unmatched_ocean_outlets,
+        ),
+    )
+    return ds_river, snapped_outlets
+
+
+def _mask_from_dataset(ds_coastline, variable_name):
+    """
+    Read an integer mask from a coastline dataset if available.
+    """
+    if variable_name not in ds_coastline:
+        return None
+    return ds_coastline[variable_name].values.astype(bool)
+
+
+def _get_land_mask(ds_coastline):
+    """
+    Derive the land mask from ocean_mask.
+    """
+    return np.logical_not(ds_coastline.ocean_mask.values.astype(bool))
+
+
+def _build_cell_kdtree(mask, lon, lat):
+    """
+    Build a 3-D spherical KD-tree from grid cells where mask is True.
+
+    Converts lon/lat to unit-sphere Cartesian coordinates so that the
+    nearest neighbour in Euclidean 3-D space equals the nearest neighbour
+    by great-circle distance.  Returns (None, None) when the mask is empty.
+    """
+    if mask is None or not np.any(mask):
+        return None, None
+    indices = np.argwhere(mask)
+    cell_lon_rad = np.deg2rad(lon[indices[:, 1]])
+    cell_lat_rad = np.deg2rad(lat[indices[:, 0]])
+    xyz = np.column_stack(
+        [
+            np.cos(cell_lat_rad) * np.cos(cell_lon_rad),
+            np.cos(cell_lat_rad) * np.sin(cell_lon_rad),
+            np.sin(cell_lat_rad),
+        ]
+    )
+    return cKDTree(xyz), indices
+
+
+def _sample_line(geometry, resolution, subsegment_fraction):
+    """
+    Sample a line densely enough to rasterize it onto a regular grid.
+    """
+    coords = np.asarray(geometry.coords)
+    sample_points = [tuple(coords[0])]
+    max_step = resolution * subsegment_fraction
+    for start, end in zip(coords[:-1], coords[1:], strict=True):
+        lon0, lat0 = start
+        lon1, lat1 = end
+        delta_lon = _wrapped_longitude_difference(lon1 - lon0)
+        delta_lat = lat1 - lat0
+        segment_extent = max(abs(delta_lon), abs(delta_lat))
+        n_steps = max(1, int(np.ceil(segment_extent / max_step)))
+        for index in range(1, n_steps + 1):
+            fraction = index / n_steps
+            sample_points.append(
+                (
+                    _wrap_longitude(lon0 + fraction * delta_lon),
+                    lat0 + fraction * delta_lat,
+                )
+            )
+    return sample_points
+
+
+def _nearest_grid_index(sample_lon, sample_lat, lon, lat):
+    """
+    Find the nearest lat-lon grid-cell center.
+    """
+    lon_index = _nearest_periodic_index(sample_lon, lon)
+    lat_index = _nearest_bounded_index(sample_lat, lat)
+    return lat_index, lon_index
+
+
+def _mark_channel_sample(mask, sample_lon, sample_lat, lon, lat, buffer_m):
+    """
+    Mark grid cells within a physical buffer of a sampled river point.
+    """
+    lat_index, lon_index = _nearest_grid_index(
+        sample_lon=sample_lon,
+        sample_lat=sample_lat,
+        lon=lon,
+        lat=lat,
+    )
+    mask[lat_index, lon_index] = 1
+    if buffer_m <= 0.0:
+        return
+
+    angular_buffer = buffer_m / EARTH_RADIUS
+    lat_delta = np.rad2deg(angular_buffer)
+    cos_lat = max(np.cos(np.deg2rad(sample_lat)), 1.0e-6)
+    lon_delta = min(180.0, np.rad2deg(angular_buffer / cos_lat))
+    lat_indices = _coordinate_window(sample_lat, lat, lat_delta)
+    lon_indices = _coordinate_window(sample_lon, lon, lon_delta, periodic=True)
+
+    candidate_lat = lat[lat_indices][:, np.newaxis]
+    candidate_lon = lon[lon_indices][np.newaxis, :]
+    distances = haversine_distance(
+        sample_lon, sample_lat, candidate_lon, candidate_lat
+    )
+    buffered_mask = distances <= buffer_m
+    mask[np.ix_(lat_indices, lon_indices)] |= buffered_mask.astype(np.int8)
+
+
+def _nearest_bounded_index(value, coord):
+    """
+    Find the nearest index in a regular coordinate array.
+    """
+    if coord.size == 1:
+        return 0
+
+    step = coord[1] - coord[0]
+    raw_index = int(np.rint((value - coord[0]) / step))
+    return int(np.clip(raw_index, 0, coord.size - 1))
+
+
+def _nearest_periodic_index(value, coord):
+    """
+    Find the nearest index in a regular periodic coordinate array.
+    """
+    if coord.size == 1:
+        return 0
+
+    step = coord[1] - coord[0]
+    raw_index = int(np.rint((value - coord[0]) / step))
+    return raw_index % coord.size
+
+
+def _coordinate_window(value, coord, delta, periodic=False):
+    """
+    Find candidate coordinate indices within one regular-grid window.
+    """
+    if coord.size == 1:
+        return np.array([0], dtype=int)
+
+    spacing = abs(coord[1] - coord[0])
+    half_width = int(np.ceil(delta / spacing)) + 1
+    if periodic:
+        center = _nearest_periodic_index(value, coord)
+        indices = np.arange(
+            center - half_width, center + half_width + 1, dtype=int
+        )
+        return np.unique(indices % coord.size)
+
+    center = _nearest_bounded_index(value, coord)
+    start = max(0, center - half_width)
+    stop = min(coord.size, center + half_width + 1)
+    return np.arange(start, stop, dtype=int)
+
+
+def _match_ocean_outlet(
+    source_lon,
+    source_lat,
+    lon,
+    lat,
+    ocean_kdtree,
+    ocean_indices_arr,
+    outlet_match_tolerance,
+):
+    """
+    Match an ocean outlet to the nearest ocean cell.
+    """
+    if ocean_kdtree is not None:
+        lon_rad = np.deg2rad(source_lon)
+        lat_rad = np.deg2rad(source_lat)
+        source_xyz = [
+            np.cos(lat_rad) * np.cos(lon_rad),
+            np.cos(lat_rad) * np.sin(lon_rad),
+            np.sin(lat_rad),
+        ]
+        _, tree_idx = ocean_kdtree.query(source_xyz)
+        lat_index = int(ocean_indices_arr[tree_idx, 0])
+        lon_index = int(ocean_indices_arr[tree_idx, 1])
+        snapped_lon = float(lon[lon_index])
+        snapped_lat = float(lat[lat_index])
+        snapping_distance = float(
+            haversine_distance(
+                source_lon, source_lat, snapped_lon, snapped_lat
+            )
+        )
+        matched_to_ocean = snapping_distance <= outlet_match_tolerance
+        if matched_to_ocean:
+            return (
+                lat_index,
+                lon_index,
+                snapped_lon,
+                snapped_lat,
+                True,
+                snapping_distance,
+            )
+
+    lat_index, lon_index = _nearest_grid_index(
+        sample_lon=source_lon,
+        sample_lat=source_lat,
+        lon=lon,
+        lat=lat,
+    )
+    snapped_lon = float(lon[lon_index])
+    snapped_lat = float(lat[lat_index])
+    snapping_distance = float(
+        haversine_distance(source_lon, source_lat, snapped_lon, snapped_lat)
+    )
+    return (
+        lat_index,
+        lon_index,
+        snapped_lon,
+        snapped_lat,
+        False,
+        snapping_distance,
+    )
+
+
+def _match_land_point(
+    source_lon,
+    source_lat,
+    lon,
+    lat,
+    land_kdtree,
+    land_indices_arr,
+):
+    """
+    Match an inland sink to the nearest land cell.
+    """
+    if land_kdtree is not None:
+        lon_rad = np.deg2rad(source_lon)
+        lat_rad = np.deg2rad(source_lat)
+        source_xyz = [
+            np.cos(lat_rad) * np.cos(lon_rad),
+            np.cos(lat_rad) * np.sin(lon_rad),
+            np.sin(lat_rad),
+        ]
+        _, tree_idx = land_kdtree.query(source_xyz)
+        lat_index = int(land_indices_arr[tree_idx, 0])
+        lon_index = int(land_indices_arr[tree_idx, 1])
+        snapped_lon = float(lon[lon_index])
+        snapped_lat = float(lat[lat_index])
+        snapping_distance = float(
+            haversine_distance(
+                source_lon, source_lat, snapped_lon, snapped_lat
+            )
+        )
+        return (
+            lat_index,
+            lon_index,
+            snapped_lon,
+            snapped_lat,
+            snapping_distance,
+        )
+
+    lat_index, lon_index = _nearest_grid_index(
+        sample_lon=source_lon,
+        sample_lat=source_lat,
+        lon=lon,
+        lat=lat,
+    )
+    snapped_lon = float(lon[lon_index])
+    snapped_lat = float(lat[lat_index])
+    snapping_distance = float(
+        haversine_distance(source_lon, source_lat, snapped_lon, snapped_lat)
+    )
+    return lat_index, lon_index, snapped_lon, snapped_lat, snapping_distance
+
+
+def _wrapped_longitude_difference(delta_lon):
+    """
+    Wrap a longitude difference into the [-180, 180) interval.
+    """
+    return (delta_lon + 180.0) % 360.0 - 180.0
+
+
+def _wrap_longitude(lon):
+    """
+    Wrap a longitude into the [-180, 180) interval.
+    """
+    return _wrapped_longitude_difference(lon)

--- a/polaris/tasks/mesh/spherical/unified/river/simplify.py
+++ b/polaris/tasks/mesh/spherical/unified/river/simplify.py
@@ -1,0 +1,887 @@
+import multiprocessing
+import os
+from collections import defaultdict
+from dataclasses import dataclass, replace
+
+import numpy as np
+import shapefile
+from shapely import line_merge, unary_union
+from shapely.geometry import LineString, Point, box, mapping, shape
+from shapely.strtree import STRtree
+
+from polaris.archive import extract_zip_subdir
+from polaris.constants import get_constant
+from polaris.mesh.spherical.unified.river.distance import (
+    haversine_distance,
+)
+from polaris.mesh.spherical.unified.river.geojson import (
+    write_geojson,
+)
+from polaris.step import Step
+
+EARTH_RADIUS = get_constant('mean_radius')
+KM2_TO_M2 = 1.0e6
+_METERS_PER_DEGREE = np.pi / 180.0 * EARTH_RADIUS
+
+# Module-level state shared with fork-based parallel workers.
+# Set by simplify_river_network_feature_collection before Pool creation.
+_WORKER_UPSTREAM_MAP = None
+_WORKER_SEGMENT_BY_ID = None
+_WORKER_DISTANCE_TOLERANCE = None
+_WORKER_TRIBUTARY_AREA_RATIO = None
+_WORKER_SEG_TREE = None
+_WORKER_SEG_LIST = None
+
+
+@dataclass(frozen=True)
+class RiverSegment:
+    """
+    Canonical representation of one river-network segment.
+
+    Attributes
+    ----------
+    geometry : shapely.geometry.LineString
+        The segment geometry in longitude-latitude coordinates
+
+    hyriv_id : int
+        The HydroRIVERS unique segment identifier
+
+    main_riv : int
+        The HydroRIVERS main-river identifier
+
+    ord_stra : int
+        The Strahler stream order
+
+    drainage_area : float
+        The upstream drainage area in square meters
+
+    next_down : int
+        The HydroRIVERS identifier of the next downstream segment
+        (0 for outlets)
+
+    endorheic : int
+        1 if the segment drains to an inland sink, 0 otherwise
+
+    river_name : str or None, optional
+        The river name, if available
+
+    outlet_type : str or None, optional
+        The outlet type (``'ocean'`` or ``'inland_sink'``), set when the
+        segment has been assigned to a basin
+
+    outlet_hyriv_id : int or None, optional
+        The HydroRIVERS identifier of the outlet for the basin this
+        segment belongs to
+    """
+
+    geometry: LineString
+    hyriv_id: int
+    main_riv: int
+    ord_stra: int
+    drainage_area: float
+    next_down: int
+    endorheic: int
+    river_name: str | None = None
+    outlet_type: str | None = None
+    outlet_hyriv_id: int | None = None
+
+    @property
+    def endpoint(self) -> tuple[float, float]:
+        """
+        Return the downstream endpoint of the segment.
+        """
+        lon, lat = self.geometry.coords[-1]
+        return float(lon), float(lat)
+
+
+class SimplifyRiverNetworkStep(Step):
+    """
+    Prepare a simplified, source-grid-independent river network.
+    """
+
+    def __init__(self, component, subdir):
+        """
+        Create a new step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        subdir : str
+            The subdirectory within the component's work directory
+        """
+        super().__init__(
+            component=component,
+            name='river_simplify',
+            subdir=subdir,
+            cpus_per_task=128,
+            min_cpus_per_task=1,
+        )
+        self.simplified_filename = 'simplified_river_network.geojson'
+        self.outlets_filename = 'retained_outlets.geojson'
+
+    def setup(self):
+        """
+        Add the HydroRIVERS shapefile archive input and declare outputs.
+        """
+        section = self.config['river_network']
+        archive_filename = section.get('hydrorivers_archive_filename')
+        source_url = section.get('hydrorivers_url')
+        self.add_input_file(
+            filename=archive_filename,
+            target=archive_filename,
+            url=source_url,
+            database='river_network',
+        )
+        self.add_output_file(filename=self.simplified_filename)
+        self.add_output_file(filename=self.outlets_filename)
+
+    def run(self):
+        """
+        Download, unpack, convert, and simplify HydroRIVERS source data.
+        """
+        import time
+
+        print(f'cpus_per_task = {self.cpus_per_task}', flush=True)
+
+        section = self.config['river_network']
+        archive_filename = section.get('hydrorivers_archive_filename')
+        shp_directory = section.get('hydrorivers_shp_directory')
+        shp_filename = section.get('hydrorivers_shp_filename')
+        _unpack_hydrorivers_archive(archive_filename, shp_directory)
+
+        drainage_area_threshold = section.getfloat('drainage_area_threshold')
+        if drainage_area_threshold < 0:
+            land_background_km = self.config.getfloat(
+                'sizing_field', 'land_background_km'
+            )
+            drainage_area_multiplier = section.getfloat(
+                'drainage_area_multiplier'
+            )
+            drainage_area_threshold = (
+                land_background_km**2 * drainage_area_multiplier * KM2_TO_M2
+            )
+
+        outlet_distance_tolerance = section.getfloat(
+            'outlet_distance_tolerance'
+        )
+        if outlet_distance_tolerance < 0:
+            river_channel_km = self.config.getfloat(
+                'sizing_field', 'river_channel_km'
+            )
+            outlet_distance_tolerance = river_channel_km * 1000.0
+
+        t0 = time.time()
+        feature_collection = _read_filtered_shapefile_feature_collection(
+            shp_filename=os.path.join(shp_directory, shp_filename),
+            drainage_area_threshold=drainage_area_threshold,
+        )
+        print(
+            f'read shapefile (filtered): {time.time() - t0:.1f} s',
+            flush=True,
+        )
+
+        t0 = time.time()
+        simplified_fc, outlets_fc = simplify_river_network_feature_collection(
+            feature_collection=feature_collection,
+            drainage_area_threshold=drainage_area_threshold,
+            outlet_distance_tolerance=outlet_distance_tolerance,
+            tributary_area_ratio=section.getfloat('tributary_area_ratio'),
+            n_cpus=self.cpus_per_task,
+        )
+        print(f'simplify: {time.time() - t0:.1f} s', flush=True)
+        simplified_fc['metadata'] = dict(
+            mesh_name=self.config.get('unified_mesh', 'mesh_name'),
+            resolution_latlon=self.config.getfloat(
+                'unified_mesh', 'resolution_latlon'
+            ),
+            hydrorivers_url=section.get('hydrorivers_url'),
+            hydrorivers_archive_filename=archive_filename,
+            hydrorivers_shp_directory=shp_directory,
+            hydrorivers_shp_filename=shp_filename,
+            drainage_area_threshold=drainage_area_threshold,
+            outlet_distance_tolerance=outlet_distance_tolerance,
+            tributary_area_ratio=section.getfloat('tributary_area_ratio'),
+        )
+        outlets_fc['metadata'] = dict(simplified_fc['metadata'])
+        t0 = time.time()
+        write_geojson(simplified_fc, self.simplified_filename)
+        write_geojson(outlets_fc, self.outlets_filename)
+        print(f'write outputs: {time.time() - t0:.1f} s', flush=True)
+
+
+def _unpack_hydrorivers_archive(archive_filename, data_directory):
+    """
+    Unpack the HydroRIVERS archive if needed.
+    """
+    if os.path.isdir(data_directory):
+        return
+
+    extract_zip_subdir(archive_filename, data_directory)
+
+    if not os.path.isdir(data_directory):
+        raise OSError(
+            'Unpacked HydroRIVERS archive but did not find the expected '
+            f'data directory {data_directory!r}.'
+        )
+
+
+def _read_filtered_shapefile_feature_collection(
+    shp_filename, drainage_area_threshold
+):
+    """
+    Read a HydroRIVERS shapefile, skipping segments below the drainage area
+    threshold before constructing geometry to avoid processing the ~97% of
+    records that would be discarded immediately afterward.
+    """
+    reader = shapefile.Reader(shp_filename)
+    features = []
+    for shape_record in reader.iterShapeRecords():
+        props = shape_record.record.as_dict()
+        upland_skm = props.get('UPLAND_SKM')
+        if upland_skm is None:
+            upland_skm = props.get('upland_skm', 0.0)
+        if float(upland_skm) * KM2_TO_M2 < drainage_area_threshold:
+            continue
+        features.append(
+            dict(
+                type='Feature',
+                properties=props,
+                geometry=shape_record.shape.__geo_interface__,
+            )
+        )
+    return dict(type='FeatureCollection', features=features)
+
+
+def _convert_hydrorivers_shapefile_to_geojson(shp_filename, output_filename):
+    """
+    Convert the HydroRIVERS shapefile to GeoJSON.
+    """
+    reader = shapefile.Reader(shp_filename)
+    features = []
+    for shape_record in reader.iterShapeRecords():
+        features.append(
+            dict(
+                type='Feature',
+                properties=shape_record.record.as_dict(),
+                geometry=shape_record.shape.__geo_interface__,
+            )
+        )
+    write_geojson(
+        dict(type='FeatureCollection', features=features), output_filename
+    )
+
+
+def simplify_river_network_feature_collection(
+    feature_collection,
+    drainage_area_threshold,
+    outlet_distance_tolerance,
+    tributary_area_ratio=0.05,
+    n_cpus=1,
+):
+    """
+    Simplify a HydroRIVERS-style feature collection.
+
+    Parameters
+    ----------
+    feature_collection : dict
+        A GeoJSON feature collection
+
+    drainage_area_threshold : float
+        Minimum retained drainage area in square meters
+
+    outlet_distance_tolerance : float
+        Minimum retained spacing between non-endorheic outlets in meters
+
+    tributary_area_ratio : float, optional
+        The minimum tributary-to-main-stem drainage-area ratio for retaining
+        a nearby tributary at a confluence
+
+    n_cpus : int, optional
+        Number of parallel worker processes for basin traversal.
+        Defaults to 1 (single-process).
+
+    Returns
+    -------
+    simplified_fc : dict
+        A GeoJSON feature collection for the simplified river network
+
+    outlets_fc : dict
+        A GeoJSON feature collection for retained outlet points
+    """
+    import time
+
+    t0 = time.time()
+    segments = read_river_segments_from_feature_collection(feature_collection)
+    n_raw = len(segments)
+    segments = [
+        segment
+        for segment in segments
+        if segment.drainage_area >= drainage_area_threshold
+    ]
+    print(
+        f'  read segments: {n_raw} raw, {len(segments)} after area filter, '
+        f'{time.time() - t0:.1f} s',
+        flush=True,
+    )
+    if len(segments) == 0:
+        raise ValueError(
+            'No river-network segments remain after applying the drainage '
+            'area threshold.'
+        )
+
+    segment_by_id = {segment.hyriv_id: segment for segment in segments}
+    _validate_acyclic_downstream_graph(segment_by_id)
+
+    upstream_map: dict[int, list[RiverSegment]] = defaultdict(list)
+    for segment in segments:
+        if segment.next_down != 0:
+            upstream_map[segment.next_down].append(segment)
+
+    outlet_candidates = [
+        segment for segment in segments if segment.next_down == 0
+    ]
+    retained_outlets = _filter_outlets(
+        outlet_candidates, outlet_distance_tolerance
+    )
+    print(
+        f'  outlet candidates: {len(outlet_candidates)}, '
+        f'retained: {len(retained_outlets)}',
+        flush=True,
+    )
+
+    t0 = time.time()
+    seg_list = list(segments)
+    seg_tree = STRtree([seg.geometry for seg in seg_list])
+    print(
+        f'  build STRtree ({len(seg_list)} geoms): {time.time() - t0:.1f} s',
+        flush=True,
+    )
+
+    retained_segments: dict[int, RiverSegment] = {}
+    n_workers = min(n_cpus, len(retained_outlets))
+    print(f'  basin traversal: n_workers={n_workers}', flush=True)
+    t0 = time.time()
+    if n_workers > 1:
+        global _WORKER_UPSTREAM_MAP, _WORKER_SEGMENT_BY_ID
+        global _WORKER_DISTANCE_TOLERANCE, _WORKER_TRIBUTARY_AREA_RATIO
+        global _WORKER_SEG_TREE, _WORKER_SEG_LIST
+        _WORKER_UPSTREAM_MAP = upstream_map
+        _WORKER_SEGMENT_BY_ID = segment_by_id
+        _WORKER_DISTANCE_TOLERANCE = outlet_distance_tolerance
+        _WORKER_TRIBUTARY_AREA_RATIO = tributary_area_ratio
+        _WORKER_SEG_TREE = seg_tree
+        _WORKER_SEG_LIST = seg_list
+        ctx = multiprocessing.get_context('fork')
+        with ctx.Pool(processes=n_workers) as pool:
+            results = pool.map(_process_outlet, retained_outlets)
+        _WORKER_UPSTREAM_MAP = None
+        _WORKER_SEGMENT_BY_ID = None
+        _WORKER_DISTANCE_TOLERANCE = None
+        _WORKER_TRIBUTARY_AREA_RATIO = None
+        _WORKER_SEG_TREE = None
+        _WORKER_SEG_LIST = None
+        for result in results:
+            retained_segments.update(result)
+    else:
+        for outlet in retained_outlets:
+            if outlet.endorheic == 1:
+                outlet_type = 'inland_sink'
+            else:
+                outlet_type = 'ocean'
+            _retain_basin_segments(
+                segment=replace(
+                    outlet,
+                    outlet_type=outlet_type,
+                    outlet_hyriv_id=outlet.hyriv_id,
+                ),
+                upstream_map=upstream_map,
+                segment_by_id=segment_by_id,
+                retained_segments=retained_segments,
+                distance_tolerance=outlet_distance_tolerance,
+                tributary_area_ratio=tributary_area_ratio,
+                seg_tree=seg_tree,
+                seg_list=seg_list,
+            )
+
+    print(f'  basin traversal: {time.time() - t0:.1f} s', flush=True)
+
+    outlet_area_by_id = {
+        outlet.hyriv_id: outlet.drainage_area for outlet in retained_outlets
+    }
+    simplified_segments = sorted(
+        retained_segments.values(),
+        key=lambda segment: (
+            -outlet_area_by_id.get(segment.outlet_hyriv_id, 0.0),
+            -segment.drainage_area,
+            segment.hyriv_id,
+        ),
+    )
+    outlet_segments = sorted(
+        [segment for segment in retained_outlets],
+        key=lambda segment: (-segment.drainage_area, segment.hyriv_id),
+    )
+
+    return (
+        river_segments_to_feature_collection(simplified_segments),
+        outlet_segments_to_feature_collection(outlet_segments),
+    )
+
+
+def read_river_segments_from_feature_collection(
+    feature_collection,
+) -> list[RiverSegment]:
+    """
+    Convert a GeoJSON feature collection to canonical river segments.
+
+    Parameters
+    ----------
+    feature_collection : dict
+        A GeoJSON feature collection with HydroRIVERS-style properties
+
+    Returns
+    -------
+    list of RiverSegment
+        Canonical river segments; geometries with duplicate HydroRIVERS
+        identifiers are merged into a single segment
+    """
+    merged_segments: dict[int, RiverSegment] = {}
+    for feature in feature_collection['features']:
+        segment = _segment_from_feature(feature)
+        existing = merged_segments.get(segment.hyriv_id)
+        if existing is None:
+            merged_segments[segment.hyriv_id] = segment
+            continue
+
+        merged_geometry = line_merge(
+            unary_union([existing.geometry, segment.geometry])
+        )
+        if not isinstance(merged_geometry, LineString):
+            merged_geometry = LineString(
+                np.vstack(
+                    [
+                        np.asarray(existing.geometry.coords),
+                        np.asarray(segment.geometry.coords),
+                    ]
+                )
+            )
+        merged_segments[segment.hyriv_id] = replace(
+            existing, geometry=merged_geometry
+        )
+
+    return list(merged_segments.values())
+
+
+def river_segments_to_feature_collection(segments):
+    """
+    Convert canonical river segments to a GeoJSON feature collection.
+
+    Parameters
+    ----------
+    segments : list of RiverSegment
+        Canonical river segments
+
+    Returns
+    -------
+    dict
+        A GeoJSON feature collection with one feature per segment,
+        preserving all HydroRIVERS properties
+    """
+    features = []
+    for segment in segments:
+        properties = dict(
+            hyriv_id=segment.hyriv_id,
+            main_riv=segment.main_riv,
+            ord_stra=segment.ord_stra,
+            drainage_area=segment.drainage_area,
+            upland_skm=segment.drainage_area / KM2_TO_M2,
+            next_down=segment.next_down,
+            endorheic=segment.endorheic,
+            outlet_type=segment.outlet_type,
+            outlet_hyriv_id=segment.outlet_hyriv_id,
+        )
+        if segment.river_name is not None:
+            properties['river_name'] = segment.river_name
+        features.append(
+            dict(
+                type='Feature',
+                properties=properties,
+                geometry=mapping(segment.geometry),
+            )
+        )
+    return dict(type='FeatureCollection', features=features)
+
+
+def outlet_segments_to_feature_collection(segments):
+    """
+    Convert retained outlet segments to a GeoJSON feature collection.
+
+    Parameters
+    ----------
+    segments : list of RiverSegment
+        Retained outlet segments
+
+    Returns
+    -------
+    dict
+        A GeoJSON feature collection of outlet point features
+    """
+    features = []
+    for segment in segments:
+        lon, lat = segment.endpoint
+        if segment.endorheic == 1:
+            outlet_type = 'inland_sink'
+        else:
+            outlet_type = 'ocean'
+        features.append(
+            dict(
+                type='Feature',
+                properties=dict(
+                    hyriv_id=segment.hyriv_id,
+                    main_riv=segment.main_riv,
+                    drainage_area=segment.drainage_area,
+                    upland_skm=segment.drainage_area / KM2_TO_M2,
+                    endorheic=segment.endorheic,
+                    outlet_type=outlet_type,
+                ),
+                geometry=mapping(Point(lon, lat)),
+            )
+        )
+    return dict(type='FeatureCollection', features=features)
+
+
+def _process_outlet(outlet):
+    """
+    Process one outlet basin in a fork-based worker process.
+    """
+    if outlet.endorheic == 1:
+        outlet_type = 'inland_sink'
+    else:
+        outlet_type = 'ocean'
+    retained: dict[int, RiverSegment] = {}
+    _retain_basin_segments(
+        segment=replace(
+            outlet,
+            outlet_type=outlet_type,
+            outlet_hyriv_id=outlet.hyriv_id,
+        ),
+        upstream_map=_WORKER_UPSTREAM_MAP,
+        segment_by_id=_WORKER_SEGMENT_BY_ID,
+        retained_segments=retained,
+        distance_tolerance=_WORKER_DISTANCE_TOLERANCE,
+        tributary_area_ratio=_WORKER_TRIBUTARY_AREA_RATIO,
+        seg_tree=_WORKER_SEG_TREE,
+        seg_list=_WORKER_SEG_LIST,
+    )
+    return retained
+
+
+def _retain_basin_segments(
+    segment,
+    upstream_map,
+    segment_by_id,
+    retained_segments,
+    distance_tolerance,
+    tributary_area_ratio,
+    seg_tree,
+    seg_list,
+):
+    """
+    Iteratively retain a main stem and major tributaries for one basin.
+    """
+    basin_visited: set[int] = set()
+    stack = [segment]
+
+    while len(stack) > 0:
+        current = stack.pop()
+        if current.hyriv_id not in segment_by_id:
+            continue
+        if current.hyriv_id in basin_visited:
+            continue
+
+        basin_visited.add(current.hyriv_id)
+        retained_segments[current.hyriv_id] = current
+
+        keep_segments = _select_upstream_segments(
+            segment=current,
+            upstream_map=upstream_map,
+            basin_id_set=basin_visited,
+            distance_tolerance=distance_tolerance,
+            tributary_area_ratio=tributary_area_ratio,
+            seg_tree=seg_tree,
+            seg_list=seg_list,
+        )
+
+        for upstream in reversed(keep_segments):
+            annotated = replace(
+                upstream,
+                outlet_type=current.outlet_type,
+                outlet_hyriv_id=current.outlet_hyriv_id,
+            )
+            stack.append(annotated)
+
+
+def _select_upstream_segments(
+    segment,
+    upstream_map,
+    basin_id_set,
+    distance_tolerance,
+    tributary_area_ratio,
+    seg_tree,
+    seg_list,
+):
+    """
+    Select retained upstream segments for one confluence.
+    """
+    upstream_segments = sorted(
+        upstream_map.get(segment.hyriv_id, []),
+        key=lambda upstream: (
+            upstream.drainage_area,
+            upstream.ord_stra,
+            upstream.hyriv_id,
+        ),
+        reverse=True,
+    )
+    if len(upstream_segments) == 0:
+        return []
+
+    keep_segments = [upstream_segments[0]]
+    primary = upstream_segments[0]
+    for upstream in upstream_segments[1:]:
+        keep = upstream.drainage_area >= (
+            tributary_area_ratio * primary.drainage_area
+        )
+        if not keep:
+            keep = (
+                _distance_to_basin(
+                    upstream,
+                    basin_id_set,
+                    seg_tree,
+                    seg_list,
+                    distance_tolerance,
+                )
+                >= distance_tolerance
+            )
+        if keep:
+            keep_segments.append(upstream)
+
+    return keep_segments
+
+
+def _validate_acyclic_downstream_graph(segment_by_id):
+    """
+    Validate that retained segments do not contain NEXT_DOWN cycles.
+    """
+    checked: set[int] = set()
+
+    for hyriv_id in segment_by_id:
+        if hyriv_id in checked:
+            continue
+
+        path: list[int] = []
+        path_index: dict[int, int] = {}
+        current_id = hyriv_id
+
+        while current_id in segment_by_id:
+            if current_id in checked:
+                break
+            if current_id in path_index:
+                cycle = path[path_index[current_id] :] + [current_id]
+                cycle_text = ' -> '.join(str(item) for item in cycle)
+                raise ValueError(
+                    'Cycle detected in retained river-network NEXT_DOWN '
+                    f'chain: {cycle_text}'
+                )
+
+            path_index[current_id] = len(path)
+            path.append(current_id)
+
+            next_down = segment_by_id[current_id].next_down
+            if next_down == 0:
+                break
+            current_id = next_down
+
+        checked.update(path)
+
+
+def _distance_to_basin(
+    segment,
+    basin_id_set,
+    seg_tree,
+    seg_list,
+    distance_tolerance,
+):
+    """
+    Compute the minimum distance from a segment to already retained segments.
+
+    Uses a spatial index to limit exact distance computations to nearby
+    candidates, and returns early once a distance below distance_tolerance
+    is found.
+    """
+    if len(basin_id_set) == 0:
+        return np.inf
+    bounds = segment.geometry.bounds
+    max_abs_lat = max(abs(bounds[1]), abs(bounds[3]))
+    cos_lat = np.cos(np.deg2rad(min(max_abs_lat, 89.0)))
+    lat_exp = distance_tolerance / _METERS_PER_DEGREE
+    lon_exp = distance_tolerance / (_METERS_PER_DEGREE * cos_lat)
+    query_box = box(
+        bounds[0] - lon_exp,
+        bounds[1] - lat_exp,
+        bounds[2] + lon_exp,
+        bounds[3] + lat_exp,
+    )
+    min_dist = np.inf
+    for idx in seg_tree.query(query_box):
+        other = seg_list[idx]
+        if other.hyriv_id not in basin_id_set:
+            continue
+        dist = _minimum_line_distance(segment.geometry, other.geometry)
+        if dist < min_dist:
+            min_dist = dist
+        if min_dist < distance_tolerance:
+            return min_dist
+    return min_dist
+
+
+def _filter_outlets(outlet_candidates, outlet_distance_tolerance):
+    """
+    Retain large, well-separated outlets while preserving inland sinks.
+    """
+    retained_outlets: list[RiverSegment] = []
+    for candidate in sorted(
+        outlet_candidates,
+        key=lambda outlet: (
+            outlet.drainage_area,
+            outlet.ord_stra,
+            outlet.hyriv_id,
+        ),
+        reverse=True,
+    ):
+        keep = True
+        lon, lat = candidate.endpoint
+        for retained in retained_outlets:
+            if candidate.endorheic == 1 and retained.endorheic == 1:
+                continue
+            retained_lon, retained_lat = retained.endpoint
+            distance = haversine_distance(lon, lat, retained_lon, retained_lat)
+            if float(distance) < outlet_distance_tolerance:
+                keep = False
+                break
+        if keep:
+            retained_outlets.append(candidate)
+
+    return retained_outlets
+
+
+def _segment_from_feature(feature):
+    """
+    Parse one GeoJSON feature into a canonical river segment.
+    """
+    properties = feature['properties']
+    geometry = _line_string_from_geojson(feature['geometry'])
+    hyriv_id = _get_int_property(properties, ('hyriv_id', 'HYRIV_ID'))
+    main_riv = _get_int_property(properties, ('main_riv', 'MAIN_RIV'))
+    ord_stra = _get_int_property(properties, ('ord_stra', 'ORD_STRA'))
+    next_down = _get_int_property(properties, ('next_down', 'NEXT_DOWN'))
+    endorheic = _get_int_property(properties, ('endorheic', 'ENDORHEIC'))
+    drainage_area = _get_float_property(
+        properties,
+        ('drainage_area',),
+        default=None,
+    )
+    if drainage_area is None:
+        drainage_area = _get_float_property(
+            properties, ('upland_skm', 'UPLAND_SKM')
+        )
+        drainage_area *= KM2_TO_M2
+    river_name = _get_str_property(
+        properties, ('river_name', 'RIVER_NAME', 'RIV_NAME', 'NAME')
+    )
+
+    return RiverSegment(
+        geometry=geometry,
+        hyriv_id=hyriv_id,
+        main_riv=main_riv,
+        ord_stra=ord_stra,
+        drainage_area=drainage_area,
+        next_down=next_down,
+        endorheic=endorheic,
+        river_name=river_name,
+    )
+
+
+def _line_string_from_geojson(geometry):
+    """
+    Convert a GeoJSON line geometry to a single LineString.
+    """
+    geom = shape(geometry)
+    if isinstance(geom, LineString):
+        return geom
+
+    merged = line_merge(geom)
+    if isinstance(merged, LineString):
+        return merged
+
+    raise ValueError(
+        f'Unsupported river geometry type {geom.geom_type!r}; expected a '
+        'LineString-compatible geometry.'
+    )
+
+
+def _get_int_property(properties, keys):
+    """
+    Read an integer property using one of several candidate keys.
+    """
+    value = _get_property(properties, keys)
+    return int(value)
+
+
+def _get_float_property(properties, keys, default=np.nan):
+    """
+    Read a float property using one of several candidate keys.
+    """
+    value = _get_property(properties, keys, default=default)
+    if value is None:
+        return None
+    return float(value)
+
+
+def _get_str_property(properties, keys):
+    """
+    Read a string property if available.
+    """
+    value = _get_property(properties, keys, default=None)
+    if value in (None, ''):
+        return None
+    return str(value)
+
+
+def _get_property(properties, keys, default=np.nan):
+    """
+    Read one of several candidate properties from a mapping.
+    """
+    for key in keys:
+        if key in properties:
+            return properties[key]
+    if default is np.nan:
+        raise ValueError(
+            f'Could not find any of the required properties {keys!r}.'
+        )
+    return default
+
+
+def _minimum_line_distance(line_a, line_b):
+    """
+    Approximate the minimum distance between two lines on the sphere.
+    """
+    coords_a = np.asarray(line_a.coords)
+    coords_b = np.asarray(line_b.coords)
+    distances = haversine_distance(
+        coords_a[:, 0:1],
+        coords_a[:, 1:2],
+        coords_b[np.newaxis, :, 0],
+        coords_b[np.newaxis, :, 1],
+    )
+    return float(np.min(distances))

--- a/polaris/tasks/mesh/spherical/unified/river/simplify.py
+++ b/polaris/tasks/mesh/spherical/unified/river/simplify.py
@@ -68,6 +68,14 @@ class RiverSegment:
     outlet_hyriv_id : int or None, optional
         The HydroRIVERS identifier of the outlet for the basin this
         segment belongs to
+
+    outlet_drainage_area : float or None, optional
+        The upstream drainage area of the outlet for the basin this segment
+        belongs to, in square meters
+
+    river_network_rank : int or None, optional
+        The 1-based size rank of this segment's basin, with 1 denoting the
+        largest retained outlet drainage area
     """
 
     geometry: LineString
@@ -79,6 +87,8 @@ class RiverSegment:
     endorheic: int
     river_name: str | None = None
     outlet_hyriv_id: int | None = None
+    outlet_drainage_area: float | None = None
+    river_network_rank: int | None = None
 
     @property
     def endpoint(self) -> tuple[float, float]:
@@ -387,13 +397,14 @@ def simplify_river_network_feature_collection(
 
     print(f'  basin traversal: {time.time() - t0:.1f} s', flush=True)
 
-    outlet_area_by_id = {
-        root.hyriv_id: root.drainage_area for root in terminal_segments
-    }
+    annotated_segments = _annotate_river_networks(
+        segments=retained_segments.values(),
+        terminal_segments=terminal_segments,
+    )
     simplified_segments = sorted(
-        retained_segments.values(),
+        annotated_segments,
         key=lambda segment: (
-            -outlet_area_by_id.get(_get_outlet_hyriv_id(segment), 0.0),
+            -_get_outlet_drainage_area(segment),
             -segment.drainage_area,
             segment.hyriv_id,
         ),
@@ -473,6 +484,10 @@ def river_segments_to_feature_collection(segments):
             endorheic=segment.endorheic,
             outlet_hyriv_id=segment.outlet_hyriv_id,
         )
+        if segment.outlet_drainage_area is not None:
+            properties['outlet_drainage_area'] = segment.outlet_drainage_area
+        if segment.river_network_rank is not None:
+            properties['river_network_rank'] = segment.river_network_rank
         if segment.river_name is not None:
             properties['river_name'] = segment.river_name
         features.append(
@@ -506,13 +521,41 @@ def _process_basin_root(root):
     return retained
 
 
-def _get_outlet_hyriv_id(segment):
+def _get_outlet_drainage_area(segment):
     """
-    Get a sortable basin-root identifier for a river segment.
+    Get a sortable outlet drainage area for a river segment.
     """
-    if segment.outlet_hyriv_id is None:
-        return 0
-    return segment.outlet_hyriv_id
+    if segment.outlet_drainage_area is None:
+        return 0.0
+    return segment.outlet_drainage_area
+
+
+def _annotate_river_networks(segments, terminal_segments):
+    """
+    Add size-rank metadata to retained river-network segments.
+    """
+    roots = sorted(
+        terminal_segments,
+        key=lambda root: (-root.drainage_area, root.hyriv_id),
+    )
+    outlet_area_by_id = {
+        root.hyriv_id: root.drainage_area for root in terminal_segments
+    }
+    rank_by_outlet_id = {
+        root.hyriv_id: index + 1 for index, root in enumerate(roots)
+    }
+
+    annotated_segments = []
+    for segment in segments:
+        outlet_hyriv_id = segment.outlet_hyriv_id
+        annotated_segments.append(
+            replace(
+                segment,
+                outlet_drainage_area=outlet_area_by_id.get(outlet_hyriv_id),
+                river_network_rank=rank_by_outlet_id.get(outlet_hyriv_id),
+            )
+        )
+    return annotated_segments
 
 
 def _retain_basin_segments(
@@ -709,6 +752,14 @@ def _segment_from_feature(feature):
     outlet_hyriv_id = _get_optional_int_property(
         properties, ('outlet_hyriv_id', 'OUTLET_HYRIV_ID')
     )
+    outlet_drainage_area = _get_float_property(
+        properties,
+        ('outlet_drainage_area', 'OUTLET_DRAINAGE_AREA'),
+        default=None,
+    )
+    river_network_rank = _get_optional_int_property(
+        properties, ('river_network_rank', 'RIVER_NETWORK_RANK')
+    )
 
     return RiverSegment(
         geometry=geometry,
@@ -720,6 +771,8 @@ def _segment_from_feature(feature):
         endorheic=endorheic,
         river_name=river_name,
         outlet_hyriv_id=outlet_hyriv_id,
+        outlet_drainage_area=outlet_drainage_area,
+        river_network_rank=river_network_rank,
     )
 
 

--- a/polaris/tasks/mesh/spherical/unified/river/simplify.py
+++ b/polaris/tasks/mesh/spherical/unified/river/simplify.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, replace
 import numpy as np
 import shapefile
 from shapely import line_merge, unary_union
-from shapely.geometry import LineString, Point, box, mapping, shape
+from shapely.geometry import LineString, box, mapping, shape
 from shapely.strtree import STRtree
 
 from polaris.archive import extract_zip_subdir
@@ -65,10 +65,6 @@ class RiverSegment:
     river_name : str or None, optional
         The river name, if available
 
-    outlet_type : str or None, optional
-        The outlet type (``'ocean'`` or ``'inland_sink'``), set when the
-        segment has been assigned to a basin
-
     outlet_hyriv_id : int or None, optional
         The HydroRIVERS identifier of the outlet for the basin this
         segment belongs to
@@ -82,7 +78,6 @@ class RiverSegment:
     next_down: int
     endorheic: int
     river_name: str | None = None
-    outlet_type: str | None = None
     outlet_hyriv_id: int | None = None
 
     @property
@@ -119,7 +114,6 @@ class SimplifyRiverNetworkStep(Step):
             min_cpus_per_task=1,
         )
         self.simplified_filename = 'simplified_river_network.geojson'
-        self.outlets_filename = 'retained_outlets.geojson'
 
     def setup(self):
         """
@@ -135,7 +129,6 @@ class SimplifyRiverNetworkStep(Step):
             database='river_network',
         )
         self.add_output_file(filename=self.simplified_filename)
-        self.add_output_file(filename=self.outlets_filename)
 
     def run(self):
         """
@@ -163,14 +156,14 @@ class SimplifyRiverNetworkStep(Step):
                 land_background_km**2 * drainage_area_multiplier * KM2_TO_M2
             )
 
-        outlet_distance_tolerance = section.getfloat(
-            'outlet_distance_tolerance'
+        branch_distance_tolerance = section.getfloat(
+            'branch_distance_tolerance'
         )
-        if outlet_distance_tolerance < 0:
+        if branch_distance_tolerance < 0:
             river_channel_km = self.config.getfloat(
                 'sizing_field', 'river_channel_km'
             )
-            outlet_distance_tolerance = river_channel_km * 1000.0
+            branch_distance_tolerance = river_channel_km * 1000.0
 
         t0 = time.time()
         feature_collection = _read_filtered_shapefile_feature_collection(
@@ -183,10 +176,10 @@ class SimplifyRiverNetworkStep(Step):
         )
 
         t0 = time.time()
-        simplified_fc, outlets_fc = simplify_river_network_feature_collection(
+        simplified_fc = simplify_river_network_feature_collection(
             feature_collection=feature_collection,
             drainage_area_threshold=drainage_area_threshold,
-            outlet_distance_tolerance=outlet_distance_tolerance,
+            branch_distance_tolerance=branch_distance_tolerance,
             tributary_area_ratio=section.getfloat('tributary_area_ratio'),
             n_cpus=self.cpus_per_task,
         )
@@ -201,13 +194,11 @@ class SimplifyRiverNetworkStep(Step):
             hydrorivers_shp_directory=shp_directory,
             hydrorivers_shp_filename=shp_filename,
             drainage_area_threshold=drainage_area_threshold,
-            outlet_distance_tolerance=outlet_distance_tolerance,
+            branch_distance_tolerance=branch_distance_tolerance,
             tributary_area_ratio=section.getfloat('tributary_area_ratio'),
         )
-        outlets_fc['metadata'] = dict(simplified_fc['metadata'])
         t0 = time.time()
         write_geojson(simplified_fc, self.simplified_filename)
-        write_geojson(outlets_fc, self.outlets_filename)
         print(f'write outputs: {time.time() - t0:.1f} s', flush=True)
 
 
@@ -276,7 +267,7 @@ def _convert_hydrorivers_shapefile_to_geojson(shp_filename, output_filename):
 def simplify_river_network_feature_collection(
     feature_collection,
     drainage_area_threshold,
-    outlet_distance_tolerance,
+    branch_distance_tolerance,
     tributary_area_ratio=0.05,
     n_cpus=1,
 ):
@@ -291,8 +282,8 @@ def simplify_river_network_feature_collection(
     drainage_area_threshold : float
         Minimum retained drainage area in square meters
 
-    outlet_distance_tolerance : float
-        Minimum retained spacing between non-endorheic outlets in meters
+    branch_distance_tolerance : float
+        Minimum retained spacing between nearby upstream branches in meters
 
     tributary_area_ratio : float, optional
         The minimum tributary-to-main-stem drainage-area ratio for retaining
@@ -307,8 +298,6 @@ def simplify_river_network_feature_collection(
     simplified_fc : dict
         A GeoJSON feature collection for the simplified river network
 
-    outlets_fc : dict
-        A GeoJSON feature collection for retained outlet points
     """
     import time
 
@@ -339,15 +328,11 @@ def simplify_river_network_feature_collection(
         if segment.next_down != 0:
             upstream_map[segment.next_down].append(segment)
 
-    outlet_candidates = [
+    terminal_segments = [
         segment for segment in segments if segment.next_down == 0
     ]
-    retained_outlets = _filter_outlets(
-        outlet_candidates, outlet_distance_tolerance
-    )
     print(
-        f'  outlet candidates: {len(outlet_candidates)}, '
-        f'retained: {len(retained_outlets)}',
+        f'  terminal basin roots: {len(terminal_segments)}',
         flush=True,
     )
 
@@ -360,7 +345,7 @@ def simplify_river_network_feature_collection(
     )
 
     retained_segments: dict[int, RiverSegment] = {}
-    n_workers = min(n_cpus, len(retained_outlets))
+    n_workers = min(n_cpus, len(terminal_segments))
     print(f'  basin traversal: n_workers={n_workers}', flush=True)
     t0 = time.time()
     if n_workers > 1:
@@ -369,13 +354,13 @@ def simplify_river_network_feature_collection(
         global _WORKER_SEG_TREE, _WORKER_SEG_LIST
         _WORKER_UPSTREAM_MAP = upstream_map
         _WORKER_SEGMENT_BY_ID = segment_by_id
-        _WORKER_DISTANCE_TOLERANCE = outlet_distance_tolerance
+        _WORKER_DISTANCE_TOLERANCE = branch_distance_tolerance
         _WORKER_TRIBUTARY_AREA_RATIO = tributary_area_ratio
         _WORKER_SEG_TREE = seg_tree
         _WORKER_SEG_LIST = seg_list
         ctx = multiprocessing.get_context('fork')
         with ctx.Pool(processes=n_workers) as pool:
-            results = pool.map(_process_outlet, retained_outlets)
+            results = pool.map(_process_basin_root, terminal_segments)
         _WORKER_UPSTREAM_MAP = None
         _WORKER_SEGMENT_BY_ID = None
         _WORKER_DISTANCE_TOLERANCE = None
@@ -385,21 +370,16 @@ def simplify_river_network_feature_collection(
         for result in results:
             retained_segments.update(result)
     else:
-        for outlet in retained_outlets:
-            if outlet.endorheic == 1:
-                outlet_type = 'inland_sink'
-            else:
-                outlet_type = 'ocean'
+        for root in terminal_segments:
             _retain_basin_segments(
                 segment=replace(
-                    outlet,
-                    outlet_type=outlet_type,
-                    outlet_hyriv_id=outlet.hyriv_id,
+                    root,
+                    outlet_hyriv_id=root.hyriv_id,
                 ),
                 upstream_map=upstream_map,
                 segment_by_id=segment_by_id,
                 retained_segments=retained_segments,
-                distance_tolerance=outlet_distance_tolerance,
+                distance_tolerance=branch_distance_tolerance,
                 tributary_area_ratio=tributary_area_ratio,
                 seg_tree=seg_tree,
                 seg_list=seg_list,
@@ -408,25 +388,18 @@ def simplify_river_network_feature_collection(
     print(f'  basin traversal: {time.time() - t0:.1f} s', flush=True)
 
     outlet_area_by_id = {
-        outlet.hyriv_id: outlet.drainage_area for outlet in retained_outlets
+        root.hyriv_id: root.drainage_area for root in terminal_segments
     }
     simplified_segments = sorted(
         retained_segments.values(),
         key=lambda segment: (
-            -outlet_area_by_id.get(segment.outlet_hyriv_id, 0.0),
+            -outlet_area_by_id.get(_get_outlet_hyriv_id(segment), 0.0),
             -segment.drainage_area,
             segment.hyriv_id,
         ),
     )
-    outlet_segments = sorted(
-        [segment for segment in retained_outlets],
-        key=lambda segment: (-segment.drainage_area, segment.hyriv_id),
-    )
 
-    return (
-        river_segments_to_feature_collection(simplified_segments),
-        outlet_segments_to_feature_collection(outlet_segments),
-    )
+    return river_segments_to_feature_collection(simplified_segments)
 
 
 def read_river_segments_from_feature_collection(
@@ -498,7 +471,6 @@ def river_segments_to_feature_collection(segments):
             upland_skm=segment.drainage_area / KM2_TO_M2,
             next_down=segment.next_down,
             endorheic=segment.endorheic,
-            outlet_type=segment.outlet_type,
             outlet_hyriv_id=segment.outlet_hyriv_id,
         )
         if segment.river_name is not None:
@@ -513,58 +485,15 @@ def river_segments_to_feature_collection(segments):
     return dict(type='FeatureCollection', features=features)
 
 
-def outlet_segments_to_feature_collection(segments):
+def _process_basin_root(root):
     """
-    Convert retained outlet segments to a GeoJSON feature collection.
-
-    Parameters
-    ----------
-    segments : list of RiverSegment
-        Retained outlet segments
-
-    Returns
-    -------
-    dict
-        A GeoJSON feature collection of outlet point features
+    Process one terminal-root basin in a fork-based worker process.
     """
-    features = []
-    for segment in segments:
-        lon, lat = segment.endpoint
-        if segment.endorheic == 1:
-            outlet_type = 'inland_sink'
-        else:
-            outlet_type = 'ocean'
-        features.append(
-            dict(
-                type='Feature',
-                properties=dict(
-                    hyriv_id=segment.hyriv_id,
-                    main_riv=segment.main_riv,
-                    drainage_area=segment.drainage_area,
-                    upland_skm=segment.drainage_area / KM2_TO_M2,
-                    endorheic=segment.endorheic,
-                    outlet_type=outlet_type,
-                ),
-                geometry=mapping(Point(lon, lat)),
-            )
-        )
-    return dict(type='FeatureCollection', features=features)
-
-
-def _process_outlet(outlet):
-    """
-    Process one outlet basin in a fork-based worker process.
-    """
-    if outlet.endorheic == 1:
-        outlet_type = 'inland_sink'
-    else:
-        outlet_type = 'ocean'
     retained: dict[int, RiverSegment] = {}
     _retain_basin_segments(
         segment=replace(
-            outlet,
-            outlet_type=outlet_type,
-            outlet_hyriv_id=outlet.hyriv_id,
+            root,
+            outlet_hyriv_id=root.hyriv_id,
         ),
         upstream_map=_WORKER_UPSTREAM_MAP,
         segment_by_id=_WORKER_SEGMENT_BY_ID,
@@ -575,6 +504,15 @@ def _process_outlet(outlet):
         seg_list=_WORKER_SEG_LIST,
     )
     return retained
+
+
+def _get_outlet_hyriv_id(segment):
+    """
+    Get a sortable basin-root identifier for a river segment.
+    """
+    if segment.outlet_hyriv_id is None:
+        return 0
+    return segment.outlet_hyriv_id
 
 
 def _retain_basin_segments(
@@ -616,7 +554,6 @@ def _retain_basin_segments(
         for upstream in reversed(keep_segments):
             annotated = replace(
                 upstream,
-                outlet_type=current.outlet_type,
                 outlet_hyriv_id=current.outlet_hyriv_id,
             )
             stack.append(annotated)
@@ -745,36 +682,6 @@ def _distance_to_basin(
     return min_dist
 
 
-def _filter_outlets(outlet_candidates, outlet_distance_tolerance):
-    """
-    Retain large, well-separated outlets while preserving inland sinks.
-    """
-    retained_outlets: list[RiverSegment] = []
-    for candidate in sorted(
-        outlet_candidates,
-        key=lambda outlet: (
-            outlet.drainage_area,
-            outlet.ord_stra,
-            outlet.hyriv_id,
-        ),
-        reverse=True,
-    ):
-        keep = True
-        lon, lat = candidate.endpoint
-        for retained in retained_outlets:
-            if candidate.endorheic == 1 and retained.endorheic == 1:
-                continue
-            retained_lon, retained_lat = retained.endpoint
-            distance = haversine_distance(lon, lat, retained_lon, retained_lat)
-            if float(distance) < outlet_distance_tolerance:
-                keep = False
-                break
-        if keep:
-            retained_outlets.append(candidate)
-
-    return retained_outlets
-
-
 def _segment_from_feature(feature):
     """
     Parse one GeoJSON feature into a canonical river segment.
@@ -799,6 +706,9 @@ def _segment_from_feature(feature):
     river_name = _get_str_property(
         properties, ('river_name', 'RIVER_NAME', 'RIV_NAME', 'NAME')
     )
+    outlet_hyriv_id = _get_optional_int_property(
+        properties, ('outlet_hyriv_id', 'OUTLET_HYRIV_ID')
+    )
 
     return RiverSegment(
         geometry=geometry,
@@ -809,6 +719,7 @@ def _segment_from_feature(feature):
         next_down=next_down,
         endorheic=endorheic,
         river_name=river_name,
+        outlet_hyriv_id=outlet_hyriv_id,
     )
 
 
@@ -835,6 +746,16 @@ def _get_int_property(properties, keys):
     Read an integer property using one of several candidate keys.
     """
     value = _get_property(properties, keys)
+    return int(value)
+
+
+def _get_optional_int_property(properties, keys):
+    """
+    Read an optional integer property using one of several candidate keys.
+    """
+    value = _get_property(properties, keys, default=None)
+    if value is None:
+        return None
     return int(value)
 
 

--- a/polaris/tasks/mesh/spherical/unified/river/steps.py
+++ b/polaris/tasks/mesh/spherical/unified/river/steps.py
@@ -118,6 +118,7 @@ def get_unified_mesh_river_steps(
             config_filename=config_filename,
             simplify_step=simplify_step,
             rasterize_step=rasterize_step,
+            clip_step=prepare_clip_step,
         )
         steps[viz_step.name] = viz_step
 

--- a/polaris/tasks/mesh/spherical/unified/river/steps.py
+++ b/polaris/tasks/mesh/spherical/unified/river/steps.py
@@ -1,0 +1,139 @@
+import os
+
+from polaris.mesh.spherical.unified import (
+    RIVER_CONFIG_FILENAME,
+    get_unified_mesh_config,
+)
+from polaris.step import Step
+from polaris.tasks.mesh.spherical.unified.coastline.steps import (
+    get_unified_mesh_coastline_steps,
+)
+from polaris.tasks.mesh.spherical.unified.river.clip import (
+    ClipRiverNetworkStep,
+)
+from polaris.tasks.mesh.spherical.unified.river.rasterize import (
+    RasterizeRiverLatLonStep,
+)
+from polaris.tasks.mesh.spherical.unified.river.simplify import (
+    SimplifyRiverNetworkStep,
+)
+from polaris.tasks.mesh.spherical.unified.river.viz import VizRiverStep
+
+
+def get_unified_mesh_river_steps(
+    mesh_name,
+    include_viz=False,
+):
+    """
+    Get shared river-network steps for one mesh (source, lat-lon, base-mesh).
+
+    Parameters
+    ----------
+    mesh_name : str
+        The name of the unified mesh
+
+    include_viz : bool, optional
+        Whether to include a visualization step
+
+    Returns
+    -------
+    steps : dict of str to polaris.Step
+        The river shared steps keyed by suggested subdir symlink in the task.
+        The steps include shared steps from the coastline workflow;
+        simplification of the source river network; rasterization of the river
+        on a lat-lon grid; and clipping of the river network to the base mesh;
+        and optional visualization.
+
+    config : polaris.config.PolarisConfigParser
+        The shared lat-lon river config options
+    """
+    component = _get_mesh_component()
+    config_filename = RIVER_CONFIG_FILENAME
+
+    config_filepath = os.path.join(
+        component.name,
+        'spherical',
+        'unified',
+        mesh_name,
+        'river',
+        config_filename,
+    )
+    config = _get_mesh_river_config(
+        mesh_name=mesh_name, filepath=config_filepath
+    )
+    lat_lon_resolution = config.getfloat('unified_mesh', 'resolution_latlon')
+
+    coastline_steps, _ = get_unified_mesh_coastline_steps(
+        resolution=lat_lon_resolution,
+        include_viz=False,
+    )
+    coastline_step = coastline_steps['coastline_final']
+
+    steps: dict[str, Step] = dict(coastline_steps)
+    simplify_subdir = os.path.join(
+        'spherical', 'unified', mesh_name, 'river', 'simplify'
+    )
+    simplify_step = component.get_or_create_shared_step(
+        step_cls=SimplifyRiverNetworkStep,
+        subdir=simplify_subdir,
+        config=config,
+        config_filename=config_filename,
+    )
+
+    rasterize_subdir = os.path.join(
+        'spherical', 'unified', mesh_name, 'river', 'rasterize'
+    )
+    rasterize_step = component.get_or_create_shared_step(
+        step_cls=RasterizeRiverLatLonStep,
+        subdir=rasterize_subdir,
+        config=config,
+        config_filename=config_filename,
+        simplify_step=simplify_step,
+        coastline_step=coastline_step,
+    )
+    steps[simplify_step.name] = simplify_step
+    steps[rasterize_step.name] = rasterize_step
+
+    clip_subdir = os.path.join(
+        'spherical', 'unified', mesh_name, 'river', 'clip'
+    )
+    prepare_clip_step = component.get_or_create_shared_step(
+        step_cls=ClipRiverNetworkStep,
+        subdir=clip_subdir,
+        config=config,
+        config_filename=config_filename,
+        simplify_step=simplify_step,
+        coastline_step=coastline_step,
+    )
+    steps[prepare_clip_step.name] = prepare_clip_step
+
+    if include_viz:
+        viz_subdir = os.path.join(
+            'spherical', 'unified', mesh_name, 'river', 'viz'
+        )
+        viz_step = component.get_or_create_shared_step(
+            step_cls=VizRiverStep,
+            subdir=viz_subdir,
+            config=config,
+            config_filename=config_filename,
+            simplify_step=simplify_step,
+            rasterize_step=rasterize_step,
+        )
+        steps[viz_step.name] = viz_step
+
+    return steps, config
+
+
+def _get_mesh_river_config(mesh_name, filepath):
+    component = _get_mesh_component()
+    if filepath in component.configs:
+        return component.configs[filepath]
+
+    return get_unified_mesh_config(mesh_name=mesh_name, filepath=filepath)
+
+
+def _get_mesh_component():
+    # Import lazily to avoid a circular import through polaris.tasks.mesh.
+    from polaris.tasks.mesh import mesh as mesh_component
+
+    return mesh_component

--- a/polaris/tasks/mesh/spherical/unified/river/task.py
+++ b/polaris/tasks/mesh/spherical/unified/river/task.py
@@ -1,0 +1,45 @@
+import os
+
+from polaris.mesh.spherical.unified import (
+    RIVER_CONFIG_FILENAME,
+)
+from polaris.task import Task
+from polaris.tasks.mesh.spherical.unified.river.steps import (
+    get_unified_mesh_river_steps,
+)
+
+
+class UnifiedRiverNetworkTask(Task):
+    """
+    A standalone task for preparing all river-network products for one mesh.
+    """
+
+    def __init__(self, component, mesh_name):
+        """
+        Create a new task.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the task belongs to
+
+        mesh_name : str
+            The name of the unified mesh
+        """
+        subdir = os.path.join(
+            'spherical', 'unified', mesh_name, 'river', 'task'
+        )
+        super().__init__(
+            component=component,
+            name=f'river_network_{mesh_name}_task',
+            subdir=subdir,
+        )
+
+        steps, river_config = get_unified_mesh_river_steps(
+            mesh_name=mesh_name, include_viz=True
+        )
+
+        self.set_shared_config(river_config, link=RIVER_CONFIG_FILENAME)
+
+        for symlink, step in steps.items():
+            self.add_step(step, symlink=symlink)

--- a/polaris/tasks/mesh/spherical/unified/river/tasks.py
+++ b/polaris/tasks/mesh/spherical/unified/river/tasks.py
@@ -1,0 +1,19 @@
+from polaris.mesh.spherical.unified import UNIFIED_MESH_NAMES
+from polaris.tasks.mesh.spherical.unified.river.task import (
+    UnifiedRiverNetworkTask,
+)
+
+
+def add_river_tasks(component):
+    """
+    Add standalone river-network tasks.
+
+    Parameters
+    ----------
+    component : polaris.Component
+        The mesh component that the tasks belong to
+    """
+    for mesh_name in UNIFIED_MESH_NAMES:
+        component.add_task(
+            UnifiedRiverNetworkTask(component=component, mesh_name=mesh_name)
+        )

--- a/polaris/tasks/mesh/spherical/unified/river/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/river/viz.py
@@ -17,10 +17,9 @@ CONUS_EXTENT = (-128.0, -65.0, 22.0, 52.0)
 COAST_COLOR = '#222222'
 LAND_COLOR = '#c8ced6'
 OCEAN_COLOR = '#e7f0f7'
-RIVER_COLOR = '#0a6ba8'
-MATCHED_COLOR = '#c43c39'
-UNMATCHED_COLOR = '#7a2cb8'
-INLAND_SINK_COLOR = '#c97800'
+SIMPLIFIED_COLOR = '#0a6ba8'
+CLIPPED_COLOR = '#c43c39'
+CHANNEL_COLOR = '#0f766e'
 
 
 class VizRiverStep(Step):
@@ -28,7 +27,9 @@ class VizRiverStep(Step):
     A step for visualizing river-network diagnostics.
     """
 
-    def __init__(self, component, simplify_step, rasterize_step, subdir):
+    def __init__(
+        self, component, simplify_step, rasterize_step, clip_step, subdir
+    ):
         """
         Create a new step.
 
@@ -43,6 +44,9 @@ class VizRiverStep(Step):
         rasterize_step : polaris.tasks.mesh.spherical.unified.river.rasterize.RasterizeRiverLatLonStep
             The shared lat-lon river step to visualize
 
+        clip_step : polaris.tasks.mesh.spherical.unified.river.clip.ClipRiverNetworkStep
+            The shared clipped river-network step
+
         subdir : str
             The subdirectory within the component's work directory
         """  # noqa: E501
@@ -55,8 +59,10 @@ class VizRiverStep(Step):
         )
         self.simplify_step = simplify_step
         self.rasterize_step = rasterize_step
+        self.clip_step = clip_step
         self.output_filenames = [
-            'river_network_overview.png',
+            'river_network_overlay.png',
+            'rasterized_river_network.png',
             'debug_summary.txt',
         ]
 
@@ -74,21 +80,15 @@ class VizRiverStep(Step):
             ),
         )
         self.add_input_file(
-            filename='retained_outlets.geojson',
+            filename='clipped_river_network.geojson',
             work_dir_target=os.path.join(
-                self.simplify_step.path, self.simplify_step.outlets_filename
+                self.clip_step.path, self.clip_step.clipped_filename
             ),
         )
         self.add_input_file(
             filename='river_network.nc',
             work_dir_target=os.path.join(
                 self.rasterize_step.path, self.rasterize_step.masks_filename
-            ),
-        )
-        self.add_input_file(
-            filename='river_outlets.geojson',
-            work_dir_target=os.path.join(
-                self.rasterize_step.path, self.rasterize_step.outlets_filename
             ),
         )
         self.add_input_file(
@@ -112,66 +112,55 @@ class VizRiverStep(Step):
         dpi = self.config['viz_river_network'].getint('dpi')
 
         simplified_fc = read_geojson('simplified_river_network.geojson')
-        retained_outlets_fc = read_geojson('retained_outlets.geojson')
-        snapped_outlets_fc = read_geojson('river_outlets.geojson')
+        clipped_fc = read_geojson('clipped_river_network.geojson')
 
         with xr.open_dataset('river_network.nc') as ds_river:
             lon = ds_river.lon.values
             lat = ds_river.lat.values
             river_channel_mask = ds_river.river_channel_mask.values > 0
-            river_outlet_mask = ds_river.river_outlet_mask.values > 0
-            river_ocean_outlet_mask = (
-                ds_river.river_ocean_outlet_mask.values > 0
-            )
-            river_inland_sink_mask = ds_river.river_inland_sink_mask.values > 0
-            matched_ocean_outlets = int(
-                ds_river.attrs['matched_ocean_outlets']
-            )
-            unmatched_ocean_outlets = int(
-                ds_river.attrs['unmatched_ocean_outlets']
-            )
 
         with xr.open_dataset('coastline.nc') as ds_coastline:
             ocean_mask = ds_coastline.ocean_mask.values > 0
             land_mask = _get_land_mask(ds_coastline)
 
-        self._plot_network_overview(
+        self._plot_network_overlay(
             lon=lon,
             lat=lat,
             land_mask=land_mask,
             ocean_mask=ocean_mask,
             simplified_fc=simplified_fc,
-            snapped_outlets_fc=snapped_outlets_fc,
+            clipped_fc=clipped_fc,
             dpi=dpi,
-            out_filename='river_network_overview.png',
+            out_filename='river_network_overlay.png',
+        )
+        self._plot_rasterized_network(
+            lon=lon,
+            lat=lat,
+            river_channel_mask=river_channel_mask,
+            dpi=dpi,
+            out_filename='rasterized_river_network.png',
         )
 
         _write_summary(
             filename='debug_summary.txt',
             simplified_fc=simplified_fc,
-            retained_outlets_fc=retained_outlets_fc,
-            snapped_outlets_fc=snapped_outlets_fc,
+            clipped_fc=clipped_fc,
             river_channel_mask=river_channel_mask,
-            river_outlet_mask=river_outlet_mask,
-            river_ocean_outlet_mask=river_ocean_outlet_mask,
-            river_inland_sink_mask=river_inland_sink_mask,
-            matched_ocean_outlets=matched_ocean_outlets,
-            unmatched_ocean_outlets=unmatched_ocean_outlets,
         )
 
-    def _plot_network_overview(
+    def _plot_network_overlay(
         self,
         lon,
         lat,
         land_mask,
         ocean_mask,
         simplified_fc,
-        snapped_outlets_fc,
+        clipped_fc,
         dpi,
         out_filename,
     ):
         """
-        Plot the simplified river network and snapped outlet classes.
+        Plot simplified and clipped river networks together.
         """
         fig, ax, inset_ax = _setup_axes_with_inset(dpi=dpi)
         for current_ax in (ax, inset_ax):
@@ -185,16 +174,49 @@ class VizRiverStep(Step):
             _plot_lines(
                 ax=current_ax,
                 feature_collection=simplified_fc,
-                color=RIVER_COLOR,
+                color=SIMPLIFIED_COLOR,
                 lw=0.9,
+                alpha=0.7,
+                zorder=2,
             )
-            _plot_snapped_points(
+            _plot_lines(
                 ax=current_ax,
-                feature_collection=snapped_outlets_fc,
-                size=38,
+                feature_collection=clipped_fc,
+                color=CLIPPED_COLOR,
+                lw=0.9,
+                alpha=0.95,
+                zorder=3,
             )
-        _add_figure_legend(fig=fig, handles=_get_overview_legend_handles())
-        ax.set_title('Simplified river network and snapped outlets')
+        _add_figure_legend(fig=fig, handles=_get_overlay_legend_handles())
+        ax.set_title('Simplified and clipped river networks')
+        fig.savefig(out_filename, bbox_inches='tight')
+        plt.close(fig)
+
+    def _plot_rasterized_network(
+        self,
+        lon,
+        lat,
+        river_channel_mask,
+        dpi,
+        out_filename,
+    ):
+        """
+        Plot the rasterized river-channel mask.
+        """
+        fig = plt.figure(figsize=(11.0, 5.0), dpi=dpi)
+        ax = plt.axes(projection=ccrs.PlateCarree())
+        ax.set_global()
+        channel = np.where(river_channel_mask, 1.0, np.nan)
+        ax.imshow(
+            channel,
+            origin='lower',
+            extent=_get_extent(lon=lon, lat=lat),
+            transform=ccrs.PlateCarree(),
+            cmap=mcolors.ListedColormap([CHANNEL_COLOR]),
+            interpolation='nearest',
+        )
+        ax.coastlines(linewidth=0.45, color=COAST_COLOR)
+        ax.set_title('Rasterized river-channel mask')
         fig.savefig(out_filename, bbox_inches='tight')
         plt.close(fig)
 
@@ -285,7 +307,7 @@ def _plot_ocean_mask(ax, lon, lat, ocean_mask):
     )
 
 
-def _plot_lines(ax, feature_collection, color, lw):
+def _plot_lines(ax, feature_collection, color, lw, alpha, zorder):
     """
     Plot river lines from a GeoJSON feature collection.
     """
@@ -304,88 +326,30 @@ def _plot_lines(ax, feature_collection, color, lw):
                 coords[:, 1],
                 color=color,
                 linewidth=lw,
-                alpha=0.95,
+                alpha=alpha,
                 transform=ccrs.PlateCarree(),
-                zorder=2,
+                zorder=zorder,
             )
 
 
-def _plot_snapped_points(ax, feature_collection, size):
+def _get_overlay_legend_handles():
     """
-    Plot snapped outlet points with colors by outlet type and match status.
-    """
-    for feature in feature_collection['features']:
-        props = feature['properties']
-        geom = shape(feature['geometry'])
-        color, marker = _get_outlet_style(
-            outlet_type=props['outlet_type'],
-            matched=props['matched_to_ocean'],
-        )
-        ax.scatter(
-            [float(geom.x)],
-            [float(geom.y)],
-            color=color,
-            marker=marker,
-            s=size,
-            edgecolors='white',
-            linewidths=0.4,
-            transform=ccrs.PlateCarree(),
-            zorder=5,
-        )
-
-
-def _get_outlet_style(outlet_type, matched):
-    """
-    Get marker styling for a snapped outlet.
-    """
-    if outlet_type == 'inland_sink':
-        return INLAND_SINK_COLOR, '^'
-    if matched:
-        return MATCHED_COLOR, 'o'
-    return UNMATCHED_COLOR, 's'
-
-
-def _get_overview_legend_handles():
-    """
-    Build legend handles for the overview figure.
+    Build legend handles for the overlay figure.
     """
     return [
         Line2D(
             [0],
             [0],
-            color=RIVER_COLOR,
+            color=SIMPLIFIED_COLOR,
             linewidth=1.4,
             label='Simplified river network',
         ),
         Line2D(
             [0],
             [0],
-            marker='o',
-            linestyle='None',
-            color=MATCHED_COLOR,
-            markerfacecolor=MATCHED_COLOR,
-            markersize=8,
-            label='Matched ocean outlet',
-        ),
-        Line2D(
-            [0],
-            [0],
-            marker='s',
-            linestyle='None',
-            color=UNMATCHED_COLOR,
-            markerfacecolor=UNMATCHED_COLOR,
-            markersize=8,
-            label='Unmatched ocean outlet',
-        ),
-        Line2D(
-            [0],
-            [0],
-            marker='^',
-            linestyle='None',
-            color=INLAND_SINK_COLOR,
-            markerfacecolor=INLAND_SINK_COLOR,
-            markersize=8,
-            label='Inland sink outlet',
+            color=CLIPPED_COLOR,
+            linewidth=1.4,
+            label='Clipped river network',
         ),
     ]
 
@@ -429,60 +393,33 @@ def _compute_edges(values):
 def _write_summary(
     filename,
     simplified_fc,
-    retained_outlets_fc,
-    snapped_outlets_fc,
+    clipped_fc,
     river_channel_mask,
-    river_outlet_mask,
-    river_ocean_outlet_mask,
-    river_inland_sink_mask,
-    matched_ocean_outlets,
-    unmatched_ocean_outlets,
 ):
     """
     Write a compact text summary of river-network diagnostics.
     """
+    simplified_segments = len(simplified_fc['features'])
+    clipped_segments = len(clipped_fc['features'])
     drainage_areas = [
         feature['properties']['drainage_area']
         for feature in simplified_fc['features']
     ]
-    snapping_distances = [
-        feature['properties']['snapping_distance_m']
-        for feature in snapped_outlets_fc['features']
-    ]
     with open(filename, 'w', encoding='utf-8') as summary:
         summary.write('River Network Diagnostics\n')
         summary.write('=========================\n\n')
+        summary.write(f'Simplified segments: {simplified_segments}\n')
+        summary.write(f'Clipped segments: {clipped_segments}\n')
         summary.write(
-            f'Simplified segments: {len(simplified_fc["features"])}\n'
-        )
-        summary.write(
-            f'Retained outlets: {len(retained_outlets_fc["features"])}\n'
+            'Segments removed by clipping: '
+            f'{simplified_segments - clipped_segments}\n'
         )
         summary.write(
             f'Rasterized channel cells: {int(np.sum(river_channel_mask))}\n'
         )
-        summary.write(
-            f'Rasterized outlet cells: {int(np.sum(river_outlet_mask))}\n'
-        )
-        summary.write(
-            'Rasterized ocean-outlet cells: '
-            f'{int(np.sum(river_ocean_outlet_mask))}\n'
-        )
-        summary.write(
-            'Rasterized inland-sink cells: '
-            f'{int(np.sum(river_inland_sink_mask))}\n'
-        )
-        summary.write(f'Matched ocean outlets: {matched_ocean_outlets}\n')
-        summary.write(f'Unmatched ocean outlets: {unmatched_ocean_outlets}\n')
         if len(drainage_areas) > 0:
             summary.write(
                 'Drainage area range (km^2): '
                 f'{min(drainage_areas) / 1.0e6:.1f} to '
                 f'{max(drainage_areas) / 1.0e6:.1f}\n'
-            )
-        if len(snapping_distances) > 0:
-            summary.write(
-                'Snapping distance range (km): '
-                f'{min(snapping_distances) / 1.0e3:.1f} to '
-                f'{max(snapping_distances) / 1.0e3:.1f}\n'
             )

--- a/polaris/tasks/mesh/spherical/unified/river/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/river/viz.py
@@ -1,0 +1,488 @@
+import os
+
+import cartopy.crs as ccrs
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from matplotlib.lines import Line2D
+from shapely.geometry import LineString, MultiLineString, box, shape
+
+from polaris.mesh.spherical.unified.river.geojson import read_geojson
+from polaris.step import Step
+from polaris.viz import use_mplstyle
+
+CONUS_EXTENT = (-128.0, -65.0, 22.0, 52.0)
+
+COAST_COLOR = '#222222'
+LAND_COLOR = '#c8ced6'
+OCEAN_COLOR = '#e7f0f7'
+RIVER_COLOR = '#0a6ba8'
+MATCHED_COLOR = '#c43c39'
+UNMATCHED_COLOR = '#7a2cb8'
+INLAND_SINK_COLOR = '#c97800'
+
+
+class VizRiverStep(Step):
+    """
+    A step for visualizing river-network diagnostics.
+    """
+
+    def __init__(self, component, simplify_step, rasterize_step, subdir):
+        """
+        Create a new step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        simplify_step : polaris.tasks.mesh.spherical.unified.river.simplify.SimplifyRiverNetworkStep
+            The shared source-level river step
+
+        rasterize_step : polaris.tasks.mesh.spherical.unified.river.rasterize.RasterizeRiverLatLonStep
+            The shared lat-lon river step to visualize
+
+        subdir : str
+            The subdirectory within the component's work directory
+        """  # noqa: E501
+        super().__init__(
+            component=component,
+            name='viz_river_network',
+            subdir=subdir,
+            cpus_per_task=1,
+            min_cpus_per_task=1,
+        )
+        self.simplify_step = simplify_step
+        self.rasterize_step = rasterize_step
+        self.output_filenames = [
+            'river_network_overview.png',
+            'debug_summary.txt',
+        ]
+
+    def setup(self):
+        """
+        Set up the step in the work directory, including linking inputs.
+        """
+        convention = self.rasterize_step.config.get(
+            'spherical_mesh', 'antarctic_boundary_convention'
+        )
+        self.add_input_file(
+            filename='simplified_river_network.geojson',
+            work_dir_target=os.path.join(
+                self.simplify_step.path, self.simplify_step.simplified_filename
+            ),
+        )
+        self.add_input_file(
+            filename='retained_outlets.geojson',
+            work_dir_target=os.path.join(
+                self.simplify_step.path, self.simplify_step.outlets_filename
+            ),
+        )
+        self.add_input_file(
+            filename='river_network.nc',
+            work_dir_target=os.path.join(
+                self.rasterize_step.path, self.rasterize_step.masks_filename
+            ),
+        )
+        self.add_input_file(
+            filename='river_outlets.geojson',
+            work_dir_target=os.path.join(
+                self.rasterize_step.path, self.rasterize_step.outlets_filename
+            ),
+        )
+        self.add_input_file(
+            filename='coastline.nc',
+            work_dir_target=os.path.join(
+                self.rasterize_step.coastline_step.path,
+                self.rasterize_step.coastline_step.output_filenames[
+                    convention
+                ],
+            ),
+        )
+        for filename in self.output_filenames:
+            self.add_output_file(filename=filename)
+
+    def run(self):
+        """
+        Run this step.
+        """
+        use_mplstyle()
+
+        dpi = self.config['viz_river_network'].getint('dpi')
+
+        simplified_fc = read_geojson('simplified_river_network.geojson')
+        retained_outlets_fc = read_geojson('retained_outlets.geojson')
+        snapped_outlets_fc = read_geojson('river_outlets.geojson')
+
+        with xr.open_dataset('river_network.nc') as ds_river:
+            lon = ds_river.lon.values
+            lat = ds_river.lat.values
+            river_channel_mask = ds_river.river_channel_mask.values > 0
+            river_outlet_mask = ds_river.river_outlet_mask.values > 0
+            river_ocean_outlet_mask = (
+                ds_river.river_ocean_outlet_mask.values > 0
+            )
+            river_inland_sink_mask = ds_river.river_inland_sink_mask.values > 0
+            matched_ocean_outlets = int(
+                ds_river.attrs['matched_ocean_outlets']
+            )
+            unmatched_ocean_outlets = int(
+                ds_river.attrs['unmatched_ocean_outlets']
+            )
+
+        with xr.open_dataset('coastline.nc') as ds_coastline:
+            ocean_mask = ds_coastline.ocean_mask.values > 0
+            land_mask = _get_land_mask(ds_coastline)
+
+        self._plot_network_overview(
+            lon=lon,
+            lat=lat,
+            land_mask=land_mask,
+            ocean_mask=ocean_mask,
+            simplified_fc=simplified_fc,
+            snapped_outlets_fc=snapped_outlets_fc,
+            dpi=dpi,
+            out_filename='river_network_overview.png',
+        )
+
+        _write_summary(
+            filename='debug_summary.txt',
+            simplified_fc=simplified_fc,
+            retained_outlets_fc=retained_outlets_fc,
+            snapped_outlets_fc=snapped_outlets_fc,
+            river_channel_mask=river_channel_mask,
+            river_outlet_mask=river_outlet_mask,
+            river_ocean_outlet_mask=river_ocean_outlet_mask,
+            river_inland_sink_mask=river_inland_sink_mask,
+            matched_ocean_outlets=matched_ocean_outlets,
+            unmatched_ocean_outlets=unmatched_ocean_outlets,
+        )
+
+    def _plot_network_overview(
+        self,
+        lon,
+        lat,
+        land_mask,
+        ocean_mask,
+        simplified_fc,
+        snapped_outlets_fc,
+        dpi,
+        out_filename,
+    ):
+        """
+        Plot the simplified river network and snapped outlet classes.
+        """
+        fig, ax, inset_ax = _setup_axes_with_inset(dpi=dpi)
+        for current_ax in (ax, inset_ax):
+            _plot_context(
+                ax=current_ax,
+                lon=lon,
+                lat=lat,
+                land_mask=land_mask,
+                ocean_mask=ocean_mask,
+            )
+            _plot_lines(
+                ax=current_ax,
+                feature_collection=simplified_fc,
+                color=RIVER_COLOR,
+                lw=0.9,
+            )
+            _plot_snapped_points(
+                ax=current_ax,
+                feature_collection=snapped_outlets_fc,
+                size=38,
+            )
+        _add_figure_legend(fig=fig, handles=_get_overview_legend_handles())
+        ax.set_title('Simplified river network and snapped outlets')
+        fig.savefig(out_filename, bbox_inches='tight')
+        plt.close(fig)
+
+
+def _setup_axes_with_inset(dpi):
+    """
+    Create a global Robinson plot with a CONUS inset.
+    """
+    fig = plt.figure(figsize=(16.0, 9.0), dpi=dpi)
+    ax = fig.add_axes([0.03, 0.12, 0.68, 0.78], projection=ccrs.Robinson())
+    ax.set_global()
+    ax.coastlines(linewidth=0.45, color=COAST_COLOR)
+
+    inset_ax = fig.add_axes(
+        [0.73, 0.17, 0.24, 0.28], projection=ccrs.PlateCarree()
+    )
+    inset_ax.set_extent(CONUS_EXTENT, crs=ccrs.PlateCarree())
+    inset_ax.coastlines(linewidth=0.45, color=COAST_COLOR)
+    inset_ax.set_title('CONUS inset', fontsize=11, pad=4.0)
+
+    _plot_inset_outline(ax=ax, extent=CONUS_EXTENT)
+    return fig, ax, inset_ax
+
+
+def _plot_context(ax, lon, lat, land_mask, ocean_mask):
+    """
+    Plot muted land and ocean context layers.
+    """
+    _plot_ocean_mask(ax=ax, lon=lon, lat=lat, ocean_mask=ocean_mask)
+    _plot_land_mask(ax=ax, lon=lon, lat=lat, land_mask=land_mask)
+
+
+def _plot_inset_outline(ax, extent):
+    """
+    Highlight the inset region on the global map.
+    """
+    ax.add_geometries(
+        [box(extent[0], extent[2], extent[1], extent[3])],
+        crs=ccrs.PlateCarree(),
+        facecolor='none',
+        edgecolor='#4a5568',
+        linewidth=1.0,
+        linestyle='--',
+        zorder=6,
+    )
+
+
+def _plot_land_mask(ax, lon, lat, land_mask):
+    """
+    Plot the land mask as a muted background.
+    """
+    if land_mask is None:
+        return
+    background = np.where(land_mask, 1.0, np.nan)
+    ax.imshow(
+        background,
+        origin='lower',
+        extent=_get_extent(lon=lon, lat=lat),
+        transform=ccrs.PlateCarree(),
+        cmap=mcolors.ListedColormap([LAND_COLOR]),
+        interpolation='nearest',
+        alpha=0.8,
+        zorder=0,
+    )
+
+
+def _get_land_mask(ds_coastline):
+    """
+    Derive the land mask from ocean_mask.
+    """
+    return ds_coastline.ocean_mask.values <= 0
+
+
+def _plot_ocean_mask(ax, lon, lat, ocean_mask):
+    """
+    Plot the ocean mask as a muted context layer.
+    """
+    ocean = np.where(ocean_mask, 1.0, np.nan)
+    ax.imshow(
+        ocean,
+        origin='lower',
+        extent=_get_extent(lon=lon, lat=lat),
+        transform=ccrs.PlateCarree(),
+        cmap=mcolors.ListedColormap([OCEAN_COLOR]),
+        interpolation='nearest',
+        alpha=0.85,
+        zorder=-1,
+    )
+
+
+def _plot_lines(ax, feature_collection, color, lw):
+    """
+    Plot river lines from a GeoJSON feature collection.
+    """
+    for feature in feature_collection['features']:
+        geom = shape(feature['geometry'])
+        if isinstance(geom, LineString):
+            line_geometries = [geom]
+        elif isinstance(geom, MultiLineString):
+            line_geometries = list(geom.geoms)
+        else:
+            continue
+        for line in line_geometries:
+            coords = np.asarray(line.coords)
+            ax.plot(
+                coords[:, 0],
+                coords[:, 1],
+                color=color,
+                linewidth=lw,
+                alpha=0.95,
+                transform=ccrs.PlateCarree(),
+                zorder=2,
+            )
+
+
+def _plot_snapped_points(ax, feature_collection, size):
+    """
+    Plot snapped outlet points with colors by outlet type and match status.
+    """
+    for feature in feature_collection['features']:
+        props = feature['properties']
+        geom = shape(feature['geometry'])
+        color, marker = _get_outlet_style(
+            outlet_type=props['outlet_type'],
+            matched=props['matched_to_ocean'],
+        )
+        ax.scatter(
+            [float(geom.x)],
+            [float(geom.y)],
+            color=color,
+            marker=marker,
+            s=size,
+            edgecolors='white',
+            linewidths=0.4,
+            transform=ccrs.PlateCarree(),
+            zorder=5,
+        )
+
+
+def _get_outlet_style(outlet_type, matched):
+    """
+    Get marker styling for a snapped outlet.
+    """
+    if outlet_type == 'inland_sink':
+        return INLAND_SINK_COLOR, '^'
+    if matched:
+        return MATCHED_COLOR, 'o'
+    return UNMATCHED_COLOR, 's'
+
+
+def _get_overview_legend_handles():
+    """
+    Build legend handles for the overview figure.
+    """
+    return [
+        Line2D(
+            [0],
+            [0],
+            color=RIVER_COLOR,
+            linewidth=1.4,
+            label='Simplified river network',
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker='o',
+            linestyle='None',
+            color=MATCHED_COLOR,
+            markerfacecolor=MATCHED_COLOR,
+            markersize=8,
+            label='Matched ocean outlet',
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker='s',
+            linestyle='None',
+            color=UNMATCHED_COLOR,
+            markerfacecolor=UNMATCHED_COLOR,
+            markersize=8,
+            label='Unmatched ocean outlet',
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker='^',
+            linestyle='None',
+            color=INLAND_SINK_COLOR,
+            markerfacecolor=INLAND_SINK_COLOR,
+            markersize=8,
+            label='Inland sink outlet',
+        ),
+    ]
+
+
+def _add_figure_legend(fig, handles):
+    """
+    Add a shared legend below the main map.
+    """
+    fig.legend(
+        handles=handles,
+        loc='lower center',
+        bbox_to_anchor=(0.5, 0.02),
+        ncol=2,
+        frameon=True,
+    )
+
+
+def _get_extent(lon, lat):
+    """
+    Get an image extent from regular lat-lon cell centers.
+    """
+    lon_edges = _compute_edges(lon)
+    lat_edges = _compute_edges(lat)
+    return [lon_edges[0], lon_edges[-1], lat_edges[0], lat_edges[-1]]
+
+
+def _compute_edges(values):
+    """
+    Compute cell edges from regular cell-center coordinates.
+    """
+    values = np.asarray(values)
+    if values.size == 1:
+        delta = 1.0
+        return np.array([values[0] - 0.5 * delta, values[0] + 0.5 * delta])
+    midpoints = 0.5 * (values[:-1] + values[1:])
+    first = values[0] - 0.5 * (values[1] - values[0])
+    last = values[-1] + 0.5 * (values[-1] - values[-2])
+    return np.concatenate(([first], midpoints, [last]))
+
+
+def _write_summary(
+    filename,
+    simplified_fc,
+    retained_outlets_fc,
+    snapped_outlets_fc,
+    river_channel_mask,
+    river_outlet_mask,
+    river_ocean_outlet_mask,
+    river_inland_sink_mask,
+    matched_ocean_outlets,
+    unmatched_ocean_outlets,
+):
+    """
+    Write a compact text summary of river-network diagnostics.
+    """
+    drainage_areas = [
+        feature['properties']['drainage_area']
+        for feature in simplified_fc['features']
+    ]
+    snapping_distances = [
+        feature['properties']['snapping_distance_m']
+        for feature in snapped_outlets_fc['features']
+    ]
+    with open(filename, 'w', encoding='utf-8') as summary:
+        summary.write('River Network Diagnostics\n')
+        summary.write('=========================\n\n')
+        summary.write(
+            f'Simplified segments: {len(simplified_fc["features"])}\n'
+        )
+        summary.write(
+            f'Retained outlets: {len(retained_outlets_fc["features"])}\n'
+        )
+        summary.write(
+            f'Rasterized channel cells: {int(np.sum(river_channel_mask))}\n'
+        )
+        summary.write(
+            f'Rasterized outlet cells: {int(np.sum(river_outlet_mask))}\n'
+        )
+        summary.write(
+            'Rasterized ocean-outlet cells: '
+            f'{int(np.sum(river_ocean_outlet_mask))}\n'
+        )
+        summary.write(
+            'Rasterized inland-sink cells: '
+            f'{int(np.sum(river_inland_sink_mask))}\n'
+        )
+        summary.write(f'Matched ocean outlets: {matched_ocean_outlets}\n')
+        summary.write(f'Unmatched ocean outlets: {unmatched_ocean_outlets}\n')
+        if len(drainage_areas) > 0:
+            summary.write(
+                'Drainage area range (km^2): '
+                f'{min(drainage_areas) / 1.0e6:.1f} to '
+                f'{max(drainage_areas) / 1.0e6:.1f}\n'
+            )
+        if len(snapping_distances) > 0:
+            summary.write(
+                'Snapping distance range (km): '
+                f'{min(snapping_distances) / 1.0e3:.1f} to '
+                f'{max(snapping_distances) / 1.0e3:.1f}\n'
+            )

--- a/polaris/tasks/mesh/spherical/unified/river/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/river/viz.py
@@ -8,6 +8,9 @@ import xarray as xr
 from matplotlib.lines import Line2D
 from shapely.geometry import LineString, MultiLineString, box, shape
 
+from polaris.mesh.spherical.unified.river.distance import (
+    haversine_distance,
+)
 from polaris.mesh.spherical.unified.river.geojson import read_geojson
 from polaris.step import Step
 from polaris.viz import use_mplstyle
@@ -108,8 +111,10 @@ class VizRiverStep(Step):
         Run this step.
         """
         use_mplstyle()
+        config = self.config
 
-        dpi = self.config['viz_river_network'].getint('dpi')
+        dpi = config['viz_river_network'].getint('dpi')
+        mesh_name = config['unified_mesh'].get('mesh_name')
 
         simplified_fc = read_geojson('simplified_river_network.geojson')
         clipped_fc = read_geojson('clipped_river_network.geojson')
@@ -130,6 +135,7 @@ class VizRiverStep(Step):
             ocean_mask=ocean_mask,
             simplified_fc=simplified_fc,
             clipped_fc=clipped_fc,
+            mesh_name=mesh_name,
             dpi=dpi,
             out_filename='river_network_overlay.png',
         )
@@ -137,6 +143,7 @@ class VizRiverStep(Step):
             lon=lon,
             lat=lat,
             river_channel_mask=river_channel_mask,
+            mesh_name=mesh_name,
             dpi=dpi,
             out_filename='rasterized_river_network.png',
         )
@@ -156,6 +163,7 @@ class VizRiverStep(Step):
         ocean_mask,
         simplified_fc,
         clipped_fc,
+        mesh_name,
         dpi,
         out_filename,
     ):
@@ -183,12 +191,12 @@ class VizRiverStep(Step):
                 ax=current_ax,
                 feature_collection=clipped_fc,
                 color=CLIPPED_COLOR,
-                lw=0.9,
-                alpha=0.95,
+                lw=1.1,
+                alpha=1.0,
                 zorder=3,
             )
         _add_figure_legend(fig=fig, handles=_get_overlay_legend_handles())
-        ax.set_title('Simplified and clipped river networks')
+        ax.set_title(f'{mesh_name}: Simplified and clipped river networks')
         fig.savefig(out_filename, bbox_inches='tight')
         plt.close(fig)
 
@@ -197,6 +205,7 @@ class VizRiverStep(Step):
         lon,
         lat,
         river_channel_mask,
+        mesh_name,
         dpi,
         out_filename,
     ):
@@ -206,7 +215,8 @@ class VizRiverStep(Step):
         fig = plt.figure(figsize=(11.0, 5.0), dpi=dpi)
         ax = plt.axes(projection=ccrs.PlateCarree())
         ax.set_global()
-        channel = np.where(river_channel_mask, 1.0, np.nan)
+        plot_mask, stride = _aggregate_mask_for_plot(river_channel_mask)
+        channel = np.where(plot_mask, 1.0, np.nan)
         ax.imshow(
             channel,
             origin='lower',
@@ -216,7 +226,10 @@ class VizRiverStep(Step):
             interpolation='nearest',
         )
         ax.coastlines(linewidth=0.45, color=COAST_COLOR)
-        ax.set_title('Rasterized river-channel mask')
+        title = f'{mesh_name}: Rasterized river mask'
+        if stride > 1:
+            title = f'{title} (max-aggregated {stride}x)'
+        ax.set_title(title)
         fig.savefig(out_filename, bbox_inches='tight')
         plt.close(fig)
 
@@ -231,7 +244,7 @@ def _setup_axes_with_inset(dpi):
     ax.coastlines(linewidth=0.45, color=COAST_COLOR)
 
     inset_ax = fig.add_axes(
-        [0.73, 0.17, 0.24, 0.28], projection=ccrs.PlateCarree()
+        [0.63, 0.17, 0.34, 0.38], projection=ccrs.PlateCarree()
     )
     inset_ax.set_extent(CONUS_EXTENT, crs=ccrs.PlateCarree())
     inset_ax.coastlines(linewidth=0.45, color=COAST_COLOR)
@@ -341,14 +354,15 @@ def _get_overlay_legend_handles():
             [0],
             [0],
             color=SIMPLIFIED_COLOR,
-            linewidth=1.4,
+            linewidth=1.0,
+            alpha=0.5,
             label='Simplified river network',
         ),
         Line2D(
             [0],
             [0],
             color=CLIPPED_COLOR,
-            linewidth=1.4,
+            linewidth=1.8,
             label='Clipped river network',
         ),
     ]
@@ -390,6 +404,66 @@ def _compute_edges(values):
     return np.concatenate(([first], midpoints, [last]))
 
 
+def _aggregate_mask_for_plot(mask, max_rows=1000, max_cols=2200):
+    """
+    Max-aggregate a dense mask so thin channels survive PNG downsampling.
+    """
+    row_stride = int(np.ceil(mask.shape[0] / max_rows))
+    col_stride = int(np.ceil(mask.shape[1] / max_cols))
+    stride = max(1, row_stride, col_stride)
+    if stride == 1:
+        return mask, stride
+
+    n_rows = int(np.ceil(mask.shape[0] / stride))
+    n_cols = int(np.ceil(mask.shape[1] / stride))
+    padded = np.zeros((n_rows * stride, n_cols * stride), dtype=bool)
+    padded[: mask.shape[0], : mask.shape[1]] = mask
+    aggregated = padded.reshape(n_rows, stride, n_cols, stride).max(
+        axis=(1, 3)
+    )
+    return aggregated, stride
+
+
+def _get_feature_ids(feature_collection):
+    """
+    Get HydroRIVERS IDs from a feature collection.
+    """
+    return {
+        feature['properties'].get('hyriv_id')
+        for feature in feature_collection['features']
+    }
+
+
+def _get_total_length_km(feature_collection):
+    """
+    Get total line length in a feature collection in kilometres.
+    """
+    total_length_m = 0.0
+    for feature in feature_collection['features']:
+        geom = shape(feature['geometry'])
+        if isinstance(geom, LineString):
+            line_geometries = [geom]
+        elif isinstance(geom, MultiLineString):
+            line_geometries = list(geom.geoms)
+        else:
+            continue
+        for line in line_geometries:
+            coords = np.asarray(line.coords, dtype=float)
+            if coords.shape[0] < 2:
+                continue
+            total_length_m += float(
+                np.sum(
+                    haversine_distance(
+                        coords[:-1, 0],
+                        coords[:-1, 1],
+                        coords[1:, 0],
+                        coords[1:, 1],
+                    )
+                )
+            )
+    return 1.0e-3 * total_length_m
+
+
 def _write_summary(
     filename,
     simplified_fc,
@@ -401,6 +475,9 @@ def _write_summary(
     """
     simplified_segments = len(simplified_fc['features'])
     clipped_segments = len(clipped_fc['features'])
+    simplified_ids = _get_feature_ids(simplified_fc)
+    clipped_ids = _get_feature_ids(clipped_fc)
+    dropped_ids = simplified_ids - clipped_ids
     drainage_areas = [
         feature['properties']['drainage_area']
         for feature in simplified_fc['features']
@@ -410,9 +487,20 @@ def _write_summary(
         summary.write('=========================\n\n')
         summary.write(f'Simplified segments: {simplified_segments}\n')
         summary.write(f'Clipped segments: {clipped_segments}\n')
+        summary.write(f'Simplified unique hyriv_id: {len(simplified_ids)}\n')
+        summary.write(f'Clipped unique hyriv_id: {len(clipped_ids)}\n')
+        summary.write(f'Dropped unique hyriv_id: {len(dropped_ids)}\n')
         summary.write(
             'Segments removed by clipping: '
             f'{simplified_segments - clipped_segments}\n'
+        )
+        summary.write(
+            'Simplified total length (km): '
+            f'{_get_total_length_km(simplified_fc):.1f}\n'
+        )
+        summary.write(
+            'Clipped total length (km): '
+            f'{_get_total_length_km(clipped_fc):.1f}\n'
         )
         summary.write(
             f'Rasterized channel cells: {int(np.sum(river_channel_mask))}\n'

--- a/tests/mesh/spherical/unified/test_river.py
+++ b/tests/mesh/spherical/unified/test_river.py
@@ -445,7 +445,7 @@ def test_condition_base_mesh_river_segments_clips_then_simplifies():
     assert segments[0].river_network_rank == 1
 
 
-def test_condition_base_mesh_river_segments_drops_short_fragments():
+def test_condition_base_mesh_river_segments_keeps_short_fragments():
     ds_coastline = xr.Dataset(
         data_vars=dict(
             ocean_mask=(('lat', 'lon'), np.zeros((2, 3), dtype=np.int8)),
@@ -453,8 +453,8 @@ def test_condition_base_mesh_river_segments_drops_short_fragments():
                 ('lat', 'lon'),
                 np.array(
                     [
-                        [1.0e5, -1.0e4, 1.0e5],
-                        [1.0e5, -1.0e4, 1.0e5],
+                        [1.0e5, -1.0e5, 1.0e5],
+                        [1.0e5, -1.0e5, 1.0e5],
                     ]
                 ),
             ),
@@ -485,7 +485,144 @@ def test_condition_base_mesh_river_segments_drops_short_fragments():
         min_segment_length_m=200.0e3,
     )
 
-    assert segments == []
+    assert len(segments) == 1
+    coords = np.asarray(segments[0].geometry.coords)
+    assert 0.0 < coords[0, 0] < 1.0
+    assert 1.0 < coords[-1, 0] < 2.0
+
+
+def test_condition_base_mesh_river_segments_keeps_reentry_pieces():
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(('lat', 'lon'), np.zeros((2, 6), dtype=np.int8)),
+            signed_distance=(
+                ('lat', 'lon'),
+                np.array(
+                    [
+                        [-1.0e5, 1.0e5, -1.0e5, 1.0e5, -1.0e5, -1.0e5],
+                        [-1.0e5, 1.0e5, -1.0e5, 1.0e5, -1.0e5, -1.0e5],
+                    ]
+                ),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([-5.0, 5.0]), dims=('lat',)),
+            lon=xr.DataArray(
+                np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+                dims=('lon',),
+            ),
+        ),
+    )
+    river_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=10,
+                coords=[(0.0, 0.0), (5.0, 0.0)],
+                next_down=0,
+                drainage_area=100.0e6,
+                endorheic=0,
+            )
+        ],
+    )
+
+    segments = condition_base_mesh_river_segments(
+        segments=read_river_segments_from_feature_collection(river_fc),
+        ds_coastline=ds_coastline,
+        clip_distance_m=20.0e3,
+        simplify_tolerance_deg=0.0,
+        min_segment_length_m=1.0e9,
+    )
+
+    assert len(segments) == 3
+    assert {segment.hyriv_id for segment in segments} == {10}
+
+
+def test_condition_base_mesh_river_segments_densifies_before_clipping():
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(('lat', 'lon'), np.zeros((2, 5), dtype=np.int8)),
+            signed_distance=(
+                ('lat', 'lon'),
+                np.array(
+                    [
+                        [1.0e5, 1.0e5, -1.0e5, 1.0e5, 1.0e5],
+                        [1.0e5, 1.0e5, -1.0e5, 1.0e5, 1.0e5],
+                    ]
+                ),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([-5.0, 5.0]), dims=('lat',)),
+            lon=xr.DataArray(
+                np.array([0.0, 1.0, 2.0, 3.0, 4.0]), dims=('lon',)
+            ),
+        ),
+    )
+    river_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=20,
+                coords=[(0.0, 0.0), (4.0, 0.0)],
+                next_down=0,
+                drainage_area=100.0e6,
+                endorheic=0,
+            )
+        ],
+    )
+
+    segments = condition_base_mesh_river_segments(
+        segments=read_river_segments_from_feature_collection(river_fc),
+        ds_coastline=ds_coastline,
+        clip_distance_m=20.0e3,
+        simplify_tolerance_deg=0.0,
+        min_segment_length_m=1.0e9,
+    )
+
+    assert len(segments) == 1
+    coords = np.asarray(segments[0].geometry.coords)
+    assert 1.0 < coords[0, 0] < 2.0
+    assert 2.0 < coords[-1, 0] < 3.0
+
+
+def test_condition_base_mesh_river_segments_simplify_fallback_keeps_geometry():
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(('lat', 'lon'), np.zeros((2, 3), dtype=np.int8)),
+            signed_distance=(
+                ('lat', 'lon'),
+                np.full((2, 3), -1.0e5),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([-5.0, 5.0]), dims=('lat',)),
+            lon=xr.DataArray(np.array([0.0, 0.1, 0.2]), dims=('lon',)),
+        ),
+    )
+    river_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=30,
+                coords=[(0.0, 0.0), (0.1, 0.01), (0.2, 0.0)],
+                next_down=0,
+                drainage_area=100.0e6,
+                endorheic=0,
+            )
+        ],
+    )
+
+    segments = condition_base_mesh_river_segments(
+        segments=read_river_segments_from_feature_collection(river_fc),
+        ds_coastline=ds_coastline,
+        clip_distance_m=20.0e3,
+        simplify_tolerance_deg=10.0,
+        min_segment_length_m=1.0e9,
+    )
+
+    assert len(segments) == 1
+    assert len(segments[0].geometry.coords) >= 2
 
 
 def test_unpack_hydrorivers_archive(tmp_path):

--- a/tests/mesh/spherical/unified/test_river.py
+++ b/tests/mesh/spherical/unified/test_river.py
@@ -1,0 +1,855 @@
+import os
+import zipfile
+
+import numpy as np
+import pytest
+import shapefile
+import xarray as xr
+
+from polaris.component import Component
+from polaris.mesh.spherical.unified import (
+    UNIFIED_MESH_NAMES,
+)
+from polaris.tasks.mesh.spherical.unified.river import (
+    add_river_tasks,
+    build_river_network_dataset,
+    get_unified_mesh_river_steps,
+    simplify_river_network_feature_collection,
+)
+from polaris.tasks.mesh.spherical.unified.river.clip import (
+    clip_outlet_feature_collection,
+    condition_base_mesh_river_segments,
+)
+from polaris.tasks.mesh.spherical.unified.river.simplify import (
+    _convert_hydrorivers_shapefile_to_geojson,
+    _unpack_hydrorivers_archive,
+    read_river_segments_from_feature_collection,
+)
+
+
+def test_simplify_river_network_filters_outlets_and_minor_tributaries():
+    feature_collection = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=10,
+                coords=[(-1.0, 0.0), (0.0, 0.0)],
+                next_down=0,
+                drainage_area=100.0e6,
+                endorheic=0,
+            ),
+            _line_feature(
+                hyriv_id=11,
+                coords=[(-2.0, 0.0), (-1.0, 0.0)],
+                next_down=10,
+                drainage_area=80.0e6,
+                endorheic=0,
+            ),
+            # ord_stra=2: not a headwater, so the area check is used (not the
+            # distance-only headwater path).  35e6 >= 0.3 * 100e6 -> kept.
+            _line_feature(
+                hyriv_id=12,
+                coords=[(-1.5, 1.0), (-1.0, 0.0)],
+                next_down=10,
+                drainage_area=35.0e6,
+                endorheic=0,
+                ord_stra=2,
+            ),
+            # ord_stra=1 (headwater): goes straight to the distance check.
+            # Its closest point to retained basin segments is ~22 km < 30 km
+            # tolerance, so it is filtered.
+            _line_feature(
+                hyriv_id=13,
+                coords=[(-1.6, 0.2), (-1.2, 0.0)],
+                next_down=10,
+                drainage_area=10.0e6,
+                endorheic=0,
+            ),
+            _line_feature(
+                hyriv_id=20,
+                coords=[(0.0, 0.05), (0.05, 0.05)],
+                next_down=0,
+                drainage_area=90.0e6,
+                endorheic=0,
+            ),
+            _line_feature(
+                hyriv_id=30,
+                coords=[(50.0, 10.0), (50.1, 10.0)],
+                next_down=0,
+                drainage_area=25.0e6,
+                endorheic=1,
+            ),
+            _line_feature(
+                hyriv_id=31,
+                coords=[(50.0, 10.05), (50.1, 10.05)],
+                next_down=0,
+                drainage_area=20.0e6,
+                endorheic=1,
+            ),
+        ],
+    )
+
+    simplified_fc, outlets_fc = simplify_river_network_feature_collection(
+        feature_collection=feature_collection,
+        drainage_area_threshold=5.0e6,
+        outlet_distance_tolerance=30.0e3,
+        # ratio relative to the BASIN OUTLET (100e6): 35e6 >= 0.3*100e6=30e6
+        tributary_area_ratio=0.3,
+    )
+
+    simplified_ids = {
+        feature['properties']['hyriv_id']
+        for feature in simplified_fc['features']
+    }
+    outlet_ids = {
+        feature['properties']['hyriv_id'] for feature in outlets_fc['features']
+    }
+
+    assert simplified_ids == {10, 11, 12, 30, 31}
+    assert outlet_ids == {10, 30, 31}
+
+
+def test_simplify_river_network_handles_deep_main_stem():
+    n_segments = 1500
+    features = []
+    for hyriv_id in range(1, n_segments + 1):
+        next_down = hyriv_id - 1 if hyriv_id > 1 else 0
+        features.append(
+            _line_feature(
+                hyriv_id=hyriv_id,
+                coords=[
+                    (-float(hyriv_id), 0.0),
+                    (-float(hyriv_id) + 1.0, 0.0),
+                ],
+                next_down=next_down,
+                drainage_area=(n_segments - hyriv_id + 1) * 1.0e6,
+                endorheic=0,
+            )
+        )
+
+    simplified_fc, outlets_fc = simplify_river_network_feature_collection(
+        feature_collection=dict(type='FeatureCollection', features=features),
+        drainage_area_threshold=1.0,
+        outlet_distance_tolerance=1.0,
+        tributary_area_ratio=0.05,
+    )
+
+    simplified_ids = {
+        feature['properties']['hyriv_id']
+        for feature in simplified_fc['features']
+    }
+    outlet_ids = {
+        feature['properties']['hyriv_id'] for feature in outlets_fc['features']
+    }
+
+    assert len(simplified_ids) == n_segments
+    assert outlet_ids == {1}
+
+
+def test_simplify_river_network_rejects_next_down_cycles():
+    feature_collection = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=10,
+                coords=[(0.0, 0.0), (1.0, 0.0)],
+                next_down=11,
+                drainage_area=50.0e6,
+                endorheic=0,
+            ),
+            _line_feature(
+                hyriv_id=11,
+                coords=[(1.0, 0.0), (2.0, 0.0)],
+                next_down=10,
+                drainage_area=60.0e6,
+                endorheic=0,
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match='Cycle detected'):
+        simplify_river_network_feature_collection(
+            feature_collection=feature_collection,
+            drainage_area_threshold=1.0,
+            outlet_distance_tolerance=1.0,
+            tributary_area_ratio=0.05,
+        )
+
+
+def test_simplify_river_network_preserves_branch_traversal_order():
+    feature_collection = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=10,
+                coords=[(0.0, 0.0), (1.0, 0.0)],
+                next_down=0,
+                drainage_area=100.0e6,
+                endorheic=0,
+                ord_stra=4,
+            ),
+            # ord_stra=3: passes the area check (80e6 >= 0.4*100e6=40e6).
+            _line_feature(
+                hyriv_id=11,
+                coords=[(-1.0, 0.0), (0.0, 0.0)],
+                next_down=10,
+                drainage_area=80.0e6,
+                endorheic=0,
+                ord_stra=3,
+            ),
+            # ord_stra=3: passes the area check (60e6 >= 0.4*100e6=40e6).
+            _line_feature(
+                hyriv_id=12,
+                coords=[(0.0, 1.0), (0.0, 0.0)],
+                next_down=10,
+                drainage_area=60.0e6,
+                endorheic=0,
+                ord_stra=3,
+            ),
+            _line_feature(
+                hyriv_id=21,
+                coords=[(-2.0, 0.02), (-1.0, 0.0)],
+                next_down=11,
+                drainage_area=70.0e6,
+                endorheic=0,
+                ord_stra=2,
+            ),
+            _line_feature(
+                hyriv_id=22,
+                coords=[(0.0, 2.0), (0.0, 1.0)],
+                next_down=12,
+                drainage_area=55.0e6,
+                endorheic=0,
+                ord_stra=2,
+            ),
+            # ord_stra=1 (headwater): skips the area check, uses only the
+            # distance check.  Its start point (0.0, 1.0) coincides with
+            # the start of segment 12, so distance ~0 < 20 km -> filtered.
+            _line_feature(
+                hyriv_id=23,
+                coords=[(-2.0, 0.03), (0.0, 1.0)],
+                next_down=12,
+                drainage_area=20.0e6,
+                endorheic=0,
+            ),
+        ],
+    )
+
+    simplified_fc, _ = simplify_river_network_feature_collection(
+        feature_collection=feature_collection,
+        drainage_area_threshold=1.0,
+        outlet_distance_tolerance=20.0e3,
+        tributary_area_ratio=0.4,
+    )
+
+    simplified_ids = {
+        feature['properties']['hyriv_id']
+        for feature in simplified_fc['features']
+    }
+
+    assert simplified_ids == {10, 11, 12, 21, 22}
+
+
+def test_build_river_network_dataset_contract_and_snapped_outlets():
+    river_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=10,
+                coords=[(-90.0, 0.0), (-45.0, 0.0)],
+                next_down=0,
+                drainage_area=100.0e6,
+                endorheic=0,
+                outlet_type='ocean',
+                outlet_hyriv_id=10,
+            ),
+            _line_feature(
+                hyriv_id=30,
+                coords=[(90.0, 0.0), (45.0, 0.0)],
+                next_down=0,
+                drainage_area=20.0e6,
+                endorheic=1,
+                outlet_type='inland_sink',
+                outlet_hyriv_id=30,
+            ),
+        ],
+    )
+    outlet_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _point_feature(
+                hyriv_id=10,
+                coords=(-46.0, 1.0),
+                drainage_area=100.0e6,
+                endorheic=0,
+                outlet_type='ocean',
+            ),
+            _point_feature(
+                hyriv_id=30,
+                coords=(46.0, 1.0),
+                drainage_area=20.0e6,
+                endorheic=1,
+                outlet_type='inland_sink',
+            ),
+        ],
+    )
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(
+                ('lat', 'lon'),
+                np.array(
+                    [
+                        [0, 0, 0, 0, 0],
+                        [0, 1, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                    ],
+                    dtype=np.int8,
+                ),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([10.0, 0.0, -10.0]), dims=('lat',)),
+            lon=xr.DataArray(
+                np.array([-90.0, -45.0, 0.0, 45.0, 90.0]), dims=('lon',)
+            ),
+        ),
+    )
+
+    ds_river, snapped_outlets = build_river_network_dataset(
+        river_feature_collection=river_fc,
+        outlet_feature_collection=outlet_fc,
+        ds_coastline=ds_coastline,
+        resolution=45.0,
+        outlet_match_tolerance=200.0e3,
+        channel_subsegment_fraction=0.5,
+    )
+
+    expected_vars = {
+        'river_channel_mask',
+        'river_outlet_mask',
+        'river_ocean_outlet_mask',
+        'river_inland_sink_mask',
+    }
+    assert expected_vars.issubset(set(ds_river.data_vars))
+    assert ds_river.attrs['matched_ocean_outlets'] == 1
+    assert ds_river.attrs['unmatched_ocean_outlets'] == 0
+
+    assert ds_river.river_channel_mask.sum() > 0
+    assert ds_river.river_ocean_outlet_mask.sel(lat=0.0, lon=-45.0) == 1
+    assert ds_river.river_inland_sink_mask.sel(lat=0.0, lon=45.0) == 1
+
+    snapped_by_id = {
+        feature['properties']['hyriv_id']: feature
+        for feature in snapped_outlets['features']
+    }
+    assert snapped_by_id[10]['properties']['snapped_lon'] == -45.0
+    assert snapped_by_id[10]['properties']['snapped_lat'] == 0.0
+    assert snapped_by_id[30]['properties']['snapped_lon'] == 45.0
+    assert snapped_by_id[30]['properties']['snapped_lat'] == 0.0
+    assert snapped_by_id[10]['properties']['matched_to_ocean']
+
+
+def test_build_river_network_dataset_applies_physical_channel_buffer():
+    river_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=10,
+                coords=[(0.0, 59.0), (0.0, 61.0)],
+                next_down=0,
+                drainage_area=100.0e6,
+                endorheic=0,
+            ),
+        ],
+    )
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(
+                ('lat', 'lon'),
+                np.zeros((3, 5), dtype=np.int8),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([61.0, 60.0, 59.0]), dims=('lat',)),
+            lon=xr.DataArray(
+                np.array([-2.0, -1.0, 0.0, 1.0, 2.0]), dims=('lon',)
+            ),
+        ),
+    )
+
+    ds_river, _ = build_river_network_dataset(
+        river_feature_collection=river_fc,
+        outlet_feature_collection=dict(type='FeatureCollection', features=[]),
+        ds_coastline=ds_coastline,
+        resolution=1.0,
+        outlet_match_tolerance=200.0e3,
+        channel_subsegment_fraction=0.5,
+        channel_buffer_km=80.0,
+    )
+
+    assert ds_river.attrs['channel_buffer_m'] == 80.0e3
+    assert ds_river.river_channel_mask.sel(lat=60.0, lon=0.0) == 1
+    assert ds_river.river_channel_mask.sel(lat=60.0, lon=-1.0) == 1
+    assert ds_river.river_channel_mask.sel(lat=60.0, lon=1.0) == 1
+    assert ds_river.river_channel_mask.sel(lat=60.0, lon=-2.0) == 0
+    assert ds_river.river_channel_mask.sel(lat=60.0, lon=2.0) == 0
+
+
+def test_build_river_network_dataset_derives_land_mask_from_ocean_mask():
+    river_fc = dict(type='FeatureCollection', features=[])
+    outlet_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _point_feature(
+                hyriv_id=30,
+                coords=(46.0, 1.0),
+                drainage_area=20.0e6,
+                endorheic=1,
+                outlet_type='inland_sink',
+            ),
+        ],
+    )
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(
+                ('lat', 'lon'),
+                np.array(
+                    [
+                        [1, 1, 1, 1, 1],
+                        [1, 1, 1, 0, 1],
+                        [1, 1, 1, 1, 1],
+                    ],
+                    dtype=np.int8,
+                ),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([10.0, 0.0, -10.0]), dims=('lat',)),
+            lon=xr.DataArray(
+                np.array([-90.0, -45.0, 0.0, 45.0, 90.0]), dims=('lon',)
+            ),
+        ),
+    )
+
+    ds_river, snapped_outlets = build_river_network_dataset(
+        river_feature_collection=river_fc,
+        outlet_feature_collection=outlet_fc,
+        ds_coastline=ds_coastline,
+        resolution=45.0,
+        outlet_match_tolerance=200.0e3,
+        channel_subsegment_fraction=0.5,
+    )
+
+    assert ds_river.river_inland_sink_mask.sel(lat=0.0, lon=45.0) == 1
+    snapped_feature = snapped_outlets['features'][0]
+    assert snapped_feature['properties']['snapped_lon'] == 45.0
+    assert snapped_feature['properties']['snapped_lat'] == 0.0
+
+
+def test_condition_base_mesh_river_segments_clips_then_simplifies():
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(('lat', 'lon'), np.zeros((2, 3), dtype=np.int8)),
+            signed_distance=(
+                ('lat', 'lon'),
+                np.array(
+                    [
+                        [-2.0e5, -2.0e5, 1.0e5],
+                        [-2.0e5, -2.0e5, 1.0e5],
+                    ]
+                ),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([-5.0, 5.0]), dims=('lat',)),
+            lon=xr.DataArray(np.array([0.0, 10.0, 20.0]), dims=('lon',)),
+        ),
+    )
+    river_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=10,
+                coords=[(0.0, 0.0), (8.0, 0.0), (16.0, 0.0)],
+                next_down=0,
+                drainage_area=100.0e6,
+                endorheic=0,
+                outlet_type='ocean',
+                outlet_hyriv_id=10,
+            )
+        ],
+    )
+
+    segments = condition_base_mesh_river_segments(
+        segments=read_river_segments_from_feature_collection(river_fc),
+        ds_coastline=ds_coastline,
+        clip_distance_m=50.0e3,
+        simplify_tolerance_deg=0.5,
+        min_segment_length_m=100.0,
+    )
+
+    assert len(segments) == 1
+    coords = np.asarray(segments[0].geometry.coords)
+    assert coords.shape[0] == 2
+    assert coords[0, 0] == 0.0
+    assert 8.0 < coords[-1, 0] < 16.0
+    assert segments[0].outlet_type is None
+    assert segments[0].outlet_hyriv_id is None
+
+
+def test_condition_base_mesh_river_segments_drops_short_fragments():
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(('lat', 'lon'), np.zeros((2, 3), dtype=np.int8)),
+            signed_distance=(
+                ('lat', 'lon'),
+                np.array(
+                    [
+                        [1.0e5, -1.0e4, 1.0e5],
+                        [1.0e5, -1.0e4, 1.0e5],
+                    ]
+                ),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([-5.0, 5.0]), dims=('lat',)),
+            lon=xr.DataArray(np.array([0.0, 1.0, 2.0]), dims=('lon',)),
+        ),
+    )
+    river_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _line_feature(
+                hyriv_id=10,
+                coords=[(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)],
+                next_down=0,
+                drainage_area=100.0e6,
+                endorheic=0,
+            )
+        ],
+    )
+
+    segments = condition_base_mesh_river_segments(
+        segments=read_river_segments_from_feature_collection(river_fc),
+        ds_coastline=ds_coastline,
+        clip_distance_m=20.0e3,
+        simplify_tolerance_deg=0.0,
+        min_segment_length_m=200.0e3,
+    )
+
+    assert segments == []
+
+
+def test_clip_outlet_feature_collection_removes_ocean_outlets():
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(('lat', 'lon'), np.zeros((2, 2), dtype=np.int8)),
+            signed_distance=(
+                ('lat', 'lon'),
+                np.array(
+                    [
+                        [-2.0e5, 1.0e5],
+                        [-2.0e5, 1.0e5],
+                    ]
+                ),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([-5.0, 5.0]), dims=('lat',)),
+            lon=xr.DataArray(np.array([0.0, 10.0]), dims=('lon',)),
+        ),
+    )
+    outlet_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _point_feature(
+                hyriv_id=10,
+                coords=(9.0, 0.0),
+                drainage_area=100.0e6,
+                endorheic=0,
+                outlet_type='ocean',
+            ),
+            _point_feature(
+                hyriv_id=20,
+                coords=(1.0, 0.0),
+                drainage_area=50.0e6,
+                endorheic=1,
+                outlet_type='inland_sink',
+            ),
+        ],
+    )
+
+    clipped = clip_outlet_feature_collection(
+        outlet_feature_collection=outlet_fc,
+        ds_coastline=ds_coastline,
+        clip_distance_m=50.0e3,
+    )
+
+    clipped_ids = {
+        feature['properties']['hyriv_id'] for feature in clipped['features']
+    }
+    assert clipped_ids == {20}
+
+
+def test_build_river_network_dataset_marks_distant_ocean_outlet_unmatched():
+    river_fc = dict(type='FeatureCollection', features=[])
+    outlet_fc = dict(
+        type='FeatureCollection',
+        features=[
+            _point_feature(
+                hyriv_id=10,
+                coords=(-46.0, 1.0),
+                drainage_area=100.0e6,
+                endorheic=0,
+                outlet_type='ocean',
+            ),
+        ],
+    )
+    ds_coastline = xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(
+                ('lat', 'lon'),
+                np.array(
+                    [
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 1],
+                        [0, 0, 0, 0, 0],
+                    ],
+                    dtype=np.int8,
+                ),
+            ),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([10.0, 0.0, -10.0]), dims=('lat',)),
+            lon=xr.DataArray(
+                np.array([-90.0, -45.0, 0.0, 45.0, 90.0]), dims=('lon',)
+            ),
+        ),
+    )
+
+    ds_river, snapped_outlets = build_river_network_dataset(
+        river_feature_collection=river_fc,
+        outlet_feature_collection=outlet_fc,
+        ds_coastline=ds_coastline,
+        resolution=45.0,
+        outlet_match_tolerance=200.0e3,
+        channel_subsegment_fraction=0.5,
+    )
+
+    assert ds_river.attrs['matched_ocean_outlets'] == 0
+    assert ds_river.attrs['unmatched_ocean_outlets'] == 1
+
+    snapped_feature = snapped_outlets['features'][0]
+    assert not snapped_feature['properties']['matched_to_ocean']
+    assert snapped_feature['properties']['snapped_lon'] == -45.0
+    assert snapped_feature['properties']['snapped_lat'] == 0.0
+
+
+def test_unpack_hydrorivers_archive(tmp_path):
+    archive_filename = tmp_path / 'HydroRIVERS_v10_shp.zip'
+    shp_directory = tmp_path / 'HydroRIVERS_v10_shp'
+
+    with zipfile.ZipFile(archive_filename, 'w') as archive:
+        archive.writestr('HydroRIVERS_v10_shp/HydroRIVERS_v10.shp', 'x')
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        _unpack_hydrorivers_archive(
+            archive_filename=str(archive_filename),
+            data_directory='HydroRIVERS_v10_shp',
+        )
+    finally:
+        os.chdir(cwd)
+
+    assert shp_directory.is_dir()
+    assert (shp_directory / 'HydroRIVERS_v10.shp').exists()
+
+
+def test_convert_hydrorivers_shapefile_to_geojson(tmp_path):
+    base = tmp_path / 'HydroRIVERS_v10'
+    writer = shapefile.Writer(str(base))
+    writer.field('HYRIV_ID', 'N', 10, 0)
+    writer.field('MAIN_RIV', 'N', 10, 0)
+    writer.field('ORD_STRA', 'N', 10, 0)
+    writer.field('UPLAND_SKM', 'F', 18, 3)
+    writer.field('NEXT_DOWN', 'N', 10, 0)
+    writer.field('ENDORHEIC', 'N', 10, 0)
+    writer.line([[[-1.0, 0.0], [0.0, 0.0]]])
+    writer.record(1, 1, 1, 100.0, 0, 0)
+    writer.close()
+
+    output_filename = tmp_path / 'source_river_network.geojson'
+    _convert_hydrorivers_shapefile_to_geojson(
+        shp_filename=f'{base}.shp',
+        output_filename=str(output_filename),
+    )
+
+    feature_collection = output_filename.read_text(encoding='utf-8')
+    assert 'HYRIV_ID' in feature_collection
+    assert 'LineString' in feature_collection
+
+
+def test_mesh_river_step_factories_use_mesh_subdirs():
+    mesh_name = 'u.oi30.lr10'
+    unified_steps, _ = get_unified_mesh_river_steps(
+        mesh_name=mesh_name,
+        include_viz=False,
+    )
+    simplify_step = unified_steps['river_simplify']
+    rasterize_step = unified_steps['river_rasterize']
+    clip_step = unified_steps['river_clip']
+
+    assert (
+        simplify_step.subdir == f'spherical/unified/{mesh_name}/river/simplify'
+    )
+    assert (
+        rasterize_step.subdir
+        == f'spherical/unified/{mesh_name}/river/rasterize'
+    )
+
+    assert clip_step.subdir == f'spherical/unified/{mesh_name}/river/clip'
+
+
+def test_mesh_river_step_factories_reuse_shared_configs():
+    mesh_name = 'u.oi30.lr10'
+
+    unified_steps_first, unified_config_first = get_unified_mesh_river_steps(
+        mesh_name=mesh_name,
+        include_viz=False,
+    )
+    unified_steps_second, unified_config_second = get_unified_mesh_river_steps(
+        mesh_name=mesh_name,
+        include_viz=True,
+    )
+
+    # source and lat-lon steps are shared across both calls
+    assert (
+        unified_steps_first['river_simplify']
+        is unified_steps_second['river_simplify']
+    )
+    assert (
+        unified_steps_first['river_rasterize']
+        is unified_steps_second['river_rasterize']
+    )
+    assert (
+        unified_steps_first['river_clip'] is unified_steps_second['river_clip']
+    )
+    assert unified_config_first is unified_config_second
+    # without viz: {combine_topo, coastline_compute, coastline_final,
+    #               river_simplify, river_rasterize, river_clip}
+    # with viz: those plus river_viz
+    print(unified_steps_first.keys())
+    print(unified_steps_second.keys())
+    assert len(unified_steps_first) == 6
+    assert len(unified_steps_second) == 7
+
+
+def test_add_river_tasks_registers_mesh_tasks():
+    component = Component(name='mesh')
+    add_river_tasks(component=component)
+
+    assert len(component.tasks) == len(UNIFIED_MESH_NAMES)
+
+    for mesh_name in UNIFIED_MESH_NAMES:
+        subdir = f'spherical/unified/{mesh_name}/river/task'
+        assert subdir in component.tasks
+        task = component.tasks[subdir]
+        assert task.name == f'river_network_{mesh_name}_task'
+
+
+def test_drainage_area_threshold_auto_derived_from_config():
+    # High-resolution mesh: 10 km land,
+    # multiplier 100 → 10² × 100 × 1e6 = 1e10 m²
+    steps_10km, config_10km = get_unified_mesh_river_steps(
+        mesh_name='u.oi30.lr10', include_viz=False
+    )
+    land_background_km = config_10km.getfloat(
+        'sizing_field', 'land_background_km'
+    )
+    multiplier = config_10km.getfloat(
+        'river_network', 'drainage_area_multiplier'
+    )
+    assert land_background_km == pytest.approx(10.0)
+    assert multiplier == pytest.approx(100.0)
+    assert land_background_km**2 * multiplier * 1e6 == pytest.approx(1.0e10)
+
+    # Coarse mesh: 240 km land, multiplier 10 → 240² × 10 × 1e6 = 5.76e11 m²
+    steps_240km, config_240km = get_unified_mesh_river_steps(
+        mesh_name='u.oi240.lr240', include_viz=False
+    )
+    land_background_km = config_240km.getfloat(
+        'sizing_field', 'land_background_km'
+    )
+    multiplier = config_240km.getfloat(
+        'river_network', 'drainage_area_multiplier'
+    )
+    assert land_background_km == pytest.approx(240.0)
+    assert multiplier == pytest.approx(10.0)
+    assert land_background_km**2 * multiplier * 1e6 == pytest.approx(5.76e11)
+
+
+def test_outlet_distance_tolerance_auto_derived_from_config():
+    # 10 km river channel → 10 000 m tolerance
+    _, config_10km = get_unified_mesh_river_steps(
+        mesh_name='u.oi30.lr10', include_viz=False
+    )
+    river_channel_km = config_10km.getfloat('sizing_field', 'river_channel_km')
+    assert river_channel_km == pytest.approx(10.0)
+    assert river_channel_km * 1000.0 == pytest.approx(10_000.0)
+
+    # 240 km river channel → 240 000 m tolerance
+    _, config_240km = get_unified_mesh_river_steps(
+        mesh_name='u.oi240.lr240', include_viz=False
+    )
+    river_channel_km = config_240km.getfloat(
+        'sizing_field', 'river_channel_km'
+    )
+    assert river_channel_km == pytest.approx(240.0)
+    assert river_channel_km * 1000.0 == pytest.approx(240_000.0)
+
+
+def _line_feature(
+    hyriv_id,
+    coords,
+    next_down,
+    drainage_area,
+    endorheic,
+    outlet_type=None,
+    outlet_hyriv_id=None,
+    ord_stra=1,
+):
+    return dict(
+        type='Feature',
+        properties=dict(
+            hyriv_id=hyriv_id,
+            main_riv=hyriv_id,
+            ord_stra=ord_stra,
+            drainage_area=drainage_area,
+            next_down=next_down,
+            endorheic=endorheic,
+            outlet_type=outlet_type,
+            outlet_hyriv_id=outlet_hyriv_id,
+        ),
+        geometry=dict(type='LineString', coordinates=coords),
+    )
+
+
+def _point_feature(
+    hyriv_id,
+    coords,
+    drainage_area,
+    endorheic,
+    outlet_type,
+):
+    return dict(
+        type='Feature',
+        properties=dict(
+            hyriv_id=hyriv_id,
+            main_riv=hyriv_id,
+            drainage_area=drainage_area,
+            endorheic=endorheic,
+            outlet_type=outlet_type,
+        ),
+        geometry=dict(type='Point', coordinates=coords),
+    )

--- a/tests/mesh/spherical/unified/test_river.py
+++ b/tests/mesh/spherical/unified/test_river.py
@@ -23,6 +23,7 @@ from polaris.tasks.mesh.spherical.unified.river.simplify import (
     _convert_hydrorivers_shapefile_to_geojson,
     _unpack_hydrorivers_archive,
     read_river_segments_from_feature_collection,
+    river_segments_to_feature_collection,
 )
 
 
@@ -106,6 +107,18 @@ def test_simplify_river_network_traverses_all_terminal_segments():
         ]
         for feature in simplified_fc['features']
     }
+    outlet_area_by_id = {
+        feature['properties']['hyriv_id']: feature['properties'][
+            'outlet_drainage_area'
+        ]
+        for feature in simplified_fc['features']
+    }
+    network_rank_by_id = {
+        feature['properties']['hyriv_id']: feature['properties'][
+            'river_network_rank'
+        ]
+        for feature in simplified_fc['features']
+    }
 
     assert simplified_ids == {10, 11, 12, 20, 30, 31}
     assert outlet_hyriv_id_by_id[10] == 10
@@ -114,6 +127,38 @@ def test_simplify_river_network_traverses_all_terminal_segments():
     assert outlet_hyriv_id_by_id[20] == 20
     assert outlet_hyriv_id_by_id[30] == 30
     assert outlet_hyriv_id_by_id[31] == 31
+    assert outlet_area_by_id[10] == 100.0e6
+    assert outlet_area_by_id[11] == 100.0e6
+    assert outlet_area_by_id[12] == 100.0e6
+    assert outlet_area_by_id[20] == 90.0e6
+    assert outlet_area_by_id[30] == 25.0e6
+    assert outlet_area_by_id[31] == 20.0e6
+    assert network_rank_by_id[10] == 1
+    assert network_rank_by_id[11] == 1
+    assert network_rank_by_id[12] == 1
+    assert network_rank_by_id[20] == 2
+    assert network_rank_by_id[30] == 3
+    assert network_rank_by_id[31] == 4
+
+    roundtrip_segments = read_river_segments_from_feature_collection(
+        simplified_fc
+    )
+    roundtrip_fc = river_segments_to_feature_collection(roundtrip_segments)
+    roundtrip_rank_by_id = {
+        feature['properties']['hyriv_id']: feature['properties'][
+            'river_network_rank'
+        ]
+        for feature in roundtrip_fc['features']
+    }
+    roundtrip_area_by_id = {
+        feature['properties']['hyriv_id']: feature['properties'][
+            'outlet_drainage_area'
+        ]
+        for feature in roundtrip_fc['features']
+    }
+
+    assert roundtrip_rank_by_id == network_rank_by_id
+    assert roundtrip_area_by_id == outlet_area_by_id
 
 
 def test_simplify_river_network_handles_deep_main_stem():
@@ -376,6 +421,8 @@ def test_condition_base_mesh_river_segments_clips_then_simplifies():
                 drainage_area=100.0e6,
                 endorheic=0,
                 outlet_hyriv_id=10,
+                outlet_drainage_area=100.0e6,
+                river_network_rank=1,
             )
         ],
     )
@@ -394,6 +441,8 @@ def test_condition_base_mesh_river_segments_clips_then_simplifies():
     assert coords[0, 0] == 0.0
     assert 8.0 < coords[-1, 0] < 16.0
     assert segments[0].outlet_hyriv_id == 10
+    assert segments[0].outlet_drainage_area == 100.0e6
+    assert segments[0].river_network_rank == 1
 
 
 def test_condition_base_mesh_river_segments_drops_short_fragments():
@@ -616,18 +665,26 @@ def _line_feature(
     drainage_area,
     endorheic,
     outlet_hyriv_id=None,
+    outlet_drainage_area=None,
+    river_network_rank=None,
     ord_stra=1,
 ):
+    properties = dict(
+        hyriv_id=hyriv_id,
+        main_riv=hyriv_id,
+        ord_stra=ord_stra,
+        drainage_area=drainage_area,
+        next_down=next_down,
+        endorheic=endorheic,
+        outlet_hyriv_id=outlet_hyriv_id,
+    )
+    if outlet_drainage_area is not None:
+        properties['outlet_drainage_area'] = outlet_drainage_area
+    if river_network_rank is not None:
+        properties['river_network_rank'] = river_network_rank
+
     return dict(
         type='Feature',
-        properties=dict(
-            hyriv_id=hyriv_id,
-            main_riv=hyriv_id,
-            ord_stra=ord_stra,
-            drainage_area=drainage_area,
-            next_down=next_down,
-            endorheic=endorheic,
-            outlet_hyriv_id=outlet_hyriv_id,
-        ),
+        properties=properties,
         geometry=dict(type='LineString', coordinates=coords),
     )

--- a/tests/mesh/spherical/unified/test_river.py
+++ b/tests/mesh/spherical/unified/test_river.py
@@ -738,63 +738,6 @@ def test_add_river_tasks_registers_mesh_tasks():
         assert task.name == f'river_network_{mesh_name}_task'
 
 
-def test_drainage_area_threshold_auto_derived_from_config():
-    # High-resolution mesh: 10 km land,
-    # multiplier 100 → 10² × 100 × 1e6 = 1e10 m²
-    steps_10km, config_10km = get_unified_mesh_river_steps(
-        mesh_name='u.oi30.lr10', include_viz=False
-    )
-    land_background_km = config_10km.getfloat(
-        'sizing_field', 'land_background_km'
-    )
-    multiplier = config_10km.getfloat(
-        'river_network', 'drainage_area_multiplier'
-    )
-    assert land_background_km == pytest.approx(10.0)
-    assert multiplier == pytest.approx(100.0)
-    assert land_background_km**2 * multiplier * 1e6 == pytest.approx(1.0e10)
-
-    # Coarse mesh: 240 km land, multiplier 10 → 240² × 10 × 1e6 = 5.76e11 m²
-    steps_240km, config_240km = get_unified_mesh_river_steps(
-        mesh_name='u.oi240.lr240', include_viz=False
-    )
-    land_background_km = config_240km.getfloat(
-        'sizing_field', 'land_background_km'
-    )
-    multiplier = config_240km.getfloat(
-        'river_network', 'drainage_area_multiplier'
-    )
-    assert land_background_km == pytest.approx(240.0)
-    assert multiplier == pytest.approx(10.0)
-    assert land_background_km**2 * multiplier * 1e6 == pytest.approx(5.76e11)
-
-
-def test_branch_distance_tolerance_auto_derived_from_config():
-    # 10 km river channel → 10 000 m tolerance
-    _, config_10km = get_unified_mesh_river_steps(
-        mesh_name='u.oi30.lr10', include_viz=False
-    )
-    river_channel_km = config_10km.getfloat('sizing_field', 'river_channel_km')
-    assert config_10km.getfloat(
-        'river_network', 'branch_distance_tolerance'
-    ) == pytest.approx(-1.0)
-    assert river_channel_km == pytest.approx(10.0)
-    assert river_channel_km * 1000.0 == pytest.approx(10_000.0)
-
-    # 240 km river channel → 240 000 m tolerance
-    _, config_240km = get_unified_mesh_river_steps(
-        mesh_name='u.oi240.lr240', include_viz=False
-    )
-    river_channel_km = config_240km.getfloat(
-        'sizing_field', 'river_channel_km'
-    )
-    assert config_240km.getfloat(
-        'river_network', 'branch_distance_tolerance'
-    ) == pytest.approx(-1.0)
-    assert river_channel_km == pytest.approx(240.0)
-    assert river_channel_km * 1000.0 == pytest.approx(240_000.0)
-
-
 def _line_feature(
     hyriv_id,
     coords,

--- a/tests/mesh/spherical/unified/test_river.py
+++ b/tests/mesh/spherical/unified/test_river.py
@@ -17,7 +17,6 @@ from polaris.tasks.mesh.spherical.unified.river import (
     simplify_river_network_feature_collection,
 )
 from polaris.tasks.mesh.spherical.unified.river.clip import (
-    clip_outlet_feature_collection,
     condition_base_mesh_river_segments,
 )
 from polaris.tasks.mesh.spherical.unified.river.simplify import (
@@ -27,7 +26,7 @@ from polaris.tasks.mesh.spherical.unified.river.simplify import (
 )
 
 
-def test_simplify_river_network_filters_outlets_and_minor_tributaries():
+def test_simplify_river_network_traverses_all_terminal_segments():
     feature_collection = dict(
         type='FeatureCollection',
         features=[
@@ -89,10 +88,10 @@ def test_simplify_river_network_filters_outlets_and_minor_tributaries():
         ],
     )
 
-    simplified_fc, outlets_fc = simplify_river_network_feature_collection(
+    simplified_fc = simplify_river_network_feature_collection(
         feature_collection=feature_collection,
         drainage_area_threshold=5.0e6,
-        outlet_distance_tolerance=30.0e3,
+        branch_distance_tolerance=30.0e3,
         # ratio relative to the BASIN OUTLET (100e6): 35e6 >= 0.3*100e6=30e6
         tributary_area_ratio=0.3,
     )
@@ -101,12 +100,20 @@ def test_simplify_river_network_filters_outlets_and_minor_tributaries():
         feature['properties']['hyriv_id']
         for feature in simplified_fc['features']
     }
-    outlet_ids = {
-        feature['properties']['hyriv_id'] for feature in outlets_fc['features']
+    outlet_hyriv_id_by_id = {
+        feature['properties']['hyriv_id']: feature['properties'][
+            'outlet_hyriv_id'
+        ]
+        for feature in simplified_fc['features']
     }
 
-    assert simplified_ids == {10, 11, 12, 30, 31}
-    assert outlet_ids == {10, 30, 31}
+    assert simplified_ids == {10, 11, 12, 20, 30, 31}
+    assert outlet_hyriv_id_by_id[10] == 10
+    assert outlet_hyriv_id_by_id[11] == 10
+    assert outlet_hyriv_id_by_id[12] == 10
+    assert outlet_hyriv_id_by_id[20] == 20
+    assert outlet_hyriv_id_by_id[30] == 30
+    assert outlet_hyriv_id_by_id[31] == 31
 
 
 def test_simplify_river_network_handles_deep_main_stem():
@@ -127,10 +134,10 @@ def test_simplify_river_network_handles_deep_main_stem():
             )
         )
 
-    simplified_fc, outlets_fc = simplify_river_network_feature_collection(
+    simplified_fc = simplify_river_network_feature_collection(
         feature_collection=dict(type='FeatureCollection', features=features),
         drainage_area_threshold=1.0,
-        outlet_distance_tolerance=1.0,
+        branch_distance_tolerance=1.0,
         tributary_area_ratio=0.05,
     )
 
@@ -138,12 +145,14 @@ def test_simplify_river_network_handles_deep_main_stem():
         feature['properties']['hyriv_id']
         for feature in simplified_fc['features']
     }
-    outlet_ids = {
-        feature['properties']['hyriv_id'] for feature in outlets_fc['features']
-    }
 
     assert len(simplified_ids) == n_segments
-    assert outlet_ids == {1}
+    root_segment = next(
+        feature
+        for feature in simplified_fc['features']
+        if feature['properties']['hyriv_id'] == 1
+    )
+    assert root_segment['properties']['outlet_hyriv_id'] == 1
 
 
 def test_simplify_river_network_rejects_next_down_cycles():
@@ -171,7 +180,7 @@ def test_simplify_river_network_rejects_next_down_cycles():
         simplify_river_network_feature_collection(
             feature_collection=feature_collection,
             drainage_area_threshold=1.0,
-            outlet_distance_tolerance=1.0,
+            branch_distance_tolerance=1.0,
             tributary_area_ratio=0.05,
         )
 
@@ -235,10 +244,10 @@ def test_simplify_river_network_preserves_branch_traversal_order():
         ],
     )
 
-    simplified_fc, _ = simplify_river_network_feature_collection(
+    simplified_fc = simplify_river_network_feature_collection(
         feature_collection=feature_collection,
         drainage_area_threshold=1.0,
-        outlet_distance_tolerance=20.0e3,
+        branch_distance_tolerance=20.0e3,
         tributary_area_ratio=0.4,
     )
 
@@ -250,7 +259,7 @@ def test_simplify_river_network_preserves_branch_traversal_order():
     assert simplified_ids == {10, 11, 12, 21, 22}
 
 
-def test_build_river_network_dataset_contract_and_snapped_outlets():
+def test_build_river_network_dataset_contract_and_channel_mask():
     river_fc = dict(
         type='FeatureCollection',
         features=[
@@ -260,7 +269,6 @@ def test_build_river_network_dataset_contract_and_snapped_outlets():
                 next_down=0,
                 drainage_area=100.0e6,
                 endorheic=0,
-                outlet_type='ocean',
                 outlet_hyriv_id=10,
             ),
             _line_feature(
@@ -269,44 +277,11 @@ def test_build_river_network_dataset_contract_and_snapped_outlets():
                 next_down=0,
                 drainage_area=20.0e6,
                 endorheic=1,
-                outlet_type='inland_sink',
                 outlet_hyriv_id=30,
             ),
         ],
     )
-    outlet_fc = dict(
-        type='FeatureCollection',
-        features=[
-            _point_feature(
-                hyriv_id=10,
-                coords=(-46.0, 1.0),
-                drainage_area=100.0e6,
-                endorheic=0,
-                outlet_type='ocean',
-            ),
-            _point_feature(
-                hyriv_id=30,
-                coords=(46.0, 1.0),
-                drainage_area=20.0e6,
-                endorheic=1,
-                outlet_type='inland_sink',
-            ),
-        ],
-    )
     ds_coastline = xr.Dataset(
-        data_vars=dict(
-            ocean_mask=(
-                ('lat', 'lon'),
-                np.array(
-                    [
-                        [0, 0, 0, 0, 0],
-                        [0, 1, 0, 0, 0],
-                        [0, 0, 0, 0, 0],
-                    ],
-                    dtype=np.int8,
-                ),
-            ),
-        ),
         coords=dict(
             lat=xr.DataArray(np.array([10.0, 0.0, -10.0]), dims=('lat',)),
             lon=xr.DataArray(
@@ -315,38 +290,17 @@ def test_build_river_network_dataset_contract_and_snapped_outlets():
         ),
     )
 
-    ds_river, snapped_outlets = build_river_network_dataset(
+    ds_river = build_river_network_dataset(
         river_feature_collection=river_fc,
-        outlet_feature_collection=outlet_fc,
         ds_coastline=ds_coastline,
         resolution=45.0,
-        outlet_match_tolerance=200.0e3,
         channel_subsegment_fraction=0.5,
     )
 
-    expected_vars = {
-        'river_channel_mask',
-        'river_outlet_mask',
-        'river_ocean_outlet_mask',
-        'river_inland_sink_mask',
-    }
+    expected_vars = {'river_channel_mask'}
     assert expected_vars.issubset(set(ds_river.data_vars))
-    assert ds_river.attrs['matched_ocean_outlets'] == 1
-    assert ds_river.attrs['unmatched_ocean_outlets'] == 0
 
     assert ds_river.river_channel_mask.sum() > 0
-    assert ds_river.river_ocean_outlet_mask.sel(lat=0.0, lon=-45.0) == 1
-    assert ds_river.river_inland_sink_mask.sel(lat=0.0, lon=45.0) == 1
-
-    snapped_by_id = {
-        feature['properties']['hyriv_id']: feature
-        for feature in snapped_outlets['features']
-    }
-    assert snapped_by_id[10]['properties']['snapped_lon'] == -45.0
-    assert snapped_by_id[10]['properties']['snapped_lat'] == 0.0
-    assert snapped_by_id[30]['properties']['snapped_lon'] == 45.0
-    assert snapped_by_id[30]['properties']['snapped_lat'] == 0.0
-    assert snapped_by_id[10]['properties']['matched_to_ocean']
 
 
 def test_build_river_network_dataset_applies_physical_channel_buffer():
@@ -377,12 +331,10 @@ def test_build_river_network_dataset_applies_physical_channel_buffer():
         ),
     )
 
-    ds_river, _ = build_river_network_dataset(
+    ds_river = build_river_network_dataset(
         river_feature_collection=river_fc,
-        outlet_feature_collection=dict(type='FeatureCollection', features=[]),
         ds_coastline=ds_coastline,
         resolution=1.0,
-        outlet_match_tolerance=200.0e3,
         channel_subsegment_fraction=0.5,
         channel_buffer_km=80.0,
     )
@@ -393,57 +345,6 @@ def test_build_river_network_dataset_applies_physical_channel_buffer():
     assert ds_river.river_channel_mask.sel(lat=60.0, lon=1.0) == 1
     assert ds_river.river_channel_mask.sel(lat=60.0, lon=-2.0) == 0
     assert ds_river.river_channel_mask.sel(lat=60.0, lon=2.0) == 0
-
-
-def test_build_river_network_dataset_derives_land_mask_from_ocean_mask():
-    river_fc = dict(type='FeatureCollection', features=[])
-    outlet_fc = dict(
-        type='FeatureCollection',
-        features=[
-            _point_feature(
-                hyriv_id=30,
-                coords=(46.0, 1.0),
-                drainage_area=20.0e6,
-                endorheic=1,
-                outlet_type='inland_sink',
-            ),
-        ],
-    )
-    ds_coastline = xr.Dataset(
-        data_vars=dict(
-            ocean_mask=(
-                ('lat', 'lon'),
-                np.array(
-                    [
-                        [1, 1, 1, 1, 1],
-                        [1, 1, 1, 0, 1],
-                        [1, 1, 1, 1, 1],
-                    ],
-                    dtype=np.int8,
-                ),
-            ),
-        ),
-        coords=dict(
-            lat=xr.DataArray(np.array([10.0, 0.0, -10.0]), dims=('lat',)),
-            lon=xr.DataArray(
-                np.array([-90.0, -45.0, 0.0, 45.0, 90.0]), dims=('lon',)
-            ),
-        ),
-    )
-
-    ds_river, snapped_outlets = build_river_network_dataset(
-        river_feature_collection=river_fc,
-        outlet_feature_collection=outlet_fc,
-        ds_coastline=ds_coastline,
-        resolution=45.0,
-        outlet_match_tolerance=200.0e3,
-        channel_subsegment_fraction=0.5,
-    )
-
-    assert ds_river.river_inland_sink_mask.sel(lat=0.0, lon=45.0) == 1
-    snapped_feature = snapped_outlets['features'][0]
-    assert snapped_feature['properties']['snapped_lon'] == 45.0
-    assert snapped_feature['properties']['snapped_lat'] == 0.0
 
 
 def test_condition_base_mesh_river_segments_clips_then_simplifies():
@@ -474,7 +375,6 @@ def test_condition_base_mesh_river_segments_clips_then_simplifies():
                 next_down=0,
                 drainage_area=100.0e6,
                 endorheic=0,
-                outlet_type='ocean',
                 outlet_hyriv_id=10,
             )
         ],
@@ -493,8 +393,7 @@ def test_condition_base_mesh_river_segments_clips_then_simplifies():
     assert coords.shape[0] == 2
     assert coords[0, 0] == 0.0
     assert 8.0 < coords[-1, 0] < 16.0
-    assert segments[0].outlet_type is None
-    assert segments[0].outlet_hyriv_id is None
+    assert segments[0].outlet_hyriv_id == 10
 
 
 def test_condition_base_mesh_river_segments_drops_short_fragments():
@@ -538,111 +437,6 @@ def test_condition_base_mesh_river_segments_drops_short_fragments():
     )
 
     assert segments == []
-
-
-def test_clip_outlet_feature_collection_removes_ocean_outlets():
-    ds_coastline = xr.Dataset(
-        data_vars=dict(
-            ocean_mask=(('lat', 'lon'), np.zeros((2, 2), dtype=np.int8)),
-            signed_distance=(
-                ('lat', 'lon'),
-                np.array(
-                    [
-                        [-2.0e5, 1.0e5],
-                        [-2.0e5, 1.0e5],
-                    ]
-                ),
-            ),
-        ),
-        coords=dict(
-            lat=xr.DataArray(np.array([-5.0, 5.0]), dims=('lat',)),
-            lon=xr.DataArray(np.array([0.0, 10.0]), dims=('lon',)),
-        ),
-    )
-    outlet_fc = dict(
-        type='FeatureCollection',
-        features=[
-            _point_feature(
-                hyriv_id=10,
-                coords=(9.0, 0.0),
-                drainage_area=100.0e6,
-                endorheic=0,
-                outlet_type='ocean',
-            ),
-            _point_feature(
-                hyriv_id=20,
-                coords=(1.0, 0.0),
-                drainage_area=50.0e6,
-                endorheic=1,
-                outlet_type='inland_sink',
-            ),
-        ],
-    )
-
-    clipped = clip_outlet_feature_collection(
-        outlet_feature_collection=outlet_fc,
-        ds_coastline=ds_coastline,
-        clip_distance_m=50.0e3,
-    )
-
-    clipped_ids = {
-        feature['properties']['hyriv_id'] for feature in clipped['features']
-    }
-    assert clipped_ids == {20}
-
-
-def test_build_river_network_dataset_marks_distant_ocean_outlet_unmatched():
-    river_fc = dict(type='FeatureCollection', features=[])
-    outlet_fc = dict(
-        type='FeatureCollection',
-        features=[
-            _point_feature(
-                hyriv_id=10,
-                coords=(-46.0, 1.0),
-                drainage_area=100.0e6,
-                endorheic=0,
-                outlet_type='ocean',
-            ),
-        ],
-    )
-    ds_coastline = xr.Dataset(
-        data_vars=dict(
-            ocean_mask=(
-                ('lat', 'lon'),
-                np.array(
-                    [
-                        [0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 1],
-                        [0, 0, 0, 0, 0],
-                    ],
-                    dtype=np.int8,
-                ),
-            ),
-        ),
-        coords=dict(
-            lat=xr.DataArray(np.array([10.0, 0.0, -10.0]), dims=('lat',)),
-            lon=xr.DataArray(
-                np.array([-90.0, -45.0, 0.0, 45.0, 90.0]), dims=('lon',)
-            ),
-        ),
-    )
-
-    ds_river, snapped_outlets = build_river_network_dataset(
-        river_feature_collection=river_fc,
-        outlet_feature_collection=outlet_fc,
-        ds_coastline=ds_coastline,
-        resolution=45.0,
-        outlet_match_tolerance=200.0e3,
-        channel_subsegment_fraction=0.5,
-    )
-
-    assert ds_river.attrs['matched_ocean_outlets'] == 0
-    assert ds_river.attrs['unmatched_ocean_outlets'] == 1
-
-    snapped_feature = snapped_outlets['features'][0]
-    assert not snapped_feature['properties']['matched_to_ocean']
-    assert snapped_feature['properties']['snapped_lon'] == -45.0
-    assert snapped_feature['properties']['snapped_lat'] == 0.0
 
 
 def test_unpack_hydrorivers_archive(tmp_path):
@@ -789,12 +583,15 @@ def test_drainage_area_threshold_auto_derived_from_config():
     assert land_background_km**2 * multiplier * 1e6 == pytest.approx(5.76e11)
 
 
-def test_outlet_distance_tolerance_auto_derived_from_config():
+def test_branch_distance_tolerance_auto_derived_from_config():
     # 10 km river channel → 10 000 m tolerance
     _, config_10km = get_unified_mesh_river_steps(
         mesh_name='u.oi30.lr10', include_viz=False
     )
     river_channel_km = config_10km.getfloat('sizing_field', 'river_channel_km')
+    assert config_10km.getfloat(
+        'river_network', 'branch_distance_tolerance'
+    ) == pytest.approx(-1.0)
     assert river_channel_km == pytest.approx(10.0)
     assert river_channel_km * 1000.0 == pytest.approx(10_000.0)
 
@@ -805,6 +602,9 @@ def test_outlet_distance_tolerance_auto_derived_from_config():
     river_channel_km = config_240km.getfloat(
         'sizing_field', 'river_channel_km'
     )
+    assert config_240km.getfloat(
+        'river_network', 'branch_distance_tolerance'
+    ) == pytest.approx(-1.0)
     assert river_channel_km == pytest.approx(240.0)
     assert river_channel_km * 1000.0 == pytest.approx(240_000.0)
 
@@ -815,7 +615,6 @@ def _line_feature(
     next_down,
     drainage_area,
     endorheic,
-    outlet_type=None,
     outlet_hyriv_id=None,
     ord_stra=1,
 ):
@@ -828,28 +627,7 @@ def _line_feature(
             drainage_area=drainage_area,
             next_down=next_down,
             endorheic=endorheic,
-            outlet_type=outlet_type,
             outlet_hyriv_id=outlet_hyriv_id,
         ),
         geometry=dict(type='LineString', coordinates=coords),
-    )
-
-
-def _point_feature(
-    hyriv_id,
-    coords,
-    drainage_area,
-    endorheic,
-    outlet_type,
-):
-    return dict(
-        type='Feature',
-        properties=dict(
-            hyriv_id=hyriv_id,
-            main_riv=hyriv_id,
-            drainage_area=drainage_area,
-            endorheic=endorheic,
-            outlet_type=outlet_type,
-        ),
-        geometry=dict(type='Point', coordinates=coords),
     )

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -7,7 +7,7 @@ import pytest
 
 def _load_archive_module():
     module_path = (
-        Path(__file__).resolve().parents[4] / 'polaris' / 'archive.py'
+        Path(__file__).resolve().parents[1] / 'polaris' / 'archive.py'
     )
     spec = importlib.util.spec_from_file_location(
         'polaris_archive', module_path
@@ -46,3 +46,22 @@ def test_find_zip_member_raises_on_ambiguous_basename(tmp_path):
     with zipfile.ZipFile(zip_path) as archive:
         with pytest.raises(ValueError, match='Multiple ZIP members'):
             archive_module.find_zip_member(archive, 'GEBCO_2023.nc')
+
+
+def test_extract_zip_subdir_extracts_matching_members(tmp_path):
+    archive_module = _load_archive_module()
+    zip_path = tmp_path / 'HydroRIVERS_v10_shp.zip'
+
+    with zipfile.ZipFile(zip_path, 'w') as archive:
+        archive.writestr('HydroRIVERS_TechDoc_v10.pdf', b'pdf')
+        archive.writestr('HydroRIVERS_v10_shp/HydroRIVERS_v10.shp', b'shp')
+        archive.writestr('HydroRIVERS_v10_shp/HydroRIVERS_v10.dbf', b'dbf')
+
+    archive_module.extract_zip_subdir(
+        str(zip_path), 'HydroRIVERS_v10_shp', out_dir=str(tmp_path)
+    )
+
+    shp_dir = tmp_path / 'HydroRIVERS_v10_shp'
+    assert (shp_dir / 'HydroRIVERS_v10.shp').read_bytes() == b'shp'
+    assert (shp_dir / 'HydroRIVERS_v10.dbf').read_bytes() == b'dbf'
+    assert not (tmp_path / 'HydroRIVERS_TechDoc_v10.pdf').exists()


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
## Summary

This PR adds `polaris/tasks/mesh/spherical/unified/river` as the shared
HydroRIVERS preprocessing workflow for unified spherical meshes. The workflow
simplifies source river geometry, rasterizes retained channels onto the
selected lat-lon target grid, prepares coastline-clipped geometry for base-mesh
conditioning, and provides diagnostic plots for inspection.

## What This PR Adds

- shared river steps for:
  - `river_simplify`, which downloads/unpacks HydroRIVERS and writes
    `simplified_river_network.geojson`
  - `river_rasterize`, which writes `river_network.nc`
  - `river_clip`, which writes `clipped_river_network.geojson` and
    `clipped_river_network.nc`
  - `viz_river_network`, which writes diagnostic plots and a summary file
- a HydroRIVERS simplification algorithm that:
  - canonicalizes duplicate segment geometries by `hyriv_id`
  - filters segments by configurable drainage area
  - validates acyclic `NEXT_DOWN` topology
  - traverses terminal basins upstream to retain main stems and significant
    tributaries
  - preserves basin metadata with `outlet_hyriv_id`,
    `outlet_drainage_area`, and `river_network_rank`
- lat-lon rasterization that writes `river_channel_mask` on the selected
  unified target grid
- coastline-aware base-mesh conditioning that clips river geometry inland of
  the selected Antarctic boundary convention, simplifies clipped segments, and
  removes short fragments
- standalone river-network tasks for each supported unified mesh, plus shared
  step factories for downstream workflows
- `river_network.cfg` settings for HydroRIVERS access, source simplification,
  target-grid rasterization, base-mesh clipping, and visualization
- user and developer documentation for the river-network workflow

## Testing

This PR adds `tests/mesh/spherical/unified/test_river.py` with coverage for:

- source-level terminal-basin traversal, deep main stems, tributary retention,
  branch ordering, and cycle rejection
- GeoJSON round-tripping of river-network metadata
- HydroRIVERS archive unpacking and shapefile-to-GeoJSON conversion helpers
- lat-lon `river_channel_mask` dataset contracts and physical channel buffering
- coastline-aware base-mesh clipping, simplification, and short-fragment removal
- shared-step factories, config-derived thresholds, and standalone task
  registration for all named unified meshes

## Notes

Outlet snapping and detailed coastline reconciliation are intentionally deferred
until after an MPAS base mesh exists. The current workflow focuses on producing
shared source, lat-lon, and clipped base-mesh river products that can be reused
by unified sizing-field and base-mesh workflows.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
