### PR TITLE
Fix caching shared steps

### DIFF
--- a/docs/developers_guide/command_line.md
+++ b/docs/developers_guide/command_line.md
@@ -94,7 +94,7 @@ The command-line options are:
 $ polaris setup --help
 usage: polaris setup [-h] [-t PATH [PATH ...]] [-n NUM [NUM ...]] [-f FILE] [-m MACH] -w
                      PATH [-b PATH] [-p PATH] [--suite_name SUITE]
-                     [--cached STEP [STEP ...]] [--copy_executable] [--clean_tasks]
+                     [--cached STEP [STEP ...]] [--free_running STEP [STEP ...]] [--copy_executable] [--clean_tasks]
                      [--model MODEL] [--build] [--branch BRANCH] [--clean_build]
                      [--quiet_build] [--cmake_flags CMAKE_FLAGS] [--debug]
 
@@ -161,6 +161,13 @@ dependencies.
 
 You can uses `--cached` to specify steps of a test case to download from
 pre-generated files if they are available (see {ref}`dev-polaris-cache`.)
+
+You can use `--free_running` to force specific steps of a task to run free
+(not cached), overriding any `default_cached = True` setting on those steps
+(see {ref}`dev-step-default-cached`). Like `--cached`, `--free_running`
+accepts a list of step names or the special value `_all` to force every step
+free-running. A step may not appear in both `--cached` and `--free_running`.
+Both flags require exactly one task to be specified.
 
 If you specify `--copy_executable`, the model executable will be copied to the
 work directory rather than just symlinked.  This is useful if wish to run

--- a/docs/developers_guide/e3sm/init/tasks/topo/combine.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/combine.md
@@ -190,6 +190,19 @@ For more details, refer to the source code of the
 {py:class}`polaris.tasks.e3sm.init.topo.combine.LatLonCombineTask` classes.
 
 ```{note}
-Since this step is expensive and time-consuming to run, most tasks will
-want to use cached outputs from this step rather than running it in full.
+Since `CombineStep` is expensive and time-consuming to run, it sets
+`self.default_cached = True` in its `__init__`.  Downstream tasks that add
+a `CombineStep` will therefore automatically use cached outputs without
+needing to opt in via the suite file or `--cached` flag.
+
+The standalone
+{py:class}`polaris.tasks.e3sm.init.topo.combine.task.CubedSphereCombineTask`
+and
+{py:class}`polaris.tasks.e3sm.init.topo.combine.task.LatLonCombineTask`
+tasks exist specifically to regenerate these products, so they add all of
+their steps to `self.free_running_steps`, overriding the `default_cached`
+default and ensuring the steps always run.
+
+See {ref}`dev-step-default-cached` for a full description of the
+`default_cached` / `free_running_steps` mechanism.
 ```

--- a/docs/developers_guide/ocean/tasks/global_ocean.md
+++ b/docs/developers_guide/ocean/tasks/global_ocean.md
@@ -28,13 +28,17 @@ The helper
 creates a shared `e3sm/init` {py:class}`polaris.tasks.e3sm.init.topo.combine.step.CombineStep`
 configured for a 0.25-degree lat-lon target grid. The
 {py:class}`polaris.tasks.ocean.global_ocean.hydrography.woa23.task.Woa23`
-task adds this step with a symlink `combine_topo` and prefers to use a cached
-version of its outputs when matching entries are available in the
-`e3sm/init` cache database.
+task adds this step with a symlink `combine_topo`.
+
+Because `CombineStep` sets `default_cached = True`, the `combine_topo` step
+is automatically treated as cached during setup — no explicit opt-in is
+needed.
 
 This keeps the expensive topography blending logic in one place and makes the
 ocean hydrography preprocessing task consistent with the broader Polaris
