### PR TITLE
Add workflow for computing sizing field (cell width) for the unified MPAS mesh

### DIFF
--- a/docs/developers_guide/mesh/api.md
+++ b/docs/developers_guide/mesh/api.md
@@ -75,3 +75,24 @@
    UnifiedRiverNetworkTask
    add_river_tasks
 ```
+
+### Unified Sizing-Field Tasks
+
+```{eval-rst}
+.. currentmodule:: polaris.tasks.mesh.spherical.unified.sizing_field
+
+.. autosummary::
+   :toctree: generated/
+
+   BuildSizingFieldStep
+   BuildSizingFieldStep.setup
+   BuildSizingFieldStep.run
+   sizing_field_dataset
+   VizSizingFieldStep
+   VizSizingFieldStep.setup
+   VizSizingFieldStep.run
+   SizingFieldTask
+   add_sizing_field_tasks
+   get_unified_mesh_sizing_field_steps
+   get_sizing_field_config
+```

--- a/docs/developers_guide/mesh/tasks/index.md
+++ b/docs/developers_guide/mesh/tasks/index.md
@@ -12,16 +12,16 @@ can be used to generate quasi-uniform (`qu`) and subdivided icosahedral
 km.  These "base" meshes cover the full sphere (include both continents and
 ocean regions).
 
-## Unified Mesh Preparation Tasks
+## Unified Mesh Tasks
 
-This section covers the shared task families that prepare reusable coastline
-and river products for named global unified meshes. These workflows are
-intended to be reused by downstream sizing-field and base-mesh tasks rather
-than implemented separately inside each consumer.
+This section covers the task families for named global unified meshes, from
+the preparatory coastline and river workflows through the sizing-field
+construction.
 
 ```{toctree}
 :titlesonly: true
 
 unified/coastline
 unified/river
+unified/sizing_field
 ```

--- a/docs/developers_guide/mesh/tasks/unified/sizing_field.md
+++ b/docs/developers_guide/mesh/tasks/unified/sizing_field.md
@@ -1,0 +1,126 @@
+(dev-mesh-unified-sizing-field)=
+
+# Sizing-Field Steps and Tasks
+
+This section of the Developer's guide covers the code for the unified-mesh
+sizing-field workflow. The {ref}`users-mesh-unified-sizing-field` section
+describes the user-facing behavior, configuration options, and output products.
+
+The `polaris.tasks.mesh.spherical.unified.sizing_field` package assembles a
+cell-width map on a shared lat-lon target grid from the coastline and river
+products produced by the upstream workflows. The sizing-field dataset is the
+key input to the JIGSAW mesh generator in the downstream base-mesh step.
+
+## Available tasks
+
+The helper
+{py:func}`polaris.tasks.mesh.spherical.unified.sizing_field.add_sizing_field_tasks`
+registers one standalone task for each mesh name in
+`polaris.mesh.spherical.unified.UNIFIED_MESH_NAMES`:
+
+- {py:class}`polaris.tasks.mesh.spherical.unified.sizing_field.SizingFieldTask`
+  at `mesh/spherical/unified/<mesh_name>/sizing_field/task`.
+
+## Task structure and shared steps
+
+`SizingFieldTask` calls
+{py:func}`polaris.tasks.mesh.spherical.unified.sizing_field.get_unified_mesh_sizing_field_steps`
+with `include_viz=True`, which in turn calls the river step factory (see
+{ref}`dev-mesh-unified-river`) to obtain all upstream steps and then creates
+{py:class}`polaris.tasks.mesh.spherical.unified.sizing_field.BuildSizingFieldStep`.
+
+The task workdir contains symlinks for all upstream coastline and river steps
+plus:
+
+- `sizing_field` — the shared `BuildSizingFieldStep`
+- `sizing_field_viz` — the shared `VizSizingFieldStep` (when
+  `include_viz=True`)
+
+## Implementation map
+
+### `build.py`
+
+`BuildSizingFieldStep.setup()` links the coastline convention file from
+the upstream coastline step and `river_network.nc` from the upstream
+lat-lon rasterize step.  It also calls the mesh-family hook
+`setup_sizing_field_step()` so family-specific inputs (e.g. the Southern
+Ocean high-resolution region GeoJSON for `so_region` meshes) can be
+registered.
+
+`BuildSizingFieldStep.run()` opens `coastline.nc` and `river_network.nc`,
+delegates ocean-background construction to the mesh family via
+`build_ocean_background()`, and calls the public helper
+{py:func}`polaris.tasks.mesh.spherical.unified.sizing_field.sizing_field_dataset`
+to compose the full sizing field.  The resulting dataset is written to
+`sizing_field.nc`.
+
+The public helper `sizing_field_dataset()` combines:
+
+- the ocean background from the mesh family (a 2-D cell-width array on the
+  lat-lon grid);
+- the land background (`land_background_km`);
+- an optional coastline-proximity refinement controlled by
+  `enable_coastline_refinement` and `coastline_transition_land_km`; and
+- optional river-channel refinement controlled by
+  `enable_river_channel_refinement` and `river_channel_km`.
+
+The result is a `cell_width` variable on the lat-lon grid, together with
+provenance attributes recording the source coastline and river steps.
+
+### `viz.py`
+
+`VizSizingFieldStep` reads `sizing_field.nc` and writes a global overview
+plot, an active-control diagnostic map (showing which refinement control
+dominates at each grid cell), and a plain-text `debug_summary.txt` with
+min/max cell widths and count statistics.
+
+## Configuration plumbing
+
+All sizing-field steps use mesh-specific configs built through
+`get_sizing_field_config(mesh_name)`, which layers:
+
+- the generic `unified_mesh.cfg` defaults;
+- the shared `river_network.cfg` file;
+- the family-specific config (e.g. `default.cfg` or `so_region.cfg`); and
+- the mesh-specific config file (e.g. `u.oi30.lr10.cfg`).
+
+`BuildSizingFieldStep` consumes the `[sizing_field]` section:
+
+- `ocean_background_mode` — `'constant'` or `'rrs_latitude'` (or delegated
+  to the mesh family)
+- `ocean_background_min_km` and `ocean_background_max_km` — cell-width bounds
+  for the ocean background
+- `land_background_km` — cell width for land cells
+- `enable_coastline_refinement` — toggle coastline-proximity refinement
+- `coastline_transition_land_km` — width of the land-side transition zone
+- `enable_river_channel_refinement` — toggle river-channel refinement
+- `river_channel_km` — target cell width along river channels
+
+`VizSizingFieldStep` consumes the `[sizing_field_viz]` section:
+
+- `dpi` — output resolution for diagnostic plots
+- `cell_width_cmap` — colormap for cell-width plots
+
+The {ref}`users-mesh-unified-sizing-field` page explains how these options
+affect the user-visible behavior of the workflow.
+
+## Extension points
+
+Common extension paths for future development are:
+
+- **Adding a new named mesh.** Create a new `.cfg` file under
+  `polaris.mesh.spherical.unified`. Task registration discovers mesh names
+  from those config files automatically.
+- **Adding a new ocean-background mode.** Implement the mode in
+  `polaris.mesh.spherical.unified.base_mesh` (or a new mesh family) and
+  handle it in `build_ocean_background()`.
+- **Adding a new refinement control.** Add parameters to `sizing_field_dataset()`
+  and the `[sizing_field]` config section, then update the visualization step
+  and the associated tests.
+
+## Test coverage
+
+Unit tests in `tests/mesh/spherical/unified/test_sizing_field.py` validate
+the public `sizing_field_dataset()` helper, the ocean-background construction
+for each supported mode, and that `get_unified_mesh_sizing_field_steps`
+creates the expected shared steps for each named mesh.

--- a/docs/users_guide/mesh/tasks/index.md
+++ b/docs/users_guide/mesh/tasks/index.md
@@ -35,14 +35,13 @@ currents along isocontours of resolution.
 
 ## Unified Mesh Tasks
 
-These tasks support the shared preprocessing workflow for named global
-unified meshes. They focus on reusable products that downstream sizing-field
-and base-mesh steps can consume directly instead of recalculating coastline
-and river information independently.
+These tasks cover the full unified-mesh workflow for named global meshes:
+coastline and river preprocessing, and sizing-field construction.
 
 ```{toctree}
 :titlesonly: true
 
 unified/coastline
 unified/river
