### PR TITLE
Switch functions for creating shared steps to return dicts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for all repository instructions.

--- a/docs/developers_guide/e3sm/init/tasks/topo/cull.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/cull.md
@@ -77,7 +77,7 @@ steps, config = get_default_cull_topo_steps(
     unsmoothed_topo_step=unsmoothed_topo_step,
     include_viz=False,
 )
-for step in steps:
+for step in steps.values():
     component.add_step(step)
 ```
 

--- a/docs/developers_guide/e3sm/init/tasks/topo/remap.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/remap.md
@@ -65,7 +65,7 @@ steps, config = get_default_remap_topo_steps(
     smoothing=True,
     include_viz=True,
 )
-for step in steps:
+for step in steps.values():
     component.add_step(step)
 ```
 

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -76,6 +76,13 @@ class CombineStep(Step):
         subdir = f'combine_{CombineStep.ANTARCTIC}_{CombineStep.GLOBAL}'
         return os.path.join('topo', subdir)
 
+    @classmethod
+    def get_name(cls):
+        """
+        Get the step name based on the current datasets.
+        """
+        return f'combine_topo_{cls.ANTARCTIC}_{cls.GLOBAL}'
+
     def __init__(self, component, subdir):
         """
         Create a new step
@@ -89,9 +96,7 @@ class CombineStep(Step):
             The subdirectory within the component's work directory
 
         """
