### PR TITLE
Add utility script to convert existing mpas-o ics to omega ics

### DIFF
--- a/docs/developers_guide/ocean/convert_mpaso_ic_to_omega.md
+++ b/docs/developers_guide/ocean/convert_mpaso_ic_to_omega.md
@@ -1,0 +1,119 @@
+(dev-ocean-convert-mpaso-ic-to-omega)=
+
+# convert_mpaso_ic_to_omega.py
+
+The script `utils/omega/convert_mpaso_ic_to_omega.py` is a developer utility
+for converting an MPAS-Ocean initial-condition file into an Omega-formatted
+initial-condition file.  It is primarily intended for cases where a developer
+already has an MPAS-Ocean initial condition and needs a corresponding Omega
+file with the expected variable names, a `PseudoThickness` field, and optional
+tracer conversion for the requested equation of state.
+
+The script complements the model-variable mapping described in
+{ref}`dev-ocean-model`.  In contrast to
+{py:meth}`polaris.ocean.model.OceanIOStep.write_model_dataset`, which maps
+datasets during task setup, this utility performs a one-time conversion of an
+existing NetCDF file on disk.
+
+## Workflow
+
+The converter performs the following operations:
+
+1. It loads the MPAS-Ocean initial condition from `--input-file`.
+2. It writes a zero-velocity MPAS-style companion file with the suffix
+   `.mpas.nc`.
+3. It rescales spherical coordinates and areas to the Polaris Earth radius
+   from `pcd.yaml`.
+4. It converts tracers according to `--eos-type`:
+
+   - `teos10` converts potential temperature to conservative temperature and
+     practical salinity to absolute salinity.
+   - `linear` leaves temperature and salinity unchanged and computes specific
+     volume from the linear EOS coefficients used by Omega.
+
+5. It computes `PseudoThickness` from `layerThickness`, the reference seawater
+   density, and specific volume.
+6. It zeros any numeric fields whose names contain `velocity`.
+7. It renames dimensions and variables using
+   `polaris/ocean/model/mpaso_to_omega.yaml`.
+8. It writes the converted Omega file with
+   {py:func}`mpas_tools.io.write_netcdf`.
+
+If `--visualization` is supplied, the script also writes diagnostic figures for
+the converted temperature and salinity fields before the final rename to Omega
+variable names.  The temperature diagnostic is an absolute difference
+(`Omega - MPAS-Ocean`) and the salinity diagnostic is a percent difference.
+
+## Command-Line Interface
+
+Typical TEOS-10 usage is:
+
+```bash
+python utils/omega/convert_mpaso_ic_to_omega.py \
+    --input-file /path/to/ocean.nc \
+    --output-file /path/to/ocean.omega.nc \
+    --eos-type teos10
+```
+
+To also write the comparison figures:
+
+```bash
+python utils/omega/convert_mpaso_ic_to_omega.py \
+    --input-file /path/to/ocean.nc \
+    --output-file /path/to/ocean.omega.nc \
+    --eos-type teos10 \
+    --visualization
+```
+
+For linear-EOS testing, use:
+
+```bash
+python utils/omega/convert_mpaso_ic_to_omega.py \
+    --input-file /path/to/ocean.nc \
+    --output-file /path/to/ocean.omega.nc \
+    --eos-type linear
+```
+
+The script appends an EOS suffix automatically unless it is already present:
+
+- `teos10` produces `*.teos10eos.nc`
+- `linear` produces `*.lineareos.nc`
+
+## Input Expectations
+
+At a minimum, the input file must contain `layerThickness`.  For TEOS-10
+conversion, the script also requires `temperature`, `salinity`, `latCell`, and
+`lonCell`.  The implementation assumes the standard MPAS-Ocean dimensions
+`Time`, `nCells`, and `nVertLevels`.
+
+When TEOS-10 conversion is enabled, the script estimates mid-layer pressure by
+integrating hydrostatically downward from the surface.  If present,
+`atmosphericPressure` and `seaIcePressure` are included in the surface pressure
+used for this integration.
+
+## Outputs
+
+The converter can produce up to four artifacts:
+
+- An MPAS-style file with zeroed velocity fields, written next to the input
+  file with the suffix `.mpas.nc`
+- An Omega-formatted initial condition written next to the requested output
+  path with an EOS-specific suffix
+- A temperature comparison figure named
+  `<output_stem>_temperature_absolute_difference.png` when
+  `--visualization` is enabled
+- A salinity comparison figure named
+  `<output_stem>_salinity_percent_difference.png` when `--visualization` is
+  enabled
+
+## Implementation Notes
+
+The renaming logic for dimensions and variables is shared with the ocean model
+support described in {ref}`dev-ocean-model`.  If new Omega variables, config
+options, or dimensions are added, update
+`polaris/ocean/model/mpaso_to_omega.yaml` so the standalone converter and the
+task-based model I/O remain consistent.
+
+The script is intentionally separate from the task framework because it is
+useful during dataset preparation and debugging outside the lifecycle of a
+Polaris task or step.

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -39,6 +39,10 @@ should be added to the `variables` section in the
 [mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml)
 file.
 
+For standalone conversion of an existing MPAS-Ocean initial-condition file to
+Omega format outside a Polaris task, see
+{ref}`dev-ocean-convert-mpaso-ic-to-omega`.
+
 ### Running an E3SM component
 
 Steps that run either Omega or MPAS-Ocean should descend from the

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -51,6 +51,10 @@ it is left as-is.  As new variables that do have an MPAS-Ocean equivalent are
 added to Omega, they should be added to the `variables` section in the
 `mpaso_to_omega.yaml` file.
 
+For standalone conversion of an existing MPAS-Ocean initial-condition file to
+Omega format outside a Polaris task, see
+{ref}`dev-ocean-convert-mpaso-ic-to-omega`.
+
 #### Canonical staged files
 
 The three files that flow through the ocean pipeline — horizontal mesh,

--- a/docs/developers_guide/ocean/index.md
+++ b/docs/developers_guide/ocean/index.md
@@ -106,5 +106,6 @@ appropriate for whichever of the {ref}`machines` you are using.
 
 tasks/index
 framework
