### PR TITLE
Fix enabling/disabling horiz. press. grad. tendency

### DIFF
--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -177,6 +177,11 @@ config:
     config_disable_thick_vadv: not ThicknessVertAdvTendencyEnable
 
 - section:
+    debug: Tendencies
+  options:
+    config_disable_vel_pgrad: not PressureGradTendencyEnable
+
+- section:
     bottom_drag: Tendencies
   options:
     config_explicit_bottom_drag_coeff: BottomDragCoeff

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -60,7 +60,6 @@ Omega:
     TracerHorzAdvTendencyEnable : false
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
-    PressureGradTendencyEnable : false
   Advection:
     FluxThicknessType: Center
   IOStreams:

--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -5,6 +5,8 @@ ocean:
   time_integration:
     config_dt: {{ dt }}
     config_time_integrator: {{ time_integrator }}
+  debug:
+    config_disable_vel_pgrad: true
 
 mpas-ocean:
   run_modes:
@@ -18,7 +20,6 @@ mpas-ocean:
     config_disable_thick_sflux: true
     config_disable_vel_all_tend: true
     config_disable_vel_coriolis: true
-    config_disable_vel_pgrad: true
     config_disable_vel_hmix: true
     config_disable_vel_surface_stress: true
     config_disable_vel_explicit_bottom_drag: true
@@ -75,7 +76,6 @@ Omega:
     TracerHorzAdvTendencyEnable : true
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
-    PressureGradTendencyEnable : false
   IOStreams:
     InitialState:
       Contents:

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -42,7 +42,6 @@ Omega:
     VelHyperDiffTendencyEnable: false
     UseCustomTendency: true
     ManufacturedSolutionTendency: true
-    PressureGradTendencyEnable : false
   IOStreams:
     InitialState:
       UsePointerFile: false

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -10,6 +10,7 @@ ocean:
     config_disable_vel_vadv: true
     config_disable_thick_vadv: true
     config_disable_thick_hadv: true
+    config_disable_vel_pgrad: true
   hmix_del2:
     config_use_mom_del2: false
     config_use_tracer_del2: false
@@ -37,7 +38,6 @@ mpas-ocean:
     config_disable_vel_all_tend: true
     config_disable_tr_hmix: true
     config_disable_vel_vmix: true
-    config_disable_vel_pgrad: true
     config_disable_tr_sflux: true
     config_disable_tr_nonlocalflux: true
     config_check_ssh_consistency: false

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -7,6 +7,8 @@ ocean:
     config_time_integrator: {{ time_integrator }}
   advection:
     config_horiz_tracer_adv_order: 3
+  debug:
+    config_disable_vel_pgrad: true
 
 mpas-ocean:
   run_modes:
@@ -22,7 +24,6 @@ mpas-ocean:
     config_disable_thick_sflux: true
     config_disable_vel_all_tend: true
     config_disable_vel_coriolis: true
-    config_disable_vel_pgrad: true
     config_disable_vel_hmix: true
     config_disable_vel_surface_stress: true
     config_disable_vel_explicit_bottom_drag: true
@@ -74,7 +75,6 @@ Omega:
     TracerHorzAdvTendencyEnable : true
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
-    PressureGradTendencyEnable : false
   IOStreams:
     InitialState:
       Contents:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This adds a mapping from the MPAS-Ocean to the Omega config option for disabling/enabling the horizontal pressure gradient tendency.

The mapping is used instead of turning off the tendency in two places in the cosine-bell and sphere-transport tests.

It also switches from the Boussinesq SSH gradient tendency to the Omega v1 HPGF tendency in two task families:
* `barotropic_gyre`
* `manufactured_solution`

Finally, `merry_go_round` had the HPGF off in MPAS-Ocean but not covered in Omega, so on by default, suggesting it was missed in #529.  This also seems to be the cause of #584.

This PR updates the Omega submodule to bring in:
* https://github.com/E3SM-Project/Omega/pull/424
* https://github.com/E3SM-Project/Omega/pull/425
* https://github.com/E3SM-Project/Omega/pull/386

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #584 