-        antarctic_dataset = self.ANTARCTIC
-        global_dataset = self.GLOBAL
-        name = f'combine_topo_{antarctic_dataset}_{global_dataset}'
+        name = self.get_name()
         super().__init__(
             component=component,
             name=name,

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -77,13 +77,24 @@ class CombineStep(Step):
         return os.path.join('topo', subdir)
 
     @classmethod
-    def get_name(cls):
+    def get_name(cls, target_grid, resolution_name):
         """
-        Get the step name based on the current datasets.
-        """
-        return f'combine_topo_{cls.ANTARCTIC}_{cls.GLOBAL}'
+        Get the step name based on the current datasets and target grid.
 
-    def __init__(self, component, subdir):
+        Parameters
+        ----------
+        target_grid : {'cubed_sphere', 'lat_lon'}
+            The type of target grid for the combined topography
+
+        resolution_name : str
+            The target resolution name for the combined topography
+        """
+        return (
+            f'combine_topo_{cls.ANTARCTIC}_{cls.GLOBAL}'
+            f'_{target_grid}_{resolution_name}'
+        )
+
+    def __init__(self, component, subdir, target_grid, resolution_name):
         """
         Create a new step
 
@@ -95,8 +106,14 @@ class CombineStep(Step):
         subdir : str
             The subdirectory within the component's work directory
 
+        target_grid : {'cubed_sphere', 'lat_lon'}
+            The type of target grid for the combined topography
+
+        resolution_name : str
+            The target resolution name for the combined topography
+
         """
-        name = self.get_name()
+        name = self.get_name(target_grid, resolution_name)
         super().__init__(
             component=component,
             name=name,

--- a/polaris/tasks/e3sm/init/topo/combine/steps.py
+++ b/polaris/tasks/e3sm/init/topo/combine/steps.py
@@ -2,6 +2,7 @@ import os
 
 from polaris.config import PolarisConfigParser
 from polaris.e3sm.init.topo import format_lat_lon_resolution_name
+from polaris.step import Step
 from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
 from polaris.tasks.e3sm.init.topo.combine.viz import VizCombinedStep
 
@@ -26,8 +27,9 @@ def get_cubed_sphere_topo_steps(component, resolution, include_viz=False):
 
     Returns
     -------
-    steps : list of polaris.Step
-        The combine topo step and optional visualization step.
+    steps : dict of str to polaris.Step
+        The combine topo step and optional visualization step, keyed by step
+        name.
 
     config : polaris.config.PolarisConfigParser
         The shared config options.
@@ -57,8 +59,9 @@ def get_lat_lon_topo_steps(component, resolution, include_viz=False):
 
     Returns
     -------
-    steps : list of polaris.Step
-        The combine topo step and optional visualization step.
+    steps : dict of str to polaris.Step
+        The combine topo step and optional visualization step, keyed by step
+        name.
 
     config : polaris.config.PolarisConfigParser
         The shared config options.
@@ -91,8 +94,9 @@ def _get_target_topo_steps(component, target_grid, resolution, include_viz):
 
     Returns
     -------
-    steps : list of polaris.Step
-        The combine topo step and optional visualization step.
+    steps : dict of str to polaris.Step
+        The combine topo step and optional visualization step, keyed by step
+        name.
 
     config : polaris.config.PolarisConfigParser
         The shared config options.
@@ -122,14 +126,14 @@ def _get_target_topo_steps(component, target_grid, resolution, include_viz):
     else:
         config.set('combine_topo', 'resolution_latlon', f'{resolution}')
 
-    steps = []
+    steps: dict[str, Step] = {}
     combine_step = component.get_or_create_shared_step(
         step_cls=CombineStep,
         subdir=subdir,
         config=config,
     )
     combine_step._set_res_and_outputs(update=False)
-    steps.append(combine_step)
+    steps[combine_step.name] = combine_step
 
     if include_viz:
         viz_subdir = os.path.join(combine_step.subdir, 'viz')
@@ -140,7 +144,7 @@ def _get_target_topo_steps(component, target_grid, resolution, include_viz):
             config_filename='combine_topo.cfg',
             combine_step=combine_step,
         )
-        steps.append(viz_step)
+        steps[viz_step.name] = viz_step
 
     return steps, config
 

--- a/polaris/tasks/e3sm/init/topo/combine/steps.py
+++ b/polaris/tasks/e3sm/init/topo/combine/steps.py
@@ -131,6 +131,8 @@ def _get_target_topo_steps(component, target_grid, resolution, include_viz):
         step_cls=CombineStep,
         subdir=subdir,
         config=config,
+        target_grid=target_grid,
+        resolution_name=resolution_name,
     )
     combine_step._set_res_and_outputs(update=False)
     steps[combine_step.name] = combine_step

--- a/polaris/tasks/e3sm/init/topo/combine/task.py
+++ b/polaris/tasks/e3sm/init/topo/combine/task.py
@@ -49,7 +49,7 @@ class CubedSphereCombineTask(Task):
             include_viz=True,
         )
         self.set_shared_config(config, link='combine_topo.cfg')
-        for step in steps:
+        for step in steps.values():
             self.add_step(step)
 
 
@@ -88,5 +88,5 @@ class LatLonCombineTask(Task):
             include_viz=True,
         )
         self.set_shared_config(config, link='combine_topo.cfg')
-        for step in steps:
+        for step in steps.values():
             self.add_step(step)

--- a/polaris/tasks/e3sm/init/topo/cull/steps.py
+++ b/polaris/tasks/e3sm/init/topo/cull/steps.py
@@ -33,8 +33,8 @@ def get_default_cull_topo_steps(
 
     Returns
     -------
-    steps : list of polaris.Step
-        Steps for masking and then culling topography
+    steps : dict of str to polaris.Step
+        Steps for masking and then culling topography, keyed by step name
     """
 
     mesh_name = base_mesh_step.mesh_name
@@ -48,7 +48,7 @@ def get_default_cull_topo_steps(
     )
     config = PolarisConfigParser(filepath=filepath)
     config.add_from_package('polaris.tasks.e3sm.init.topo.cull', 'cull.cfg')
-    steps: list[Step] = []
+    steps: dict[str, Step] = {}
 
     step_name = 'cull_mask'
     subdir = os.path.join(mesh_name, 'topo', 'cull', 'mask')
@@ -61,7 +61,7 @@ def get_default_cull_topo_steps(
         unsmoothed_topo_step=unsmoothed_topo_step,
         name=step_name,
     )
-    steps.append(cull_mask_step)
+    steps[cull_mask_step.name] = cull_mask_step
 
     step_name = 'cull_mesh'
     subdir = os.path.join(mesh_name, 'topo', 'cull', 'mesh')
@@ -74,6 +74,6 @@ def get_default_cull_topo_steps(
         cull_mask_step=cull_mask_step,
         name=step_name,
     )
-    steps.append(cull_mesh_step)
+    steps[cull_mesh_step.name] = cull_mesh_step
 
     return steps, config

--- a/polaris/tasks/e3sm/init/topo/cull/task.py
+++ b/polaris/tasks/e3sm/init/topo/cull/task.py
@@ -75,7 +75,7 @@ class CullTopoTask(Task):
             include_viz=include_viz,
         )
         self.set_shared_config(config, link='cull_topo.cfg')
-        for step in steps:
+        for step in steps.values():
             self.add_step(step)
 
         self.combine_topo_step = combine_topo_step

--- a/polaris/tasks/e3sm/init/topo/cull/tasks.py
+++ b/polaris/tasks/e3sm/init/topo/cull/tasks.py
@@ -27,7 +27,9 @@ def add_cull_topo_tasks(component):
         combine_topo_steps, _ = get_cubed_sphere_topo_steps(
             component=component, resolution=resolution
         )
