### PR TITLE
Add Antarctic boundary convention 

### DIFF
--- a/docs/developers_guide/e3sm/init/tasks/topo/cull.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/cull.md
@@ -51,6 +51,10 @@ The culling steps are configured through the `[cull_mesh]` section in the config
 
 See `cull.cfg` for the full set of options.
 
+The Antarctic land-ice ownership mask also includes southern cells that have
+already been removed from the open-ocean cull mask, so the cull workflow
+remains consistent with the remapped topography masks.
+
 ## Workflow
 
 1. **Mask Generation**: The `CullMaskStep` creates masks for ocean, ocean

--- a/docs/developers_guide/e3sm/init/tasks/topo/remap.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/remap.md
@@ -31,20 +31,32 @@ The typical dependency chain is:
 
 ## Configuration Options
 
-The remapping steps are configured through the `[remap_topography]` section in
-the configuration file. Key options include:
+The remapping steps are configured through the shared `[spherical_mesh]`
+section and the `[remap_topography]` section in the configuration file. Key
+options include:
 
+- `antarctic_boundary_convention`: Antarctic boundary convention used when
+  masking the combined topography before remapping. Supported values are
+  `calving_front`, `grounding_line`, and `bedrock_zero`.
 - `ntasks` and `min_tasks`: Number of MPI tasks for remapping.
 - `renorm_threshold`: Fractional threshold for renormalizing elevation variables.
 - `expand_distance` and `expand_factor`: Smoothing parameters (set to 0 and 1 for no smoothing).
 - Additional options for visualization colormaps and normalization.
+
+The Antarctic boundary convention controls which below-sea-level Antarctic
+cells are treated as ocean before remapping. `calving_front` excludes all
+ice-covered cells from the ocean mask, `grounding_line` excludes grounded ice
+but includes ice shelves, and `bedrock_zero` treats all below-sea-level
+bedrock as ocean.
 
 For the low-resolution version, additional configuration options are provided
 in the `remap_low_res.cfg` file.
 
 ## Workflow
 
-1. **Masking**: The `MaskTopoStep` applies land and ocean masks to the combined topography dataset, producing masked fields and fractional coverage variables.
+1. **Masking**: The `MaskTopoStep` applies convention-aware land and ocean
+   masks to the combined topography dataset, producing masked fields and
+   fractional coverage variables.
 2. **Remapping**: The `RemapTopoStep` remaps the masked topography fields to the MPAS mesh. If smoothing is enabled, both unsmoothed and smoothed steps are created, with the smoothed step depending on the unsmoothed output.
 3. **Smoothing**: Smoothing parameters are controlled via configuration. If no smoothing is requested, the smoothed step simply symlinks the unsmoothed results.
 4. **Visualization**: The `VizRemappedTopoStep` can be added to plot each remapped field using configuration-driven colormaps and normalization.

--- a/docs/users_guide/e3sm/init/tasks/topo.md
+++ b/docs/users_guide/e3sm/init/tasks/topo.md
@@ -78,12 +78,13 @@ normalization settings.
 
 ### Remap Tasks
 
-Remap tasks use the `[mask_topography]` and `[remap_topography]` sections.
+Remap tasks use the shared `[spherical_mesh]` section together with
+`[remap_topography]`.
 
 Common user-tunable options are:
 
-- `ocean_includes_grounded_ice`: Whether grounded Antarctic ice is treated as
-	part of the ocean mask.
+- `antarctic_boundary_convention`: Antarctic coastline convention used to
+	mask topography before remapping.
 - `description`: Metadata description written to the remapped product.
 - `ntasks` and `min_tasks`: Target and minimum MPI task counts for remapping.
 - `renorm_threshold`: Minimum land or ocean area fraction required before

--- a/polaris/mesh/spherical/spherical.cfg
+++ b/polaris/mesh/spherical/spherical.cfg
@@ -22,6 +22,10 @@ min_cell_width = <<<missing>>>
 # min_cell_width
 max_cell_width = <<<missing>>>
 
+# Antarctic land-ice ownership convention shared by spherical mesh workflows
+# and downstream topography-based culling
+antarctic_boundary_convention = calving_front
+
 
 # options related to writing out and plotting cell widths
 plot_cell_width = True

--- a/polaris/tasks/e3sm/init/topo/cull/mask.py
+++ b/polaris/tasks/e3sm/init/topo/cull/mask.py
@@ -524,20 +524,17 @@ class CullMaskStep(Step):
 
         ds_topo = xr.open_dataset('topography_unsmoothed.nc')
         land_ice_frac = ds_topo.ice_frac
-        land_ice_present = land_ice_frac > land_ice_min_fraction
 
         ds_ocean_cull_mask = xr.open_dataset('ocean_cull_mask.nc')
         ocean_cull_mask = ds_ocean_cull_mask.oceanCullMask > 0
 
