### PR TITLE
Update to v1.0.0-alpha.8 with mache v3.7.0

### DIFF
--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "polaris",
-    "mache_version": "3.6.0",
+    "mache_version": "3.7.0",
     "description": "Deploy polaris environment"
   },
   "arguments": [

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -3,7 +3,7 @@
 bootstrap_python = 3.14
 python = 3.14
 geometric_features = 1.6.3
-mache = 3.6.0
+mache = 3.7.0
 mpas_tools = 1.6.0
 otps = 2021.10
 parallelio = 2.6.9

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -581,7 +581,7 @@ def _run_task(task, available_resources):
             else:
                 property_str = fail_str
             _print_to_stdout(
-                task, f'          property checks:   {property_str}'
+                task, f'          property checks:  {property_str}'
             )
             property_passed = _accumulate_baselines(property_passed, status)
 

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.0-alpha.7'
+__version__ = '1.0.0-alpha.8'


### PR DESCRIPTION
This version of mache (https://github.com/E3SM-Project/mache/releases/tag/3.7.0) brings in two important fixes needed on Chrysalis:
* Fix chrysalis cores per node: 64 not 128 by @xylar in https://github.com/E3SM-Project/mache/pull/424
* Unload python or conda modules in mache.deploy load scripts by @xylar in https://github.com/E3SM-Project/mache/pull/430

We were previously using 128 cores per node (which includes hyperthreading, and is not how E3SM runs on Chrysalis).

The move to `oneapi-ifx` has meant that the python system module gets reloaded when the compiler module gets changed, and this in turn puts the python module "in front of" the Polaris pixi python path.  This causes python scripts like the Omega CTest utility to fail with missing dependencies.  With mache 3.7.0, we unload any python module before loading other system modules.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