-        combine_steps[low_res] = combine_topo_steps[CombineStep.get_name()]
+        combine_steps[low_res] = combine_topo_steps[
+            CombineStep.get_name('cubed_sphere', f'ne{resolution}')
+        ]
 
     base_mesh_steps = get_base_mesh_steps()
 

--- a/polaris/tasks/e3sm/init/topo/cull/tasks.py
+++ b/polaris/tasks/e3sm/init/topo/cull/tasks.py
@@ -6,6 +6,7 @@ from polaris.mesh.base import get_base_mesh_steps
 from polaris.tasks.e3sm.init.topo.combine import (
     get_cubed_sphere_topo_steps,
 )
+from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
 from polaris.tasks.e3sm.init.topo.cull.task import CullTopoTask
 from polaris.tasks.e3sm.init.topo.remap.steps import (
     get_default_remap_topo_steps,
@@ -26,7 +27,7 @@ def add_cull_topo_tasks(component):
         combine_topo_steps, _ = get_cubed_sphere_topo_steps(
             component=component, resolution=resolution
         )
-        combine_steps[low_res] = combine_topo_steps[0]
+        combine_steps[low_res] = combine_topo_steps[CombineStep.get_name()]
 
     base_mesh_steps = get_base_mesh_steps()
 
@@ -42,8 +43,8 @@ def add_cull_topo_tasks(component):
             smoothing=True,
             include_viz=False,
         )
