### PR TITLE
Move `horiz_press_grad` tests from `ocean` to `ocean/column` in working directory

### DIFF
--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -26,9 +26,9 @@ Each task includes:
 The tasks currently provided are:
 
 ```
-ocean/horiz_press_grad/salinity_gradient
-ocean/horiz_press_grad/temperature_gradient
-ocean/horiz_press_grad/ztilde_gradient
+ocean/column/horiz_press_grad/salinity_gradient
+ocean/column/horiz_press_grad/temperature_gradient
+ocean/column/horiz_press_grad/ztilde_gradient
 ```
 
 ```{image} images/horiz_press_grad_salin_grad.png

--- a/polaris/suites/ocean/omega_nightly.txt
+++ b/polaris/suites/ocean/omega_nightly.txt
@@ -1,7 +1,7 @@
+ocean/column/horiz_press_grad/salinity_gradient
+ocean/column/horiz_press_grad/temperature_gradient
+ocean/column/horiz_press_grad/ztilde_gradient
 ocean/planar/barotropic_gyre/munk/free-slip
-ocean/horiz_press_grad/salinity_gradient
-ocean/horiz_press_grad/temperature_gradient
-ocean/horiz_press_grad/ztilde_gradient
 ocean/planar/manufactured_solution/convergence_both/default
 ocean/planar/manufactured_solution/convergence_both/del2
 ocean/planar/manufactured_solution/convergence_both/del4

--- a/polaris/suites/ocean/omega_pr.txt
+++ b/polaris/suites/ocean/omega_pr.txt
@@ -1,5 +1,5 @@
+ocean/column/horiz_press_grad/salinity_gradient
 ocean/planar/barotropic_gyre/munk/free-slip
-ocean/horiz_press_grad/salinity_gradient
 ocean/planar/manufactured_solution/convergence_both/default
 ocean/planar/manufactured_solution/convergence_both/del2
 ocean/planar/manufactured_solution/convergence_both/del4

--- a/polaris/tasks/ocean/horiz_press_grad/task.py
+++ b/polaris/tasks/ocean/horiz_press_grad/task.py
@@ -40,7 +40,7 @@ class HorizPressGradTask(Task):
             <name>.cfg config file in the horiz_press_grad package that
             specifies which properties vary betweeen the columns.
         """
-        subdir = os.path.join('horiz_press_grad', name)
+        subdir = os.path.join('column', 'horiz_press_grad', name)
         super().__init__(component=component, name=name, subdir=subdir)
 
         self.config.add_from_package(


### PR DESCRIPTION
Move `horiz_press_grad` tests from `ocean` to `ocean/column` in working directory. A companion commit in https://github.com/E3SM-Project/polaris/pull/435 moves the `ocean/single_column` tests to `ocean/column`

Checklist
* [X] User's Guide has been updated
* [N/A] Developer's Guide has been updated
* [N/A] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes
* [X] New tests have been added to a test suite