-approach to shared, cacheable preprocessing steps.
+approach to shared, cacheable preprocessing steps.  See
+{ref}`dev-step-default-cached` for a full description of the
+`default_cached` / `free_running_steps` mechanism.
 
 (dev-ocean-global-ocean-woa23)=
 

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -1054,6 +1054,55 @@ recommended.
 More details on cached outputs are available in the compass design document
 [Caching outputs from compass steps](https://mpas-dev.github.io/compass/latest/design_docs/cached_outputs.html).
 
+(dev-step-default-cached)=
+
+### Automatic caching with `default_cached` and `free_running_steps`
+
+Expensive step classes can declare that their outputs should be treated as
+cached by default by setting `self.default_cached = True` in their
+`__init__`.  This lets downstream tasks consume prebuilt products without
+each caller having to opt in via the suite file or the `--cached` CLI flag.
+
+The caching resolution order during setup is (highest to lowest priority):
+
+1. **Free-running override** — if any selected task adds a step's `subdir`
+   to `self.free_running_steps`, that step is always run, even if
+   `default_cached` is `True` or `--cached` was passed on the command line.
+2. **CLI `--cached`** — steps explicitly requested via `polaris setup
+   --cached` or the `c`-suffix notation in suites.
+3. **Factory default** — steps whose `default_cached` attribute is `True`.
+
+**Setting `default_cached` in a step class:**
+
+Steps that are shared across many tasks and are expensive to run should set
+this flag in their `__init__`:
+
+```python
+self.default_cached = True
+```
+
+See {py:class}`polaris.tasks.e3sm.init.topo.combine.step.CombineStep` for
+a concrete example.
+
+**Opting out with `free_running_steps`:**
+
+A task that *owns* a step (e.g. a standalone task whose sole purpose is to
+regenerate an expensive shared product) should add the step's `subdir` to
+`self.free_running_steps` so that the outputs are always regenerated:
+
+```python
+self.free_running_steps.add(step.subdir)
+```
+
+A task can also do this conditionally in its `configure()` method, which
+runs before caching resolution.  For example, a task might add a step to
+`free_running_steps` only when the cached outputs are not yet available in
+the cache database.
+
+See {py:class}`polaris.tasks.e3sm.init.topo.combine.task.CubedSphereCombineTask`
+and {py:class}`polaris.tasks.ocean.global_ocean.hydrography.woa23.task.Woa23`
+for concrete examples.
+
 (dev-step-dependencies)=
 
 ### Adding other steps as dependencies

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -1066,7 +1066,8 @@ each caller having to opt in via the suite file or the `--cached` CLI flag.
 The caching resolution order during setup is (highest to lowest priority):
 
 1. **Free-running override** — if any selected task adds a step's `subdir`
-   to `self.free_running_steps`, that step is always run, even if
+   to `self.free_running_steps`, *or* if `--free_running` was passed on the
+   command line for that step, that step is always run, even if
    `default_cached` is `True` or `--cached` was passed on the command line.
 2. **CLI `--cached`** — steps explicitly requested via `polaris setup
    --cached` or the `c`-suffix notation in suites.
@@ -1084,7 +1085,7 @@ self.default_cached = True
 See {py:class}`polaris.tasks.e3sm.init.topo.combine.step.CombineStep` for
 a concrete example.
 
-**Opting out with `free_running_steps`:**
+**Opting out with `free_running_steps` or `--free_running`:**
 
 A task that *owns* a step (e.g. a standalone task whose sole purpose is to
 regenerate an expensive shared product) should add the step's `subdir` to
@@ -1098,6 +1099,12 @@ A task can also do this conditionally in its `configure()` method, which
 runs before caching resolution.  For example, a task might add a step to
 `free_running_steps` only when the cached outputs are not yet available in
 the cache database.
+
+Alternatively, a developer setting up a single task interactively can pass
+`--free_running <step> [<step> ...]` (or `--free_running _all`) to
+`polaris setup` to force steps free-running at the command line without
+modifying task code.  A step may not appear in both `--cached` and
+`--free_running`.
 
 See {py:class}`polaris.tasks.e3sm.init.topo.combine.task.CubedSphereCombineTask`
 and {py:class}`polaris.tasks.ocean.global_ocean.hydrography.woa23.task.Woa23`

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -982,7 +982,7 @@ and symlinked rather than being computed each time.
 
 Cached output files are be stored in the `polaris_cache` database within each
 component's space on that LCRC server (see {ref}`dev-step-input-download`).
-If the "cached" version of a step is selected, as we will describe below, each
+If a step is configured to use cached outputs, as we will describe below, each
 of the task's outputs will have a corresponding "input" file added with
 the `target` being a cache file on the LCRC server and the `filename` being
 the output file.  Polaris uses the `cached_files.json` database to know
@@ -1016,8 +1016,8 @@ The line can be indented for visual clarity, but must begin with `cached:`,
 followed by a list of steps separated by a single space.
 
 Similarly, a user setting up tasks has two mechanisms for specifying which
-tasks and steps should have cached outputs.  If all steps in a task
-should have cached outputs, the suffix `c` can be added to the test number:
+tasks and steps should use cached outputs.  If all steps in a task
+should use cached outputs, the suffix `c` can be added to the test number:
 
 ```none
 polaris setup -n 90c 91c 92 ...
@@ -1056,7 +1056,7 @@ More details on cached outputs are available in the compass design document
 
 (dev-step-default-cached)=
 
-### Automatic caching with `default_cached` and `free_running_steps`
+### Automatic cache use with `default_cached` and `free_running_steps`
 
 Expensive step classes can declare that their outputs should be treated as
 cached by default by setting `self.default_cached = True` in their

--- a/docs/users_guide/e3sm/init/tasks/topo.md
+++ b/docs/users_guide/e3sm/init/tasks/topo.md
@@ -24,6 +24,13 @@ Latitude-longitude product names follow the naming convention used by
 5 decimal places and appends `_degree`. For example, `0.125` becomes
 `0.12500_degree` and `0.03125` becomes `0.03125_degree`.
 
+The standalone combine tasks listed below always regenerate the combined
+topography from scratch — they are not affected by the automatic caching
+that applies to downstream tasks.  Other tasks that depend on a shared
+combine step (such as remap or ocean hydrography tasks) will automatically
+use cached outputs when they are available, without needing to opt in
+explicitly.
+
 Standalone tasks are available to create each combined topography product:
 
 - `e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne3000/task`

--- a/polaris/e3sm/init/cached_files.json
+++ b/polaris/e3sm/init/cached_files.json
@@ -4,5 +4,15 @@
     "e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne3000/ne3000.g": "topo/combine_bedmap3_gebco2023/ne3000.250523.g",
     "e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne120/ne120.scrip.nc": "topo/combine_bedmap3_gebco2023_low_res/ne120.scrip.250523.nc",
     "e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne120/bedmap3_gebco2023_ne120.nc": "topo/combine_bedmap3_gebco2023_low_res/bedmap3_gebco2023_ne120.250523.nc",
-    "e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne120/ne120.g": "topo/combine_bedmap3_gebco2023_low_res/ne120.250523.g"
+    "e3sm/init/topo/combine_bedmap3_gebco2023/cubed_sphere/ne120/ne120.g": "topo/combine_bedmap3_gebco2023_low_res/ne120.250523.g",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/1.00000_degree/1.00000_degree.scrip.nc": "topo/combine_bedmap3_gebco2023/lat_lon/1.00000_degree/1.00000_degree.scrip.260512.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/1.00000_degree/bedmap3_gebco2023_1.00000_degree.nc": "topo/combine_bedmap3_gebco2023/lat_lon/1.00000_degree/bedmap3_gebco2023_1.00000_degree.260512.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.25000_degree/0.25000_degree.scrip.nc": "topo/combine_bedmap3_gebco2023/lat_lon/0.25000_degree/0.25000_degree.scrip.260512.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.25000_degree/bedmap3_gebco2023_0.25000_degree.nc": "topo/combine_bedmap3_gebco2023/lat_lon/0.25000_degree/bedmap3_gebco2023_0.25000_degree.260512.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.12500_degree/0.12500_degree.scrip.nc": "topo/combine_bedmap3_gebco2023/lat_lon/0.12500_degree/0.12500_degree.scrip.260512.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.12500_degree/bedmap3_gebco2023_0.12500_degree.nc": "topo/combine_bedmap3_gebco2023/lat_lon/0.12500_degree/bedmap3_gebco2023_0.12500_degree.260512.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.06250_degree/0.06250_degree.scrip.nc": "topo/combine_bedmap3_gebco2023/lat_lon/0.06250_degree/0.06250_degree.scrip.260512.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.06250_degree/bedmap3_gebco2023_0.06250_degree.nc": "topo/combine_bedmap3_gebco2023/lat_lon/0.06250_degree/bedmap3_gebco2023_0.06250_degree.260512.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.03125_degree/0.03125_degree.scrip.nc": "topo/combine_bedmap3_gebco2023/lat_lon/0.03125_degree/0.03125_degree.scrip.260511.nc",
+    "e3sm/init/topo/combine_bedmap3_gebco2023/lat_lon/0.03125_degree/bedmap3_gebco2023_0.03125_degree.nc": "topo/combine_bedmap3_gebco2023/lat_lon/0.03125_degree/bedmap3_gebco2023_0.03125_degree.260511.nc"
 }

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -75,9 +75,9 @@ def setup_tasks(
         ``'custom'`` if not
 
     cached : list of list of str, optional
-        For each task in ``tasks``, which steps (if any) should be cached,
-        or a list with "_all" as the first entry if all steps in the task
-        should be cached
+        For each task in ``tasks``, which steps (if any) should read their
+        outputs from the cache, or a list with "_all" as the first entry if
+        all steps in the task should use cached outputs
 
     free_running : list of list of str, optional
         For the single task in ``tasks``, which steps (if any) should be
@@ -308,8 +308,8 @@ def setup_task(path, task, machine, work_dir, baseline_dir, cached_steps):
         Location of baselines that can be compared to
 
     cached_steps : list of str
-        Which steps (if any) should be cached, identified by a list of
-        subdirectories in the component
+        Which steps (if any) should read their outputs from the cache,
+        identified by a list of subdirectories in the component
     """
 
     print(f'  {path}')
@@ -468,8 +468,8 @@ def main():
         nargs='+',
         help='A list of steps in a single task supplied with '
         '--tasks or --task_number that should use cached '
-        "outputs, or '_all' if all steps should be "
-        'cached.',
+        "outputs, or '_all' if all steps should "
+        'use cached outputs.',
         metavar='STEP',
     )
     parser.add_argument(
@@ -597,7 +597,7 @@ def _expand_and_mark_cached_steps(tasks, cached_steps):
     Resolution order (highest to lowest priority):
 
     1. Free-running: if any selected task added a step subdir to
-       ``free_running_steps``, that step is never cached.
+       ``free_running_steps``, that step always runs (never reads from cache).
     2. CLI ``--cached``: steps explicitly requested via command line.
     3. Factory default: steps whose ``default_cached`` flag is True.
     """

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -28,6 +28,7 @@ def setup_tasks(
     component_path=None,
     suite_name='custom',
     cached=None,
+    free_running=None,
     copy_executable=False,
     clean_tasks=False,
     model=None,
@@ -77,6 +78,13 @@ def setup_tasks(
         For each task in ``tasks``, which steps (if any) should be cached,
         or a list with "_all" as the first entry if all steps in the task
         should be cached
+
+    free_running : list of list of str, optional
+        For the single task in ``tasks``, which steps (if any) should be
+        forced free-running (not cached), overriding ``default_cached``,
+        or a list with ``"_all"`` as the first entry if all steps should
+        be free-running.  A step may not appear in both ``cached`` and
+        ``free_running``.
 
     copy_executable : bool, optional
         Whether to copy the model executable to the work directory
@@ -192,6 +200,39 @@ def setup_tasks(
         work_dir=work_dir,
         copy_executable=copy_executable,
     )
+
+    # Apply CLI --free_running before caching resolution so that Phase 4
+    # (free-running wins) in _expand_and_mark_cached_steps picks them up.
+    if free_running is not None:
+        # Exactly one task is guaranteed by earlier validation.
+        path = next(iter(tasks.keys()))
+        task = tasks[path]
+        fr_steps = free_running[0]
+        fr_step_list = (
+            list(task.steps.keys()) if fr_steps[0] == '_all' else fr_steps
+        )
+        for step_name in fr_step_list:
+            if step_name not in task.steps:
+                raise ValueError(
+                    f'Step {step_name!r} is not in the task. '
+                    f'Available steps: {list(task.steps.keys())}'
+                )
+            task.free_running_steps.add(task.steps[step_name].subdir)
+
+        # Raise an error if any step is listed in both --cached and
+        # --free_running (after expanding _all in cached_steps).
+        cached_list = (
+            list(task.steps.keys())
+            if cached_steps.get(path, []) == ['_all']
+            else cached_steps.get(path, [])
+        )
+        conflicts = sorted(set(cached_list) & set(fr_step_list))
+        if conflicts:
+            raise ValueError(
+                f'Steps {conflicts} are listed in both --cached and '
+                '--free_running. Each step must be unambiguously cached, '
+                'free-running, or left at its default.'
+            )
 
     # do this after _setup_configs() in case tasks mark additional steps
     # as cached in their configure() methods
@@ -432,6 +473,16 @@ def main():
         metavar='STEP',
     )
     parser.add_argument(
+        '--free_running',
+        dest='free_running',
+        nargs='+',
+        help='A list of steps in a single task supplied with '
+        '--tasks or --task_number that should be free-running '
+        "(not cached), overriding default_cached, or '_all' "
+        'if all steps should be free-running.',
+        metavar='STEP',
+    )
+    parser.add_argument(
         '--copy_executable',
         dest='copy_executable',
         action='store_true',
@@ -502,6 +553,19 @@ def main():
         # cached is a list of lists
         cached = [args.cached]
 
+    free_running = None
+    if args.free_running is not None:
+        if args.tasks is not None and len(args.tasks) != 1:
+            raise ValueError(
+                'You can only set free-running steps for one task at a time.'
+            )
+        if args.task_num is not None and len(args.task_num) != 1:
+            raise ValueError(
+                'You can only set free-running steps for one task at a time.'
+            )
+        # free_running is a list of lists
+        free_running = [args.free_running]
+
     setup_tasks(
         task_list=args.tasks,
         numbers=args.task_num,
@@ -512,6 +576,7 @@ def main():
         component_path=args.component_path,
         suite_name=args.suite_name,
         cached=cached,
+        free_running=free_running,
         copy_executable=args.copy_executable,
         clean_tasks=args.clean_tasks,
         model=args.model,

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -618,7 +618,7 @@ def _expand_and_mark_cached_steps(tasks, cached_steps):
         for step_name in cached_steps[path]:
             task.steps[step_name].cached = True
 
-    # Phase 3: Apply default_cached for steps not yet cached
+    # Phase 3: Apply default_cached for steps not yet designated as cached
     for task in tasks.values():
         for step in task.steps.values():
             if not step.cached and getattr(step, 'default_cached', False):

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -526,17 +526,46 @@ def main():
 
 def _expand_and_mark_cached_steps(tasks, cached_steps):
     """
-    Mark any steps that will be cached.  If any task asked for a step to
-    be cached, it will be cached for all tasks that share the step.
+    Mark any steps that will be cached.
+
+    Resolution order (highest to lowest priority):
+
+    1. Free-running: if any selected task added a step subdir to
+       ``free_running_steps``, that step is never cached.
+    2. CLI ``--cached``: steps explicitly requested via command line.
+    3. Factory default: steps whose ``default_cached`` flag is True.
     """
+    # Expand _all shorthand
     for path, task in tasks.items():
         cached_names = cached_steps[path]
         if len(cached_names) > 0 and cached_names[0] == '_all':
             cached_steps[path] = list(task.steps.keys())
 
+    # Phase 1: collect free-running preferences from all selected tasks
+    # (includes additions made by configure(), which runs before this)
+    free_running_subdirs: set[str] = set()
+    for task in tasks.values():
+        free_running_subdirs.update(getattr(task, 'free_running_steps', set()))
+
+    # Phase 2: apply CLI-specified caching
+    for path, task in tasks.items():
         for step_name in cached_steps[path]:
             task.steps[step_name].cached = True
 
+    # Phase 3: apply factory defaults for steps not yet cached
+    for task in tasks.values():
+        for step in task.steps.values():
+            if not step.cached and getattr(step, 'default_cached', False):
+                step.cached = True
+
+    # Phase 4: free-running wins — override any cached=True
+    for task in tasks.values():
+        for step in task.steps.values():
+            if step.subdir in free_running_subdirs:
+                step.cached = False
+
+    # Propagate cached status to cached_steps for display/tracking
+    for path, task in tasks.items():
         for step_name, step in task.steps.items():
             if step.cached and step_name not in cached_steps[path]:
                 cached_steps[path].append(step_name)

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -526,7 +526,8 @@ def main():
 
 def _expand_and_mark_cached_steps(tasks, cached_steps):
     """
-    Mark any steps that will be cached.
+    Mark any cached steps that will get their outputs from the cache database,
+    rather than being run.
 
     Resolution order (highest to lowest priority):
 
@@ -552,7 +553,7 @@ def _expand_and_mark_cached_steps(tasks, cached_steps):
         for step_name in cached_steps[path]:
             task.steps[step_name].cached = True
 
-    # Phase 3: apply factory defaults for steps not yet cached
+    # Phase 3: Apply default_cached for steps not yet cached
     for task in tasks.values():
         for step in task.steps.values():
             if not step.cached and getattr(step, 'default_cached', False):

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -146,9 +146,9 @@ class Step:
         cached outputs for this component
 
     default_cached : bool
-        If True, this step will be cached by default when set up by a
-        downstream task.  Set to ``True`` in the ``__init__`` of expensive
-        step classes (e.g. :class:`CombineStep`,
+        If True, this step will read its outputs from the cache by default
+        when set up by a downstream task.  Set to ``True`` in the
+        ``__init__`` of expensive step classes (e.g. :class:`CombineStep`,
         :class:`ComputeCoastlineStep`) to indicate that their outputs should
         be reused across tasks without requiring each caller to opt in.
         Tasks that require free-running execution should add this step's

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -145,6 +145,16 @@ class Step:
         Whether to get all of the outputs for the step from the database of
         cached outputs for this component
 
+    default_cached : bool
+        If True, this step will be cached by default when set up by a
+        downstream task.  Set to ``True`` in the ``__init__`` of expensive
+        step classes (e.g. :class:`CombineStep`,
+        :class:`ComputeCoastlineStep`) to indicate that their outputs should
+        be reused across tasks without requiring each caller to opt in.
+        Tasks that require free-running execution should add this step's
+        ``subdir`` to ``self.free_running_steps`` in their ``__init__``
+        rather than modifying this flag.
+
     run_as_subprocess : bool
         Whether to run this step as a subprocess, rather than just running
         it directly from the task.  It is useful to run a step as a
@@ -291,6 +301,7 @@ class Step:
 
         # output caching
         self.cached = cached
+        self.default_cached = False
 
     def set_resources(
         self,

--- a/polaris/task.py
+++ b/polaris/task.py
@@ -67,6 +67,12 @@ class Task:
         Whether to create a new log file for each step or to log output to a
         common log file for the whole task.  The latter is used when
         running the task as part of a suite
+
+    free_running_steps : set of str
+        The subdirs of steps that this task wants to run free (not cached),
+        resolved at setup time.  Free-running wins over ``default_cached``
+        and CLI ``--cached``.  Add step subdirs here during ``__init__``
+        rather than setting ``step.cached = False`` directly.
     """
 
     def __init__(self, component, name, subdir=None, indir=None):
@@ -106,6 +112,7 @@ class Task:
         self.steps = dict()
         self.step_symlinks = dict()
         self.steps_to_run = list()
+        self.free_running_steps: set[str] = set()
 
         # these will be set during setup, dummy values for now
         self.work_dir = ''

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -121,6 +121,7 @@ class CombineStep(Step):
             ntasks=None,
             min_tasks=None,
         )
+        self.default_cached = True
         self.resolution = None
         self.resolution_name = None
         self.combined_filename = None

--- a/polaris/tasks/e3sm/init/topo/combine/steps.py
+++ b/polaris/tasks/e3sm/init/topo/combine/steps.py
@@ -14,6 +14,13 @@ def get_cubed_sphere_topo_steps(component, resolution, include_viz=False):
     """
     Get shared combined-topography steps for a cubed-sphere target grid.
 
+    The :class:`CombineStep` (and :class:`VizCombinedStep` when requested) set
+    ``default_cached = True`` in their constructors because they are expensive
+    to produce.  Downstream tasks benefit from cached outputs automatically.
+    Tasks that require free-running execution (e.g. standalone combine tasks)
+    should add each returned step's ``subdir`` to ``self.free_running_steps``
+    in their ``__init__``, as :class:`CubedSphereCombineTask` does.
+
     Parameters
     ----------
     component : polaris.Component
@@ -45,6 +52,13 @@ def get_cubed_sphere_topo_steps(component, resolution, include_viz=False):
 def get_lat_lon_topo_steps(component, resolution, include_viz=False):
     """
     Get shared combined-topography steps for a latitude-longitude target grid.
+
+    The :class:`CombineStep` (and :class:`VizCombinedStep` when requested) set
+    ``default_cached = True`` in their constructors because they are expensive
+    to produce.  Downstream tasks benefit from cached outputs automatically.
+    Tasks that require free-running execution (e.g. standalone combine tasks)
+    should add each returned step's ``subdir`` to ``self.free_running_steps``
+    in their ``__init__``, as :class:`LatLonCombineTask` does.
 
     Parameters
     ----------

--- a/polaris/tasks/e3sm/init/topo/combine/task.py
+++ b/polaris/tasks/e3sm/init/topo/combine/task.py
@@ -51,6 +51,7 @@ class CubedSphereCombineTask(Task):
         self.set_shared_config(config, link='combine_topo.cfg')
         for step in steps.values():
             self.add_step(step)
+            self.free_running_steps.add(step.subdir)
 
 
 class LatLonCombineTask(Task):
@@ -90,3 +91,4 @@ class LatLonCombineTask(Task):
         self.set_shared_config(config, link='combine_topo.cfg')
         for step in steps.values():
             self.add_step(step)
+            self.free_running_steps.add(step.subdir)

--- a/polaris/tasks/e3sm/init/topo/combine/viz.py
+++ b/polaris/tasks/e3sm/init/topo/combine/viz.py
@@ -45,6 +45,7 @@ class VizCombinedStep(Step):
             cpus_per_task=128,
             min_cpus_per_task=1,
         )
+        self.default_cached = True
         self.combine_step = combine_step
 
     def setup(self):

--- a/polaris/tasks/ocean/global_ocean/hydrography/woa23/task.py
+++ b/polaris/tasks/ocean/global_ocean/hydrography/woa23/task.py
@@ -1,5 +1,3 @@
-import os
-
 from polaris import Task
 from polaris.tasks.ocean.global_ocean.hydrography.woa23.steps import (
     get_woa23_steps,
@@ -34,17 +32,3 @@ class Woa23(Task):
         self.add_step(self.combine_topo_step, symlink='combine_topo')
         for step in steps.values():
             self.add_step(step, run_by_default=step.name != 'viz')
-
-    def configure(self):
-        """
-        Use the cached combined-topography product from ``e3sm/init``.
-        """
-        super().configure()
-        cache_keys = [
-            os.path.join(self.combine_topo_step.path, output)
-            for output in self.combine_topo_step.outputs
-        ]
-        cached_files = self.combine_topo_step.component.cached_files
-        self.combine_topo_step.cached = all(
-            filename in cached_files for filename in cache_keys
-        )


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Prior to this fix, there was not a good process for creating shared steps that sometimes run but often are cached.  It is impractical to mark particular shared steps as cached repeatedly in each subsequent task that uses them.  Instead, it is desirable for expensive shared steps to know that they should be cached unless otherwise indicated.

A complication is that whether a step is cached or free-running must be determined at setup time depending on which tasks are requested.  If all tasks agree that a shared step can be cached, it should be cached but if any task needs the free-running version of the step, it should be free-running.  This merge accomplishes these goals.

This PR adds a `default_cached` attribute to `Step` and a `free_running_steps` attribute to `Task`.

During setup, these attributes are used to determine if a shared step that otherwise would be cached should instead be free-running.  This typically happens in standalone tasks focused on steps that are otherwise too expensive to run every time (and are therefore marked as `default_cached` either internally or in their step factories).

Steps in `e3sm/init/topo/combine` are updated to use this new caching approach, since they are all quite expensive.  The steps themselves set `default_cached`, while the standalone tasks set `free_running_steps` to make sure they are *not* cached.

The outputs from the lat-lon version of the `topo/combine` steps have been cached and the cache manifest has been updated to indicate this.

Finally, the ocean's WOA23 hydrography task has been simplified.  It can just use the cached topogrpahy steps now that they are available.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