+convert_mpaso_ic_to_omega
 models/index
 ```

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -21,32 +21,32 @@ variables:
   verticesOnEdge: VerticesOnEdge
   cellsOnVertex: CellsOnVertex
   edgesOnVertex: EdgesOnVertex
-  nEdgesOnCell: NEdgesOnCell
-  nEdgesOnEdge: NEdgesOnEdge
-  latCell: LatCell
-  lonCell: LonCell
-  latEdge: LatEdge
-  lonEdge: LonEdge
-  latVertex: LatVertex
-  lonVertex: LonVertex
-  xCell: XCell
-  yCell: YCell
-  zCell: ZCell
-  xEdge: XEdge
-  yEdge: YEdge
-  zEdge: ZEdge
-  xVertex: XVertex
-  yVertex: YVertex
-  zVertex: ZVertex
-  dcEdge: DcEdge
-  dvEdge: DvEdge
-  areaCell: AreaCell
-  areaTriangle: AreaTriangle
-  kiteAreasOnVertex: KiteAreasOnVertex
-  fCell: FCell
-  fEdge: FEdge
-  fVertex: FVertex
-  angleEdge: AngleEdge
+  #nEdgesOnCell: NEdgesOnCell
+  #nEdgesOnEdge: NEdgesOnEdge
+  #latCell: LatCell
+  #lonCell: LonCell
+  #latEdge: LatEdge
+  #lonEdge: LonEdge
+  #latVertex: LatVertex
+  #lonVertex: LonVertex
+  #xCell: XCell
+  #yCell: YCell
+  #zCell: ZCell
+  #xEdge: XEdge
+  #yEdge: YEdge
+  #zEdge: ZEdge
+  #xVertex: XVertex
+  #yVertex: YVertex
+  #zVertex: ZVertex
+  #dcEdge: DcEdge
+  #dvEdge: DvEdge
+  #areaCell: AreaCell
+  #areaTriangle: AreaTriangle
+  #kiteAreasOnVertex: KiteAreasOnVertex
+  #fCell: FCell
+  #fEdge: FEdge
+  #fVertex: FVertex
+  #angleEdge: AngleEdge
 
   # vertical coordinate
   minLevelCell: MinLayerCell

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -21,32 +21,6 @@ variables:
   verticesOnEdge: VerticesOnEdge
   cellsOnVertex: CellsOnVertex
   edgesOnVertex: EdgesOnVertex
-  #nEdgesOnCell: NEdgesOnCell
-  #nEdgesOnEdge: NEdgesOnEdge
-  #latCell: LatCell
-  #lonCell: LonCell
-  #latEdge: LatEdge
-  #lonEdge: LonEdge
-  #latVertex: LatVertex
-  #lonVertex: LonVertex
-  #xCell: XCell
-  #yCell: YCell
-  #zCell: ZCell
-  #xEdge: XEdge
-  #yEdge: YEdge
-  #zEdge: ZEdge
-  #xVertex: XVertex
-  #yVertex: YVertex
-  #zVertex: ZVertex
-  #dcEdge: DcEdge
-  #dvEdge: DvEdge
-  #areaCell: AreaCell
-  #areaTriangle: AreaTriangle
-  #kiteAreasOnVertex: KiteAreasOnVertex
-  #fCell: FCell
-  #fEdge: FEdge
-  #fVertex: FVertex
-  #angleEdge: AngleEdge
 
   # vertical coordinate
   minLevelCell: MinLayerCell

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -21,6 +21,32 @@ variables:
   verticesOnEdge: VerticesOnEdge
   cellsOnVertex: CellsOnVertex
   edgesOnVertex: EdgesOnVertex
+  nEdgesOnCell: NEdgesOnCell
+  nEdgesOnEdge: NEdgesOnEdge
+  latCell: LatCell
+  lonCell: LonCell
+  latEdge: LatEdge
+  lonEdge: LonEdge
+  latVertex: LatVertex
+  lonVertex: LonVertex
+  xCell: XCell
+  yCell: YCell
+  zCell: ZCell
+  xEdge: XEdge
+  yEdge: YEdge
+  zEdge: ZEdge
+  xVertex: XVertex
+  yVertex: YVertex
+  zVertex: ZVertex
+  dcEdge: DcEdge
+  dvEdge: DvEdge
+  areaCell: AreaCell
+  areaTriangle: AreaTriangle
+  kiteAreasOnVertex: KiteAreasOnVertex
+  fCell: FCell
+  fEdge: FEdge
+  fVertex: FVertex
+  angleEdge: AngleEdge
 
   # vertical coordinate
   minLevelCell: MinLayerCell

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -21,32 +21,32 @@ variables:
   verticesOnEdge: VerticesOnEdge
   cellsOnVertex: CellsOnVertex
   edgesOnVertex: EdgesOnVertex
-  nEdgesOnCell: NEdgesOnCell
-  nEdgesOnEdge: NEdgesOnEdge
-  latCell: LatCell
-  lonCell: LonCell
-  latEdge: LatEdge
-  lonEdge: LonEdge
-  latVertex: LatVertex
-  lonVertex: LonVertex
-  xCell: XCell
-  yCell: YCell
-  zCell: ZCell
-  xEdge: XEdge
-  yEdge: YEdge
-  zEdge: ZEdge
-  xVertex: XVertex
-  yVertex: YVertex
-  zVertex: ZVertex
-  dcEdge: DcEdge
-  dvEdge: DvEdge
-  areaCell: AreaCell
-  areaTriangle: AreaTriangle
-  kiteAreasOnVertex: KiteAreasOnVertex
-  fCell: FCell
-  fEdge: FEdge
-  fVertex: FVertex
-  angleEdge: AngleEdge
+  #nEdgesOnCell: NEdgesOnCell
+  #nEdgesOnEdge: NEdgesOnEdge
+  #latCell: LatCell
+  #lonCell: LonCell
+  #latEdge: LatEdge
+  #lonEdge: LonEdge
+  #latVertex: LatVertex
+  #lonVertex: LonVertex
+  #xCell: XCell
+  #yCell: YCell
+  #zCell: ZCell
+  #xEdge: XEdge
+  #yEdge: YEdge
+  #zEdge: ZEdge
+  #xVertex: XVertex
+  #yVertex: YVertex
+  #zVertex: ZVertex
+  #dcEdge: DcEdge
+  #dvEdge: DvEdge
+  #areaCell: AreaCell
+  #areaTriangle: AreaTriangle
+  #kiteAreasOnVertex: KiteAreasOnVertex
+  #fCell: FCell
+  #fEdge: FEdge
+  #fVertex: FVertex
+  #angleEdge: AngleEdge
 
   # mesh coordinates
   xCell: XCell

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -21,6 +21,32 @@ variables:
   verticesOnEdge: VerticesOnEdge
   cellsOnVertex: CellsOnVertex
   edgesOnVertex: EdgesOnVertex
+  nEdgesOnCell: NEdgesOnCell
+  nEdgesOnEdge: NEdgesOnEdge
+  latCell: LatCell
+  lonCell: LonCell
+  latEdge: LatEdge
+  lonEdge: LonEdge
+  latVertex: LatVertex
+  lonVertex: LonVertex
+  xCell: XCell
+  yCell: YCell
+  zCell: ZCell
+  xEdge: XEdge
+  yEdge: YEdge
+  zEdge: ZEdge
+  xVertex: XVertex
+  yVertex: YVertex
+  zVertex: ZVertex
+  dcEdge: DcEdge
+  dvEdge: DvEdge
+  areaCell: AreaCell
+  areaTriangle: AreaTriangle
+  kiteAreasOnVertex: KiteAreasOnVertex
+  fCell: FCell
+  fEdge: FEdge
+  fVertex: FVertex
+  angleEdge: AngleEdge
 
   # mesh coordinates
   xCell: XCell

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -21,32 +21,6 @@ variables:
   verticesOnEdge: VerticesOnEdge
   cellsOnVertex: CellsOnVertex
   edgesOnVertex: EdgesOnVertex
-  #nEdgesOnCell: NEdgesOnCell
-  #nEdgesOnEdge: NEdgesOnEdge
-  #latCell: LatCell
-  #lonCell: LonCell
-  #latEdge: LatEdge
-  #lonEdge: LonEdge
-  #latVertex: LatVertex
-  #lonVertex: LonVertex
-  #xCell: XCell
-  #yCell: YCell
-  #zCell: ZCell
-  #xEdge: XEdge
-  #yEdge: YEdge
-  #zEdge: ZEdge
-  #xVertex: XVertex
-  #yVertex: YVertex
-  #zVertex: ZVertex
-  #dcEdge: DcEdge
-  #dvEdge: DvEdge
-  #areaCell: AreaCell
-  #areaTriangle: AreaTriangle
-  #kiteAreasOnVertex: KiteAreasOnVertex
-  #fCell: FCell
-  #fEdge: FEdge
-  #fVertex: FVertex
-  #angleEdge: AngleEdge
 
   # mesh coordinates
   xCell: XCell

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -91,6 +91,7 @@ def convert_to_omega(input_file, output_file, eos_type, zero_velocity_mpas_file)
     _add_pseudo_thickness(ds, valid, spec_vol)
     velocity_fields = _zero_velocity_fields(ds)
     ds = _map_mpaso_to_omega(ds)
+    ds = _rename_geom_vars_for_omega(ds)
 
     ds.to_netcdf(output_file)
 
@@ -284,6 +285,26 @@ def _map_mpaso_to_omega(ds):
     rename.update(rename_vars)
 
     return ds.rename(rename)
+
+
+def _rename_geom_vars_for_omega(ds):
+    rename = {}
+
+    if 'zMid' in ds.variables:
+        rename['zMid'] = 'GeomZMid'
+
+    if 'refZMid' in ds.variables:
+        rename['refZMid'] = 'RefGeomZMid'
+
+    if 'LayerThickness' in ds.variables:
+        rename['LayerThickness'] = 'GeomLayerThickness'
+    elif 'layerThickness' in ds.variables:
+        rename['layerThickness'] = 'GeomLayerThickness'
+
+    if rename:
+        ds = ds.rename(rename)
+
+    return ds
 
 
 def main():

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -9,6 +9,7 @@ import xarray as xr
 from ruamel.yaml import YAML
 
 from polaris.constants import get_constant
+from polaris.ocean.vertical import compute_zint_zmid_from_layer_thickness
 
 
 def parse_args():
@@ -45,14 +46,16 @@ def parse_args():
         default='teos10',
         help=(
             'Equation of state mode: teos10 converts tracers '
-            '(pt/SA -> CT/SP), linear leaves tracers unchanged '
-            '(potential temperature and absolute salinity).'
+            '(pt/PS -> CT/AS), linear leaves tracers unchanged '
+            '(potential temperature and practical salinity).'
         ),
     )
     return parser.parse_args()
 
 
-def convert_to_omega(input_file, output_file, eos_type, zero_velocity_mpas_file):
+def convert_to_omega(
+    input_file, output_file, eos_type, zero_velocity_mpas_file
+):
     with xr.open_dataset(input_file, decode_times=False) as ds_in:
         ds = ds_in.load()
 
@@ -70,8 +73,7 @@ def convert_to_omega(input_file, output_file, eos_type, zero_velocity_mpas_file)
     print(f'Wrote {zero_velocity_mpas_file}')
     if mpas_velocity_fields:
         print(
-            'Zeroed MPAS velocity fields: '
-            f'{", ".join(mpas_velocity_fields)}'
+            f'Zeroed MPAS velocity fields: {", ".join(mpas_velocity_fields)}'
         )
     else:
         print('No MPAS velocity fields found to zero')
@@ -85,24 +87,23 @@ def convert_to_omega(input_file, output_file, eos_type, zero_velocity_mpas_file)
     if eos_type == 'teos10':
         z_mid = _get_z_mid(ds)
         spec_vol = _convert_teos10_tracers(ds, valid, z_mid)
-    else:
-        spec_vol = 1.0 / get_constant('seawater_density_reference')
+    elif eos_type == 'linear':
+        spec_vol = _compute_linear_spec_vol(ds, valid)
 
     _add_pseudo_thickness(ds, valid, spec_vol)
     velocity_fields = _zero_velocity_fields(ds)
     ds = _map_mpaso_to_omega(ds)
-    ds = _rename_geom_vars_for_omega(ds)
 
     ds.to_netcdf(output_file)
 
     print(f'Wrote {output_file}')
     if eos_type == 'teos10':
         print('Converted temperature: potential -> conservative')
-        print('Converted salinity: absolute -> practical')
+        print('Converted salinity: practical -> absolute')
     else:
         print(
             'Kept temperature and salinity unchanged '
-            '(potential temperature and absolute salinity)'
+            '(potential temperature and practical salinity)'
         )
     print('Added PseudoThickness')
     if velocity_fields:
@@ -136,25 +137,48 @@ def _append_eos_suffix(output_file, eos_type):
 
 
 def _get_z_mid(ds):
-    required_vars = ['layerThickness', 'bottomDepth']
-    missing = [name for name in required_vars if name not in ds.variables]
-    if missing:
-        raise ValueError(
-            f'Missing required variables for depth computation: {missing}'
+    if 'zMid' in ds.keys():
+        return ds['zMid']
+    else:
+        required_vars = ['layerThickness', 'bottomDepth']
+        missing = [name for name in required_vars if name not in ds.variables]
+        if missing:
+            raise ValueError(
+                f'Missing required variables for depth computation: {missing}'
+            )
+
+        layer_thickness = ds['layerThickness']
+        bottom_depth = ds['bottomDepth']
+
+        n_cells = ds.sizes['nCells']
+        n_vert_levels = ds.sizes['nVertLevels']
+
+        if 'minLevelCell' not in ds.variables:
+            min_level_cell = xr.DataArray(
+                np.zeros(n_cells, dtype=int),
+                dims=['nCells'],
+                name='minLevelCell',
+            )
+        else:
+            min_level_cell = ds['minLevelCell']
+
+        if 'maxLevelCell' not in ds.variables:
+            max_level_cell = xr.DataArray(
+                np.full(n_cells, n_vert_levels - 1, dtype=int),
+                dims=['nCells'],
+                name='maxLevelCell',
+            )
+        else:
+            max_level_cell = ds['maxLevelCell']
+
+        _, z_mid = compute_zint_zmid_from_layer_thickness(
+            layer_thickness,
+            bottom_depth,
+            min_level_cell,
+            max_level_cell,
         )
 
-    layer_thickness = ds['layerThickness'].values
-    bottom_depth = ds['bottomDepth'].values[np.newaxis, :, np.newaxis]
-    total_thickness = np.sum(layer_thickness, axis=2, keepdims=True)
-    ssh = total_thickness - bottom_depth
-    z_top = ssh - np.concatenate(
-        [
-            np.zeros(layer_thickness.shape[:2] + (1,), dtype=float),
-            np.cumsum(layer_thickness[:, :, :-1], axis=2),
-        ],
-        axis=2,
-    )
-    return z_top - 0.5 * layer_thickness
+        return z_mid.values
 
 
 def _convert_teos10_tracers(ds, valid, z_mid):
@@ -175,7 +199,7 @@ def _convert_teos10_tracers(ds, valid, z_mid):
     lon = _to_degrees(ds['lonCell'].values)
 
     conservative_temperature = np.full(temperature.shape, np.nan)
-    practical_salinity = np.full(salinity.shape, np.nan)
+    absolute_salinity = np.full(salinity.shape, np.nan)
     spec_vol = np.full(ds['layerThickness'].shape, np.nan)
 
     for time_index in range(ds.sizes['Time']):
@@ -183,7 +207,7 @@ def _convert_teos10_tracers(ds, valid, z_mid):
             potential_temperature = temperature.isel(
                 Time=time_index, nVertLevels=depth_index
             ).values
-            absolute_salinity = salinity.isel(
+            practical_salinity = salinity.isel(
                 Time=time_index, nVertLevels=depth_index
             ).values
             z = z_mid[time_index, :, depth_index]
@@ -191,7 +215,7 @@ def _convert_teos10_tracers(ds, valid, z_mid):
 
             mask = (
                 np.isfinite(potential_temperature)
-                & np.isfinite(absolute_salinity)
+                & np.isfinite(practical_salinity)
                 & np.isfinite(pressure_dbar)
                 & np.isfinite(lat)
                 & np.isfinite(lon)
@@ -199,21 +223,21 @@ def _convert_teos10_tracers(ds, valid, z_mid):
             )
 
             conservative_slice = np.full(potential_temperature.shape, np.nan)
-            practical_slice = np.full(absolute_salinity.shape, np.nan)
-            spec_vol_slice = np.full(absolute_salinity.shape, np.nan)
+            absolute_slice = np.full(practical_salinity.shape, np.nan)
+            spec_vol_slice = np.full(practical_salinity.shape, np.nan)
 
             conservative_slice[mask] = gsw.CT_from_pt(
-                absolute_salinity[mask],
+                practical_salinity[mask],
                 potential_temperature[mask],
             )
-            practical_slice[mask] = gsw.SP_from_SA(
-                absolute_salinity[mask],
+            absolute_slice[mask] = gsw.SA_from_SP(
+                practical_salinity[mask],
                 pressure_dbar[mask],
                 lon[mask],
                 lat[mask],
             )
             spec_vol_slice[mask] = gsw.specvol(
-                absolute_salinity[mask],
+                absolute_slice[mask],
                 conservative_slice[mask],
                 pressure_dbar[mask],
             )
@@ -221,7 +245,7 @@ def _convert_teos10_tracers(ds, valid, z_mid):
             conservative_temperature[time_index, :, depth_index] = (
                 conservative_slice
             )
-            practical_salinity[time_index, :, depth_index] = practical_slice
+            absolute_salinity[time_index, :, depth_index] = absolute_slice
             spec_vol[time_index, :, depth_index] = spec_vol_slice
 
     ds['temperature'] = xr.DataArray(
@@ -230,15 +254,17 @@ def _convert_teos10_tracers(ds, valid, z_mid):
         attrs=temperature.attrs,
     )
     ds['salinity'] = xr.DataArray(
-        practical_salinity,
+        absolute_salinity,
         dims=salinity.dims,
         attrs=salinity.attrs,
     )
 
-    ds.temperature.attrs['standard_name'] = 'sea_water_conservative_temperature'
+    ds.temperature.attrs['standard_name'] = (
+        'sea_water_conservative_temperature'
+    )
     ds.temperature.attrs['long_name'] = 'Conservative temperature'
-    ds.salinity.attrs['standard_name'] = 'sea_water_practical_salinity'
-    ds.salinity.attrs['long_name'] = 'Practical salinity'
+    ds.salinity.attrs['standard_name'] = 'sea_water_absolute_salinity'
+    ds.salinity.attrs['long_name'] = 'Absolute salinity'
 
     return spec_vol
 
@@ -253,9 +279,37 @@ def _add_pseudo_thickness(ds, valid, spec_vol):
         attrs={
             'long_name': 'pseudo-layer thickness',
             'units': 'm',
-            'description': 'PseudoThickness = layerThickness / (RhoSw * SpecVol)',
+            'description': 'PseudoThickness = layerThickness / '
+            '(RhoSw * SpecVol)',
         },
     )
+
+
+def _compute_linear_spec_vol(ds, valid):
+    required_vars = ['temperature', 'salinity']
+    missing = [name for name in required_vars if name not in ds.variables]
+    if missing:
+        raise ValueError(
+            f'Missing required variables for linear EOS: {missing}'
+        )
+
+    # Match Omega LinearEos defaults in Eos.h:
+    # SpecVol = 1 / (RhoT0S0 + DRhodT*T + DRhodS*S)
+    drhodt = -0.2
+    drhods = 0.8
+    rho_t0s0 = 1.000e3
+
+    density = (
+        rho_t0s0
+        + drhodt * ds['temperature'].values
+        + drhods * ds['salinity'].values
+    )
+    spec_vol = np.full(ds['layerThickness'].shape, np.nan)
+
+    mask = valid & np.isfinite(density) & (density > 0.0)
+    spec_vol[mask] = 1.0 / density[mask]
+
+    return spec_vol
 
 
 def _zero_velocity_fields(ds):
@@ -271,7 +325,10 @@ def _zero_velocity_fields(ds):
 def _map_mpaso_to_omega(ds):
     yaml_path = (
         Path(__file__).resolve().parents[2]
-        / 'polaris' / 'ocean' / 'model' / 'mpaso_to_omega.yaml'
+        / 'polaris'
+        / 'ocean'
+        / 'model'
+        / 'mpaso_to_omega.yaml'
     )
     mapping_text = yaml_path.read_text()
     yaml = YAML(typ='rt')
@@ -280,31 +337,15 @@ def _map_mpaso_to_omega(ds):
     dim_map = mapping['dimensions']
     var_map = mapping['variables']
 
-    rename = {name: target for name, target in dim_map.items() if name in ds.dims}
-    rename_vars = {name: target for name, target in var_map.items() if name in ds}
+    rename = {
+        name: target for name, target in dim_map.items() if name in ds.dims
+    }
+    rename_vars = {
+        name: target for name, target in var_map.items() if name in ds
+    }
     rename.update(rename_vars)
 
     return ds.rename(rename)
-
-
-def _rename_geom_vars_for_omega(ds):
-    rename = {}
-
-    if 'zMid' in ds.variables:
-        rename['zMid'] = 'GeomZMid'
-
-    if 'refZMid' in ds.variables:
-        rename['refZMid'] = 'RefGeomZMid'
-
-    if 'LayerThickness' in ds.variables:
-        rename['LayerThickness'] = 'GeomLayerThickness'
-    elif 'layerThickness' in ds.variables:
-        rename['layerThickness'] = 'GeomLayerThickness'
-
-    if rename:
-        ds = ds.rename(rename)
-
-    return ds
 
 
 def main():

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+
+import gsw
+import numpy as np
+import xarray as xr
+from ruamel.yaml import YAML
+
+from polaris.constants import get_constant
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Convert MPAS-Ocean initial conditions to Omega variable names, '
+            'convert TEOS-10 tracers (pt/SA -> CT/SP), zero velocity fields, '
+            'and add PseudoThickness.'
+        )
+    )
+    parser.add_argument(
+        '--input-file',
+        required=True,
+        help='Input MPAS-Ocean initial condition file.',
+    )
+    parser.add_argument(
+        '--output-file',
+        required=True,
+        help=(
+            'Base output initial condition file with Omega names. The script '
+            'appends .teos10eos.nc or .lineareos.nc based on --eos-type.'
+        ),
+    )
+    parser.add_argument(
+        '--zero-velocity-mpas-file',
+        help=(
+            'Output MPAS-O initial condition file with only velocity fields '
+            'zeroed. If omitted, defaults to <input-file>.zero_velocity.nc.'
+        ),
+    )
+    parser.add_argument(
+        '--eos-type',
+        choices=['teos10', 'linear'],
+        default='teos10',
+        help=(
+            'Equation of state mode: teos10 converts tracers '
+            '(pt/SA -> CT/SP), linear leaves tracers unchanged '
+            '(potential temperature and absolute salinity).'
+        ),
+    )
+    return parser.parse_args()
+
+
+def convert_to_omega(input_file, output_file, eos_type, zero_velocity_mpas_file):
+    with xr.open_dataset(input_file, decode_times=False) as ds_in:
+        ds = ds_in.load()
+
+    output_file = _append_eos_suffix(output_file, eos_type)
+
+    if zero_velocity_mpas_file is None:
+        input_path = Path(input_file)
+        zero_velocity_mpas_file = (
+            str(input_path.with_suffix('')) + '.zero_velocity.nc'
+        )
+
+    ds_mpas_zero = ds.copy(deep=True)
+    mpas_velocity_fields = _zero_velocity_fields(ds_mpas_zero)
+    ds_mpas_zero.to_netcdf(zero_velocity_mpas_file)
+    print(f'Wrote {zero_velocity_mpas_file}')
+    if mpas_velocity_fields:
+        print(
+            'Zeroed MPAS velocity fields: '
+            f'{", ".join(mpas_velocity_fields)}'
+        )
+    else:
+        print('No MPAS velocity fields found to zero')
+
+    required_vars = ['layerThickness']
+    missing = [name for name in required_vars if name not in ds.variables]
+    if missing:
+        raise ValueError(f'Missing required variables: {missing}')
+
+    valid = ds['layerThickness'].values > 0.0
+    if eos_type == 'teos10':
+        z_mid = _get_z_mid(ds)
+        spec_vol = _convert_teos10_tracers(ds, valid, z_mid)
+    else:
+        spec_vol = 1.0 / get_constant('seawater_density_reference')
+
+    _add_pseudo_thickness(ds, valid, spec_vol)
+    velocity_fields = _zero_velocity_fields(ds)
+    ds = _map_mpaso_to_omega(ds)
+
+    ds.to_netcdf(output_file)
+
+    print(f'Wrote {output_file}')
+    if eos_type == 'teos10':
+        print('Converted temperature: potential -> conservative')
+        print('Converted salinity: absolute -> practical')
+    else:
+        print(
+            'Kept temperature and salinity unchanged '
+            '(potential temperature and absolute salinity)'
+        )
+    print('Added PseudoThickness')
+    if velocity_fields:
+        print(f'Zeroed velocity fields: {", ".join(velocity_fields)}')
+    else:
+        print('No velocity fields found to zero')
+
+
+def _to_degrees(angle):
+    finite = np.isfinite(angle)
+    if not np.any(finite):
+        return angle
+    max_abs = np.nanmax(np.abs(angle[finite]))
+    if max_abs <= 2.0 * np.pi + 1.0e-12:
+        return np.rad2deg(angle)
+    return angle
+
+
+def _append_eos_suffix(output_file, eos_type):
+    eos_suffix = '.teos10eos.nc' if eos_type == 'teos10' else '.lineareos.nc'
+
+    if output_file.endswith('.teos10eos.nc') or output_file.endswith(
+        '.lineareos.nc'
+    ):
+        return output_file
+
+    if output_file.endswith('.nc'):
+        return f'{output_file[:-3]}{eos_suffix}'
+
+    return f'{output_file}{eos_suffix}'
+
+
+def _get_z_mid(ds):
+    required_vars = ['layerThickness', 'bottomDepth']
+    missing = [name for name in required_vars if name not in ds.variables]
+    if missing:
+        raise ValueError(
+            f'Missing required variables for depth computation: {missing}'
+        )
+
+    layer_thickness = ds['layerThickness'].values
+    bottom_depth = ds['bottomDepth'].values[np.newaxis, :, np.newaxis]
+    total_thickness = np.sum(layer_thickness, axis=2, keepdims=True)
+    ssh = total_thickness - bottom_depth
+    z_top = ssh - np.concatenate(
+        [
+            np.zeros(layer_thickness.shape[:2] + (1,), dtype=float),
+            np.cumsum(layer_thickness[:, :, :-1], axis=2),
+        ],
+        axis=2,
+    )
+    return z_top - 0.5 * layer_thickness
+
+
+def _convert_teos10_tracers(ds, valid, z_mid):
+    required_vars = [
+        'temperature',
+        'salinity',
+        'latCell',
+        'lonCell',
+    ]
+    missing = [name for name in required_vars if name not in ds.variables]
+    if missing:
+        raise ValueError(f'Missing required variables: {missing}')
+
+    temperature = ds['temperature']
+    salinity = ds['salinity']
+
+    lat = _to_degrees(ds['latCell'].values)
+    lon = _to_degrees(ds['lonCell'].values)
+
+    conservative_temperature = np.full(temperature.shape, np.nan)
+    practical_salinity = np.full(salinity.shape, np.nan)
+    spec_vol = np.full(ds['layerThickness'].shape, np.nan)
+
+    for time_index in range(ds.sizes['Time']):
+        for depth_index in range(ds.sizes['nVertLevels']):
+            potential_temperature = temperature.isel(
+                Time=time_index, nVertLevels=depth_index
+            ).values
+            absolute_salinity = salinity.isel(
+                Time=time_index, nVertLevels=depth_index
+            ).values
+            z = z_mid[time_index, :, depth_index]
+            pressure_dbar = gsw.p_from_z(z, lat)
+
+            mask = (
+                np.isfinite(potential_temperature)
+                & np.isfinite(absolute_salinity)
+                & np.isfinite(pressure_dbar)
+                & np.isfinite(lat)
+                & np.isfinite(lon)
+                & valid[time_index, :, depth_index]
+            )
+
+            conservative_slice = np.full(potential_temperature.shape, np.nan)
+            practical_slice = np.full(absolute_salinity.shape, np.nan)
+            spec_vol_slice = np.full(absolute_salinity.shape, np.nan)
+
+            conservative_slice[mask] = gsw.CT_from_pt(
+                absolute_salinity[mask],
+                potential_temperature[mask],
+            )
+            practical_slice[mask] = gsw.SP_from_SA(
+                absolute_salinity[mask],
+                pressure_dbar[mask],
+                lon[mask],
+                lat[mask],
+            )
+            spec_vol_slice[mask] = gsw.specvol(
+                absolute_salinity[mask],
+                conservative_slice[mask],
+                pressure_dbar[mask],
+            )
+
+            conservative_temperature[time_index, :, depth_index] = (
+                conservative_slice
+            )
+            practical_salinity[time_index, :, depth_index] = practical_slice
+            spec_vol[time_index, :, depth_index] = spec_vol_slice
+
+    ds['temperature'] = xr.DataArray(
+        conservative_temperature,
+        dims=temperature.dims,
+        attrs=temperature.attrs,
+    )
+    ds['salinity'] = xr.DataArray(
+        practical_salinity,
+        dims=salinity.dims,
+        attrs=salinity.attrs,
+    )
+
+    ds.temperature.attrs['standard_name'] = 'sea_water_conservative_temperature'
+    ds.temperature.attrs['long_name'] = 'Conservative temperature'
+    ds.salinity.attrs['standard_name'] = 'sea_water_practical_salinity'
+    ds.salinity.attrs['long_name'] = 'Practical salinity'
+
+    return spec_vol
+
+
+def _add_pseudo_thickness(ds, valid, spec_vol):
+    rho_sw = get_constant('seawater_density_reference')
+    pseudo_thickness = ds['layerThickness'].values / (rho_sw * spec_vol)
+    pseudo_thickness = np.where(valid, pseudo_thickness, 0.0)
+    ds['PseudoThickness'] = xr.DataArray(
+        data=pseudo_thickness,
+        dims=ds['layerThickness'].dims,
+        attrs={
+            'long_name': 'pseudo-layer thickness',
+            'units': 'm',
+            'description': 'PseudoThickness = layerThickness / (RhoSw * SpecVol)',
+        },
+    )
+
+
+def _zero_velocity_fields(ds):
+    velocity_fields = []
+    for var_name, data_array in ds.data_vars.items():
+        is_numeric = np.issubdtype(data_array.dtype, np.number)
+        if is_numeric and 'velocity' in var_name.lower():
+            ds[var_name] = xr.zeros_like(data_array)
+            velocity_fields.append(var_name)
+    return velocity_fields
+
+
+def _map_mpaso_to_omega(ds):
+    yaml_path = (
+        Path(__file__).resolve().parents[2]
+        / 'polaris' / 'ocean' / 'model' / 'mpaso_to_omega.yaml'
+    )
+    mapping_text = yaml_path.read_text()
+    yaml = YAML(typ='rt')
+    mapping = yaml.load(mapping_text)
+
+    dim_map = mapping['dimensions']
+    var_map = mapping['variables']
+
+    rename = {name: target for name, target in dim_map.items() if name in ds.dims}
+    rename_vars = {name: target for name, target in var_map.items() if name in ds}
+    rename.update(rename_vars)
+
+    return ds.rename(rename)
+
+
+def main():
+    args = parse_args()
+    convert_to_omega(
+        args.input_file,
+        args.output_file,
+        args.eos_type,
+        args.zero_velocity_mpas_file,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -9,7 +9,6 @@ import xarray as xr
 from ruamel.yaml import YAML
 
 from polaris.constants import get_constant
-from polaris.ocean.vertical import compute_zint_zmid_from_layer_thickness
 
 
 def parse_args():
@@ -85,8 +84,7 @@ def convert_to_omega(
 
     valid = ds['layerThickness'].values > 0.0
     if eos_type == 'teos10':
-        z_mid = _get_z_mid(ds)
-        spec_vol = _convert_teos10_tracers(ds, valid, z_mid)
+        spec_vol = _convert_teos10_tracers(ds, valid)
     elif eos_type == 'linear':
         spec_vol = _compute_linear_spec_vol(ds, valid)
 
@@ -117,8 +115,8 @@ def _to_degrees(angle):
     if not np.any(finite):
         return angle
     max_abs = np.nanmax(np.abs(angle[finite]))
-    if max_abs <= 2.0 * np.pi + 1.0e-12:
-        return np.rad2deg(angle)
+    if max_abs <= 2.0 * get_constant('pi') + 1.0e-12:
+        return angle * get_constant('radian')
     return angle
 
 
@@ -136,57 +134,13 @@ def _append_eos_suffix(output_file, eos_type):
     return f'{output_file}{eos_suffix}'
 
 
-def _get_z_mid(ds):
-    if 'zMid' in ds.keys():
-        return ds['zMid']
-    else:
-        required_vars = ['layerThickness', 'bottomDepth']
-        missing = [name for name in required_vars if name not in ds.variables]
-        if missing:
-            raise ValueError(
-                f'Missing required variables for depth computation: {missing}'
-            )
-
-        layer_thickness = ds['layerThickness']
-        bottom_depth = ds['bottomDepth']
-
-        n_cells = ds.sizes['nCells']
-        n_vert_levels = ds.sizes['nVertLevels']
-
-        if 'minLevelCell' not in ds.variables:
-            min_level_cell = xr.DataArray(
-                np.zeros(n_cells, dtype=int),
-                dims=['nCells'],
-                name='minLevelCell',
-            )
-        else:
-            min_level_cell = ds['minLevelCell']
-
-        if 'maxLevelCell' not in ds.variables:
-            max_level_cell = xr.DataArray(
-                np.full(n_cells, n_vert_levels - 1, dtype=int),
-                dims=['nCells'],
-                name='maxLevelCell',
-            )
-        else:
-            max_level_cell = ds['maxLevelCell']
-
-        _, z_mid = compute_zint_zmid_from_layer_thickness(
-            layer_thickness,
-            bottom_depth,
-            min_level_cell,
-            max_level_cell,
-        )
-
-        return z_mid.values
-
-
-def _convert_teos10_tracers(ds, valid, z_mid):
+def _convert_teos10_tracers(ds, valid):
     required_vars = [
         'temperature',
         'salinity',
         'latCell',
         'lonCell',
+        'layerThickness',
     ]
     missing = [name for name in required_vars if name not in ds.variables]
     if missing:
@@ -202,39 +156,112 @@ def _convert_teos10_tracers(ds, valid, z_mid):
     absolute_salinity = np.full(salinity.shape, np.nan)
     spec_vol = np.full(ds['layerThickness'].shape, np.nan)
 
+    g = get_constant('standard_acceleration_of_gravity')
+    Pa_per_dbar = 1.0e4  # 1 dbar = 10000 Pa
+
     for time_index in range(ds.sizes['Time']):
+        # Pressure at the top interface of the current layer (dbar),
+        # accumulated downward via hydrostatic integration.
+        # Start with surface pressure from atmospheric and sea ice
+        # contributions if available, otherwise zero.
+        p_interface = np.zeros(ds.sizes['nCells'])
+        if 'atmosphericPressure' in ds:
+            p_interface = p_interface + (
+                ds['atmosphericPressure'].isel(Time=time_index).values
+                / Pa_per_dbar
+            )
+        if 'seaIcePressure' in ds:
+            p_interface = p_interface + (
+                ds['seaIcePressure'].isel(Time=time_index).values / Pa_per_dbar
+            )
+        rho_prev = np.full(ds.sizes['nCells'], np.nan)
+
         for depth_index in range(ds.sizes['nVertLevels']):
+            # Extract the current layer's potential temperature,
+            # practical salinity, and thickness
             potential_temperature = temperature.isel(
                 Time=time_index, nVertLevels=depth_index
             ).values
             practical_salinity = salinity.isel(
                 Time=time_index, nVertLevels=depth_index
             ).values
-            z = z_mid[time_index, :, depth_index]
-            pressure_dbar = gsw.p_from_z(z, lat)
+            dz = (
+                ds['layerThickness']
+                .isel(Time=time_index, nVertLevels=depth_index)
+                .values
+            )
 
-            mask = (
+            # Create a mask for valid data points where all required inputs
+            # are finite
+            base_mask = (
                 np.isfinite(potential_temperature)
                 & np.isfinite(practical_salinity)
-                & np.isfinite(pressure_dbar)
+                & np.isfinite(dz)
                 & np.isfinite(lat)
                 & np.isfinite(lon)
                 & valid[time_index, :, depth_index]
             )
 
+            # Initialize output slices with NaNs
             conservative_slice = np.full(potential_temperature.shape, np.nan)
             absolute_slice = np.full(practical_salinity.shape, np.nan)
             spec_vol_slice = np.full(practical_salinity.shape, np.nan)
 
-            conservative_slice[mask] = gsw.CT_from_pt(
-                practical_salinity[mask],
-                potential_temperature[mask],
+            # First-pass mid-layer pressure using previous layer's density
+            # For the top layer, use the interface pressure directly since
+            # we have no layer above to integrate through
+            if depth_index == 0:
+                p_mid_est = p_interface
+            else:
+                p_mid_est = p_interface + 0.5 * rho_prev * g * dz / Pa_per_dbar
+
+            # Compute SA and CT to update the mid-layer pressure
+            sa_tmp = np.full(practical_salinity.shape, np.nan)
+            mask_tmp = base_mask & np.isfinite(p_mid_est)
+            sa_tmp[mask_tmp] = gsw.SA_from_SP(
+                practical_salinity[mask_tmp],
+                p_mid_est[mask_tmp],
+                lon[mask_tmp],
+                lat[mask_tmp],
             )
+            conservative_tmp = np.full(potential_temperature.shape, np.nan)
+            mask_ct_tmp = mask_tmp & np.isfinite(sa_tmp)
+            conservative_tmp[mask_ct_tmp] = gsw.CT_from_pt(
+                sa_tmp[mask_ct_tmp],
+                potential_temperature[mask_ct_tmp],
+            )
+
+            # Compute in-situ density using the estimated mid-layer pressure
+            rho = np.full(practical_salinity.shape, np.nan)
+            mask_rho = mask_ct_tmp & np.isfinite(conservative_tmp)
+            rho[mask_rho] = gsw.rho(
+                sa_tmp[mask_rho],
+                conservative_tmp[mask_rho],
+                p_mid_est[mask_rho],
+            )
+
+            # Updated mid-layer pressure from hydrostatic integration
+            pressure_dbar = np.full(practical_salinity.shape, np.nan)
+            pressure_dbar[mask_rho] = (
+                p_interface[mask_rho]
+                + 0.5 * rho[mask_rho] * g * dz[mask_rho] / Pa_per_dbar
+            )
+
+            # Final mask for valid points where we can compute absolute
+            # salinity and specific volume
+            mask = base_mask & np.isfinite(pressure_dbar)
+
+            # Compute final SA, CT, and specific volume for valid points using
+            # the updated mid-layer pressure.
             absolute_slice[mask] = gsw.SA_from_SP(
                 practical_salinity[mask],
                 pressure_dbar[mask],
                 lon[mask],
                 lat[mask],
+            )
+            conservative_slice[mask] = gsw.CT_from_pt(
+                absolute_slice[mask],
+                potential_temperature[mask],
             )
             spec_vol_slice[mask] = gsw.specvol(
                 absolute_slice[mask],
@@ -242,11 +269,22 @@ def _convert_teos10_tracers(ds, valid, z_mid):
                 pressure_dbar[mask],
             )
 
+            # Store the converted tracers and specific volume back into the
+            # output arrays
             conservative_temperature[time_index, :, depth_index] = (
                 conservative_slice
             )
             absolute_salinity[time_index, :, depth_index] = absolute_slice
             spec_vol[time_index, :, depth_index] = spec_vol_slice
+
+            # Advance interface pressure to the bottom of this layer
+            # and carry rho forward as the first-pass for the next layer
+            p_interface = np.where(
+                mask_rho,
+                p_interface + rho * g * dz / Pa_per_dbar,
+                p_interface,
+            )
+            rho_prev = np.where(mask_rho, rho, rho_prev)
 
     ds['temperature'] = xr.DataArray(
         conservative_temperature,

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -48,7 +48,8 @@ def parse_args():
         action='store_true',
         help=(
             'Generate temperature/salinity percent-difference slice '
-            'figures and save next to the output NetCDF file.'
+            'figures and save next to the output NetCDF file. Figures '
+            'are not generated for planar meshes (i.e., on_a_sphere = 0).'
         ),
     )
     return parser.parse_args()
@@ -113,15 +114,15 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
     velocity_fields = _zero_velocity_fields(ds_omega)
     if ds_omega.attrs['sphere_radius'] > 0.0:
         _rescale_sphere_radius(ds_omega)
-
-    if visualization:
-        _save_percent_difference_visualizations(
-            ds_original=ds_mpas_zero,
-            ds_omega=ds_omega,
-            output_file=output_file,
-        )
+        if visualization:
+            _save_percent_difference_visualizations(
+                ds_original=ds_mpas_zero,
+                ds_omega=ds_omega,
+                output_file=output_file,
+            )
 
     ds_omega = _map_mpaso_to_omega(ds_omega)
+    ds_omega = _rename_resting_thickness_for_omega(ds_omega)
     _keep_selected_global_attrs(ds_omega)
 
     write_netcdf(ds_omega, output_file)
@@ -149,6 +150,7 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
     print(
         'Renamed variables to Omega names based on mpaso_to_omega.yaml mapping'
     )
+    print('Renamed refLayerThickness to RefPseudoThickness for Omega output')
     print('Removed unnecessary global attributes')
     if visualization:
         print('Saved temperature/salinity percent-difference visualizations')
@@ -497,6 +499,12 @@ def _map_mpaso_to_omega(ds):
     rename.update(rename_vars)
 
     return ds.rename(rename)
+
+
+def _rename_resting_thickness_for_omega(ds):
+    if 'restingThickness' in ds.variables:
+        ds = ds.rename({'restingThickness': 'RefPseudoThickness'})
+    return ds
 
 
 def _select_visualization_levels(ds_original, count=5):

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -33,13 +33,6 @@ def parse_args():
         ),
     )
     parser.add_argument(
-        '--zero-velocity-mpas-file',
-        help=(
-            'Output MPAS-O initial condition file with only velocity fields '
-            'zeroed. If omitted, defaults to <input-file>.zero_velocity.nc.'
-        ),
-    )
-    parser.add_argument(
         '--eos-type',
         choices=['teos10', 'linear'],
         default='teos10',
@@ -52,30 +45,38 @@ def parse_args():
     return parser.parse_args()
 
 
-def convert_to_omega(
-    input_file, output_file, eos_type, zero_velocity_mpas_file
-):
+def convert_to_omega(input_file, output_file, eos_type):
     with xr.open_dataset(input_file, decode_times=False) as ds_in:
         ds = ds_in.load()
 
     output_file = _append_eos_suffix(output_file, eos_type)
 
-    if zero_velocity_mpas_file is None:
-        input_path = Path(input_file)
-        zero_velocity_mpas_file = (
-            str(input_path.with_suffix('')) + '.zero_velocity.nc'
-        )
+    input_path = Path(input_file)
+    zero_velocity_mpas_file = str(input_path.with_suffix('')) + '.mpas.nc'
 
     ds_mpas_zero = ds.copy(deep=True)
     mpas_velocity_fields = _zero_velocity_fields(ds_mpas_zero)
+    _rescale_sphere_radius(ds_mpas_zero)
+    _keep_selected_global_attrs(ds_mpas_zero)
+
+    # Remove unlimited dimensions that don't exist in the current dataset
+    if 'unlimited_dims' in ds_mpas_zero.encoding:
+        ds_mpas_zero.encoding['unlimited_dims'] = [
+            d
+            for d in ds_mpas_zero.encoding['unlimited_dims']
+            if d in ds_mpas_zero.dims
+        ]
     ds_mpas_zero.to_netcdf(zero_velocity_mpas_file)
     print(f'Wrote {zero_velocity_mpas_file}')
+    print(
+        'Rescaled MPAS earth radius, coordinates, and areas based on '
+        'earth radius in pcd.yaml'
+    )
     if mpas_velocity_fields:
-        print(
-            f'Zeroed MPAS velocity fields: {", ".join(mpas_velocity_fields)}'
-        )
+        print(f'Zeroed velocity fields: {", ".join(mpas_velocity_fields)}')
     else:
-        print('No MPAS velocity fields found to zero')
+        print('No velocity fields found to zero')
+    print('Removed unnecessary global attributes')
 
     required_vars = ['layerThickness']
     missing = [name for name in required_vars if name not in ds.variables]
@@ -90,24 +91,41 @@ def convert_to_omega(
 
     _add_pseudo_thickness(ds, valid, spec_vol)
     velocity_fields = _zero_velocity_fields(ds)
+    _rescale_sphere_radius(ds)
     ds = _map_mpaso_to_omega(ds)
+    _keep_selected_global_attrs(ds)
 
+    # Remove unlimited dimensions that don't exist in the current dataset
+    if 'unlimited_dims' in ds.encoding:
+        ds.encoding['unlimited_dims'] = [
+            d for d in ds.encoding['unlimited_dims'] if d in ds.dims
+        ]
     ds.to_netcdf(output_file)
 
     print(f'Wrote {output_file}')
     if eos_type == 'teos10':
-        print('Converted temperature: potential -> conservative')
-        print('Converted salinity: practical -> absolute')
+        print(
+            'Converted to Omega TEOS-10 temperature: potential -> conservative'
+        )
+        print('Converted to Omega TEOS-10 salinity: practical -> absolute')
     else:
         print(
             'Kept temperature and salinity unchanged '
             '(potential temperature and practical salinity)'
         )
-    print('Added PseudoThickness')
+    print('Added Omega variable PseudoThickness')
+    print(
+        'Rescaled Omega earth radius, coordinates, and areas based on '
+        'earth radius in pcd.yaml'
+    )
     if velocity_fields:
         print(f'Zeroed velocity fields: {", ".join(velocity_fields)}')
     else:
         print('No velocity fields found to zero')
+    print(
+        'Renamed variables to Omega names based on mpaso_to_omega.yaml mapping'
+    )
+    print('Removed unnecessary global attributes')
 
 
 def _to_degrees(angle):
@@ -350,6 +368,75 @@ def _compute_linear_spec_vol(ds, valid):
     return spec_vol
 
 
+def _rescale_sphere_radius(ds):
+    if 'sphere_radius' not in ds.attrs:
+        raise ValueError(
+            'Global attribute sphere_radius is required to rescale xCell'
+        )
+
+    sphere_radius = float(ds.attrs['sphere_radius'])
+    if sphere_radius <= 0.0:
+        raise ValueError(f'Invalid sphere_radius: {sphere_radius}')
+
+    mean_radius = get_constant('mean_radius')
+
+    # Rescale coordinates and areas based on the ratio of mean_radius
+    # in pcd.yaml versus sphere_radius in input file
+    ds['xCell'] = mean_radius * ds['xCell'] / sphere_radius
+    ds['yCell'] = mean_radius * ds['yCell'] / sphere_radius
+    ds['zCell'] = mean_radius * ds['zCell'] / sphere_radius
+
+    ds['xEdge'] = mean_radius * ds['xEdge'] / sphere_radius
+    ds['yEdge'] = mean_radius * ds['yEdge'] / sphere_radius
+    ds['zEdge'] = mean_radius * ds['zEdge'] / sphere_radius
+
+    ds['xVertex'] = mean_radius * ds['xVertex'] / sphere_radius
+    ds['yVertex'] = mean_radius * ds['yVertex'] / sphere_radius
+    ds['zVertex'] = mean_radius * ds['zVertex'] / sphere_radius
+
+    ds['dcEdge'] = mean_radius * ds['dcEdge'] / sphere_radius
+    ds['dvEdge'] = mean_radius * ds['dvEdge'] / sphere_radius
+
+    ds['areaCell'] = (
+        mean_radius
+        * mean_radius
+        * ds['areaCell']
+        / (sphere_radius * sphere_radius)
+    )
+    ds['areaTriangle'] = (
+        mean_radius
+        * mean_radius
+        * ds['areaTriangle']
+        / (sphere_radius * sphere_radius)
+    )
+    ds['kiteAreasOnVertex'] = (
+        mean_radius
+        * mean_radius
+        * ds['kiteAreasOnVertex']
+        / (sphere_radius * sphere_radius)
+    )
+
+    # Update sphere_radius global attribute to be consistent with mean_radius
+    # in pcd.yaml
+    ds.attrs['sphere_radius'] = mean_radius
+
+
+def _keep_selected_global_attrs(ds):
+    keep_attrs = {
+        'on_a_sphere',
+        'sphere_radius',
+        'is_periodic',
+        'x_period',
+        'y_period',
+        'mesh_spec',
+        'Conventions',
+        'file_id',
+    }
+    ds.attrs = {
+        name: value for name, value in ds.attrs.items() if name in keep_attrs
+    }
+
+
 def _zero_velocity_fields(ds):
     velocity_fields = []
     for var_name, data_array in ds.data_vars.items():
@@ -392,7 +479,6 @@ def main():
         args.input_file,
         args.output_file,
         args.eos_type,
-        args.zero_velocity_mpas_file,
     )
 
 

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import gsw
 import numpy as np
 import xarray as xr
+from mpas_tools.io import write_netcdf
 from ruamel.yaml import YAML
 
 from polaris.constants import get_constant
@@ -42,31 +43,32 @@ def parse_args():
             '(potential temperature and practical salinity).'
         ),
     )
+    parser.add_argument(
+        '--visualization',
+        action='store_true',
+        help=(
+            'Generate temperature/salinity percent-difference slice '
+            'figures and save next to the output NetCDF file.'
+        ),
+    )
     return parser.parse_args()
 
 
-def convert_to_omega(input_file, output_file, eos_type):
+def convert_to_omega(input_file, output_file, eos_type, visualization=False):
     with xr.open_dataset(input_file, decode_times=False) as ds_in:
-        ds = ds_in.load()
+        ds_input = ds_in.load()
 
     output_file = _append_eos_suffix(output_file, eos_type)
 
     input_path = Path(input_file)
     zero_velocity_mpas_file = str(input_path.with_suffix('')) + '.mpas.nc'
 
-    ds_mpas_zero = ds.copy(deep=True)
+    ds_mpas_zero = ds_input.copy(deep=True)
     mpas_velocity_fields = _zero_velocity_fields(ds_mpas_zero)
     _rescale_sphere_radius(ds_mpas_zero)
     _keep_selected_global_attrs(ds_mpas_zero)
 
-    # Remove unlimited dimensions that don't exist in the current dataset
-    if 'unlimited_dims' in ds_mpas_zero.encoding:
-        ds_mpas_zero.encoding['unlimited_dims'] = [
-            d
-            for d in ds_mpas_zero.encoding['unlimited_dims']
-            if d in ds_mpas_zero.dims
-        ]
-    ds_mpas_zero.to_netcdf(zero_velocity_mpas_file)
+    write_netcdf(ds_mpas_zero, zero_velocity_mpas_file)
     print(f'Wrote {zero_velocity_mpas_file}')
     print(
         'Rescaled MPAS earth radius, coordinates, and areas based on '
@@ -79,28 +81,47 @@ def convert_to_omega(input_file, output_file, eos_type):
     print('Removed unnecessary global attributes')
 
     required_vars = ['layerThickness']
-    missing = [name for name in required_vars if name not in ds.variables]
+    missing = [
+        name for name in required_vars if name not in ds_input.variables
+    ]
     if missing:
         raise ValueError(f'Missing required variables: {missing}')
 
-    valid = ds['layerThickness'].values > 0.0
+    # Keep the original input dataset untouched; all Omega transforms
+    # happen on a separate working copy.
+    ds_omega = ds_input.copy(deep=True)
+
+    # Create valid mask with shape (Time, nCells, nVertLevels)
+    layer_thickness_valid = ds_omega['layerThickness'].values > 0.0
+    if layer_thickness_valid.ndim == 2:
+        # Broadcast (nCells, nVertLevels) to (nTime, nCells, nVertLevels)
+        valid = np.tile(
+            layer_thickness_valid[np.newaxis, :, :],
+            (ds_omega.sizes['Time'], 1, 1),
+        )
+    else:
+        valid = layer_thickness_valid
+
     if eos_type == 'teos10':
-        spec_vol = _convert_teos10_tracers(ds, valid)
+        spec_vol = _convert_teos10_tracers(ds_omega, valid)
     elif eos_type == 'linear':
-        spec_vol = _compute_linear_spec_vol(ds, valid)
+        spec_vol = _compute_linear_spec_vol(ds_omega, valid)
 
-    _add_pseudo_thickness(ds, valid, spec_vol)
-    velocity_fields = _zero_velocity_fields(ds)
-    _rescale_sphere_radius(ds)
-    ds = _map_mpaso_to_omega(ds)
-    _keep_selected_global_attrs(ds)
+    _add_pseudo_thickness(ds_omega, valid, spec_vol)
+    velocity_fields = _zero_velocity_fields(ds_omega)
+    _rescale_sphere_radius(ds_omega)
 
-    # Remove unlimited dimensions that don't exist in the current dataset
-    if 'unlimited_dims' in ds.encoding:
-        ds.encoding['unlimited_dims'] = [
-            d for d in ds.encoding['unlimited_dims'] if d in ds.dims
-        ]
-    ds.to_netcdf(output_file)
+    if visualization:
+        _save_percent_difference_visualizations(
+            ds_original=ds_mpas_zero,
+            ds_omega=ds_omega,
+            output_file=output_file,
+        )
+
+    ds_omega = _map_mpaso_to_omega(ds_omega)
+    _keep_selected_global_attrs(ds_omega)
+
+    write_netcdf(ds_omega, output_file)
 
     print(f'Wrote {output_file}')
     if eos_type == 'teos10':
@@ -126,6 +147,8 @@ def convert_to_omega(input_file, output_file, eos_type):
         'Renamed variables to Omega names based on mpaso_to_omega.yaml mapping'
     )
     print('Removed unnecessary global attributes')
+    if visualization:
+        print('Saved temperature/salinity percent-difference visualizations')
 
 
 def _to_degrees(angle):
@@ -473,12 +496,218 @@ def _map_mpaso_to_omega(ds):
     return ds.rename(rename)
 
 
+def _select_visualization_levels(ds_original, count=5):
+    n_levels = ds_original.sizes['nVertLevels']
+    if n_levels <= 1:
+        return np.array([0], dtype=int), np.array([0.0])
+
+    raw = np.array(
+        [
+            0,
+            max(1, n_levels // 4),
+            max(1, n_levels // 2),
+            max(1, (3 * n_levels) // 4),
+            n_levels - 1,
+        ],
+        dtype=int,
+    )
+    levels = np.unique(np.clip(raw, 0, n_levels - 1))
+    if levels.size < count:
+        levels = np.unique(
+            np.round(np.linspace(0, n_levels - 1, count)).astype(int)
+        )
+
+    layer_thickness = ds_original['layerThickness'].isel(Time=0).values
+    valid = layer_thickness > 0.0
+    z_interface = np.zeros(
+        (ds_original.sizes['nCells'], ds_original.sizes['nVertLevels'] + 1)
+    )
+    z_interface[:, 1:] = np.cumsum(layer_thickness, axis=1)
+    z_mid = 0.5 * (z_interface[:, :-1] + z_interface[:, 1:])
+    ref_z = np.nanmedian(np.where(valid, z_mid, np.nan), axis=0)
+
+    return levels, ref_z[levels]
+
+
+def _save_percent_difference_visualizations(
+    ds_original, ds_omega, output_file
+):
+    try:
+        import cartopy.crs as ccrs
+        import cartopy.feature as cfeature
+        import cmocean
+        import matplotlib.colors as mcolors
+        import matplotlib.pyplot as plt
+        import mosaic
+    except ImportError as exc:
+        raise ImportError(
+            'Visualization requires cartopy, cmocean, matplotlib, and mosaic.'
+        ) from exc
+
+    transform = ccrs.Geodetic()
+
+    ds_mesh = ds_original.copy(deep=False)
+    ds_mesh.attrs['is_periodic'] = 'NO'
+    salinity_projection = ccrs.PlateCarree(central_longitude=0.0)
+    temperature_projection = ccrs.PlateCarree(central_longitude=180.0)
+    salinity_descriptor = mosaic.Descriptor(
+        ds_mesh,
+        projection=salinity_projection,
+        transform=transform,
+        use_latlon=True,
+    )
+    temperature_descriptor = mosaic.Descriptor(
+        ds_mesh,
+        projection=temperature_projection,
+        transform=transform,
+        use_latlon=True,
+    )
+
+    levels, depths = _select_visualization_levels(ds_original, count=5)
+    valid_original = ds_original['layerThickness'].isel(Time=0).values > 0.0
+    valid_omega = ds_omega['layerThickness'].isel(Time=0).values > 0.0
+    output_path = Path(output_file)
+
+    def _plot_variable(var_name, label):
+        diff_slices = []
+        for level in levels:
+            original = (
+                ds_original[var_name].isel(Time=0, nVertLevels=level).values
+            )
+            omega = ds_omega[var_name].isel(Time=0, nVertLevels=level).values
+            valid = (
+                valid_original[:, level]
+                & valid_omega[:, level]
+                & np.isfinite(original)
+                & np.isfinite(omega)
+                & (np.abs(omega) > 1.0e-12)
+            )
+            diff_field = np.full(original.shape, np.nan)
+            if var_name == 'temperature':
+                diff_field[valid] = original[valid] - omega[valid]
+            else:
+                diff_field[valid] = (
+                    100.0 * (omega[valid] - original[valid]) / omega[valid]
+                )
+            diff_slices.append(diff_field)
+
+        all_values = np.concatenate(
+            [values[np.isfinite(values)] for values in diff_slices]
+        )
+        max_abs = (
+            float(np.nanpercentile(np.abs(all_values), 99))
+            if all_values.size > 0
+            else 1.0
+        )
+        if max_abs <= 0.0:
+            max_abs = 1.0
+
+        if var_name == 'temperature':
+            projection = temperature_projection
+            descriptor = temperature_descriptor
+        else:
+            projection = salinity_projection
+            descriptor = salinity_descriptor
+
+        fig, axes = plt.subplots(
+            len(levels),
+            1,
+            figsize=(10, 4.5 * len(levels)),
+            subplot_kw=dict(projection=projection),
+            constrained_layout=True,
+        )
+        if len(levels) == 1:
+            axes = [axes]
+
+        if var_name == 'temperature':
+            fig.suptitle(
+                f'{label} absolute difference: MPAS-Ocean - Omega',
+                fontsize=12,
+                y=1.01,
+            )
+        else:
+            fig.suptitle(
+                f'{label} percent difference: 100*(Omega - MPAS-Ocean)/Omega',
+                fontsize=12,
+                y=1.01,
+            )
+
+        for ax, level, depth, diff_field in zip(
+            axes, levels, depths, diff_slices, strict=True
+        ):
+            da = xr.DataArray(diff_field, dims=['nCells'])
+            if var_name == 'salinity':
+                norm = mcolors.Normalize(vmin=0.47, vmax=0.496)
+                pc = mosaic.polypcolor(
+                    ax,
+                    descriptor,
+                    da,
+                    cmap='jet',  # cmocean.cm.thermal,
+                    norm=norm,
+                    antialiased=False,
+                    zorder=2,
+                )
+            else:
+                norm = mcolors.TwoSlopeNorm(vmin=-0.2, vcenter=0.0, vmax=0.15)
+                pc = mosaic.polypcolor(
+                    ax,
+                    descriptor,
+                    da,
+                    cmap=cmocean.cm.balance,
+                    norm=norm,
+                    antialiased=False,
+                    zorder=2,
+                )
+
+            ax.add_feature(cfeature.LAND, facecolor='lightgray', zorder=3)
+            ax.add_feature(cfeature.COASTLINE, linewidth=0.4, zorder=4)
+            ax.add_feature(
+                cfeature.BORDERS, linewidth=0.2, linestyle=':', zorder=4
+            )
+            ax.gridlines(
+                color='gray',
+                linestyle=':',
+                linewidth=0.4,
+                draw_labels=False,
+                zorder=5,
+            )
+            ax.set_global()
+            ax.set_title(
+                f'Level {int(level)} | ~{float(depth):.0f} m', fontsize=9
+            )
+
+            plt.colorbar(
+                pc,
+                ax=ax,
+                orientation='vertical',
+                label='%' if var_name == 'salinity' else '\u00b0C',
+                shrink=0.7,
+                pad=0.02,
+            )
+
+        suffix = (
+            'absolute_difference'
+            if var_name == 'temperature'
+            else 'percent_difference'
+        )
+        figure_path = output_path.with_name(
+            f'{output_path.stem}_{var_name}_{suffix}.png'
+        )
+        fig.savefig(figure_path, dpi=150, bbox_inches='tight')
+        plt.close(fig)
+        print(f'Wrote {figure_path}')
+
+    _plot_variable('temperature', 'Temperature')
+    _plot_variable('salinity', 'Salinity')
+
+
 def main():
     args = parse_args()
     convert_to_omega(
         args.input_file,
         args.output_file,
         args.eos_type,
+        args.visualization,
     )
 
 

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -65,7 +65,9 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
 
     ds_mpas_zero = ds_input.copy(deep=True)
     mpas_velocity_fields = _zero_velocity_fields(ds_mpas_zero)
-    _rescale_sphere_radius(ds_mpas_zero)
+    # if ds_mpas_zero['sphere_radius'].attrs.get('value', 0.0) > 0.0:
+    if ds_mpas_zero.attrs['sphere_radius'] > 0.0:
+        _rescale_sphere_radius(ds_mpas_zero)
     _keep_selected_global_attrs(ds_mpas_zero)
 
     write_netcdf(ds_mpas_zero, zero_velocity_mpas_file)
@@ -109,7 +111,8 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
 
     _add_pseudo_thickness(ds_omega, valid, spec_vol)
     velocity_fields = _zero_velocity_fields(ds_omega)
-    _rescale_sphere_radius(ds_omega)
+    if ds_omega.attrs['sphere_radius'] > 0.0:
+        _rescale_sphere_radius(ds_omega)
 
     if visualization:
         _save_percent_difference_visualizations(

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -8,6 +8,7 @@ import numpy as np
 import xarray as xr
 from mpas_tools.io import write_netcdf
 from ruamel.yaml import YAML
+from scipy.interpolate import CubicSpline
 
 from polaris.constants import get_constant
 
@@ -47,9 +48,10 @@ def parse_args():
         '--visualization',
         action='store_true',
         help=(
-            'Generate temperature/salinity percent-difference slice '
-            'figures and save next to the output NetCDF file. Figures '
-            'are not generated for planar meshes (i.e., on_a_sphere = 0).'
+            'Generate temperature/salinity difference slices and '
+            'surface wind stress visualizations figures and save '
+            'next to the output NetCDF file. Figures are not '
+            'generated for planar meshes (i.e., on_a_sphere = 0).'
         ),
     )
     return parser.parse_args()
@@ -66,9 +68,9 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
 
     ds_mpas_zero = ds_input.copy(deep=True)
     mpas_velocity_fields = _zero_velocity_fields(ds_mpas_zero)
-    # if ds_mpas_zero['sphere_radius'].attrs.get('value', 0.0) > 0.0:
     if ds_mpas_zero.attrs['sphere_radius'] > 0.0:
         _rescale_sphere_radius(ds_mpas_zero)
+    _add_wind_stress(ds_mpas_zero)
     _keep_selected_global_attrs(ds_mpas_zero)
 
     write_netcdf(ds_mpas_zero, zero_velocity_mpas_file)
@@ -114,12 +116,13 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
     velocity_fields = _zero_velocity_fields(ds_omega)
     if ds_omega.attrs['sphere_radius'] > 0.0:
         _rescale_sphere_radius(ds_omega)
-        if visualization:
-            _save_percent_difference_visualizations(
-                ds_original=ds_mpas_zero,
-                ds_omega=ds_omega,
-                output_file=output_file,
-            )
+    _add_wind_stress(ds_omega)
+    if visualization and ds_omega.attrs.get('sphere_radius', 0.0) > 0.0:
+        _save_percent_difference_visualizations(
+            ds_original=ds_mpas_zero,
+            ds_omega=ds_omega,
+            output_file=output_file,
+        )
 
     ds_omega = _map_mpaso_to_omega(ds_omega)
     ds_omega = _rename_resting_thickness_for_omega(ds_omega)
@@ -151,6 +154,7 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
         'Renamed variables to Omega names based on mpaso_to_omega.yaml mapping'
     )
     print('Renamed refLayerThickness to RefPseudoThickness for Omega output')
+    print('Added ZonalStressCell and MeridStressCell fields')
     print('Removed unnecessary global attributes')
     if visualization:
         print('Saved temperature/salinity percent-difference visualizations')
@@ -507,6 +511,77 @@ def _rename_resting_thickness_for_omega(ds):
     return ds
 
 
+def _add_wind_stress(ds):
+    """
+    Add a wind stress fields (ZonalStressCell and MeridStressCell).
+    ZonalStressCell varies with latitude using piecewise cubic
+    interpolation, while MeridStressCell is set to zero.
+    This is a simplified representation of typical zonal wind stress
+    patterns.
+
+    The field is added to dimensions (Time, nCells) with values that depend
+    only on latitude, not longitude. Automatically detects whether the dataset
+    uses 'Time' or 'time' and 'NCells' or 'nCells' dimension names.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset to which ZonalStressCell and MeridStressCell will be added.
+        Must contain latCell.
+    """
+    # Fixed latitude-value pairs for cubic interpolation
+    # These can be modified by editing the arrays below
+    fixed_latitudes = np.array(
+        [-70.0, -45.0, -15.0, 0.0, 15.0, 45.0, 70.0]
+    )  # degrees
+    fixed_values = np.array([0.0, 0.2, -0.1, -0.02, -0.1, 0.1, 0.0])  # Pa
+
+    lat = _to_degrees(ds['latCell'].values)
+
+    # Create cubic spline interpolation function
+    cs = CubicSpline(fixed_latitudes, fixed_values, bc_type='natural')
+
+    # Interpolate wind stress zonal values at each cell's latitude
+    wind_stress_zonal_values = cs(lat)
+
+    # Zero out values outside the range of fixed_latitudes
+    outside = (lat < fixed_latitudes[0]) | (lat > fixed_latitudes[-1])
+    wind_stress_zonal_values[outside] = 0.0
+
+    # Detect which time dimension name exists in the dataset
+    ncell_dim = 'NCells' if 'NCells' in ds.dims else 'nCells'
+    time_dim = 'Time' if 'Time' in ds.dims else 'time'
+
+    # Create the field with (time_dim, nCells) dimensions
+    n_time = ds.sizes[time_dim]
+    n_cells = ds.sizes[ncell_dim]
+    wind_stress_zonal = np.tile(
+        wind_stress_zonal_values[np.newaxis, :], (n_time, 1)
+    )
+
+    ds['ZonalStressCell'] = xr.DataArray(
+        data=wind_stress_zonal,
+        dims=[time_dim, ncell_dim],
+        attrs={
+            'long_name': 'zonal wind stress',
+            'units': 'N m^{-2}',
+            'standard_name': '',
+        },
+    )
+
+    # Create meridional wind stress field (set to zero)
+    wind_stress_merid = np.zeros((n_time, n_cells))
+    ds['MeridStressCell'] = xr.DataArray(
+        data=wind_stress_merid,
+        dims=[time_dim, ncell_dim],
+        attrs={
+            'long_name': 'meridional wind stress',
+            'units': 'N m^{-2}',
+            'standard_name': '',
+        },
+    )
+
+
 def _select_visualization_levels(ds_original, count=5):
     n_levels = ds_original.sizes['nVertLevels']
     if n_levels <= 1:
@@ -708,8 +783,70 @@ def _save_percent_difference_visualizations(
         plt.close(fig)
         print(f'Wrote {figure_path}')
 
+    def _plot_surface_variable(var_name, label, ds_omega_local):
+        if var_name not in ds_omega_local.variables:
+            return
+
+        field = ds_omega_local[var_name].isel(Time=0).values
+        valid = np.isfinite(field) & (field != 0.0)
+
+        if not np.any(valid):
+            return
+
+        fig, ax = plt.subplots(
+            1,
+            1,
+            figsize=(14, 8),
+            subplot_kw=dict(projection=salinity_projection),
+            constrained_layout=True,
+        )
+
+        da = xr.DataArray(field, dims=['nCells'])
+        norm = mcolors.TwoSlopeNorm(vmin=-0.2, vcenter=0.0, vmax=0.2)
+        pc = mosaic.polypcolor(
+            ax,
+            salinity_descriptor,
+            da,
+            cmap='coolwarm',
+            norm=norm,
+            antialiased=False,
+            zorder=2,
+        )
+
+        ax.add_feature(cfeature.LAND, facecolor='lightgray', zorder=3)
+        ax.add_feature(cfeature.COASTLINE, linewidth=0.4, zorder=4)
+        ax.add_feature(
+            cfeature.BORDERS, linewidth=0.2, linestyle=':', zorder=4
+        )
+        ax.gridlines(
+            color='gray',
+            linestyle=':',
+            linewidth=0.4,
+            draw_labels=False,
+            zorder=5,
+        )
+        ax.set_global()
+        ax.set_title(f'{label} (surface)', fontsize=12)
+
+        plt.colorbar(
+            pc,
+            ax=ax,
+            orientation='vertical',
+            label=r'N m^{-2}',
+            shrink=0.7,
+            pad=0.02,
+        )
+
+        figure_path = output_path.with_name(
+            f'{output_path.stem}_{var_name}.png'
+        )
+        fig.savefig(figure_path, dpi=150, bbox_inches='tight')
+        plt.close(fig)
+        print(f'Wrote {figure_path}')
+
     _plot_variable('temperature', 'Temperature')
     _plot_variable('salinity', 'Salinity')
+    _plot_surface_variable('ZonalStressCell', 'Zonal Wind Stress', ds_omega)
 
 
 def main():

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -154,7 +154,7 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
         'Renamed variables to Omega names based on mpaso_to_omega.yaml mapping'
     )
     print('Renamed refLayerThickness to RefPseudoThickness for Omega output')
-    print('Added ZonalStressCell and MeridStressCell fields')
+    print('Added WindStressZonal and WindStressMeridional fields')
     print('Removed unnecessary global attributes')
     if visualization:
         print('Saved temperature/salinity percent-difference visualizations')
@@ -513,9 +513,9 @@ def _rename_resting_thickness_for_omega(ds):
 
 def _add_wind_stress(ds):
     """
-    Add a wind stress fields (ZonalStressCell and MeridStressCell).
-    ZonalStressCell varies with latitude using piecewise cubic
-    interpolation, while MeridStressCell is set to zero.
+    Add a wind stress fields (WindStressZonal and WindStressMeridional).
+    WindStressZonal varies with latitude using piecewise cubic
+    interpolation, while WindStressMeridional is set to zero.
     This is a simplified representation of typical zonal wind stress
     patterns.
 
@@ -526,8 +526,8 @@ def _add_wind_stress(ds):
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset to which ZonalStressCell and MeridStressCell will be added.
-        Must contain latCell.
+        Dataset to which WindStressZonal and WindStressMeridional will be
+        added. Must contain latCell.
     """
     # Fixed latitude-value pairs for cubic interpolation
     # These can be modified by editing the arrays below
@@ -559,7 +559,7 @@ def _add_wind_stress(ds):
         wind_stress_zonal_values[np.newaxis, :], (n_time, 1)
     )
 
-    ds['ZonalStressCell'] = xr.DataArray(
+    ds['WindStressZonal'] = xr.DataArray(
         data=wind_stress_zonal,
         dims=[time_dim, ncell_dim],
         attrs={
@@ -571,7 +571,7 @@ def _add_wind_stress(ds):
 
     # Create meridional wind stress field (set to zero)
     wind_stress_merid = np.zeros((n_time, n_cells))
-    ds['MeridStressCell'] = xr.DataArray(
+    ds['WindStressMeridional'] = xr.DataArray(
         data=wind_stress_merid,
         dims=[time_dim, ncell_dim],
         attrs={
@@ -846,7 +846,7 @@ def _save_percent_difference_visualizations(
 
     _plot_variable('temperature', 'Temperature')
     _plot_variable('salinity', 'Salinity')
-    _plot_surface_variable('ZonalStressCell', 'Zonal Wind Stress', ds_omega)
+    _plot_surface_variable('WindStressZonal', 'Zonal Wind Stress', ds_omega)
 
 
 def main():

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -154,7 +154,7 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
         'Renamed variables to Omega names based on mpaso_to_omega.yaml mapping'
     )
     print('Renamed refLayerThickness to RefPseudoThickness for Omega output')
-    print('Added WindStressZonal and WindStressMeridional fields')
+    print('Added SfcStressZonal and SfcStressMeridional fields')
     print('Removed unnecessary global attributes')
     if visualization:
         print('Saved temperature/salinity percent-difference visualizations')
@@ -513,9 +513,9 @@ def _rename_resting_thickness_for_omega(ds):
 
 def _add_wind_stress(ds):
     """
-    Add a wind stress fields (WindStressZonal and WindStressMeridional).
-    WindStressZonal varies with latitude using piecewise cubic
-    interpolation, while WindStressMeridional is set to zero.
+    Add a wind stress fields (SfcStressZonal and SfcStressMeridional).
+    SfcStressZonal varies with latitude using piecewise cubic
+    interpolation, while SfcStressMeridional is set to zero.
     This is a simplified representation of typical zonal wind stress
     patterns.
 
@@ -526,7 +526,7 @@ def _add_wind_stress(ds):
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset to which WindStressZonal and WindStressMeridional will be
+        Dataset to which SfcStressZonal and SfcStressMeridional will be
         added. Must contain latCell.
     """
     # Fixed latitude-value pairs for cubic interpolation
@@ -559,11 +559,11 @@ def _add_wind_stress(ds):
         wind_stress_zonal_values[np.newaxis, :], (n_time, 1)
     )
 
-    ds['WindStressZonal'] = xr.DataArray(
+    ds['SfcStressZonal'] = xr.DataArray(
         data=wind_stress_zonal,
         dims=[time_dim, ncell_dim],
         attrs={
-            'long_name': 'zonal wind stress',
+            'long_name': 'surface zonal wind stress',
             'units': 'N m^{-2}',
             'standard_name': '',
         },
@@ -571,11 +571,11 @@ def _add_wind_stress(ds):
 
     # Create meridional wind stress field (set to zero)
     wind_stress_merid = np.zeros((n_time, n_cells))
-    ds['WindStressMeridional'] = xr.DataArray(
+    ds['SfcStressMeridional'] = xr.DataArray(
         data=wind_stress_merid,
         dims=[time_dim, ncell_dim],
         attrs={
-            'long_name': 'meridional wind stress',
+            'long_name': 'surface meridional wind stress',
             'units': 'N m^{-2}',
             'standard_name': '',
         },
@@ -846,7 +846,7 @@ def _save_percent_difference_visualizations(
 
     _plot_variable('temperature', 'Temperature')
     _plot_variable('salinity', 'Salinity')
-    _plot_surface_variable('WindStressZonal', 'Zonal Wind Stress', ds_omega)
+    _plot_surface_variable('SfcStressZonal', 'Zonal Wind Stress', ds_omega)
 
 
 def main():

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -45,6 +45,11 @@ def parse_args():
         ),
     )
     parser.add_argument(
+        '--include-wind-stress',
+        action='store_true',
+        help=('Include wind stress fields.'),
+    )
+    parser.add_argument(
         '--visualization',
         action='store_true',
         help=(
@@ -57,7 +62,13 @@ def parse_args():
     return parser.parse_args()
 
 
-def convert_to_omega(input_file, output_file, eos_type, visualization=False):
+def convert_to_omega(
+    input_file,
+    output_file,
+    eos_type,
+    include_wind_stress=True,
+    visualization=False,
+):
     with xr.open_dataset(input_file, decode_times=False) as ds_in:
         ds_input = ds_in.load()
 
@@ -70,7 +81,12 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
     mpas_velocity_fields = _zero_velocity_fields(ds_mpas_zero)
     if ds_mpas_zero.attrs['sphere_radius'] > 0.0:
         _rescale_sphere_radius(ds_mpas_zero)
-    _add_wind_stress(ds_mpas_zero)
+    if include_wind_stress:
+        _add_wind_stress(
+            ds_mpas_zero,
+            zonal_name='windStressZonal',
+            meridional_name='windStressMeridional',
+        )
     _keep_selected_global_attrs(ds_mpas_zero)
 
     write_netcdf(ds_mpas_zero, zero_velocity_mpas_file)
@@ -79,6 +95,8 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
         'Rescaled MPAS earth radius, coordinates, and areas based on '
         'earth radius in pcd.yaml'
     )
+    if include_wind_stress:
+        print('Added windStressZonal and windStressMeridional fields')
     if mpas_velocity_fields:
         print(f'Zeroed velocity fields: {", ".join(mpas_velocity_fields)}')
     else:
@@ -116,7 +134,13 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
     velocity_fields = _zero_velocity_fields(ds_omega)
     if ds_omega.attrs['sphere_radius'] > 0.0:
         _rescale_sphere_radius(ds_omega)
-    _add_wind_stress(ds_omega)
+    if include_wind_stress:
+        _add_wind_stress(
+            ds_omega,
+            zonal_name='SfcStressZonal',
+            meridional_name='SfcStressMeridional',
+        )
+    _add_surface_pressure(ds_omega)
     if visualization and ds_omega.attrs.get('sphere_radius', 0.0) > 0.0:
         _save_percent_difference_visualizations(
             ds_original=ds_mpas_zero,
@@ -154,7 +178,11 @@ def convert_to_omega(input_file, output_file, eos_type, visualization=False):
         'Renamed variables to Omega names based on mpaso_to_omega.yaml mapping'
     )
     print('Renamed refLayerThickness to RefPseudoThickness for Omega output')
-    print('Added SfcStressZonal and SfcStressMeridional fields')
+    if include_wind_stress:
+        print('Added SfcStressZonal and SfcStressMeridional fields')
+    else:
+        print('Skipped SfcStressZonal and SfcStressMeridional fields')
+    print('Added SurfacePressure field')
     print('Removed unnecessary global attributes')
     if visualization:
         print('Saved temperature/salinity percent-difference visualizations')
@@ -508,27 +536,12 @@ def _map_mpaso_to_omega(ds):
 def _rename_resting_thickness_for_omega(ds):
     if 'restingThickness' in ds.variables:
         ds = ds.rename({'restingThickness': 'RefPseudoThickness'})
+    if 'layerThickness' in ds.variables:
+        ds = ds.rename({'layerThickness': 'GeomLayerThickness'})
     return ds
 
 
-def _add_wind_stress(ds):
-    """
-    Add a wind stress fields (SfcStressZonal and SfcStressMeridional).
-    SfcStressZonal varies with latitude using piecewise cubic
-    interpolation, while SfcStressMeridional is set to zero.
-    This is a simplified representation of typical zonal wind stress
-    patterns.
-
-    The field is added to dimensions (Time, nCells) with values that depend
-    only on latitude, not longitude. Automatically detects whether the dataset
-    uses 'Time' or 'time' and 'NCells' or 'nCells' dimension names.
-
-    Parameters
-    ----------
-    ds : xarray.Dataset
-        Dataset to which SfcStressZonal and SfcStressMeridional will be
-        added. Must contain latCell.
-    """
+def _add_wind_stress(ds, zonal_name, meridional_name):
     # Fixed latitude-value pairs for cubic interpolation
     # These can be modified by editing the arrays below
     fixed_latitudes = np.array(
@@ -559,7 +572,7 @@ def _add_wind_stress(ds):
         wind_stress_zonal_values[np.newaxis, :], (n_time, 1)
     )
 
-    ds['SfcStressZonal'] = xr.DataArray(
+    ds[zonal_name] = xr.DataArray(
         data=wind_stress_zonal,
         dims=[time_dim, ncell_dim],
         attrs={
@@ -571,12 +584,33 @@ def _add_wind_stress(ds):
 
     # Create meridional wind stress field (set to zero)
     wind_stress_merid = np.zeros((n_time, n_cells))
-    ds['SfcStressMeridional'] = xr.DataArray(
+    ds[meridional_name] = xr.DataArray(
         data=wind_stress_merid,
         dims=[time_dim, ncell_dim],
         attrs={
             'long_name': 'surface meridional wind stress',
             'units': 'N m^{-2}',
+            'standard_name': '',
+        },
+    )
+
+
+def _add_surface_pressure(ds):
+    # Detect which time dimension name exists in the dataset
+    ncell_dim = 'NCells' if 'NCells' in ds.dims else 'nCells'
+    time_dim = 'Time' if 'Time' in ds.dims else 'time'
+
+    # Create the field with (time_dim, nCells) dimensions
+    n_time = ds.sizes[time_dim]
+    n_cells = ds.sizes[ncell_dim]
+
+    # Create surface pressure field (set to zero)
+    ds['SurfacePressure'] = xr.DataArray(
+        data=np.zeros((n_time, n_cells)),
+        dims=[time_dim, ncell_dim],
+        attrs={
+            'long_name': 'surface pressure',
+            'units': 'Pa',
             'standard_name': '',
         },
     )
@@ -855,6 +889,7 @@ def main():
         args.input_file,
         args.output_file,
         args.eos_type,
+        args.include_wind_stress,
         args.visualization,
     )
 

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -89,7 +89,12 @@ def convert_to_omega(
         )
     _keep_selected_global_attrs(ds_mpas_zero)
 
-    write_netcdf(ds_mpas_zero, zero_velocity_mpas_file)
+    write_netcdf(
+        ds_mpas_zero,
+        zero_velocity_mpas_file,
+        format="NETCDF3_64BIT_DATA",
+        engine="netcdf4"
+    )
     print(f'Wrote {zero_velocity_mpas_file}')
     print(
         'Rescaled MPAS earth radius, coordinates, and areas based on '
@@ -152,7 +157,12 @@ def convert_to_omega(
     ds_omega = _rename_resting_thickness_for_omega(ds_omega)
     _keep_selected_global_attrs(ds_omega)
 
-    write_netcdf(ds_omega, output_file)
+    write_netcdf(
+        ds_omega,
+        output_file,
+        format="NETCDF3_64BIT_DATA",
+        engine="netcdf4"
+    )
 
     print(f'Wrote {output_file}')
     if eos_type == 'teos10':

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -92,8 +92,8 @@ def convert_to_omega(
     write_netcdf(
         ds_mpas_zero,
         zero_velocity_mpas_file,
-        format="NETCDF3_64BIT_DATA",
-        engine="netcdf4"
+        format='NETCDF3_64BIT_DATA',
+        engine='netcdf4',
     )
     print(f'Wrote {zero_velocity_mpas_file}')
     print(
@@ -158,10 +158,7 @@ def convert_to_omega(
     _keep_selected_global_attrs(ds_omega)
 
     write_netcdf(
-        ds_omega,
-        output_file,
-        format="NETCDF3_64BIT_DATA",
-        engine="netcdf4"
+        ds_omega, output_file, format='NETCDF3_64BIT_DATA', engine='netcdf4'
     )
 
     print(f'Wrote {output_file}')


### PR DESCRIPTION
PR adds a utility script to convert existing MPAS-O initial conditions to Omega initial conditions. 

In general, it:
1. converts potential temperature/absolute salinity to conservative temperature/practical salinity using the GSW toolbox
2. sets the velocity fields to zero
3. renames variables to match expected names in Omega using `mpaso_to_omega.yaml`
4. computes and adds `PseudoThickness`
5. adds `RefPseudoThickness` and sets it equal to `restingThickness` from MPAS
6. adds in two wind stress fields if flag `--include-wind-stress` is included, `WindStressMeridional` and `WindStressZonal` (or `windStressZonal` and `windStressMeridional` for MPAS-O), where the first (zonal) is set to zero everywhere and the second (meridional) is set to a latitudinally dependent piecewise polynomial wind stress profile similar to that used in the NeverWorld2 idealized configuration (Marques et al, 2022). This wind stress profile is configurable within the script, but not through the command line. 
7. add in a `SurfacePressure` field that is initialized to zero everywhere
8. outputs two netcdf files, one for Omega and one for MPAS (essentially equal to the input file but with velocity = 0, the addition of the wind stress fields (if flagged), and a reduction of unneeded metadata)

Flags:
`--input-file` (required) = input path and name of MPAS-O initial condition file.
`--output-file` (required) = output path and name of Omega initial condition file.
`--eos-type` (optional, defaults to `teos10`) = choose between `teos10` and `linear` to either convert to conservative temperature and practical salinity for use with `TEOS-10` EOS option in Omega, or keep the same potential temperature and absolute salinity for use with the `Linear` EOS option in Omega. Output file is appended with `teos10eos` or `lineareos` to help keep track.
`--include-wind-stress` (otional, defaults to off) = adds in the two idealized wind stress fields described above to both the Omega and MPAS-O output files
`--visualization` (optional, defaults to off) = produces 3 figures: 1. a comparison of the difference between surface potential temp from MPAS and surface conservative Temp from Omega, 2. a comparison of the percent difference between surface absolute salinity in Omega and the surface practical salinity in MPAS, 3. a plot of the surface zonal wind stress assigned to `WindStressZonal`.

Note: `mpaso_to_omega.yaml` does not contain all the variable names we need to convert (eg. `areaCell` to `AreaCell`). For now these are still included in the new omega ic file, but with the old names. I am making an assumption that these will be fixed as the names get changed in Omega.

Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [ ] New tests have been added to a test suite