-        lat_cell = np.degrees(ds_base_mesh.latCell)
-        antarctic_not_ocean = np.logical_and(
-            ocean_cull_mask > 0, lat_cell < land_ice_max_latitude
+        land_ice_present = self._antarctic_land_ice_ownership(
+            ds_topo=ds_topo,
+            ocean_cull_mask=ocean_cull_mask,
+            lat_cell=np.degrees(ds_base_mesh.latCell),
+            land_ice_max_latitude=land_ice_max_latitude,
+            land_ice_min_fraction=land_ice_min_fraction,
         )
-
-        # include areas we're culling from the ocean that are south of
-        # land_ice_max_latitude -- if it's not ocean, it's land ice.  This
-        # should also take care of critical transects
-        land_ice_present = np.logical_or(land_ice_present, antarctic_not_ocean)
 
         # flood fill the land ice mask from the south pole
         logger.info('Flood filling land ice mask from south pole.')
@@ -686,3 +683,20 @@ class CullMaskStep(Step):
 
         write_netcdf(ds_masks, 'cull_masks.nc')
         logger.info('Wrote cull_masks.nc.')
+
+    @staticmethod
+    def _antarctic_land_ice_ownership(
+        ds_topo,
+        ocean_cull_mask,
+        lat_cell,
+        land_ice_max_latitude,
+        land_ice_min_fraction,
+    ):
+        """
+        Determine Antarctic cells that should be owned by land ice.
+        """
+        land_ice_present = ds_topo.ice_frac > land_ice_min_fraction
+        antarctic_not_ocean = np.logical_and(
+            ocean_cull_mask, lat_cell < land_ice_max_latitude
+        )
+        return np.logical_or(land_ice_present, antarctic_not_ocean)

--- a/polaris/tasks/e3sm/init/topo/cull/steps.py
+++ b/polaris/tasks/e3sm/init/topo/cull/steps.py
@@ -48,6 +48,16 @@ def get_default_cull_topo_steps(
     )
     config = PolarisConfigParser(filepath=filepath)
     config.add_from_package('polaris.tasks.e3sm.init.topo.cull', 'cull.cfg')
+    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+    convention = base_mesh_step.config.get(
+        'spherical_mesh', 'antarctic_boundary_convention'
+    )
+    config.set(
+        'spherical_mesh',
+        'antarctic_boundary_convention',
+        convention,
+    )
+
     steps: dict[str, Step] = {}
 
     step_name = 'cull_mask'

--- a/polaris/tasks/e3sm/init/topo/remap/mask.py
+++ b/polaris/tasks/e3sm/init/topo/remap/mask.py
@@ -3,6 +3,7 @@ import os
 import xarray as xr
 
 from polaris import Step
+from polaris.mesh.spherical.coastline import CONVENTIONS
 
 
 class MaskTopoStep(Step):
@@ -63,11 +64,11 @@ class MaskTopoStep(Step):
         and 1, where 1 indicates the cell is fully covered by land or ocean,
         respectively.
 
-        The default implementation sets the ocean mask to locations where the
-        base elevation is less than 0 and the Antarctic ice sheet is not
-        grounded, and the land mask to locations where the base elevation is
-        greater than 0 or the Antarctic ice sheet is present.  The two overlap
-        for Antarctic ice shelves, which are included in both masks.
+        The default implementation sets the ocean mask based on
+        ``antarctic_boundary_convention`` and the land mask to locations where
+        the base elevation is greater than 0 or the Antarctic ice sheet is
+        present. The two overlap for Antarctic ice shelves, which are included
+        in both masks.
 
         Parameters
         ----------
@@ -83,11 +84,7 @@ class MaskTopoStep(Step):
             The mask array with the same shape as the topography fields
         """
         config = self.config
-        section = config['mask_topography']
-        ocean_includes_grounded_ice = section.getboolean(
-            'ocean_includes_grounded_ice'
-        )
-        # Default implementation
+        convention = self._get_antarctic_boundary_convention(config)
         base_elevation = ds.base_elevation
         ice_mask = ds.ice_mask
 
@@ -97,15 +94,65 @@ class MaskTopoStep(Step):
         # above sea level or below sea leve but part of Antarcica
         land_mask = above_sea_level + below_sea_level * ice_mask
 
-        if ocean_includes_grounded_ice:
-            ocean_mask = below_sea_level
-        else:
-            grounded_mask = ds.grounded_mask
-            not_grounded = 1.0 - grounded_mask
-            # below sea level and not under grounded Antarctic ice
-            ocean_mask = below_sea_level * not_grounded
+        ocean_mask = self._get_ocean_mask(
+            base_elevation=base_elevation,
+            ice_mask=ice_mask,
+            grounded_mask=ds.grounded_mask,
+            convention=convention,
+        )
 
         return ocean_mask, land_mask
+
+    @staticmethod
+    def _get_antarctic_boundary_convention(config):
+        """
+        Get and validate the Antarctic boundary convention from config.
+        """
+        if not config.has_option(
+            'spherical_mesh', 'antarctic_boundary_convention'
+        ):
+            raise ValueError(
+                'Missing spherical_mesh.antarctic_boundary_convention '
+                'in remap topography config.'
+            )
+
+        convention = config.get(
+            'spherical_mesh', 'antarctic_boundary_convention'
+        )
+        if convention not in CONVENTIONS:
+            valid = ', '.join(CONVENTIONS)
+            raise ValueError(
+                f'Unexpected antarctic_boundary_convention {convention!r}. '
+                f'Valid options are: {valid}'
+            )
+        return convention
+
+    @staticmethod
+    def _get_ocean_mask(
+        base_elevation,
+        ice_mask,
+        grounded_mask,
+        convention,
+    ):
+        """
+        Get the ocean mask before remapping.
+        """
+        below_sea_level = (base_elevation < 0.0).astype(float)
+
+        if convention == 'calving_front':
+            return below_sea_level * (1.0 - ice_mask)
+
+        if convention == 'grounding_line':
+            return below_sea_level * (1.0 - grounded_mask)
+
+        if convention == 'bedrock_zero':
+            return below_sea_level
+
+        valid = ', '.join(CONVENTIONS)
+        raise ValueError(
+            f'Unexpected antarctic_boundary_convention {convention!r}. '
+            f'Valid options are: {valid}'
+        )
 
     def run(self):
         in_filename = 'topography.nc'

--- a/polaris/tasks/e3sm/init/topo/remap/remap.cfg
+++ b/polaris/tasks/e3sm/init/topo/remap/remap.cfg
@@ -1,10 +1,3 @@
-# config options related to masking topography
-[mask_topography]
-
-# whether the ocean includes Antarctic grounded ice
-ocean_includes_grounded_ice = False
-
-
 # config options related to remapping topography to an MPAS mesh
 [remap_topography]
 

--- a/polaris/tasks/e3sm/init/topo/remap/steps.py
+++ b/polaris/tasks/e3sm/init/topo/remap/steps.py
@@ -71,6 +71,16 @@ def get_default_remap_topo_steps(
         config.add_from_package(
             'polaris.tasks.e3sm.init.topo.remap', 'remap_low_res.cfg'
         )
+    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+    convention = base_mesh_step.config.get(
+        'spherical_mesh', 'antarctic_boundary_convention'
+    )
+    config.set(
+        'spherical_mesh',
+        'antarctic_boundary_convention',
+        convention,
+    )
+
     steps: dict[str, Step] = {}
 
     step_name = 'mask_topo'

--- a/tests/e3sm/init/topo/test_antarctic_boundary.py
+++ b/tests/e3sm/init/topo/test_antarctic_boundary.py
@@ -1,0 +1,171 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.component import Component
+from polaris.config import PolarisConfigParser
+from polaris.tasks.e3sm.init.topo.cull.mask import CullMaskStep
+from polaris.tasks.e3sm.init.topo.cull.steps import (
+    get_default_cull_topo_steps,
+)
+from polaris.tasks.e3sm.init.topo.remap.mask import MaskTopoStep
+from polaris.tasks.e3sm.init.topo.remap.steps import (
+    get_default_remap_topo_steps,
+)
+
+
+@pytest.mark.parametrize(
+    ('convention', 'expected_ocean'),
+    [
+        ('calving_front', [0.0, 0.0, 1.0, 0.0]),
+        ('grounding_line', [0.0, 1.0, 1.0, 0.0]),
+        ('bedrock_zero', [1.0, 1.0, 1.0, 0.0]),
+    ],
+)
+def test_remap_mask_antarctic_boundary_convention(convention, expected_ocean):
+    step = _mask_topo_step(convention=convention)
+    ocean_mask, land_mask = step.define_masks(_topo_dataset())
+
+    np.testing.assert_allclose(ocean_mask.values, expected_ocean)
+    np.testing.assert_allclose(land_mask.values, [1.0, 1.0, 0.0, 1.0])
+
+
+def test_remap_mask_requires_antarctic_boundary_convention():
+    step = _mask_topo_step(convention=None)
+
+    with pytest.raises(ValueError, match='Missing spherical_mesh'):
+        step.define_masks(_topo_dataset())
+
+
+def test_remap_mask_rejects_invalid_antarctic_boundary_convention():
+    step = _mask_topo_step(convention='ice_shelf_edge')
+
+    with pytest.raises(ValueError, match='Unexpected'):
+        step.define_masks(_topo_dataset())
+
+
+def test_spherical_mesh_config_default_convention():
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+
+    assert (
+        config.get('spherical_mesh', 'antarctic_boundary_convention')
+        == 'calving_front'
+    )
+
+
+def test_topo_configs_inherit_base_mesh_convention(monkeypatch):
+    monkeypatch.setattr(
+        'polaris.step.MachineInfo', lambda *args, **kwargs: None
+    )
+    component = Component(name='e3sm/init')
+    base_mesh_step = _base_mesh_step(convention='bedrock_zero')
+    combine_topo_step = SimpleNamespace(
+        path='combine_topo', combined_filename='topography.nc'
+    )
+    unsmoothed_topo_step = SimpleNamespace(path='remap_unsmoothed')
+
+    _, remap_config = get_default_remap_topo_steps(
+        component=component,
+        base_mesh_step=base_mesh_step,
+        combine_topo_step=combine_topo_step,
+        low_res=False,
+    )
+    _, cull_config = get_default_cull_topo_steps(
+        component=component,
+        base_mesh_step=base_mesh_step,
+        unsmoothed_topo_step=unsmoothed_topo_step,
+    )
+
+    for config in [remap_config, cull_config]:
+        assert (
+            config.get('spherical_mesh', 'antarctic_boundary_convention')
+            == 'bedrock_zero'
+        )
+
+
+def test_antarctic_land_ice_ownership_includes_southern_non_ocean_cells():
+    ds_topo = _cull_topo_dataset(
+        ocean_frac=[1.0, 0.0, 0.0],
+        land_frac=[0.0, 1.0, 1.0],
+        ice_frac=[0.2, 0.0, 0.0],
+        grounded_mask=[0.0, 0.0, 0.0],
+        base_elevation=[-100.0, 100.0, 100.0],
+    )
+    ocean_cull_mask = xr.DataArray([False, True, True], dims=('nCells',))
+    lat_cell = xr.DataArray([-80.0, -75.0, -40.0], dims=('nCells',))
+
+    land_ice = CullMaskStep._antarctic_land_ice_ownership(
+        ds_topo=ds_topo,
+        ocean_cull_mask=ocean_cull_mask,
+        lat_cell=lat_cell,
+        land_ice_max_latitude=-60.0,
+        land_ice_min_fraction=0.01,
+    )
+
+    np.testing.assert_array_equal(land_ice.values, [True, True, False])
+
+
+def _mask_topo_step(convention):
+    config = PolarisConfigParser()
+    if convention is not None:
+        config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+        config.set(
+            'spherical_mesh', 'antarctic_boundary_convention', convention
+        )
+
+    step = MaskTopoStep.__new__(MaskTopoStep)
+    step.config = config
+    return step
+
+
+def _base_mesh_step(convention):
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+    config.set('spherical_mesh', 'prefix', 'QU')
+    config.set('spherical_mesh', 'min_cell_width', '240')
+    config.set('spherical_mesh', 'max_cell_width', '240')
+    config.set('spherical_mesh', 'antarctic_boundary_convention', convention)
+    return SimpleNamespace(
+        mesh_name='QU240',
+        config=config,
+    )
+
+
+def _topo_dataset():
+    return xr.Dataset(
+        data_vars=dict(
+            base_elevation=(
+                'nCells',
+                np.array([-100.0, -100.0, -100.0, 1.0]),
+            ),
+            ice_mask=('nCells', np.array([1.0, 1.0, 0.0, 0.0])),
+            grounded_mask=('nCells', np.array([1.0, 0.0, 0.0, 0.0])),
+        )
+    )
+
+
+def _cull_topo_dataset(
+    ocean_frac,
+    land_frac,
+    ice_frac,
+    grounded_mask,
+    base_elevation,
+):
+    return xr.Dataset(
+        data_vars=dict(
+            ocean_frac=('nCells', np.asarray(ocean_frac, dtype=float)),
+            land_frac=('nCells', np.asarray(land_frac, dtype=float)),
+            ice_frac=('nCells', np.asarray(ice_frac, dtype=float)),
+            grounded_mask=(
+                'nCells',
+                np.asarray(grounded_mask, dtype=float),
+            ),
+            base_elevation=(
+                'nCells',
+                np.asarray(base_elevation, dtype=float),
+            ),
+        )
+    )


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge introduces a config option `[spherical_mesh]/antarctic_boundary_convention` that is used to determine where the ocean boundary is around Antarctica.

Currently, this is used by the `e3sm/init` components to remap topography and cull the mesh to land and ocean regions, but it will also be used in generating the sizing field for unified MPAS meshes.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