-        remap_mask_step = remap_topo_steps[0]
-        unsmoothed_topo_step = remap_topo_steps[1]
+        remap_mask_step = remap_topo_steps['mask_topo']
+        unsmoothed_topo_step = remap_topo_steps['remap_unsmoothed']
 
         task = CullTopoTask(
             component=component,

--- a/polaris/tasks/e3sm/init/topo/remap/steps.py
+++ b/polaris/tasks/e3sm/init/topo/remap/steps.py
@@ -50,9 +50,10 @@ def get_default_remap_topo_steps(
 
     Returns
     -------
-    steps : list of polaris.Step
+    steps : dict of str to polaris.Step
         Steps for remapping topography (without smoothing and optionally with
-        smoothing) as well as, if requested, for visualizing the results.
+        smoothing) as well as, if requested, for visualizing the results,
+        keyed by step name.
     """
 
     mesh_name = base_mesh_step.mesh_name
@@ -70,7 +71,7 @@ def get_default_remap_topo_steps(
         config.add_from_package(
             'polaris.tasks.e3sm.init.topo.remap', 'remap_low_res.cfg'
         )
-    steps: list[Step] = []
+    steps: dict[str, Step] = {}
 
     step_name = 'mask_topo'
     subdir = os.path.join(mesh_name, 'topo', 'remap', 'mask')
@@ -82,7 +83,7 @@ def get_default_remap_topo_steps(
         combine_topo_step=combine_topo_step,
         name=step_name,
     )
-    steps.append(mask_step)
+    steps[mask_step.name] = mask_step
 
     if smoothing:
         suffixes = ['unsmoothed', 'smoothed']
@@ -108,7 +109,7 @@ def get_default_remap_topo_steps(
 
         if suffix == 'unsmoothed':
             unsmoothed_topo = remap_step
-        steps.append(remap_step)
+        steps[remap_step.name] = remap_step
 
         if include_viz:
             step_name = f'viz_remapped_{suffix}'
@@ -121,6 +122,6 @@ def get_default_remap_topo_steps(
                 remap_step=remap_step,
                 name=step_name,
             )
-            steps.append(viz_step)
+            steps[viz_step.name] = viz_step
 
     return steps, config

--- a/polaris/tasks/e3sm/init/topo/remap/task.py
+++ b/polaris/tasks/e3sm/init/topo/remap/task.py
@@ -72,7 +72,7 @@ class RemapTopoTask(Task):
             include_viz=include_viz,
         )
         self.set_shared_config(config, link='remap_topo.cfg')
-        for step in steps:
+        for step in steps.values():
             self.add_step(step)
 
         self.combine_topo_step = combine_topo_step

--- a/polaris/tasks/e3sm/init/topo/remap/tasks.py
+++ b/polaris/tasks/e3sm/init/topo/remap/tasks.py
@@ -24,7 +24,9 @@ def add_remap_topo_tasks(component):
         combine_topo_steps, _ = get_cubed_sphere_topo_steps(
             component=component, resolution=resolution
         )
-        combine_steps[low_res] = combine_topo_steps[CombineStep.get_name()]
+        combine_steps[low_res] = combine_topo_steps[
+            CombineStep.get_name('cubed_sphere', f'ne{resolution}')
+        ]
 
     base_mesh_steps = get_base_mesh_steps()
 

--- a/polaris/tasks/e3sm/init/topo/remap/tasks.py
+++ b/polaris/tasks/e3sm/init/topo/remap/tasks.py
@@ -6,6 +6,7 @@ from polaris.mesh.base import get_base_mesh_steps
 from polaris.tasks.e3sm.init.topo.combine import (
     get_cubed_sphere_topo_steps,
 )
+from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
 from polaris.tasks.e3sm.init.topo.remap import RemapTopoTask
 
 
@@ -23,7 +24,7 @@ def add_remap_topo_tasks(component):
         combine_topo_steps, _ = get_cubed_sphere_topo_steps(
             component=component, resolution=resolution
         )
-        combine_steps[low_res] = combine_topo_steps[0]
+        combine_steps[low_res] = combine_topo_steps[CombineStep.get_name()]
 
     base_mesh_steps = get_base_mesh_steps()
 

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
@@ -1,6 +1,7 @@
 import os
 
 from polaris.config import PolarisConfigParser
+from polaris.e3sm.init.topo import format_lat_lon_resolution_name
 from polaris.step import Step
 from polaris.tasks.e3sm.init import e3sm_init
 from polaris.tasks.e3sm.init.topo.combine import (
@@ -28,7 +29,8 @@ def get_woa23_topography_step():
     steps, _ = get_lat_lon_topo_steps(
         component=e3sm_init, resolution=0.25, include_viz=False
     )
-    return steps[TopoCombineStep.get_name()]
+    woa23_res_name = format_lat_lon_resolution_name(0.25)
+    return steps[TopoCombineStep.get_name('lat_lon', woa23_res_name)]
 
 
 def get_woa23_steps(component, combine_topo_step):

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
@@ -5,6 +5,9 @@ from polaris.tasks.e3sm.init import e3sm_init
 from polaris.tasks.e3sm.init.topo.combine import (
     get_lat_lon_topo_steps,
 )
+from polaris.tasks.e3sm.init.topo.combine.step import (
+    CombineStep as TopoCombineStep,
+)
 
 from .combine import CombineStep
 from .extrapolate import ExtrapolateStep
@@ -24,7 +27,7 @@ def get_woa23_topography_step():
     steps, _ = get_lat_lon_topo_steps(
         component=e3sm_init, resolution=0.25, include_viz=False
     )
-    return steps[0]
+    return steps[TopoCombineStep.get_name()]
 
 
 def get_woa23_steps(component, combine_topo_step):

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/steps.py
@@ -1,6 +1,7 @@
 import os
 
 from polaris.config import PolarisConfigParser
+from polaris.step import Step
 from polaris.tasks.e3sm.init import e3sm_init
 from polaris.tasks.e3sm.init.topo.combine import (
     get_lat_lon_topo_steps,
@@ -45,8 +46,9 @@ def get_woa23_steps(component, combine_topo_step):
 
     Returns
     -------
-    steps : list of polaris.Step
-        Shared steps for combining and extrapolating WOA23 data.
+    steps : dict of {str: polaris.Step}
+        Shared steps for combining and extrapolating WOA23 data, keyed by
+        step name.
 
     config : polaris.config.PolarisConfigParser
         The shared config options for the task and its steps.
@@ -89,4 +91,9 @@ def get_woa23_steps(component, combine_topo_step):
         combine_topo_step=combine_topo_step,
     )
 
-    return [combine_step, extrapolate_step, viz_step], config
+    steps: dict[str, Step] = {
+        combine_step.name: combine_step,
+        extrapolate_step.name: extrapolate_step,
+        viz_step.name: viz_step,
+    }
+    return steps, config

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/task.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/task.py
@@ -32,7 +32,7 @@ class Woa23(Task):
         self.set_shared_config(config)
 
         self.add_step(self.combine_topo_step, symlink='combine_topo')
-        for step in steps:
+        for step in steps.values():
             self.add_step(step, run_by_default=step.name != 'viz')
 
     def configure(self):


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This clean-up PR switches several functions that produce lists of steps (so-called "step factories") to produce dicts instead, with step names as keys. This helps in downstream step factories to more cleanly identify individual shared steps.

I'm also adding a few other bits of clean-up here:
* Point Claude to AGENTS.md
* Include not just target grid and resolution in combine topo step names so they're unique.

These changes will be used in the unified mesh workflows.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