+unified/sizing_field
 ```

--- a/docs/users_guide/mesh/tasks/unified/river.md
+++ b/docs/users_guide/mesh/tasks/unified/river.md
@@ -4,7 +4,8 @@
 
 The unified-mesh river-network tasks simplify HydroRIVERS source data,
 build target-grid channel masks, and prepare clipped base-mesh geometry that
-downstream sizing-field and base-mesh workflows can
+downstream sizing-field and base-mesh workflows (see
+{ref}`users-mesh-unified-sizing-field` and {ref}`mesh-base-mesh-task`) can
 consume directly.
 
 The standalone task runs the full river workflow in one place: source

--- a/docs/users_guide/mesh/tasks/unified/sizing_field.md
+++ b/docs/users_guide/mesh/tasks/unified/sizing_field.md
@@ -1,0 +1,101 @@
+(users-mesh-unified-sizing-field)=
+
+# Sizing-field tasks
+
+The `mesh/spherical/unified/<mesh_name>/sizing_field` tasks build a
+cell-width map on a shared latitude-longitude grid for each named unified
+mesh. The sizing field combines the coastline and river products from the
+upstream workflows into a single target cell-width dataset that the
+downstream base-mesh step (see {ref}`users-mesh-unified-base-mesh`) passes
+to the JIGSAW mesh generator.
+
+Running these tasks is most useful when you want to inspect or tune the
+sizing field without committing to a full mesh generation.
+
+## Available tasks
+
+Polaris registers one sizing-field task for each named unified mesh:
+
+- `mesh/spherical/unified/<mesh_name>/sizing_field/task`
+
+Supported `mesh_name` values are:
+
+- `u.oi240.lr240`
+- `u.oi30.lr10`
+- `u.oi6to18.lr6to10`
+- `u.oi.so12to30.lr10`
+
+The task work directory contains symlinks to all upstream coastline and river
+shared steps, plus:
+
+- `sizing_field`, the step that builds `sizing_field.nc`; and
+- `sizing_field_viz`, a diagnostic step that writes cell-width overview
+  plots and a summary text file.
+
+## What the sizing field contains
+
+`sizing_field.nc` stores a `cell_width` variable on the mesh's lat-lon target
+grid. Each grid cell holds the target MPAS cell width in km. The field is
+built by combining:
+
+- the ocean background (a 2-D cell-width array derived from the mesh family
+  configuration, e.g. constant or RRS latitude-dependent);
+- the land background (`land_background_km`); and
+- optional refinement controls derived from the coastline and river masks.
+
+## Refinement controls
+
+Two optional refinements can be enabled independently:
+
+**Coastline refinement** (`enable_coastline_refinement`)
+Sets the target cell width at the coastline raster edge to the finest cell
+width between ocean and land backgrounds. A linear transition of width
+`coastline_transition_land_km` can be applied on the land side of the
+coastline to smooth the transition back to the land background.
+
+**River-channel refinement** (`enable_river_channel_refinement`)
+Reduces the target cell width to `river_channel_km` on rasterized river
+channels. This aligns mesh edges with river centerlines in the final JIGSAW
+mesh.
+
+## Configuration
+
+The sizing-field task shares the mesh's `sizing_field.cfg` file. The
+relevant options are in the `[sizing_field]` section:
+
+- `ocean_background_mode`: background ocean resolution mode. Options are
+  `constant` (one cell width everywhere) and `rrs_latitude` (latitude-
+  dependent). The `so_region` mesh family uses an additional mode for
+  Southern Ocean refinement.
+- `ocean_background_min_km`: minimum ocean background cell width in km.
+  For `constant` mode, set equal to `ocean_background_max_km`.
+- `ocean_background_max_km`: maximum ocean background cell width in km.
+  For `rrs_latitude`, this is the equatorial resolution. For `so_region`,
+  this is the coarse background.
+- `land_background_km`: background land cell width in km.
+- `enable_coastline_refinement`: whether to apply coastline-proximity
+  refinement.
+- `coastline_transition_land_km`: width in km of the linear-transition zone
+  on the land side of the coastline. Set to `0` to apply only at the
+  raster edge.
+- `enable_river_channel_refinement`: whether to refine cells on the
+  river-channel mask.
+- `river_channel_km`: target cell width in km along river channels.
+
+Visualization options are in `[sizing_field_viz]`:
+
+- `dpi`: output resolution for diagnostic plots.
+- `cell_width_cmap`: colormap for cell-width plots.
+
+## Running a task
+
+```bash
+polaris setup -t \
+    mesh/spherical/unified/u.oi30.lr10/sizing_field/task \
+    -w sizing_field_30km
+```
+
+The `sizing_field_viz` step writes `sizing_field_overview.png` (a global
+cell-width map), an active-control diagnostic map (showing which refinement
+control dominates at each grid cell), and `debug_summary.txt` with min/max
+cell widths and count statistics.

--- a/docs/users_guide/mesh/tasks/unified/sizing_field.md
+++ b/docs/users_guide/mesh/tasks/unified/sizing_field.md
@@ -6,7 +6,7 @@ The `mesh/spherical/unified/<mesh_name>/sizing_field` tasks build a
 cell-width map on a shared latitude-longitude grid for each named unified
 mesh. The sizing field combines the coastline and river products from the
 upstream workflows into a single target cell-width dataset that the
-downstream base-mesh step (see {ref}`users-mesh-unified-base-mesh`) passes
+downstream base-mesh step passes
 to the JIGSAW mesh generator.
 
 Running these tasks is most useful when you want to inspect or tune the

--- a/polaris/mesh/base/so/__init__.py
+++ b/polaris/mesh/base/so/__init__.py
@@ -1,11 +1,7 @@
 import numpy as np
-from geometric_features import read_feature_collection
-from mpas_tools.mesh.creation.signed_distance import (
-    signed_distance_from_geojson,
-)
 
-from polaris.constants import get_constant
 from polaris.mesh import QuasiUniformSphericalMeshStep
+from polaris.mesh.base.so.background import build_southern_ocean_background
 
 
 class SOBaseMesh(QuasiUniformSphericalMeshStep):
@@ -19,7 +15,8 @@ class SOBaseMesh(QuasiUniformSphericalMeshStep):
         """
 
         self.add_input_file(
-            filename='high_res_region.geojson', package=self.__module__
+            filename='high_res_region.geojson',
+            package='polaris.mesh.base.so',
         )
 
         super().setup()
@@ -47,29 +44,17 @@ class SOBaseMesh(QuasiUniformSphericalMeshStep):
 
         dlon = 0.1
         dlat = dlon
-        earth_radius = get_constant('mean_radius')
         nlon = int(360.0 / dlon) + 1
         nlat = int(180.0 / dlat) + 1
         lon = np.linspace(-180.0, 180.0, nlon)
         lat = np.linspace(-90.0, 90.0, nlat)
 
-        # start with a uniform max_res km background resolution
-        cell_width = max_res * np.ones((nlat, nlon))
-
-        fc = read_feature_collection('high_res_region.geojson')
-
-        so_signed_distance = signed_distance_from_geojson(
-            fc, lon, lat, earth_radius, max_length=0.25
+        cell_width = build_southern_ocean_background(
+            lat=lat,
+            lon=lon,
+            high_res_km=min_res,
+            low_res_km=max_res,
+            region_filename='high_res_region.geojson',
         )
-
-        # Equivalent to 20 degrees latitude
-        trans_width = 1600e3
-        trans_start = 500e3
-
-        weights = 0.5 * (
-            1 + np.tanh((so_signed_distance - trans_start) / trans_width)
-        )
-
-        cell_width = min_res * (1 - weights) + cell_width * weights
 
         return cell_width, lon, lat

--- a/polaris/mesh/base/so/background.py
+++ b/polaris/mesh/base/so/background.py
@@ -1,0 +1,34 @@
+import numpy as np
+from geometric_features import read_feature_collection
+from mpas_tools.mesh.creation.signed_distance import (
+    signed_distance_from_geojson,
+)
+
+from polaris.constants import get_constant
+
+
+def build_southern_ocean_background(
+    lat, lon, high_res_km, low_res_km, region_filename
+):
+    """
+    Build a Southern Ocean background field on a regular lat-lon grid.
+    """
+    earth_radius = get_constant('mean_radius')
+    fc = read_feature_collection(region_filename)
+
+    so_signed_distance = signed_distance_from_geojson(
+        fc, lon, lat, earth_radius, max_length=0.25
+    )
+
+    # Equivalent to 20 degrees latitude
+    transition_width_m = 1600e3
+    transition_start_m = 500e3
+
+    weights = 0.5 * (
+        1
+        + np.tanh(
+            (so_signed_distance - transition_start_m) / transition_width_m
+        )
+    )
+
+    return high_res_km * (1 - weights) + low_res_km * weights

--- a/polaris/mesh/spherical/unified/__init__.py
+++ b/polaris/mesh/spherical/unified/__init__.py
@@ -1,3 +1,6 @@
+from polaris.mesh.spherical.unified.cell_width import (
+    UnifiedCellWidthMeshStep as UnifiedCellWidthMeshStep,
+)
 from polaris.mesh.spherical.unified.configs import (
     RIVER_CONFIG_FILENAME as RIVER_CONFIG_FILENAME,
 )
@@ -6,6 +9,9 @@ from polaris.mesh.spherical.unified.configs import (
 )
 from polaris.mesh.spherical.unified.configs import (
     get_unified_mesh_config as get_unified_mesh_config,
+)
+from polaris.mesh.spherical.unified.families import (
+    get_unified_mesh_family as get_unified_mesh_family,
 )
 from polaris.mesh.spherical.unified.resolutions import (
     LAT_LON_TARGET_GRID_RESOLUTIONS as LAT_LON_TARGET_GRID_RESOLUTIONS,

--- a/polaris/mesh/spherical/unified/cell_width.py
+++ b/polaris/mesh/spherical/unified/cell_width.py
@@ -1,0 +1,61 @@
+import os
+
+import xarray as xr
+
+from polaris.mesh import QuasiUniformSphericalMeshStep
+
+
+class UnifiedCellWidthMeshStep(QuasiUniformSphericalMeshStep):
+    """
+    A spherical mesh step that consumes an upstream unified sizing field.
+    """
+
+    def __init__(
+        self,
+        component,
+        sizing_field_step=None,
+        name='unified_base_mesh',
+        subdir=None,
+        mesh_name='mesh',
+    ):
+        super().__init__(
+            component=component,
+            name=name,
+            subdir=subdir,
+            cell_width=None,
+            mesh_name=mesh_name,
+        )
+        self.sizing_field_step = sizing_field_step
+        self.sizing_field_filename = 'sizing_field.nc'
+
+    def setup(self):
+        """
+        Link an upstream sizing field if one has been provided.
+        """
+        if self.sizing_field_step is not None:
+            self.add_input_file(
+                filename=self.sizing_field_filename,
+                work_dir_target=os.path.join(
+                    self.sizing_field_step.path,
+                    self.sizing_field_step.sizing_field_filename,
+                ),
+            )
+        super().setup()
+
+    def build_cell_width_lat_lon(self):
+        """
+        Read the cell width, lon, and lat directly from sizing_field.nc.
+        """
+        with xr.open_dataset(self.sizing_field_filename) as ds_sizing:
+            if 'cellWidth' not in ds_sizing:
+                raise ValueError(
+                    'Expected variable "cellWidth" in sizing_field.nc.'
+                )
+            if 'lat' not in ds_sizing.coords or 'lon' not in ds_sizing.coords:
+                raise ValueError(
+                    'Expected lat/lon coordinates in sizing_field.nc.'
+                )
+            cell_width = ds_sizing.cellWidth.values
+            lon = ds_sizing.lon.values
+            lat = ds_sizing.lat.values
+        return cell_width, lon, lat

--- a/polaris/mesh/spherical/unified/configs.py
+++ b/polaris/mesh/spherical/unified/configs.py
@@ -4,9 +4,13 @@ import os
 from polaris.config import PolarisConfigParser
 
 PACKAGE = 'polaris.mesh.spherical.unified'
+FAMILY_CONFIG_PACKAGE = 'polaris.mesh.spherical.unified.families'
 RIVER_CONFIG_PACKAGE = 'polaris.mesh.spherical.unified.river'
 RIVER_CONFIG_FILENAME = 'river_network.cfg'
+SIZING_FIELD_CONFIG_PACKAGE = 'polaris.mesh.spherical.unified.sizing_field'
+SIZING_FIELD_CONFIG_FILENAME = 'sizing_field.cfg'
 DEFAULT_CONFIG_FILENAME = 'unified_mesh.cfg'
+DEFAULT_FAMILY_NAME = 'default'
 
 
 def _discover_mesh_names():
@@ -47,16 +51,40 @@ UNIFIED_MESH_NAMES = _discover_mesh_names()
 
 def get_unified_mesh_config(mesh_name, filepath=None):
     """
-    Load default, generic river and per-mesh unified-mesh configs.
+    Load default, generic workflow and per-mesh unified-mesh configs.
     """
     config_filename = _get_mesh_config_filename(mesh_name)
+    family_name = _get_mesh_family_name(config_filename)
     config = PolarisConfigParser(filepath=filepath)
     config.add_from_package(PACKAGE, DEFAULT_CONFIG_FILENAME)
     config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
     config.add_from_package(RIVER_CONFIG_PACKAGE, RIVER_CONFIG_FILENAME)
+    config.add_from_package(
+        SIZING_FIELD_CONFIG_PACKAGE, SIZING_FIELD_CONFIG_FILENAME
+    )
+    _add_family_config(config=config, family_name=family_name)
     config.add_from_package(PACKAGE, config_filename)
     config.combine()
     return config
+
+
+def _add_family_config(config, family_name):
+    package_files = imp_res.files(FAMILY_CONFIG_PACKAGE)
+    family_config_filename = f'{family_name}.cfg'
+    family_config = package_files.joinpath(family_config_filename)
+    if family_config.is_file():
+        config.add_from_package(FAMILY_CONFIG_PACKAGE, family_config_filename)
+
+
+def _get_mesh_family_name(config_filename):
+    config = PolarisConfigParser()
+    config.add_from_package(PACKAGE, config_filename)
+    config.combine()
+    combined = config.combined
+    assert combined is not None
+    return combined.get(
+        'unified_mesh', 'mesh_family', fallback=DEFAULT_FAMILY_NAME
+    )
 
 
 def _get_mesh_config_filename(mesh_name):

--- a/polaris/mesh/spherical/unified/families/__init__.py
+++ b/polaris/mesh/spherical/unified/families/__init__.py
@@ -1,0 +1,48 @@
+from typing import Protocol
+
+from polaris.mesh.spherical.unified.families.default import (
+    DefaultUnifiedMeshFamily,
+    build_ocean_background_from_mode,
+)
+from polaris.mesh.spherical.unified.families.so_region import (
+    SORegionUnifiedMeshFamily,
+)
+
+
+class UnifiedMeshFamily(Protocol):
+    name: str
+
+    def setup_sizing_field_step(self, step): ...
+
+    def build_ocean_background(self, ds_coastline, section): ...
+
+
+_FAMILY_LIST: list[UnifiedMeshFamily] = [
+    DefaultUnifiedMeshFamily(),
+    SORegionUnifiedMeshFamily(),
+]
+
+_FAMILIES: dict[str, UnifiedMeshFamily] = {
+    family.name: family for family in _FAMILY_LIST
+}
+
+
+def get_unified_mesh_family(config):
+    """
+    Get the unified-mesh family object for a combined mesh config.
+    """
+    family_name = config.get('unified_mesh', 'mesh_family')
+    try:
+        return _FAMILIES[family_name]
+    except KeyError as exc:
+        valid_families = ', '.join(sorted(_FAMILIES))
+        raise ValueError(
+            f'Unexpected unified mesh family {family_name!r}. Valid '
+            f'families are: {valid_families}'
+        ) from exc
+
+
+__all__ = [
+    'build_ocean_background_from_mode',
+    'get_unified_mesh_family',
+]

--- a/polaris/mesh/spherical/unified/families/default.py
+++ b/polaris/mesh/spherical/unified/families/default.py
@@ -1,0 +1,54 @@
+import mpas_tools.mesh.creation.mesh_definition_tools as mdt
+import numpy as np
+
+
+class DefaultUnifiedMeshFamily:
+    """
+    The default unified-mesh family for built-in ocean backgrounds.
+    """
+
+    name = 'default'
+
+    def setup_sizing_field_step(self, step):
+        """
+        Add any family-specific sizing-field inputs.
+        """
+
+    def build_ocean_background(self, ds_coastline, section):
+        """
+        Build the family ocean background on the shared target grid.
+        """
+        return build_ocean_background_from_mode(
+            lat=ds_coastline.lat.values,
+            lon=ds_coastline.lon.values,
+            mode=section.get('ocean_background_mode'),
+            min_km=section.getfloat('ocean_background_min_km'),
+            max_km=section.getfloat('ocean_background_max_km'),
+        )
+
+
+def build_ocean_background_from_mode(lat, lon, mode, min_km, max_km):
+    """
+    Build a 2D ocean-background field in km from the default family modes.
+    """
+    if mode == 'constant':
+        if not np.isclose(min_km, max_km):
+            raise ValueError(
+                'Constant ocean backgrounds require '
+                'ocean_background_min_km and '
+                'ocean_background_max_km to be equal.'
+            )
+        values = np.full((lat.size, lon.size), max_km, dtype=float)
+    elif mode == 'rrs_latitude':
+        cell_width_vs_lat = mdt.RRS_CellWidthVsLat(
+            lat, cellWidthEq=max_km, cellWidthPole=min_km
+        )
+        values = np.outer(cell_width_vs_lat, np.ones(lon.size))
+    else:
+        raise ValueError(
+            f'Unexpected ocean background mode {mode!r}. Valid options are '
+            'constant and rrs_latitude. Mesh-specific ocean backgrounds '
+            'belong in a unified mesh family implementation.'
+        )
+
+    return values.astype(float)

--- a/polaris/mesh/spherical/unified/families/so_region.py
+++ b/polaris/mesh/spherical/unified/families/so_region.py
@@ -1,0 +1,34 @@
+SO_REGION_FILENAME = 'high_res_region.geojson'
+SO_REGION_PACKAGE = 'polaris.mesh.base.so'
+
+
+class SORegionUnifiedMeshFamily:
+    """
+    The Southern Ocean unified-mesh family.
+    """
+
+    name = 'so_region'
+
+    def setup_sizing_field_step(self, step):
+        """
+        Link the shared Southern Ocean refinement region.
+        """
+        step.add_input_file(
+            filename=SO_REGION_FILENAME, package=SO_REGION_PACKAGE
+        )
+
+    def build_ocean_background(self, ds_coastline, section):
+        """
+        Build the Southern Ocean background on the shared target grid.
+        """
+        from polaris.mesh.base.so.background import (
+            build_southern_ocean_background,
+        )
+
+        return build_southern_ocean_background(
+            lat=ds_coastline.lat.values,
+            lon=ds_coastline.lon.values,
+            high_res_km=section.getfloat('ocean_background_min_km'),
+            low_res_km=section.getfloat('ocean_background_max_km'),
+            region_filename=SO_REGION_FILENAME,
+        )

--- a/polaris/mesh/spherical/unified/sizing_field/sizing_field.cfg
+++ b/polaris/mesh/spherical/unified/sizing_field/sizing_field.cfg
@@ -1,27 +1,3 @@
-[unified_mesh]
-# name of this unified mesh; must match the config filename
-mesh_name = u.oi30.lr10
-
-# shared lat-lon target-grid resolution for coastline, river and sizing-field
-# masks (degrees)
-resolution_latlon = 0.125
-
-[river_network]
-# inland clip distance used for base-mesh river products (km)
-base_mesh_clip_distance_km = 60.0
-
-# geometry simplification tolerance used for base-mesh river products (km)
-base_mesh_simplify_tolerance_km = 5.0
-
-# minimum retained segment length after base-mesh clipping (km)
-base_mesh_min_segment_length_km = 5.0
-
-[river_rasterize]
-# physical buffer radius around river channels for the lat-lon channel mask;
-# 0 preserves single-cell line rasterization
-# We use twice the river resolution
-channel_buffer_km = 20.0
-
 [sizing_field]
 # Whether to add a coastline refinement candidate field
 enable_coastline_refinement = true
@@ -37,18 +13,26 @@ ocean_background_mode = constant
 
 # Minimum ocean background cell width (km). For constant backgrounds, set this
 # equal to ocean_background_max_km.
-ocean_background_min_km = 30.0
+ocean_background_min_km = 240.0
 
 # Maximum ocean background cell width (km). For rrs_latitude, this is the
 # equatorial resolution. For so_region, this is the coarse background.
-ocean_background_max_km = 30.0
+ocean_background_max_km = 240.0
 
 # Background land cell width (km)
-land_background_km = 10.0
+land_background_km = 240.0
 
 # Distance (km) over which the land side of the coastline refinement
 # transitions back to the land background cell width
-coastline_transition_land_km = 60.0
+coastline_transition_land_km = 0.0
 
 # Target cell width (km) along rasterized river channels
-river_channel_km = 10.0
+river_channel_km = 240.0
+
+
+[sizing_field_viz]
+# output resolution for diagnostic plots
+dpi = 200
+
+# colormap for cell-width diagnostic plots
+cell_width_cmap = cmo.deep_r

--- a/polaris/mesh/spherical/unified/u.oi.so12to30.lr10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi.so12to30.lr10.cfg
@@ -2,6 +2,9 @@
 # name of this unified mesh; must match the config filename
 mesh_name = u.oi.so12to30.lr10
 
+# Mesh family used to specialize shared unified-mesh behavior
+mesh_family = so_region
+
 # shared lat-lon target-grid resolution for coastline, river and sizing-field
 # masks (degrees)
 resolution_latlon = 0.0625
@@ -16,16 +19,33 @@ base_mesh_simplify_tolerance_km = 5.0
 # minimum retained segment length after base-mesh clipping (km)
 base_mesh_min_segment_length_km = 5.0
 
-[river_lat_lon]
+[river_rasterize]
 # physical buffer radius around river channels for the lat-lon channel mask;
 # 0 preserves single-cell line rasterization
 # We use twice the river resolution
 channel_buffer_km = 20.0
 
 [sizing_field]
-# background land cell width (km); used to derive drainage_area_threshold
+# Whether to add a coastline refinement candidate field
+enable_coastline_refinement = true
+
+# Whether to add a river-channel refinement candidate field
+enable_river_channel_refinement = true
+
+# Minimum ocean background cell width (km). For constant backgrounds, set this
+# equal to ocean_background_max_km.
+ocean_background_min_km = 12.0
+
+# Maximum ocean background cell width (km). For rrs_latitude, this is the
+# equatorial resolution. For so_region, this is the coarse background.
+ocean_background_max_km = 30.0
+
+# Background land cell width (km)
 land_background_km = 10.0
 
-# target cell width (km) along rasterized river channels; used to derive
-# outlet_distance_tolerance
+# Distance (km) over which the land side of the coastline refinement
+# transitions back to the land background cell width
+coastline_transition_land_km = 60.0
+
+# Target cell width (km) along rasterized river channels
 river_channel_km = 10.0

--- a/polaris/mesh/spherical/unified/u.oi240.lr240.cfg
+++ b/polaris/mesh/spherical/unified/u.oi240.lr240.cfg
@@ -22,16 +22,40 @@ base_mesh_simplify_tolerance_km = 30.0
 # finer than 1/2 river resolution so river network isn't over-simplified
 base_mesh_min_segment_length_km = 30.0
 
-[river_lat_lon]
+[river_rasterize]
 # physical buffer radius around river channels for the lat-lon channel mask;
 # 0 preserves single-cell line rasterization
 # We use twice the river resolution
 channel_buffer_km = 360.0
 
 [sizing_field]
-# background land cell width (km); used to derive drainage_area_threshold
+# Whether to add a coastline refinement candidate field
+enable_coastline_refinement = true
+
+# Whether to add a river-channel refinement candidate field
+enable_river_channel_refinement = true
+
+# Background ocean resolution mode. Options are:
+#   constant: one ocean cell width everywhere
+#   rrs_latitude: RRS latitude-dependent ocean cell width
+# Complex ocean backgrounds are delegated to mesh-family implementations.
+ocean_background_mode = constant
+
+# Minimum ocean background cell width (km). For constant backgrounds, set this
+# equal to ocean_background_max_km.
+ocean_background_min_km = 240.0
+
+# Maximum ocean background cell width (km). For rrs_latitude, this is the
+# equatorial resolution. For so_region, this is the coarse background.
+ocean_background_max_km = 240.0
+
+
+# Background land cell width (km)
 land_background_km = 240.0
 
-# target cell width (km) along rasterized river channels; used to derive
-# outlet_distance_tolerance
+# Distance (km) over which the land side of the coastline refinement
+# transitions back to the land background cell width
+coastline_transition_land_km = 480.0
+
+# Target cell width (km) along rasterized river channels
 river_channel_km = 240.0

--- a/polaris/mesh/spherical/unified/u.oi6to18.lr6to10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi6to18.lr6to10.cfg
@@ -16,16 +16,41 @@ base_mesh_simplify_tolerance_km = 3.0
 # minimum retained segment length after base-mesh clipping (km)
 base_mesh_min_segment_length_km = 3.0
 
-[river_lat_lon]
+[river_rasterize]
 # physical buffer radius around river channels for the lat-lon channel mask;
 # 0 preserves single-cell line rasterization
 # We use twice the river resolution
 channel_buffer_km = 12.0
 
 [sizing_field]
-# background land cell width (km); used to derive drainage_area_threshold
+# Whether to add a coastline refinement candidate field
+enable_coastline_refinement = true
+
+# Whether to add a river-channel refinement candidate field
+enable_river_channel_refinement = true
+
+# Background ocean resolution mode. Options are:
+#   constant: one ocean cell width everywhere
+#   rrs_latitude: RRS latitude-dependent ocean cell width
+# Complex ocean backgrounds are delegated to mesh-family implementations.
+ocean_background_mode = rrs_latitude
+
+# Minimum ocean background cell width (km). For constant backgrounds, set this
+# equal to ocean_background_max_km.
+ocean_background_min_km = 6.0
+
+# Maximum ocean background cell width (km). For rrs_latitude, this is the
+# equatorial resolution. For so_region, this is the coarse background.
+ocean_background_max_km = 18.0
+
+# Background land cell width (km)
 land_background_km = 10.0
 
-# target cell width (km) along rasterized river channels; used to derive
-# outlet_distance_tolerance
+# Distance (km) over which the land side of the coastline refinement
+# transitions back to the land background cell width
+# about double the coarsest ocean cell size, because we don't want finer land
+# or river resolution limiting ocean time steps
+coastline_transition_land_km = 36.0
+
+# Target cell width (km) along rasterized river channels
 river_channel_km = 6.0

--- a/polaris/mesh/spherical/unified/unified_mesh.cfg
+++ b/polaris/mesh/spherical/unified/unified_mesh.cfg
@@ -1,1 +1,3 @@
 [unified_mesh]
+# Mesh family used to specialize shared unified-mesh behavior
+mesh_family = default

--- a/polaris/tasks/mesh/add_tasks.py
+++ b/polaris/tasks/mesh/add_tasks.py
@@ -3,6 +3,9 @@ from polaris.tasks.mesh.spherical.unified.coastline import (
     add_coastline_tasks,
 )
 from polaris.tasks.mesh.spherical.unified.river import add_river_tasks
+from polaris.tasks.mesh.spherical.unified.sizing_field import (
+    add_sizing_field_tasks,
+)
 
 
 def add_mesh_tasks(component):
@@ -16,3 +19,4 @@ def add_mesh_tasks(component):
     add_base_mesh_tasks(component=component)
     add_coastline_tasks(component=component)
     add_river_tasks(component=component)
+    add_sizing_field_tasks(component=component)

--- a/polaris/tasks/mesh/spherical/unified/__init__.py
+++ b/polaris/tasks/mesh/spherical/unified/__init__.py
@@ -1,1 +1,19 @@
-"""Unified spherical mesh tasks."""
+from polaris.tasks.mesh.spherical.unified.sizing_field import (
+    BuildSizingFieldStep,
+    SizingFieldTask,
+    VizSizingFieldStep,
+    add_sizing_field_tasks,
+    get_sizing_field_config,
+    get_unified_mesh_sizing_field_steps,
+    sizing_field_dataset,
+)
+
+__all__ = [
+    'BuildSizingFieldStep',
+    'SizingFieldTask',
+    'VizSizingFieldStep',
+    'add_sizing_field_tasks',
+    'sizing_field_dataset',
+    'get_unified_mesh_sizing_field_steps',
+    'get_sizing_field_config',
+]

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/__init__.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/__init__.py
@@ -1,0 +1,29 @@
+from polaris.tasks.mesh.spherical.unified.sizing_field.build import (
+    BuildSizingFieldStep,
+    sizing_field_dataset,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field.configs import (
+    get_sizing_field_config,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field.steps import (
+    get_unified_mesh_sizing_field_steps,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field.task import (
+    SizingFieldTask,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field.tasks import (
+    add_sizing_field_tasks,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field.viz import (
+    VizSizingFieldStep,
+)
+
+__all__ = [
+    'BuildSizingFieldStep',
+    'SizingFieldTask',
+    'VizSizingFieldStep',
+    'add_sizing_field_tasks',
+    'sizing_field_dataset',
+    'get_unified_mesh_sizing_field_steps',
+    'get_sizing_field_config',
+]

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
@@ -1,0 +1,407 @@
+import os
+
+import numpy as np
+import xarray as xr
+
+from polaris.mesh.spherical.unified import get_unified_mesh_family
+from polaris.step import Step
+
+
+class BuildSizingFieldStep(Step):
+    """
+    Build a unified sizing field on a shared lat-lon target grid.
+
+    The step reads the prepared coastline and river-network products for one
+    mesh, delegates ocean-background construction to the mesh family, and
+    writes a multi-variable sizing-field dataset to ``sizing_field.nc``.
+
+    Attributes
+    ----------
+    coastline_step : polaris.Step
+        The shared coastline-preparation step whose outputs are consumed
+
+    river_step : polaris.Step
+        The shared lat-lon river-network step whose masks are consumed
+
+    sizing_field_filename : str
+        Name of the output sizing-field NetCDF file
+    """
+
+    def __init__(self, component, coastline_step, river_step, subdir):
+        """
+        Create a new step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        coastline_step : polaris.Step
+            The shared coastline-preparation step for the lat-lon grid
+
+        river_step : polaris.Step
+            The shared lat-lon river-network step
+
+        subdir : str
+            The subdirectory within the component work directory where the
+            step runs
+        """
+        super().__init__(
+            component=component,
+            name='sizing_field',
+            subdir=subdir,
+            cpus_per_task=1,
+            min_cpus_per_task=1,
+        )
+        self.coastline_step = coastline_step
+        self.river_step = river_step
+        self.sizing_field_filename = 'sizing_field.nc'
+
+    def setup(self):
+        """
+        Link coastline and river products, configure the mesh family, and
+        declare outputs.
+
+        This method links the coastline convention file and river-network mask
+        file as inputs, calls the mesh-family hook to register any additional
+        family-specific inputs (such as SO-region masks), and declares the
+        output sizing-field file.
+        """
+        convention = self.config.get(
+            'spherical_mesh', 'antarctic_boundary_convention'
+        )
+        self.add_input_file(
+            filename='coastline.nc',
+            work_dir_target=os.path.join(
+                self.coastline_step.path,
+                self.coastline_step.output_filenames[convention],
+            ),
+        )
+        self.add_input_file(
+            filename='river_network.nc',
+            work_dir_target=os.path.join(
+                self.river_step.path, self.river_step.masks_filename
+            ),
+        )
+        self._get_mesh_family().setup_sizing_field_step(self)
+        self.add_output_file(filename=self.sizing_field_filename)
+
+    def run(self):
+        """
+        Build the sizing-field dataset and write it to NetCDF.
+
+        Opens the coastline and river-network files, constructs the
+        ocean-background field via the mesh family, calls
+        :py:func:`sizing_field_dataset` to compose the full sizing field, and
+        writes the result to ``sizing_field.nc``.
+        """
+        section = self.config['sizing_field']
+        unified_section = self.config['unified_mesh']
+
+        with xr.open_dataset('coastline.nc') as ds_coastline:
+            with xr.open_dataset('river_network.nc') as ds_river:
+                ocean_background = self._get_ocean_background(
+                    ds_coastline=ds_coastline, section=section
+                )
+                ds_sizing = sizing_field_dataset(
+                    ds_coastline=ds_coastline,
+                    ds_river=ds_river,
+                    resolution=unified_section.getfloat('resolution_latlon'),
+                    mesh_name=unified_section.get('mesh_name'),
+                    ocean_background=ocean_background,
+                    land_background_km=section.getfloat('land_background_km'),
+                    enable_coastline_refinement=section.getboolean(
+                        'enable_coastline_refinement'
+                    ),
+                    coastline_transition_land_km=section.getfloat(
+                        'coastline_transition_land_km'
+                    ),
+                    enable_river_channel_refinement=section.getboolean(
+                        'enable_river_channel_refinement'
+                    ),
+                    river_channel_km=section.getfloat('river_channel_km'),
+                )
+
+        ds_sizing.attrs['source_coastline_step'] = self.coastline_step.subdir
+        ds_sizing.attrs['source_river_step'] = self.river_step.subdir
+        ds_sizing.to_netcdf(self.sizing_field_filename)
+
+    def _get_ocean_background(self, ds_coastline, section):
+        """
+        Build the ocean background field for the shared target grid.
+        """
+        return self._get_mesh_family().build_ocean_background(
+            ds_coastline=ds_coastline, section=section
+        )
+
+    def _get_mesh_family(self):
+        """
+        Get the unified-mesh family object for this step's shared config.
+        """
+        return get_unified_mesh_family(self.config)
+
+
+def sizing_field_dataset(
+    ds_coastline,
+    ds_river,
+    resolution,
+    mesh_name,
+    ocean_background,
+    land_background_km=240.0,
+    enable_coastline_refinement=True,
+    coastline_transition_land_km=0.0,
+    enable_river_channel_refinement=True,
+    river_channel_km=240.0,
+):
+    """
+    Build the unified sizing-field dataset from coastline and river products.
+
+    Parameters
+    ----------
+    ds_coastline : xarray.Dataset
+        Coastline dataset with ``ocean_mask``, ``signed_distance``, ``lat``,
+        and ``lon`` variables on a shared lat-lon target grid
+
+    ds_river : xarray.Dataset
+        River-network dataset with ``river_channel_mask`` on the same
+        lat-lon grid as ``ds_coastline``
+
+    resolution : float
+        The latitude-longitude grid resolution in degrees; stored as a
+        dataset attribute
+
+    mesh_name : str
+        The name of the unified mesh; stored as a dataset attribute
+
+    ocean_background : array-like
+        2-D array of shape ``(n_lat, n_lon)`` giving the target cell width in
+        km for open-ocean cells
+
+    land_background_km : float, optional
+        Target cell width in km for land cells that are not modified by any
+        refinement control
+
+    enable_coastline_refinement : bool, optional
+        Whether to apply the coastline-proximity refinement
+
+    coastline_transition_land_km : float, optional
+        Width in km of the linear-transition zone on the land side of the
+        coastline; 0 means apply the ocean background only at the coastline
+        raster edge
+
+    enable_river_channel_refinement : bool, optional
+        Whether to refine cells on the river-channel mask
+
+    river_channel_km : float, optional
+        Target cell width in km on river-channel mask cells
+
+    Returns
+    -------
+    ds_sizing : xarray.Dataset
+        Dataset on the shared lat-lon grid containing ``cellWidth`` (the
+        final cell-width field in km) and diagnostic variables that record
+        each intermediate sizing stage and the active control index
+    """
+    _validate_shared_grid(ds_coastline=ds_coastline, ds_river=ds_river)
+
+    lat = ds_coastline.lat.values
+    lon = ds_coastline.lon.values
+    dims = ('lat', 'lon')
+    ocean_background = np.asarray(ocean_background, dtype=float)
+    expected_shape = (lat.size, lon.size)
+    if ocean_background.shape != expected_shape:
+        raise ValueError(
+            'Ocean background must have shape '
+            f'{expected_shape}, got {ocean_background.shape}.'
+        )
+
+    ocean_mask = ds_coastline.ocean_mask.values.astype(bool)
+    signed_distance = ds_coastline.signed_distance.values.astype(float)
+    river_channel_mask = ds_river.river_channel_mask.values.astype(bool)
+    land_background = np.full(ocean_background.shape, land_background_km)
+    background = np.where(ocean_mask, ocean_background, land_background)
+
+    river_channel_candidate = _build_mask_candidate(
+        background=land_background,
+        mask=river_channel_mask,
+        enabled=enable_river_channel_refinement,
+        target_km=river_channel_km,
+    )
+
+    land_river_stack = np.stack(
+        [
+            land_background,
+            river_channel_candidate,
+        ],
+        axis=0,
+    )
+    land_river_control = np.argmin(land_river_stack, axis=0).astype(np.int8)
+    land_river_cell_width = np.take_along_axis(
+        land_river_stack, land_river_control[np.newaxis, ...], axis=0
+    )[0]
+    land_river_control = np.array([0, 2], dtype=np.int8)[land_river_control]
+
+    composed_background = np.where(
+        ocean_mask, ocean_background, land_river_cell_width
+    )
+    coastline_candidate = _build_coastline_candidate(
+        background=composed_background,
+        ocean_background=ocean_background,
+        ocean_mask=ocean_mask,
+        signed_distance=signed_distance,
+        enabled=enable_coastline_refinement,
+        land_transition_km=coastline_transition_land_km,
+    )
+    final_cell_width = coastline_candidate
+
+    active_control = np.where(ocean_mask, 0, land_river_control)
+    active_control = active_control.astype(np.int8)
+    coastline_active = ~np.isclose(coastline_candidate, composed_background)
+    active_control[coastline_active] = 1
+    coastal_transition_delta = final_cell_width - composed_background
+
+    ds_sizing = xr.Dataset(
+        coords=dict(lat=ds_coastline.lat, lon=ds_coastline.lon)
+    )
+    data_vars = {
+        'cellWidth': final_cell_width.astype(np.float32),
+        'background_cell_width': background.astype(np.float32),
+        'ocean_background_cell_width': ocean_background.astype(np.float32),
+        'land_river_cell_width': land_river_cell_width.astype(np.float32),
+        'pre_coastline_cell_width': composed_background.astype(np.float32),
+        'coastline_cell_width': coastline_candidate.astype(np.float32),
+        'coastal_transition_delta': coastal_transition_delta.astype(
+            np.float32
+        ),
+        'river_channel_cell_width': river_channel_candidate.astype(np.float32),
+        'active_control': active_control,
+    }
+    for var_name, values in data_vars.items():
+        ds_sizing[var_name] = xr.DataArray(values, dims=dims)
+
+    ds_sizing.attrs.update(
+        dict(
+            mesh_name=mesh_name,
+            target_grid='lat_lon',
+            target_grid_resolution_degrees=resolution,
+            active_control_meanings=(
+                '0=background 1=coastline 2=river_channel'
+            ),
+        )
+    )
+    _add_mask_candidate_attrs(
+        ds_sizing=ds_sizing,
+        prefix='river_channel',
+        mask=river_channel_mask,
+        candidate=river_channel_candidate,
+        background=land_background,
+    )
+    ds_sizing.cellWidth.attrs['units'] = 'km'
+    ds_sizing.background_cell_width.attrs['units'] = 'km'
+    ds_sizing.ocean_background_cell_width.attrs['units'] = 'km'
+    ds_sizing.land_river_cell_width.attrs['units'] = 'km'
+    ds_sizing.pre_coastline_cell_width.attrs['units'] = 'km'
+    ds_sizing.coastline_cell_width.attrs['units'] = 'km'
+    ds_sizing.coastal_transition_delta.attrs['units'] = 'km'
+    ds_sizing.river_channel_cell_width.attrs['units'] = 'km'
+    ds_sizing.active_control.attrs['long_name'] = (
+        'Index of the active sizing control'
+    )
+
+    return ds_sizing
+
+
+def _validate_shared_grid(ds_coastline, ds_river):
+    """
+    Validate that coastline and river products share the same target grid.
+    """
+    for coord_name in ['lat', 'lon']:
+        if (
+            coord_name not in ds_coastline.coords
+            or coord_name not in ds_river.coords
+        ):
+            raise ValueError(f'Missing required coordinate {coord_name!r}.')
+
+        if not np.array_equal(
+            ds_coastline[coord_name].values, ds_river[coord_name].values
+        ):
+            raise ValueError(
+                'Coastline and river products must share the same lat-lon '
+                f'grid. Mismatch found in coordinate {coord_name!r}.'
+            )
+
+
+def _add_mask_candidate_attrs(ds_sizing, prefix, mask, candidate, background):
+    """
+    Add provenance counts for a mask-based sizing candidate.
+    """
+    ds_sizing.attrs[f'{prefix}_mask_count'] = int(np.count_nonzero(mask))
+    ds_sizing.attrs[f'{prefix}_finer_than_background_count'] = int(
+        np.count_nonzero(mask & (candidate < background))
+    )
+    ds_sizing.attrs[f'{prefix}_equal_to_background_count'] = int(
+        np.count_nonzero(mask & np.isclose(candidate, background))
+    )
+    ds_sizing.attrs[f'{prefix}_coarser_than_background_count'] = int(
+        np.count_nonzero(mask & (candidate > background))
+    )
+
+
+def _build_mask_candidate(background, mask, enabled, target_km):
+    """
+    Build a mask-based candidate field in km.
+    """
+    if not enabled:
+        return background.copy()
+
+    return np.where(mask, target_km, background).astype(float)
+
+
+def _build_coastline_candidate(
+    background,
+    ocean_background,
+    ocean_mask,
+    signed_distance,
+    enabled,
+    land_transition_km,
+):
+    """
+    Build the coastline candidate field in km.
+    """
+    candidate = background.copy()
+    if not enabled:
+        return candidate
+
+    land_transition_m = land_transition_km * 1.0e3
+    land_side = np.logical_not(ocean_mask) & (signed_distance <= 0.0)
+
+    _apply_transition(
+        candidate=candidate,
+        target=ocean_background.astype(float),
+        background=background,
+        signed_distance=np.abs(signed_distance),
+        mask=land_side,
+        transition_m=land_transition_m,
+    )
+    return candidate
+
+
+def _apply_transition(
+    candidate, target, background, signed_distance, mask, transition_m
+):
+    """
+    Apply a linear transition from the coastline target back to background.
+    """
+    if transition_m < 0.0:
+        raise ValueError('Transition widths must be nonnegative.')
+
+    if transition_m == 0.0:
+        zero_mask = mask & np.isclose(signed_distance, 0.0)
+        candidate[zero_mask] = target[zero_mask]
+        return
+
+    transition_mask = mask & (signed_distance <= transition_m)
+    fraction = signed_distance[transition_mask] / transition_m
+    candidate[transition_mask] = target[transition_mask] + fraction * (
+        background[transition_mask] - target[transition_mask]
+    )

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/configs.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/configs.py
@@ -1,0 +1,40 @@
+from polaris.mesh.spherical.unified.configs import (
+    UNIFIED_MESH_NAMES,
+    get_unified_mesh_config,
+)
+
+
+def get_sizing_field_config(mesh_name, filepath=None):
+    """
+    Load one unified mesh config with sizing-field defaults.
+
+    Parameters
+    ----------
+    mesh_name : str
+        The name of the unified mesh; must be a member of
+        :py:data:`polaris.mesh.spherical.unified.UNIFIED_MESH_NAMES`
+
+    filepath : str, optional
+        The path to the config file; passed directly to
+        :py:func:`polaris.mesh.spherical.unified.get_unified_mesh_config`
+
+    Returns
+    -------
+    config : polaris.config.PolarisConfigParser
+        The merged config that combines the generic ``unified_mesh.cfg``
+        defaults, the shared sizing-field defaults, and the named-mesh
+        config file
+
+    Raises
+    ------
+    ValueError
+        If ``mesh_name`` is not a recognized unified mesh name
+    """
+    if mesh_name not in UNIFIED_MESH_NAMES:
+        valid_mesh_names = ', '.join(UNIFIED_MESH_NAMES)
+        raise ValueError(
+            f'Unexpected unified mesh {mesh_name!r}. Valid mesh names '
+            f'are: {valid_mesh_names}'
+        )
+
+    return get_unified_mesh_config(mesh_name=mesh_name, filepath=filepath)

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/steps.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/steps.py
@@ -1,0 +1,120 @@
+import os
+
+from polaris.step import Step
+from polaris.tasks.mesh.spherical.unified.river.steps import (
+    get_unified_mesh_river_steps,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field.build import (
+    BuildSizingFieldStep,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field.configs import (
+    get_sizing_field_config,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field.viz import (
+    VizSizingFieldStep,
+)
+
+
+def get_unified_mesh_sizing_field_steps(
+    mesh_name,
+    include_viz=False,
+):
+    """
+    Get shared sizing-field steps for one named mesh.
+
+    Calls the upstream step factory for river network, then creates the
+    sizing-field build step.  The returned dict contains all the river-network
+    shared steps plus sizing-field, and optionally visualization.
+
+    Parameters
+    ----------
+    mesh_name : str
+        The name of the unified mesh
+
+    include_viz : bool, optional
+        Whether to include a visualization step
+
+    Returns
+    -------
+    steps : dict of str to polaris.Step
+        All upstream steps plus the sizing-field build step, keyed by suggested
+        subdir symlink in tasks.
+
+    config : polaris.config.PolarisConfigParser
+        The shared sizing-field config options
+    """
+    component = _get_mesh_component()
+    config_filename = 'sizing_field.cfg'
+    filepath = os.path.join(
+        component.name,
+        'spherical',
+        'unified',
+        mesh_name,
+        'sizing_field',
+        config_filename,
+    )
+    config = _get_lat_lon_sizing_field_config(
+        mesh_name=mesh_name, filepath=filepath
+    )
+
+    river_steps, _ = get_unified_mesh_river_steps(
+        mesh_name=mesh_name,
+        include_viz=False,
+    )
+
+    coastline_step = river_steps['coastline_final']
+    river_step = river_steps['river_rasterize']
+
+    subdir = os.path.join(
+        'spherical',
+        'unified',
+        mesh_name,
+        'sizing_field',
+        'build',
+    )
+
+    build_step = component.get_or_create_shared_step(
+        step_cls=BuildSizingFieldStep,
+        subdir=subdir,
+        config=config,
+        config_filename=config_filename,
+        coastline_step=coastline_step,
+        river_step=river_step,
+    )
+
+    steps: dict[str, Step] = dict(river_steps)
+    steps[build_step.name] = build_step
+
+    if include_viz:
+        viz_subdir = os.path.join(
+            'spherical',
+            'unified',
+            mesh_name,
+            'sizing_field',
+            'viz',
+        )
+        viz_step = component.get_or_create_shared_step(
+            step_cls=VizSizingFieldStep,
+            subdir=viz_subdir,
+            config=config,
+            config_filename=config_filename,
+            sizing_step=build_step,
+        )
+        steps[viz_step.name] = viz_step
+
+    return steps, config
+
+
+def _get_lat_lon_sizing_field_config(mesh_name, filepath):
+    component = _get_mesh_component()
+    if filepath in component.configs:
+        return component.configs[filepath]
+
+    return get_sizing_field_config(mesh_name=mesh_name, filepath=filepath)
+
+
+def _get_mesh_component():
+    # Import lazily to avoid a circular import through polaris.tasks.mesh.
+    from polaris.tasks.mesh import mesh as mesh_component
+
+    return mesh_component

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/task.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/task.py
@@ -1,0 +1,41 @@
+import os
+
+from polaris.task import Task
+from polaris.tasks.mesh.spherical.unified.sizing_field.steps import (
+    get_unified_mesh_sizing_field_steps,
+)
+
+
+class SizingFieldTask(Task):
+    """
+    A standalone task for building one named unified sizing field.
+
+    Parameters
+    ----------
+    component : polaris.Component
+        The component the task belongs to
+
+    mesh_name : str
+        The name of the unified mesh
+    """
+
+    def __init__(self, component, mesh_name):
+        subdir = os.path.join(
+            'spherical',
+            'unified',
+            mesh_name,
+            'sizing_field',
+            'task',
+        )
+        super().__init__(
+            component=component,
+            name=f'sizing_field_{mesh_name}_task',
+            subdir=subdir,
+        )
+
+        sizing_steps, config = get_unified_mesh_sizing_field_steps(
+            mesh_name=mesh_name, include_viz=True
+        )
+        self.set_shared_config(config, link='sizing_field.cfg')
+        for symlink, step in sizing_steps.items():
+            self.add_step(step, symlink=symlink)

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/tasks.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/tasks.py
@@ -1,0 +1,22 @@
+from polaris.mesh.spherical.unified import UNIFIED_MESH_NAMES
+from polaris.tasks.mesh.spherical.unified.sizing_field.task import (
+    SizingFieldTask,
+)
+
+
+def add_sizing_field_tasks(component):
+    """
+    Add standalone sizing-field tasks for all supported unified meshes.
+
+    One :py:class:`SizingFieldTask` is registered for each mesh name in
+    :py:data:`polaris.mesh.spherical.unified.UNIFIED_MESH_NAMES`.
+
+    Parameters
+    ----------
+    component : polaris.Component
+        The component to register the tasks with
+    """
+    for mesh_name in UNIFIED_MESH_NAMES:
+        component.add_task(
+            SizingFieldTask(component=component, mesh_name=mesh_name)
+        )

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/viz.py
@@ -1,0 +1,333 @@
+import os
+
+import cartopy.crs as ccrs
+import cmocean  # noqa: F401
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
+from polaris.step import Step
+from polaris.viz import use_mplstyle
+
+
+class VizSizingFieldStep(Step):
+    """
+    Visualize sizing-field diagnostics produced by
+    :py:class:`BuildSizingFieldStep`.
+
+    The step writes a global overview plot, an active-control map, and a
+    plain-text summary of min/max cell widths and provenance counts.
+
+    Attributes
+    ----------
+    sizing_step : polaris.Step
+        The shared sizing-field build step whose output is visualized
+
+    output_filenames : list of str
+        The names of the output files written by this step
+    """
+
+    def __init__(self, component, sizing_step, subdir):
+        """
+        Create a new step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        sizing_step : polaris.Step
+            The shared sizing-field build step
+
+        subdir : str
+            The subdirectory within the component work directory where the
+            step runs
+        """
+        super().__init__(
+            component=component,
+            name='sizing_field_viz',
+            subdir=subdir,
+            cpus_per_task=1,
+            min_cpus_per_task=1,
+        )
+        self.sizing_step = sizing_step
+        self.output_filenames = [
+            'sizing_field_overview.png',
+            'active_control.png',
+            'debug_summary.txt',
+        ]
+
+    def setup(self):
+        """
+        Link the sizing-field dataset and declare outputs.
+        """
+        self.add_input_file(
+            filename='sizing_field.nc',
+            work_dir_target=os.path.join(
+                self.sizing_step.path, self.sizing_step.sizing_field_filename
+            ),
+        )
+        for filename in self.output_filenames:
+            self.add_output_file(filename=filename)
+
+    def run(self):
+        """
+        Create simple global diagnostic plots and a text summary.
+        """
+        use_mplstyle()
+        dpi = self.config['sizing_field_viz'].getint('dpi')
+        cmap = self.config['sizing_field_viz'].get('cell_width_cmap')
+
+        with xr.open_dataset('sizing_field.nc') as ds:
+            lon = ds.lon.values
+            lat = ds.lat.values
+            cell_width_fields = [
+                ('cellWidth', 'Final cell width (km)'),
+                ('ocean_background_cell_width', 'Ocean background (km)'),
+                ('land_river_cell_width', 'Land/river composite (km)'),
+            ]
+            delta_field = ds.coastal_transition_delta.values
+
+            fig = plt.figure(
+                figsize=(15.0, 9.2), dpi=dpi, constrained_layout=True
+            )
+            grid = fig.add_gridspec(4, 2, height_ratios=[1.0, 1.0, 0.12, 0.14])
+            axes = np.array(
+                [
+                    fig.add_subplot(grid[0, 0], projection=ccrs.PlateCarree()),
+                    fig.add_subplot(grid[0, 1], projection=ccrs.PlateCarree()),
+                    fig.add_subplot(grid[1, 0], projection=ccrs.PlateCarree()),
+                    fig.add_subplot(grid[1, 1], projection=ccrs.PlateCarree()),
+                ]
+            )
+            delta_cax = fig.add_subplot(grid[2, 1])
+            shared_cax = fig.add_subplot(grid[3, :])
+            norm, ticks = _get_cell_width_norm_and_ticks(
+                fields=[
+                    ds[var_name].values for var_name, _ in cell_width_fields
+                ]
+            )
+            image = None
+            for ax, (var_name, title) in zip(
+                axes[:3], cell_width_fields, strict=True
+            ):
+                image = self._plot_scalar_field(
+                    ax=ax,
+                    lon=lon,
+                    lat=lat,
+                    field=ds[var_name].values,
+                    title=title,
+                    cmap=cmap,
+                    norm=norm,
+                    add_colorbar=False,
+                )
+            delta_norm, delta_ticks = _get_difference_norm_and_ticks(
+                field=delta_field
+            )
+            delta_image = self._plot_scalar_field(
+                ax=axes[3],
+                lon=lon,
+                lat=lat,
+                field=delta_field,
+                title='Coastal transition delta (km)',
+                cmap='cmo.balance',
+                norm=delta_norm,
+                add_colorbar=False,
+            )
+            assert image is not None
+            colorbar = fig.colorbar(
+                image,
+                cax=shared_cax,
+                orientation='horizontal',
+                label='Cell width (km)',
+            )
+            if ticks is not None:
+                colorbar.set_ticks(np.asarray(ticks).tolist())
+            delta_colorbar = fig.colorbar(
+                delta_image,
+                cax=delta_cax,
+                orientation='horizontal',
+                label='Final minus pre-coastline cell width (km)',
+            )
+            if delta_ticks is not None:
+                delta_colorbar.set_ticks(delta_ticks)
+            fig.savefig('sizing_field_overview.png', bbox_inches='tight')
+            plt.close(fig)
+
+            fig = plt.figure(figsize=(11.0, 5.0), dpi=dpi)
+            ax = plt.axes(projection=ccrs.PlateCarree())
+            control_cmap = mcolors.ListedColormap(
+                ['#3b528b', '#5ec962', '#fdae61']
+            )
+            control_norm = mcolors.BoundaryNorm(
+                np.arange(-0.5, 3.5, 1.0), control_cmap.N
+            )
+            image = self._plot_scalar_field(
+                ax=ax,
+                lon=lon,
+                lat=lat,
+                field=ds.active_control.values,
+                title='Active sizing control',
+                cmap=control_cmap,
+                norm=control_norm,
+                add_colorbar=False,
+            )
+            colorbar = fig.colorbar(
+                image, ax=ax, ticks=np.arange(3), shrink=0.75
+            )
+            colorbar.ax.set_yticklabels(
+                ['background', 'coastline', 'river channel']
+            )
+            fig.savefig('active_control.png', bbox_inches='tight')
+            plt.close(fig)
+
+            self._write_summary(ds)
+
+    def _plot_scalar_field(
+        self,
+        ax,
+        lon,
+        lat,
+        field,
+        title,
+        cmap,
+        norm=None,
+        vmin=None,
+        vmax=None,
+        add_colorbar=True,
+    ):
+        """
+        Plot one scalar field on a simple global Plate Carree map.
+        """
+        ax.set_global()
+        image = ax.imshow(
+            field,
+            origin='lower',
+            extent=[lon.min(), lon.max(), lat.min(), lat.max()],
+            transform=ccrs.PlateCarree(),
+            cmap=cmap,
+            norm=norm,
+            vmin=vmin,
+            vmax=vmax,
+            interpolation='nearest',
+        )
+        ax.set_title(title)
+        if add_colorbar:
+            plt.colorbar(image, ax=ax, shrink=0.75)
+        return image
+
+    @staticmethod
+    def _write_summary(ds):
+        """
+        Write a compact summary of the sizing-field dataset.
+        """
+        with open('debug_summary.txt', 'w') as summary:
+            summary.write(f'mesh_name: {ds.attrs["mesh_name"]}\n')
+            summary.write(
+                'target_grid_resolution_degrees: '
+                f'{ds.attrs["target_grid_resolution_degrees"]}\n'
+            )
+            summary.write(
+                f'cellWidth_min_km: {float(np.min(ds.cellWidth.values)):.6f}\n'
+            )
+            summary.write(
+                f'cellWidth_max_km: {float(np.max(ds.cellWidth.values)):.6f}\n'
+            )
+            background = ds.background_cell_width.values
+            count = int(np.count_nonzero(ds.cellWidth.values != background))
+            summary.write(
+                f'cellWidth_differs_from_background_count: {count}\n'
+            )
+            for var_name in [
+                'background_cell_width',
+                'ocean_background_cell_width',
+                'land_river_cell_width',
+                'pre_coastline_cell_width',
+                'coastline_cell_width',
+                'coastal_transition_delta',
+                'river_channel_cell_width',
+            ]:
+                values = ds[var_name].values
+                summary.write(
+                    f'{var_name}_min_km: {float(np.min(values)):.6f}\n'
+                )
+                summary.write(
+                    f'{var_name}_max_km: {float(np.max(values)):.6f}\n'
+                )
+                if var_name not in [
+                    'background_cell_width',
+                    'ocean_background_cell_width',
+                    'coastal_transition_delta',
+                ]:
+                    count = int(np.count_nonzero(values < background))
+                    summary.write(
+                        f'{var_name}_finer_than_background_count: {count}\n'
+                    )
+            for prefix in ['river_channel']:
+                _write_attr_count_summary(
+                    summary=summary, attrs=ds.attrs, prefix=prefix
+                )
+            for control_value, label in enumerate(
+                ['background', 'coastline', 'river_channel']
+            ):
+                count = int(
+                    np.count_nonzero(ds.active_control.values == control_value)
+                )
+                summary.write(f'{label}_count: {count}\n')
+
+
+def _get_cell_width_norm_and_ticks(fields):
+    """
+    Get a shared linear norm and optional readable ticks for cell-width plots.
+    """
+    finite_values = np.concatenate(
+        [field[np.isfinite(field)].ravel() for field in fields]
+    )
+    vmin = float(np.min(finite_values))
+    vmax = float(np.max(finite_values))
+
+    if np.isclose(vmin, vmax):
+        padding = max(abs(vmin) * 0.01, 1.0)
+        return mcolors.Normalize(vmin=vmin - padding, vmax=vmax + padding), [
+            vmin
+        ]
+
+    unique_values = np.unique(finite_values)
+    if unique_values.size <= 6:
+        ticks = unique_values
+    else:
+        ticks = None
+    return mcolors.Normalize(vmin=vmin, vmax=vmax), ticks
+
+
+def _get_difference_norm_and_ticks(field):
+    """
+    Get a zero-centered norm and optional readable ticks for difference plots.
+    """
+    finite_values = field[np.isfinite(field)]
+    max_abs = float(np.max(np.abs(finite_values)))
+    if np.isclose(max_abs, 0.0):
+        max_abs = 1.0
+        ticks = [0.0]
+    else:
+        ticks = [-max_abs, 0.0, max_abs]
+
+    return mcolors.TwoSlopeNorm(
+        vmin=-max_abs, vcenter=0.0, vmax=max_abs
+    ), ticks
+
+
+def _write_attr_count_summary(summary, attrs, prefix):
+    """
+    Write optional sizing-candidate provenance counts.
+    """
+    for suffix in [
+        'mask_count',
+        'finer_than_background_count',
+        'equal_to_background_count',
+        'coarser_than_background_count',
+    ]:
+        attr_name = f'{prefix}_{suffix}'
+        if attr_name in attrs:
+            summary.write(f'{attr_name}: {attrs[attr_name]}\n')

--- a/tests/e3sm/init/topo/test_remap_mask.py
+++ b/tests/e3sm/init/topo/test_remap_mask.py
@@ -1,0 +1,47 @@
+import configparser
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.tasks.e3sm.init.topo.remap.mask import MaskTopoStep
+
+
+def test_ocean_masks_follow_antarctic_boundary_conventions():
+    ds_topo = xr.Dataset(
+        data_vars=dict(
+            base_elevation=(
+                'nCells',
+                np.asarray([-100.0, -200.0, -300.0, 100.0, 50.0]),
+            ),
+            ice_mask=('nCells', np.asarray([0.0, 1.0, 1.0, 0.0, 1.0])),
+            grounded_mask=(
+                'nCells',
+                np.asarray([0.0, 0.0, 1.0, 0.0, 1.0]),
+            ),
+        )
+    )
+
+    expected = {
+        'calving_front': [1.0, 0.0, 0.0, 0.0, 0.0],
+        'grounding_line': [1.0, 1.0, 0.0, 0.0, 0.0],
+        'bedrock_zero': [1.0, 1.0, 1.0, 0.0, 0.0],
+    }
+
+    for convention, expected_ocean in expected.items():
+        ocean_mask = MaskTopoStep._get_ocean_mask(
+            base_elevation=ds_topo.base_elevation,
+            ice_mask=ds_topo.ice_mask,
+            grounded_mask=ds_topo.grounded_mask,
+            convention=convention,
+        )
+
+        np.testing.assert_array_equal(ocean_mask.values, expected_ocean)
+
+
+def test_missing_antarctic_boundary_convention_raises():
+    config = configparser.ConfigParser()
+    config.add_section('spherical_mesh')
+
+    with pytest.raises(ValueError, match='Missing .*antarctic_boundary'):
+        MaskTopoStep._get_antarctic_boundary_convention(config)

--- a/tests/mesh/spherical/unified/test_sizing_field.py
+++ b/tests/mesh/spherical/unified/test_sizing_field.py
@@ -1,0 +1,502 @@
+import importlib.resources as imp_res
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import xarray as xr
+
+from polaris.component import Component
+from polaris.mesh.spherical.unified import (
+    UNIFIED_MESH_NAMES,
+    UnifiedCellWidthMeshStep,
+    get_unified_mesh_family,
+)
+from polaris.mesh.spherical.unified.families.default import (
+    build_ocean_background_from_mode,
+)
+from polaris.mesh.spherical.unified.families.so_region import (
+    SO_REGION_FILENAME,
+    SO_REGION_PACKAGE,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field import (
+    BuildSizingFieldStep,
+    get_sizing_field_config,
+    get_unified_mesh_sizing_field_steps,
+    sizing_field_dataset,
+)
+from polaris.tasks.mesh.spherical.unified.sizing_field.tasks import (
+    add_sizing_field_tasks,
+)
+
+
+def test_sizing_field_mesh_outputs_and_active_control():
+    ds_coastline = _make_coastline_dataset(
+        ocean_mask=np.array([[1, 1, 0], [1, 0, 0]], dtype=np.int8),
+        signed_distance=np.array(
+            [[1000.0, 2000.0, -500.0], [3000.0, -4000.0, -1000.0]]
+        ),
+        lat=np.array([-60.0, 0.0]),
+    )
+    ds_river = _make_river_dataset(
+        river_channel_mask=np.array([[0, 0, 0], [0, 1, 0]], dtype=np.int8),
+        lat=np.array([-60.0, 0.0]),
+    )
+
+    ds_uniform = sizing_field_dataset(
+        ds_coastline=ds_coastline,
+        ds_river=ds_river,
+        resolution=0.25,
+        mesh_name='u.oi240.lr240',
+        ocean_background=_constant_ocean_background(
+            ds_coastline=ds_coastline, value=240.0
+        ),
+        land_background_km=240.0,
+        river_channel_km=240.0,
+    )
+    assert ds_uniform.attrs['mesh_name'] == 'u.oi240.lr240'
+    assert 'profile_name' not in ds_uniform.attrs
+    np.testing.assert_allclose(ds_uniform.cellWidth.values, 240.0)
+    assert np.all(ds_uniform.active_control.values == 0)
+
+    ds_split = sizing_field_dataset(
+        ds_coastline=ds_coastline,
+        ds_river=ds_river,
+        resolution=0.125,
+        mesh_name='u.oi30.lr10',
+        ocean_background=_constant_ocean_background(
+            ds_coastline=ds_coastline, value=30.0
+        ),
+        land_background_km=10.0,
+        river_channel_km=10.0,
+    )
+    expected_split = np.array([[30.0, 30.0, 10.0], [30.0, 10.0, 10.0]])
+    np.testing.assert_allclose(ds_split.cellWidth.values, expected_split)
+    assert ds_split.active_control.values[0, 1] == 0
+    assert ds_split.active_control.values[1, 1] == 0
+    assert ds_split.attrs['river_channel_mask_count'] == 1
+    assert ds_split.attrs['river_channel_finer_than_background_count'] == 0
+    assert ds_split.attrs['river_channel_equal_to_background_count'] == 1
+
+    ds_rrs = sizing_field_dataset(
+        ds_coastline=ds_coastline,
+        ds_river=ds_river,
+        resolution=0.03125,
+        mesh_name='u.oi6to18.lr6to10',
+        ocean_background=build_ocean_background_from_mode(
+            lat=ds_coastline.lat.values,
+            lon=ds_coastline.lon.values,
+            mode='rrs_latitude',
+            min_km=6.0,
+            max_km=18.0,
+        ),
+        land_background_km=12.0,
+        river_channel_km=6.0,
+    )
+    ocean_values = ds_rrs.cellWidth.values[:, 0]
+    assert ocean_values[0] < ocean_values[1]
+    assert np.isclose(ds_rrs.cellWidth.values[0, 1], ocean_values[0])
+    assert np.isclose(ds_rrs.cellWidth.values[1, 1], 6.0)
+    assert ds_rrs.active_control.values[0, 1] == 0
+    assert ds_rrs.active_control.values[1, 1] == 2
+
+
+def test_sizing_field_coastline_transition_on_land():
+    ds_coastline = _make_coastline_dataset(
+        ocean_mask=np.array([[1, 1, 0, 0]], dtype=np.int8),
+        signed_distance=np.array([[0.0, 1000.0, -1000.0, -3000.0]]),
+        lat=np.array([0.0]),
+        lon=np.array([-30.0, -10.0, 10.0, 30.0]),
+    )
+    ds_river = _make_river_dataset(
+        river_channel_mask=np.array([[0, 0, 0, 0]], dtype=np.int8),
+        lat=np.array([0.0]),
+        lon=np.array([-30.0, -10.0, 10.0, 30.0]),
+    )
+
+    ds_sizing = sizing_field_dataset(
+        ds_coastline=ds_coastline,
+        ds_river=ds_river,
+        resolution=0.125,
+        mesh_name='transition_test',
+        ocean_background=_constant_ocean_background(
+            ds_coastline=ds_coastline, value=30.0
+        ),
+        land_background_km=10.0,
+        coastline_transition_land_km=2.0,
+        enable_river_channel_refinement=False,
+    )
+
+    np.testing.assert_allclose(
+        ds_sizing.coastline_cell_width.values[0],
+        np.array([30.0, 30.0, 20.0, 10.0]),
+    )
+    np.testing.assert_allclose(
+        ds_sizing.cellWidth.values[0], np.array([30.0, 30.0, 20.0, 10.0])
+    )
+    np.testing.assert_array_equal(
+        ds_sizing.active_control.values[0],
+        np.array([0, 0, 1, 0], dtype=np.int8),
+    )
+
+
+def test_sizing_field_rivers_composed_before_coastline_transition():
+    ds_coastline = _make_coastline_dataset(
+        ocean_mask=np.array([[1, 1, 1, 0]], dtype=np.int8),
+        signed_distance=np.array([[0.0, 1000.0, 3000.0, -1000.0]]),
+        lat=np.array([0.0]),
+        lon=np.array([-30.0, -10.0, 10.0, 30.0]),
+    )
+    ds_river = _make_river_dataset(
+        river_channel_mask=np.array([[1, 0, 1, 0]], dtype=np.int8),
+        lat=np.array([0.0]),
+        lon=np.array([-30.0, -10.0, 10.0, 30.0]),
+    )
+
+    ds_sizing = sizing_field_dataset(
+        ds_coastline=ds_coastline,
+        ds_river=ds_river,
+        resolution=0.125,
+        mesh_name='river_transition_test',
+        ocean_background=_constant_ocean_background(
+            ds_coastline=ds_coastline, value=30.0
+        ),
+        land_background_km=10.0,
+        coastline_transition_land_km=0.0,
+        river_channel_km=5.0,
+    )
+
+    np.testing.assert_allclose(
+        ds_sizing.river_channel_cell_width.values[0],
+        np.array([5.0, 10.0, 5.0, 10.0]),
+    )
+    np.testing.assert_allclose(
+        ds_sizing.ocean_background_cell_width.values[0],
+        np.array([30.0, 30.0, 30.0, 30.0]),
+    )
+    np.testing.assert_allclose(
+        ds_sizing.land_river_cell_width.values[0],
+        np.array([5.0, 10.0, 5.0, 10.0]),
+    )
+    np.testing.assert_allclose(
+        ds_sizing.pre_coastline_cell_width.values[0],
+        np.array([30.0, 30.0, 30.0, 10.0]),
+    )
+    np.testing.assert_allclose(
+        ds_sizing.cellWidth.values[0], np.array([30.0, 30.0, 30.0, 10.0])
+    )
+    np.testing.assert_allclose(
+        ds_sizing.coastal_transition_delta.values[0],
+        np.array([0.0, 0.0, 0.0, 0.0]),
+    )
+    np.testing.assert_array_equal(
+        ds_sizing.active_control.values[0],
+        np.array([0, 0, 0, 0], dtype=np.int8),
+    )
+
+
+def test_sizing_field_coastline_overrides_finer_land_and_river_controls():
+    ds_coastline = _make_coastline_dataset(
+        ocean_mask=np.array([[1, 0, 0]], dtype=np.int8),
+        signed_distance=np.array([[0.0, -1000.0, -3000.0]]),
+        lat=np.array([0.0]),
+        lon=np.array([-30.0, 0.0, 30.0]),
+    )
+    ds_river = _make_river_dataset(
+        river_channel_mask=np.array([[0, 1, 0]], dtype=np.int8),
+        lat=np.array([0.0]),
+        lon=np.array([-30.0, 0.0, 30.0]),
+    )
+
+    ds_sizing = sizing_field_dataset(
+        ds_coastline=ds_coastline,
+        ds_river=ds_river,
+        resolution=0.125,
+        mesh_name='coastal_override_test',
+        ocean_background=_constant_ocean_background(
+            ds_coastline=ds_coastline, value=30.0
+        ),
+        land_background_km=10.0,
+        coastline_transition_land_km=2.0,
+        river_channel_km=5.0,
+    )
+
+    np.testing.assert_allclose(
+        ds_sizing.land_river_cell_width.values[0], np.array([10.0, 5.0, 10.0])
+    )
+    np.testing.assert_allclose(
+        ds_sizing.coastline_cell_width.values[0], np.array([30.0, 17.5, 10.0])
+    )
+    np.testing.assert_allclose(
+        ds_sizing.cellWidth.values[0], np.array([30.0, 17.5, 10.0])
+    )
+    np.testing.assert_allclose(
+        ds_sizing.coastal_transition_delta.values[0],
+        np.array([0.0, 12.5, 0.0]),
+    )
+    np.testing.assert_array_equal(
+        ds_sizing.active_control.values[0], np.array([0, 1, 0], dtype=np.int8)
+    )
+
+
+def test_unified_cell_width_mesh_step_reads_sizing_field(tmp_path):
+    step = UnifiedCellWidthMeshStep(
+        component=Component(name='mesh'),
+        subdir='spherical/unified/base_mesh/test',
+    )
+    step.work_dir = str(tmp_path)
+
+    ds = xr.Dataset(
+        data_vars=dict(
+            cellWidth=(('lat', 'lon'), np.array([[1.0, 2.0], [3.0, 4.0]]))
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.array([-45.0, 45.0]), dims=('lat',)),
+            lon=xr.DataArray(np.array([-90.0, 90.0]), dims=('lon',)),
+        ),
+    )
+    ds.to_netcdf(tmp_path / 'sizing_field.nc')
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        cell_width, lon, lat = step.build_cell_width_lat_lon()
+    finally:
+        os.chdir(cwd)
+
+    np.testing.assert_allclose(cell_width, ds.cellWidth.values)
+    np.testing.assert_allclose(lon, ds.lon.values)
+    np.testing.assert_allclose(lat, ds.lat.values)
+
+
+def test_generic_ocean_background_modes():
+    lat = np.array([-60.0, 0.0])
+    lon = np.array([-120.0, 0.0, 120.0])
+
+    constant = build_ocean_background_from_mode(
+        lat=lat,
+        lon=lon,
+        mode='constant',
+        min_km=30.0,
+        max_km=30.0,
+    )
+    np.testing.assert_allclose(constant, 30.0)
+
+    rrs = build_ocean_background_from_mode(
+        lat=lat,
+        lon=lon,
+        mode='rrs_latitude',
+        min_km=6.0,
+        max_km=18.0,
+    )
+    assert rrs.shape == (2, 3)
+    assert rrs[0, 0] < rrs[1, 0]
+
+
+def test_constant_ocean_background_requires_equal_min_max():
+    lat = np.array([-60.0, 0.0])
+    lon = np.array([-120.0, 0.0, 120.0])
+
+    try:
+        build_ocean_background_from_mode(
+            lat=lat,
+            lon=lon,
+            mode='constant',
+            min_km=6.0,
+            max_km=18.0,
+        )
+    except ValueError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError('Expected constant mode to raise ValueError.')
+
+    assert 'ocean_background_min_km' in message
+    assert 'ocean_background_max_km' in message
+
+
+def test_generic_ocean_background_rejects_ec_latitude():
+    lat = np.array([-60.0, 0.0])
+    lon = np.array([-120.0, 0.0, 120.0])
+
+    try:
+        build_ocean_background_from_mode(
+            lat=lat,
+            lon=lon,
+            mode='ec_latitude',
+            min_km=6.0,
+            max_km=18.0,
+        )
+    except ValueError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError('Expected ec_latitude to raise ValueError.')
+
+    assert 'ec_latitude' in message
+    assert 'Mesh-specific ocean backgrounds' in message
+
+
+def test_add_sizing_field_tasks_registers_named_meshes():
+    component = Component(name='mesh')
+    add_sizing_field_tasks(component=component)
+
+    assert 'u.oi.so12to30.lr10' in UNIFIED_MESH_NAMES
+    assert len(component.tasks) == len(UNIFIED_MESH_NAMES)
+
+    for mesh_name in UNIFIED_MESH_NAMES:
+        subdir = f'spherical/unified/{mesh_name}/sizing_field/task'
+        assert subdir in component.tasks
+        task = component.tasks[subdir]
+        assert task.name == f'sizing_field_{mesh_name}_task'
+
+
+def test_sizing_field_step_factory_uses_mesh_subdir():
+    mesh_name = 'u.oi30.lr10'
+    steps, config = get_unified_mesh_sizing_field_steps(
+        mesh_name=mesh_name,
+        include_viz=True,
+    )
+
+    assert (
+        steps['sizing_field'].subdir
+        == f'spherical/unified/{mesh_name}/sizing_field/build'
+    )
+    assert (
+        steps['sizing_field_viz'].subdir
+        == f'spherical/unified/{mesh_name}/sizing_field/viz'
+    )
+    assert config.get('unified_mesh', 'mesh_name') == mesh_name
+    assert config.has_option('spherical_mesh', 'antarctic_boundary_convention')
+
+
+def test_sizing_field_step_factory_uses_mesh_family():
+    mesh_name = 'u.oi.so12to30.lr10'
+
+    steps, config = get_unified_mesh_sizing_field_steps(
+        mesh_name=mesh_name,
+        include_viz=False,
+    )
+
+    assert type(steps['sizing_field']) is BuildSizingFieldStep
+    assert config.get('unified_mesh', 'mesh_family') == 'so_region'
+    assert get_unified_mesh_family(config).name == 'so_region'
+
+
+def test_sizing_field_step_factory_reuses_shared_config_for_viz():
+    mesh_name = 'u.oi30.lr10'
+
+    build_steps, _ = get_unified_mesh_sizing_field_steps(
+        mesh_name=mesh_name,
+        include_viz=False,
+    )
+    steps, config = get_unified_mesh_sizing_field_steps(
+        mesh_name=mesh_name,
+        include_viz=True,
+    )
+    component = steps['sizing_field'].component
+
+    assert steps['sizing_field'] is build_steps['sizing_field']
+    # 1 combine topo, 2 coastline, 3 river, 1 sizing field, 1 viz
+    assert len(steps) == 8
+    assert config is component.configs[config.filepath]
+
+
+def test_so_mesh_family_links_shared_region_and_builds_field(
+    tmp_path,
+):
+    component = Component(name='mesh')
+    coastline_step = SimpleNamespace(
+        subdir='spherical/unified/coastline/lat_lon/0.06250_degree/prepare',
+        path='coastline',
+        output_filenames={'calving_front': 'coastline.nc'},
+    )
+    river_step = SimpleNamespace(
+        subdir='spherical/unified/u.oi.so12to30.lr10/river/lat_lon/prepare',
+        path='river',
+        masks_filename='river_network.nc',
+    )
+    config = get_sizing_field_config(
+        mesh_name='u.oi.so12to30.lr10',
+        filepath='mesh/spherical/unified/'
+        'u.oi.so12to30.lr10/sizing_field/sizing_field.cfg',
+    )
+    step = BuildSizingFieldStep(
+        component=component,
+        coastline_step=coastline_step,
+        river_step=river_step,
+        subdir='spherical/unified/u.oi.so12to30.lr10/sizing_field/build',
+    )
+    step.set_shared_config(config, link='sizing_field.cfg')
+    step.setup()
+
+    assert get_unified_mesh_family(config).name == 'so_region'
+    assert any(
+        input_file['filename'] == SO_REGION_FILENAME
+        and input_file['package'] == SO_REGION_PACKAGE
+        for input_file in step.input_data
+    )
+
+    ds_coastline = _make_coastline_dataset(
+        ocean_mask=np.ones((3, 4), dtype=np.int8),
+        signed_distance=np.zeros((3, 4), dtype=float),
+        lat=np.array([-80.0, -60.0, -20.0]),
+        lon=np.array([-180.0, -60.0, 60.0, 180.0]),
+    )
+
+    region_resource = imp_res.files(SO_REGION_PACKAGE).joinpath(
+        SO_REGION_FILENAME
+    )
+    with imp_res.as_file(region_resource) as region_path:
+        os.symlink(region_path, tmp_path / SO_REGION_FILENAME)
+        cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            ocean_background = step._get_ocean_background(
+                ds_coastline=ds_coastline,
+                section=config['sizing_field'],
+            )
+        finally:
+            os.chdir(cwd)
+
+    assert ocean_background.shape == (3, 4)
+    assert np.min(ocean_background) < np.max(ocean_background)
+    assert np.mean(ocean_background[0, :]) < np.mean(ocean_background[-1, :])
+
+
+def _make_coastline_dataset(ocean_mask, signed_distance, lat=None, lon=None):
+    if lat is None:
+        lat = np.array([-30.0, 30.0])
+    if lon is None:
+        lon = np.array([-120.0, 0.0, 120.0])
+
+    return xr.Dataset(
+        data_vars=dict(
+            ocean_mask=(('lat', 'lon'), ocean_mask),
+            signed_distance=(('lat', 'lon'), signed_distance),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.asarray(lat), dims=('lat',)),
+            lon=xr.DataArray(np.asarray(lon), dims=('lon',)),
+        ),
+    )
+
+
+def _make_river_dataset(river_channel_mask, lat=None, lon=None):
+    if lat is None:
+        lat = np.array([-30.0, 30.0])
+    if lon is None:
+        lon = np.array([-120.0, 0.0, 120.0])
+
+    return xr.Dataset(
+        data_vars=dict(
+            river_channel_mask=(('lat', 'lon'), river_channel_mask),
+        ),
+        coords=dict(
+            lat=xr.DataArray(np.asarray(lat), dims=('lat',)),
+            lon=xr.DataArray(np.asarray(lon), dims=('lon',)),
+        ),
+    )
+
+
+def _constant_ocean_background(ds_coastline, value):
+    lat_size = ds_coastline.sizes['lat']
+    lon_size = ds_coastline.sizes['lon']
+    return np.full((lat_size, lon_size), value, dtype=float)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

### Summary

Introduces a `BuildSizingFieldStep` that composites ocean background, land
background, river-channel refinement, and coastline refinement into a single
`sizing_field.nc` on the shared lat-lon target grid. The output is a
multi-variable NetCDF dataset (containing `cellWidth` and several diagnostic
fields) that can be consumed by a new `UnifiedCellWidthMeshStep` to drive mesh
generation without recomputing the field in-process.

### Algorithm

`sizing_field_dataset` in
`polaris/tasks/mesh/spherical/unified/sizing_field/build.py` assembles the
sizing field in four stages:

1. **Background.** Start from an ocean background (delegated to the mesh
   family — see below) and a uniform land background. The combined `background`
   is ocean-valued where `ocean_mask` is true, land-valued elsewhere.

2. **River-channel candidate.** Where `river_channel_mask` is true and
   river-channel refinement is enabled, replace the land background with
   `river_channel_km`; otherwise keep the land background. The land/river
   composite is the element-wise minimum of the land background and the
   river-channel candidate (computed via `np.argmin` on a 2-element stack).

3. **Coastline candidate.** On the land side of the coast
   (`signed_distance ≤ 0`), apply a linear ramp from the ocean background value
   at the shoreline edge back to the land/river composite over
   `coastline_transition_land_km`. When `coastline_transition_land_km = 0`, the
   ocean background value is assigned only to rasterized coastline pixels
   (`signed_distance ≈ 0`).

4. **Final field.** The coastline candidate becomes `cellWidth`. An
   `active_control` integer field records which control
   (background=0, coastline=1, river-channel=2) is dominant at each grid cell.

### Mesh families

A `UnifiedMeshFamily` protocol in
`polaris/mesh/spherical/unified/families/` dispatches ocean-background
construction:

- **`DefaultUnifiedMeshFamily`** — supports `constant` (uniform) and
  `rrs_latitude` (RRS curve via `mdt.RRS_CellWidthVsLat`) modes.
- **`SORegionUnifiedMeshFamily`** — reuses the extracted
  `build_southern_ocean_background` from
  `polaris/mesh/base/so/background.py`, which blends high- and low-resolution
  values with a tanh ramp based on signed distance from a GeoJSON polygon.

The active family is read from the `mesh_family` key in each mesh's `.cfg`
file. `get_unified_mesh_config` was extended to load a family-specific config
overlay and the new `sizing_field.cfg` defaults before the per-mesh config.

### New `UnifiedCellWidthMeshStep`

`polaris/mesh/spherical/unified/cell_width.py` adds a
`QuasiUniformSphericalMeshStep` subclass that reads `cellWidth`, `lat`, and
`lon` directly from an upstream `sizing_field.nc` instead of computing them
inline, enabling mesh-generation steps to depend on a pre-built sizing field.

### Refactoring

- The Southern Ocean background logic was extracted from
  `SOBaseMesh.build_cell_width_lat_lon` into the standalone
  `build_southern_ocean_background` function so it can be reused by both the
  base-mesh and the new `SORegionUnifiedMeshFamily`.
- Per-mesh configs gained full `[sizing_field]` sections (ocean background
  mode, min/max km, land background km, coastline transition km,
  river-channel km) replacing the previous stub entries.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
