### PR TITLE
Add configurable feature-mask tasks for mesh and ocean components

### DIFF
--- a/docs/developers_guide/mesh/api.md
+++ b/docs/developers_guide/mesh/api.md
@@ -24,6 +24,28 @@
    BaseMeshTask
 ```
 
+### Feature-Mask Tasks
+
+```{eval-rst}
+.. currentmodule:: polaris.tasks.mesh.spherical.feature_masks
+
+.. autosummary::
+   :toctree: generated/
+
+   ComputeFeatureMasksStep
+   ComputeFeatureMasksStep.setup
+   ComputeFeatureMasksStep.constrain_resources
+   ComputeFeatureMasksStep.run
+   ComputeFeatureMasksStep._open_mesh_dataset
+   ComputeFeatureMasksStep._write_mask_dataset
+   FeatureMasksTask
+   add_feature_mask_tasks
+   build_mask_feature_collection
+   compute_feature_masks
+   get_feature_mask_steps
+   get_feature_object_type
+```
+
 ### Unified Coastline Tasks
 
 ```{eval-rst}

--- a/docs/developers_guide/mesh/api.md
+++ b/docs/developers_guide/mesh/api.md
@@ -46,6 +46,16 @@
    get_feature_object_type
 ```
 
+```{eval-rst}
+.. currentmodule:: polaris.tasks.mesh.spherical.feature_masks.moc
+
+.. autosummary::
+   :toctree: generated/
+
+   add_moc_transects
+   moc_masks_filename
+```
+
 ### Unified Coastline Tasks
 
 ```{eval-rst}

--- a/docs/developers_guide/mesh/tasks/base_mesh.md
+++ b/docs/developers_guide/mesh/tasks/base_mesh.md
@@ -1,0 +1,12 @@
+(dev-mesh-base-mesh-task)=
+
+# Base Mesh Tasks
+
+The base mesh tasks defined by
+{py:class}`polaris.tasks.mesh.base.BaseMeshTask` can be used to generate
+quasi-uniform (`qu`) and subdivided icosahedral (`icos`) spherical meshes at
+quasi-uniform resolutions ranging from 30 to 480 km.  These base meshes cover
+the full sphere, including both continents and ocean regions.
+
+The same task family also includes the supported variable-resolution base
+meshes such as `rrs6to18km` and `so12to30km`.

--- a/docs/developers_guide/mesh/tasks/feature_masks.md
+++ b/docs/developers_guide/mesh/tasks/feature_masks.md
@@ -1,0 +1,59 @@
+(dev-mesh-feature-masks)=
+
+# Feature Masks
+
+The {py:mod}`polaris.tasks.mesh.spherical.feature_masks` package provides the
+model-neutral implementation for creating region or transect masks on standard
+MPAS meshes.
+
+The mesh component owns only standard MPAS behavior:
+
+- {py:class}`polaris.tasks.mesh.spherical.feature_masks.ComputeFeatureMasksStep`
+  opens a standard MPAS mesh with `xarray`;
+- helper functions build the feature collection, detect whether it contains
+  regions or transects, validate mask types, and dispatch to `mpas_tools`;
+- output files use standard `mpas_tools` region/transect mask conventions.
+
+The mesh package must not contain Omega-specific translation. Ocean-native
+input support lives in {py:mod}`polaris.tasks.ocean.feature_masks`, where
+{py:class}`polaris.tasks.ocean.feature_masks.ComputeOceanFeatureMasksStep`
+subclasses the mesh step and overrides mesh opening and mask writing through
+the ocean component's native I/O translation. See {ref}`dev-ocean-feature-masks`.
+
+## Shared Steps
+
+Use
+{py:func}`polaris.tasks.mesh.spherical.feature_masks.get_feature_mask_steps`
+when another mesh workflow already has an upstream mesh-producing step. The
+caller provides:
+
+- `mesh_name`, used for output filenames and metadata;
+- `mask_group`, passed to `get_aggregator_by_name()`;
+- `mesh_step` and `mesh_filename`, when the mesh is produced by another step.
+
+The shared step does not special-case base meshes or culled meshes.  Workflows
+such as E3SM init should pass the relevant upstream step and filename
+explicitly.
+
+## Implementation Map
+
+{py:class}`polaris.tasks.mesh.spherical.feature_masks.FeatureMasksTask`
+registers the configurable task at
+`mesh/spherical/feature_masks/configurable`.
+
+{py:func}`polaris.tasks.mesh.spherical.feature_masks.build_mask_feature_collection`
+uses `geometric_features.get_aggregator_by_name()` to build the feature
+collection and return the filename prefix and date stamp.
+
+{py:func}`polaris.tasks.mesh.spherical.feature_masks.get_feature_object_type`
+validates that the collection contains only regions or only transects.
+
+{py:func}`polaris.tasks.mesh.spherical.feature_masks.compute_feature_masks`
+dispatches to `mpas_tools.mesh.mask.compute_mpas_region_masks()` or
+`mpas_tools.mesh.mask.compute_mpas_transect_masks()`.
+
+## Testing
+
+Unit tests cover object-type detection, mask-type validation, shared-step
+configuration, configurable setup, output metadata, and the ocean subclass's
+Omega-name translation boundary.

--- a/docs/developers_guide/mesh/tasks/feature_masks.md
+++ b/docs/developers_guide/mesh/tasks/feature_masks.md
@@ -52,8 +52,45 @@ validates that the collection contains only regions or only transects.
 dispatches to `mpas_tools.mesh.mask.compute_mpas_region_masks()` or
 `mpas_tools.mesh.mask.compute_mpas_transect_masks()`.
 
+(dev-mesh-feature-masks-moc)=
+
+## MOC Helpers
+
+{py:mod}`polaris.tasks.mesh.spherical.feature_masks.moc` is a leaf module
+holding the two pieces of `'MOC Basins'` behavior that are not specific to any
+model:
+
+- {py:func}`polaris.tasks.mesh.spherical.feature_masks.moc.moc_masks_filename`
+  applies the `mocBasinsAndTransects` filename convention that E3SM already
+  uses, as in `oRRS18to6v3_mocBasinsAndTransects20210623.nc`;
+- {py:func}`polaris.tasks.mesh.spherical.feature_masks.moc.add_moc_transects`
+  calls `mpas_tools.ocean.moc.add_moc_southern_boundary_transects()` to append
+  southern-boundary transect masks derived algorithmically from the basin cell
+  masks, then drops the string variables `'history'` and `'constituents'`,
+  which that function may attach and which are incompatible with CDF5 output.
+
+The module also defines `MOC_MASK_GROUP` (`'MOC Basins'`) and `MOC_PREFIX`
+(`'mocBasinsAndTransects'`).
+
+Neither helper needs a step, and neither touches an ocean model: they operate
+on standard MPAS meshes and masks.  `mpas_tools.ocean.moc` is a plain
+`mpas_tools` module, so importing it does not pull in
+{py:mod}`polaris.tasks.ocean` or require an `[ocean]` config section.  That is
+what lets a step in another component — for example the `e3sm/init`
+`component_inputs` staging of the per-mesh MOC file that MPAS-Ocean reads
+through its `regionalMasksInput` and `transectMasksInput` streams — subclass
+the model-neutral {py:class}`polaris.tasks.mesh.spherical.feature_masks.ComputeFeatureMasksStep`
+and call the same two functions.
+
+{py:class}`polaris.tasks.ocean.feature_masks.ComputeOceanFeatureMasksStep`
+delegates to these helpers rather than implementing the behavior itself, so
+the MOC logic lives in exactly one place.  See
+{ref}`dev-ocean-feature-masks`.
+
 ## Testing
 
 Unit tests cover object-type detection, mask-type validation, shared-step
-configuration, configurable setup, output metadata, and the ocean subclass's
-Omega-name translation boundary.
+configuration, configurable setup, output metadata, the MOC helpers (including
+that importing the `moc` module does not import
+{py:mod}`polaris.tasks.ocean`), and the ocean subclass's Omega-name
+translation boundary.

--- a/docs/developers_guide/mesh/tasks/index.md
+++ b/docs/developers_guide/mesh/tasks/index.md
@@ -2,15 +2,17 @@
 
 # Tasks
 
-(dev-mesh-base-mesh-task)=
+## Spherical Mesh Tasks
 
-## Base Mesh Task
+These task families operate on spherical MPAS meshes and are not tied to the
+unified-mesh workflow.
 
-The the base mesh tasks defined by {py:class}`polaris.tasks.mesh.base.BaseMeshTask`
-can be used to generate quasi-uniform (`qu`) and subdivided icosahedral
-(`icos`) spherical meshes at quasi-uniform resolutions ranging from 30 to 480
-km.  These "base" meshes cover the full sphere (include both continents and
-ocean regions).
+```{toctree}
+:titlesonly: true
+
+base_mesh
+feature_masks
+```
 
 ## Unified Mesh Tasks
 

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -172,6 +172,21 @@
    VizTransect.run
 ```
 
+### feature_masks
+
+```{eval-rst}
+.. currentmodule:: polaris.tasks.ocean.feature_masks
+
+.. autosummary::
+   :toctree: generated/
+
+   ComputeOceanFeatureMasksStep
+   ComputeOceanFeatureMasksStep._open_mesh_dataset
+   ComputeOceanFeatureMasksStep._write_mask_dataset
+   OceanFeatureMasksTask
+   add_feature_mask_tasks
+```
+
 ### geostrophic
 
 ```{eval-rst}

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -169,6 +169,21 @@
    VizTransect.run
 ```
 
+### feature_masks
+
+```{eval-rst}
+.. currentmodule:: polaris.tasks.ocean.feature_masks
+
+.. autosummary::
+   :toctree: generated/
+
+   ComputeOceanFeatureMasksStep
+   ComputeOceanFeatureMasksStep._open_mesh_dataset
+   ComputeOceanFeatureMasksStep._write_mask_dataset
+   OceanFeatureMasksTask
+   add_feature_mask_tasks
+```
+
 ### geostrophic
 
 ```{eval-rst}

--- a/docs/developers_guide/ocean/tasks/feature_masks.md
+++ b/docs/developers_guide/ocean/tasks/feature_masks.md
@@ -1,0 +1,34 @@
+(dev-ocean-feature-masks)=
+
+# Feature Masks
+
+The {py:mod}`polaris.tasks.ocean.feature_masks` package contains the
+ocean-specific feature-mask task and step. It exists so native ocean I/O
+translation, in particular Omega mesh-name translation, stays in the ocean
+framework rather than in the model-neutral mesh component.
+
+This page covers only the ocean-specific extension. The shared mask-generation
+design, helper functions, and standard MPAS output conventions are documented
+in {ref}`dev-mesh-feature-masks`.
+
+{py:class}`polaris.tasks.ocean.feature_masks.ComputeOceanFeatureMasksStep`
+subclasses the mesh component's
+{py:class}`polaris.tasks.mesh.spherical.feature_masks.ComputeFeatureMasksStep`
+and overrides the model-specific I/O hooks:
+
+- standard MPAS-Ocean input passes through unchanged;
+- Omega-format mesh input is mapped to MPAS-Ocean names with
+  {py:meth}`polaris.tasks.ocean.Ocean.open_model_dataset`;
+- mask computation is delegated to the shared, model-neutral mesh helpers
+  documented in {ref}`dev-mesh-feature-masks`;
+- mask output is mapped back to native ocean names, such as `NCells`,
+  `NEdges`, `NRegions`, and `RegionCellMasks` for Omega.
+
+{py:class}`polaris.tasks.ocean.feature_masks.OceanFeatureMasksTask` registers
+the configurable task at `ocean/feature_masks/configurable`. It uses the same
+`[feature_masks]` config section as the mesh task and swaps in the ocean step
+class so ocean model detection and native I/O translation are available during
+setup and run.
+
+Future Omega-friendly output naming or variable filtering should also stay in
+this ocean package, not in {py:mod}`polaris.tasks.mesh.spherical.feature_masks`.

--- a/docs/developers_guide/ocean/tasks/feature_masks.md
+++ b/docs/developers_guide/ocean/tasks/feature_masks.md
@@ -32,3 +32,29 @@ setup and run.
 
 Future Omega-friendly output naming or variable filtering should also stay in
 this ocean package, not in {py:mod}`polaris.tasks.mesh.spherical.feature_masks`.
+
+## MOC Basins Extension
+
+`ComputeOceanFeatureMasksStep` overrides two protected hooks to handle the
+`'MOC Basins'` mask group as a special case.
+
+**`_set_output_filenames(mesh_name, mask_group)`** — calls `super()` to set
+the normal filenames and then, for `mask_group == 'MOC Basins'`, replaces
+`output_filename` with `{mesh_name}_mocBasinsAndTransects{date}.nc`.
+`geojson_filename` is left as `mocBasins{date}.geojson` (the intermediate
+GeoJSON used by `compute_mpas_region_masks`).  The renamed output matches the
+convention expected by MPAS-Analysis.
+
+**`_post_process_masks(ds_masks, ds_mesh, mask_group)`** — for
+`mask_group == 'MOC Basins'`, calls
+`mpas_tools.ocean.moc.add_moc_southern_boundary_transects(ds_masks, ds_mesh,
+logger=self.logger)`, which appends southern-boundary transect masks derived
+algorithmically from the basin cell masks.  The string variables `'history'`
+and `'constituents'`, which `add_moc_southern_boundary_transects` may attach
+and which are incompatible with CDF5 output, are dropped if present.  For all
+other mask groups the method is a no-op.
+
+The hook is defined on the model-neutral base class
+{py:class}`polaris.tasks.mesh.spherical.feature_masks.ComputeFeatureMasksStep`
+as a no-op return; `add_moc_southern_boundary_transects` lives in
+`mpas_tools.ocean` and must not be imported by the mesh package.

--- a/docs/developers_guide/ocean/tasks/feature_masks.md
+++ b/docs/developers_guide/ocean/tasks/feature_masks.md
@@ -36,25 +36,24 @@ this ocean package, not in {py:mod}`polaris.tasks.mesh.spherical.feature_masks`.
 ## MOC Basins Extension
 
 `ComputeOceanFeatureMasksStep` overrides two protected hooks to handle the
-`'MOC Basins'` mask group as a special case.
+`'MOC Basins'` mask group as a special case.  Neither hook implements the MOC
+behavior itself; both delegate to the model-neutral helpers in
+{py:mod}`polaris.tasks.mesh.spherical.feature_masks.moc`, described in
+{ref}`dev-mesh-feature-masks-moc`, so the same behavior is available to steps
+in other components.
 
 **`_set_output_filenames(mesh_name, mask_group)`** — calls `super()` to set
-the normal filenames and then, for `mask_group == 'MOC Basins'`, replaces
-`output_filename` with `{mesh_name}_mocBasinsAndTransects{date}.nc`.
+the normal filenames and then, for `mask_group == MOC_MASK_GROUP`, replaces
+`output_filename` with the result of `moc_masks_filename(mesh_name, date)`.
 `geojson_filename` is left as `mocBasins{date}.geojson` (the intermediate
 GeoJSON used by `compute_mpas_region_masks`).  The renamed output matches the
 convention expected by MPAS-Analysis.
 
 **`_post_process_masks(ds_masks, ds_mesh, mask_group)`** — for
-`mask_group == 'MOC Basins'`, calls
-`mpas_tools.ocean.moc.add_moc_southern_boundary_transects(ds_masks, ds_mesh,
-logger=self.logger)`, which appends southern-boundary transect masks derived
-algorithmically from the basin cell masks.  The string variables `'history'`
-and `'constituents'`, which `add_moc_southern_boundary_transects` may attach
-and which are incompatible with CDF5 output, are dropped if present.  For all
-other mask groups the method is a no-op.
+`mask_group == MOC_MASK_GROUP`, returns
+`add_moc_transects(ds_masks, ds_mesh, logger=self.logger)`.  For all other
+mask groups the method is a no-op.
 
 The hook is defined on the model-neutral base class
 {py:class}`polaris.tasks.mesh.spherical.feature_masks.ComputeFeatureMasksStep`
-as a no-op return; `add_moc_southern_boundary_transects` lives in
-`mpas_tools.ocean` and must not be imported by the mesh package.
+as a no-op return.

--- a/docs/developers_guide/ocean/tasks/index.md
+++ b/docs/developers_guide/ocean/tasks/index.md
@@ -12,6 +12,7 @@ correlated_tracers_2d
 cosine_bell
 customizable_viz
 external_gravity_wave
+feature_masks
 geostrophic
 global_ocean
 horiz_press_grad

--- a/docs/developers_guide/ocean/tasks/index.md
+++ b/docs/developers_guide/ocean/tasks/index.md
@@ -12,6 +12,7 @@ correlated_tracers_2d
 cosine_bell
 customizable_viz
 external_gravity_wave
+feature_masks
 geostrophic
 horiz_press_grad
 divergent_2d

--- a/docs/users_guide/mesh/tasks/base_mesh.md
+++ b/docs/users_guide/mesh/tasks/base_mesh.md
@@ -1,0 +1,30 @@
+(mesh-base-mesh-task)=
+
+# Base Mesh Tasks
+
+The `mesh/spherical/qu/base_mesh/XXXkm/task` and
+`mesh/spherical/icos/base_mesh/XXXkm/task` tasks can be used to create
+spherical, uniform MPAS meshes at the given resolution that are either
+quasi-uniform (`qu`) or subdivided icosahedral (`icos`).
+
+There are also two variable-resolution base meshes: `rrs6to18km` and
+`so12to30km`.
+
+The RRS mesh has a resolution that ranges from 6 km at the poles to 18 km at
+the equator, approximately scaling with the Rossby radius.
+
+```{image} ../../../developers_guide/mesh/framework/images/rrs.png
+:align: center
+:width: 500 px
+```
+
+The SO mesh has a quasi-uniform, 30 km background resolution that transitions
+to 12 km in a region surrounding the Southern Ocean.  The boundary of the
+high-resolution region attempts to approximately follow dynamical contours in
+the ocean, since rapid changes in resolution have been shown to steer ocean
+currents along isocontours of resolution.
+
+```{image} ../../../developers_guide/mesh/framework/images/so.png
+:align: center
+:width: 500 px
+```

--- a/docs/users_guide/mesh/tasks/feature_masks.md
+++ b/docs/users_guide/mesh/tasks/feature_masks.md
@@ -1,0 +1,62 @@
+(users-mesh-feature-masks)=
+
+# Feature Masks
+
+The `mesh/spherical/feature_masks/configurable` task creates standard MPAS mask
+files on an existing MPAS mesh.  The masks are based on a named `mask_group`
+supported by `geometric_features.get_aggregator_by_name()`.
+
+Both polygon region groups and transect groups are supported.  Polaris inspects
+the feature collection and calls the appropriate `mpas_tools.mesh.mask`
+function:
+
+- region groups produce variables such as `regionCellMasks`,
+  `regionVertexMasks`, and `regionNames`;
+- transect groups produce variables such as `transectCellMasks`,
+  `transectEdgeMasks`, `transectVertexMasks`, and `transectNames`.
+
+The mesh-component task expects a standard MPAS mesh file.  Omega-format mesh
+input is handled by the ocean component's feature-mask task because Omega I/O
+translation is ocean-specific; see {ref}`users-ocean-feature-masks`.
+The ocean task derives from the same mesh mask-generation behavior and only
+changes how native ocean mesh files are opened.
+
+## Configuration
+
+The configurable task uses `feature_masks.cfg` and the `[feature_masks]`
+section.
+The required options are:
+
+- `mesh_filename`: path to the standard MPAS mesh file;
+- `mesh_name`: name used in output filenames and metadata;
+- `mask_group`: one of the supported aggregation group names.
+
+The output filename is:
+
+```text
+<mesh_name>_<prefix><date>.nc
+```
+
+where `prefix` and `date` come from the selected mask group.  The task also
+writes the GeoJSON feature collection used to create the masks.
+
+Common optional settings include:
+
+- `mask_types`: use `default`, or a space-separated list from `cell`, `edge`,
+  and `vertex`;
+- `add_edge_sign`: add `transectEdgeMaskSigns` for transect edge masks;
+- `cpus_per_task` and `min_cpus_per_task`: multiprocessing resources;
+- `chunk_size`, `subdivision_threshold`, and `subdivision_resolution`:
+  controls passed to `mpas_tools`.
+
+## Example
+
+```bash
+polaris setup -t mesh/spherical/feature_masks/configurable -w feature_masks
+```
+
+Edit
+`feature_masks/mesh/spherical/feature_masks/configurable/feature_masks.cfg`
+to point at the desired mesh and select the mask group, then run the task.
+Missing required options are reported when the task runs, after the work-dir
+config has been edited.

--- a/docs/users_guide/mesh/tasks/index.md
+++ b/docs/users_guide/mesh/tasks/index.md
@@ -2,35 +2,16 @@
 
 # Tasks
 
-(mesh-base-mesh-task)=
+## Spherical Mesh Tasks
 
-## Base Mesh Tasks
+These tasks operate on spherical MPAS meshes without being specific to the
+unified-mesh workflow.
 
-The `mesh/spherical/qu/base_mesh/XXXkm/task` and
-`mesh/spherical/icos/base_mesh/XXXkm/task` tasks can be used to create
-spherical, uniform MPAS meshes at the given resolution that are either
-quasi-uniform (`qu`) or subdivided icosahedral (`icos`).
+```{toctree}
+:titlesonly: true
 
-There are also two variable resolution base meshes: `rrs6to18km` and
-`so12to30km`.
-
-The RRS mesh has a resolution that ranges from 6 km at the
-poles to 18 km at the equator, approximately scaling with the Rossby radius.
-
-```{image} ../../../developers_guide/mesh/framework/images/rrs.png
-:align: center
-:width: 500 px
-```
-
-The SO mesh has a quasi-uniform, 30 km background resolution that transitions
-to 12 km in region surrounding the Southern Ocean.  The boundary of high
-resolution region attempts to approximatly follow dynamical contours in
-the ocean, since rapid changes in resolution have been shown to steer ocean
-currents along isocontours of resolution.
-
-```{image} ../../../developers_guide/mesh/framework/images/so.png
-:align: center
-:width: 500 px
+base_mesh
+feature_masks
 ```
 
 ## Unified Mesh Tasks

--- a/docs/users_guide/ocean/tasks/feature_masks.md
+++ b/docs/users_guide/ocean/tasks/feature_masks.md
@@ -1,0 +1,29 @@
+(users-ocean-feature-masks)=
+
+# Feature Masks
+
+The `ocean/feature_masks/configurable` task creates standard MPAS mask files on
+an existing native ocean mesh.  It uses the same `[feature_masks]` options as
+the mesh-component feature-mask task, including `mesh_filename`, `mesh_name`,
+and `mask_group`; see {ref}`users-mesh-feature-masks` for the common mask
+behavior and output conventions.
+
+This ocean task is the place to use Omega-format mesh input.  The step opens
+the mesh through the ocean component's model I/O layer, so Omega variable and
+dimension names are translated back to standard MPAS-Ocean names before mask
+creation.  For Omega, the mask output is then mapped back to native names,
+such as `NCells`, `NEdges`, `NRegions`, and `RegionCellMasks`.
+
+Use the mesh-component task instead when the input file is already a standard
+MPAS mesh and no ocean-model-specific I/O translation is needed.
+
+## Example
+
+```bash
+polaris setup -t ocean/feature_masks/configurable -w ocean_feature_masks
+```
+
+Edit `ocean_feature_masks/ocean/feature_masks/configurable/feature_masks.cfg`
+to point at the mesh file and select the mask group, then run the task.
+Missing required options are reported when the task runs, after the work-dir
+config has been edited.

--- a/docs/users_guide/ocean/tasks/feature_masks.md
+++ b/docs/users_guide/ocean/tasks/feature_masks.md
@@ -17,6 +17,19 @@ such as `NCells`, `NEdges`, `NRegions`, and `RegionCellMasks`.
 Use the mesh-component task instead when the input file is already a standard
 MPAS mesh and no ocean-model-specific I/O translation is needed.
 
+## MOC Basins
+
+When `mask_group = MOC Basins`, the step performs an extra post-processing pass
+after the normal region-mask computation.
+`mpas_tools.ocean.moc.add_moc_southern_boundary_transects` is called with the
+basin cell masks and the mesh dataset to derive southern-boundary transect masks
+for each MOC basin; these are appended to the output dataset alongside the
+region masks.
+
+The output file is named `{mesh_name}_mocBasinsAndTransects{date}.nc` (instead
+of the normal `{mesh_name}_mocBasins{date}.nc`) so downstream tools such as
+MPAS-Analysis can locate the combined file.
+
 ## Example
 
 ```bash

--- a/docs/users_guide/ocean/tasks/index.md
+++ b/docs/users_guide/ocean/tasks/index.md
@@ -12,6 +12,7 @@ correlated_tracers_2d
 cosine_bell
 customizable_viz
 external_gravity_wave
+feature_masks
 geostrophic
 realistic_global
 horiz_press_grad

--- a/docs/users_guide/ocean/tasks/index.md
+++ b/docs/users_guide/ocean/tasks/index.md
@@ -12,6 +12,7 @@ correlated_tracers_2d
 cosine_bell
 customizable_viz
 external_gravity_wave
+feature_masks
 geostrophic
 global_ocean
 horiz_press_grad

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -3,6 +3,8 @@ dimensions:
   nCells: NCells
   nEdges: NEdges
   nVertices: NVertices
+  nRegions: NRegions
+  nTransects: NTransects
   nTracers: NTracers
   maxEdges: MaxEdges
   maxEdges2: MaxEdges2

--- a/polaris/tasks/mesh/add_tasks.py
+++ b/polaris/tasks/mesh/add_tasks.py
@@ -1,4 +1,5 @@
 from polaris.tasks.mesh.base import add_base_mesh_tasks
+from polaris.tasks.mesh.spherical.feature_masks import add_feature_mask_tasks
 from polaris.tasks.mesh.spherical.unified.base_mesh import (
     add_unified_base_mesh_tasks,
 )
@@ -22,5 +23,6 @@ def add_mesh_tasks(component):
     add_base_mesh_tasks(component=component)
     add_unified_base_mesh_tasks(component=component)
     add_coastline_tasks(component=component)
+    add_feature_mask_tasks(component=component)
     add_river_tasks(component=component)
     add_sizing_field_tasks(component=component)

--- a/polaris/tasks/mesh/spherical/feature_masks/__init__.py
+++ b/polaris/tasks/mesh/spherical/feature_masks/__init__.py
@@ -1,0 +1,21 @@
+from polaris.tasks.mesh.spherical.feature_masks.compute import (
+    ComputeFeatureMasksStep as ComputeFeatureMasksStep,
+)
+from polaris.tasks.mesh.spherical.feature_masks.compute import (
+    build_mask_feature_collection as build_mask_feature_collection,
+)
+from polaris.tasks.mesh.spherical.feature_masks.compute import (
+    compute_feature_masks as compute_feature_masks,
+)
+from polaris.tasks.mesh.spherical.feature_masks.compute import (
+    get_feature_object_type as get_feature_object_type,
+)
+from polaris.tasks.mesh.spherical.feature_masks.steps import (
+    get_feature_mask_steps as get_feature_mask_steps,
+)
+from polaris.tasks.mesh.spherical.feature_masks.task import (
+    FeatureMasksTask as FeatureMasksTask,
+)
+from polaris.tasks.mesh.spherical.feature_masks.tasks import (
+    add_feature_mask_tasks as add_feature_mask_tasks,
+)

--- a/polaris/tasks/mesh/spherical/feature_masks/compute.py
+++ b/polaris/tasks/mesh/spherical/feature_masks/compute.py
@@ -1,0 +1,490 @@
+import multiprocessing
+import os
+
+import xarray as xr
+from geometric_features import GeometricFeatures
+from geometric_features.aggregation import get_aggregator_by_name
+from mpas_tools.cime.constants import constants
+from mpas_tools.io import write_netcdf
+from mpas_tools.mesh.mask import (
+    compute_mpas_region_masks,
+    compute_mpas_transect_masks,
+)
+from mpas_tools.parallel import create_pool
+
+from polaris.step import Step
+
+VALID_MASK_TYPES = {'cell', 'edge', 'vertex'}
+
+
+class ComputeFeatureMasksStep(Step):
+    """
+    A step for creating region or transect masks on a standard MPAS mesh.
+    """
+
+    def __init__(
+        self,
+        component,
+        name='compute_feature_masks',
+        subdir=None,
+        mesh_step=None,
+        mesh_filename=None,
+        mesh_name=None,
+        mask_group=None,
+    ):
+        """
+        Create a new feature-mask step.
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        name : str, optional
+            The name of the step
+
+        subdir : str, optional
+            The subdirectory for the step
+
+        mesh_step : polaris.Step, optional
+            An upstream step that produces the mesh
+
+        mesh_filename : str, optional
+            The mesh filename, either from ``mesh_step`` or configurable
+            task config
+
+        mesh_name : str, optional
+            The mesh name for output filenames and metadata
+
+        mask_group : str, optional
+            A group name supported by ``get_aggregator_by_name()``
+        """
+        super().__init__(
+            component=component,
+            name=name,
+            subdir=subdir,
+            cpus_per_task=None,
+            min_cpus_per_task=None,
+        )
+        self.mesh_step = mesh_step
+        self.mesh_filename = mesh_filename
+        self.mesh_name = mesh_name
+        self.mask_group = mask_group
+        self.output_filename = None
+        self.geojson_filename = None
+
+    def setup(self):
+        """
+        Set up the step in the work directory, including linking inputs.
+        """
+        super().setup()
+        section = self.config['feature_masks']
+        mesh_filename = _resolve_optional_option(
+            self.mesh_filename, section.get('mesh_filename')
+        )
+        mesh_name = _resolve_optional_option(
+            self.mesh_name, section.get('mesh_name')
+        )
+        mask_group = _resolve_optional_option(
+            self.mask_group, section.get('mask_group')
+        )
+
+        if self.mesh_step is None:
+            if mesh_filename is not None:
+                self.add_input_file(filename='mesh.nc', target=mesh_filename)
+        else:
+            mesh_filename = _require_option(mesh_filename, 'mesh_filename')
+            self.add_input_file(
+                filename='mesh.nc',
+                work_dir_target=os.path.join(
+                    self.mesh_step.path, mesh_filename
+                ),
+            )
+
+        if mesh_name is not None and mask_group is not None:
+            self._set_output_filenames(mesh_name, mask_group)
+            self.add_output_file(filename=self.output_filename)
+            self.add_output_file(filename=self.geojson_filename)
+
+        self.cpus_per_task = section.getint('cpus_per_task')
+        self.min_cpus_per_task = section.getint('min_cpus_per_task')
+
+    def constrain_resources(self, available_resources):
+        """
+        Constrain resources based on available cores.
+        """
+        section = self.config['feature_masks']
+        self.cpus_per_task = section.getint('cpus_per_task')
+        self.min_cpus_per_task = section.getint('min_cpus_per_task')
+        super().constrain_resources(available_resources)
+
+    def runtime_setup(self):
+        """
+        Set up runtime filenames after the work-dir config has been edited.
+        """
+        self._resolve_runtime_config()
+
+    def run(self):
+        """
+        Run the feature-mask step.
+        """
+        super().run()
+        section = self.config['feature_masks']
+        mesh_filename, mesh_name, mask_group = self._resolve_runtime_config()
+        source_mesh_filename = mesh_filename
+
+        fc_mask, prefix, date = build_mask_feature_collection(mask_group)
+        fc_mask.to_geojson(self.geojson_filename)
+
+        feature_object_type = get_feature_object_type(fc_mask)
+        mask_types = get_mask_types(
+            section.get('mask_types'), feature_object_type
+        )
+        subdivision_resolution = _get_optional_float(
+            section.get('subdivision_resolution')
+        )
+
+        pool = None
+        try:
+            pool = create_mask_pool(
+                process_count=self.cpus_per_task,
+                method=section.get('multiprocessing_method'),
+            )
+            if self.mesh_step is None:
+                open_mesh_filename = mesh_filename
+            else:
+                open_mesh_filename = 'mesh.nc'
+            ds_mesh = self._open_mesh_dataset(open_mesh_filename)
+            ds_masks = compute_feature_masks(
+                ds_mesh=ds_mesh,
+                fc_mask=fc_mask,
+                feature_object_type=feature_object_type,
+                mask_types=mask_types,
+                logger=self.logger,
+                pool=pool,
+                chunk_size=section.getint('chunk_size'),
+                show_progress=section.getboolean('show_progress'),
+                subdivision_threshold=section.getfloat(
+                    'subdivision_threshold'
+                ),
+                subdivision_resolution=subdivision_resolution,
+                add_edge_sign=section.getboolean('add_edge_sign'),
+            )
+        finally:
+            if pool is not None:
+                pool.terminate()
+
+        ds_masks.attrs['mesh_name'] = mesh_name
+        ds_masks.attrs['mask_group'] = mask_group
+        ds_masks.attrs['feature_object_type'] = feature_object_type
+        ds_masks.attrs['geometric_features_prefix'] = prefix
+        ds_masks.attrs['geometric_features_date'] = date
+        ds_masks.attrs['source_mesh_filename'] = source_mesh_filename
+
+        self._write_mask_dataset(ds_masks, self.output_filename)
+
+    def _open_mesh_dataset(self, filename):
+        """
+        Open a standard MPAS mesh dataset.
+        """
+        return xr.open_dataset(filename, decode_cf=False, decode_times=False)
+
+    def _write_mask_dataset(self, ds_masks, filename):
+        """
+        Write a standard MPAS mask dataset.
+        """
+        write_netcdf(ds_masks, filename, logger=self.logger)
+
+    def _resolve_runtime_config(self):
+        """
+        Resolve required runtime config and update expected outputs.
+        """
+        section = self.config['feature_masks']
+        mesh_filename = _resolve_required_option(
+            self.mesh_filename, section.get('mesh_filename'), 'mesh_filename'
+        )
+        mesh_name = _resolve_required_option(
+            self.mesh_name, section.get('mesh_name'), 'mesh_name'
+        )
+        mask_group = _resolve_required_option(
+            self.mask_group, section.get('mask_group'), 'mask_group'
+        )
+
+        self._set_output_filenames(mesh_name, mask_group)
+        assert self.output_filename is not None
+        assert self.geojson_filename is not None
+        self.outputs = [
+            os.path.abspath(os.path.join(self.work_dir, self.output_filename)),
+            os.path.abspath(
+                os.path.join(self.work_dir, self.geojson_filename)
+            ),
+        ]
+
+        return mesh_filename, mesh_name, mask_group
+
+    def _set_output_filenames(self, mesh_name, mask_group):
+        """
+        Set output filenames from mesh and mask-group names.
+        """
+        _, prefix, date = get_aggregator_by_name(mask_group)
+        self.output_filename = get_feature_masks_filename(
+            mesh_name=mesh_name, prefix=prefix, date=date
+        )
+        self.geojson_filename = f'{prefix}{date}.geojson'
+
+
+def build_mask_feature_collection(mask_group):
+    """
+    Build the feature collection for a named mask group.
+
+    Parameters
+    ----------
+    mask_group : str
+        A group name supported by
+        :func:`geometric_features.get_aggregator_by_name`
+
+    Returns
+    -------
+    fc_mask : geometric_features.FeatureCollection
+        The feature collection
+
+    prefix : str
+        The filename prefix for the mask group
+
+    date : str
+        The date stamp for the mask group
+    """
+    aggregation_function, prefix, date = get_aggregator_by_name(mask_group)
+    gf = GeometricFeatures()
+    fc_mask = aggregation_function(gf)
+    return fc_mask, prefix, date
+
+
+def get_feature_object_type(fc_mask):
+    """
+    Get the common object type in a feature collection.
+
+    Parameters
+    ----------
+    fc_mask : geometric_features.FeatureCollection
+        The feature collection
+
+    Returns
+    -------
+    object_type : {'region', 'transect'}
+        The common feature object type
+    """
+    object_types = set()
+    for feature in fc_mask.features:
+        properties = feature.get('properties', {})
+        object_type = properties.get('object', None)
+        if object_type is None:
+            name = properties.get('name', '<unnamed>')
+            raise ValueError(
+                f'Feature {name} is missing the required object property.'
+            )
+        object_types.add(object_type)
+
+    if len(object_types) == 0:
+        raise ValueError('The mask feature collection is empty.')
+
+    if len(object_types) > 1:
+        object_types_str = ', '.join(sorted(object_types))
+        raise ValueError(
+            f'Mask feature collections must contain a single object type. '
+            f'Found: {object_types_str}.'
+        )
+
+    object_type = object_types.pop()
+    if object_type not in ['region', 'transect']:
+        raise ValueError(
+            f'Unsupported mask feature object type {object_type}. '
+            f'Expected region or transect.'
+        )
+
+    return object_type
+
+
+def get_mask_types(mask_types, feature_object_type):
+    """
+    Resolve and validate mask types.
+
+    Parameters
+    ----------
+    mask_types : str or list of str
+        Mask types from config or caller
+
+    feature_object_type : {'region', 'transect'}
+        The common feature object type
+
+    Returns
+    -------
+    mask_types : tuple of str
+        The resolved mask types
+    """
+    if isinstance(mask_types, str):
+        mask_types = mask_types.strip()
+        if mask_types == 'default':
+            if feature_object_type == 'region':
+                return ('cell', 'vertex')
+            return ('cell', 'edge', 'vertex')
+        mask_types = mask_types.split()
+
+    mask_types = tuple(mask_types)
+    invalid = sorted(set(mask_types) - VALID_MASK_TYPES)
+    if invalid:
+        invalid_str = ', '.join(invalid)
+        valid_str = ', '.join(sorted(VALID_MASK_TYPES))
+        raise ValueError(
+            f'Invalid mask type(s): {invalid_str}. Valid mask types are: '
+            f'{valid_str}.'
+        )
+
+    return mask_types
+
+
+def get_feature_masks_filename(mesh_name, prefix, date):
+    """
+    Get the output filename for a feature-mask file.
+    """
+    return f'{mesh_name}_{prefix}{date}.nc'
+
+
+def compute_feature_masks(
+    ds_mesh,
+    fc_mask,
+    feature_object_type,
+    mask_types,
+    logger,
+    pool,
+    chunk_size,
+    show_progress,
+    subdivision_threshold,
+    subdivision_resolution,
+    add_edge_sign,
+):
+    """
+    Compute masks for a region or transect feature collection.
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        A standard MPAS mesh dataset
+
+    fc_mask : geometric_features.FeatureCollection
+        The mask features
+
+    feature_object_type : {'region', 'transect'}
+        The common feature object type
+
+    mask_types : tuple of {'cell', 'edge', 'vertex'}
+        The mask types to compute
+
+    logger : logging.Logger
+        Logger for progress output
+
+    pool : multiprocessing.Pool
+        Pool for parallel computation
+
+    chunk_size : int
+        Number of points to process per chunk
+
+    show_progress : bool
+        Whether to show progress bars
+
+    subdivision_threshold : float
+        Region polygon subdivision threshold in degrees
+
+    subdivision_resolution : float or None
+        Transect subdivision resolution in meters
+
+    add_edge_sign : bool
+        Whether to add transect edge signs
+
+    Returns
+    -------
+    ds_masks : xarray.Dataset
+        The computed masks
+    """
+    if feature_object_type == 'region':
+        if add_edge_sign:
+            raise ValueError(
+                'add_edge_sign=True is only valid for transect masks.'
+            )
+        return compute_mpas_region_masks(
+            dsMesh=ds_mesh,
+            fcMask=fc_mask,
+            maskTypes=mask_types,
+            logger=logger,
+            pool=pool,
+            chunkSize=chunk_size,
+            showProgress=show_progress,
+            subdivisionThreshold=subdivision_threshold,
+        )
+
+    if add_edge_sign and 'edge' not in mask_types:
+        raise ValueError(
+            'add_edge_sign=True requires edge to be included in mask_types.'
+        )
+
+    return compute_mpas_transect_masks(
+        dsMesh=ds_mesh,
+        fcMask=fc_mask,
+        earthRadius=constants['SHR_CONST_REARTH'],
+        maskTypes=mask_types,
+        logger=logger,
+        pool=pool,
+        chunkSize=chunk_size,
+        showProgress=show_progress,
+        subdivisionResolution=subdivision_resolution,
+        addEdgeSign=add_edge_sign,
+    )
+
+
+def create_mask_pool(process_count, method):
+    """
+    Create a multiprocessing pool for mask creation.
+    """
+    try:
+        return create_pool(process_count=process_count, method=method)
+    except RuntimeError:
+        # The start method may already be fixed in a long-lived Python
+        # process, such as a test runner.
+        if process_count is None:
+            process_count = multiprocessing.cpu_count()
+        else:
+            process_count = min(process_count, multiprocessing.cpu_count())
+        if process_count <= 1:
+            return None
+        context = multiprocessing.get_context()
+        return context.Pool(process_count)
+
+
+def _resolve_required_option(constructor_value, config_value, option):
+    value = _resolve_optional_option(constructor_value, config_value)
+    return _require_option(value, option)
+
+
+def _resolve_optional_option(constructor_value, config_value):
+    value = constructor_value
+    if value is None:
+        value = config_value
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if value == '' or value == '<<<missing>>>':
+            return None
+    return value
+
+
+def _require_option(value, option):
+    if value is None:
+        raise ValueError(f'[feature_masks] {option} must be provided.')
+    return value
+
+
+def _get_optional_float(value):
+    if value is None or value.lower() == 'none':
+        return None
+    return float(value)

--- a/polaris/tasks/mesh/spherical/feature_masks/compute.py
+++ b/polaris/tasks/mesh/spherical/feature_masks/compute.py
@@ -144,17 +144,18 @@ class ComputeFeatureMasksStep(Step):
             section.get('subdivision_resolution')
         )
 
+        if self.mesh_step is None:
+            open_mesh_filename = mesh_filename
+        else:
+            open_mesh_filename = 'mesh.nc'
+        ds_mesh = self._open_mesh_dataset(open_mesh_filename)
+
         pool = None
         try:
             pool = create_mask_pool(
                 process_count=self.cpus_per_task,
                 method=section.get('multiprocessing_method'),
             )
-            if self.mesh_step is None:
-                open_mesh_filename = mesh_filename
-            else:
-                open_mesh_filename = 'mesh.nc'
-            ds_mesh = self._open_mesh_dataset(open_mesh_filename)
             ds_masks = compute_feature_masks(
                 ds_mesh=ds_mesh,
                 fc_mask=fc_mask,
@@ -181,6 +182,7 @@ class ComputeFeatureMasksStep(Step):
         ds_masks.attrs['geometric_features_date'] = date
         ds_masks.attrs['source_mesh_filename'] = source_mesh_filename
 
+        ds_masks = self._post_process_masks(ds_masks, ds_mesh, mask_group)
         self._write_mask_dataset(ds_masks, self.output_filename)
 
     def _open_mesh_dataset(self, filename):
@@ -194,6 +196,13 @@ class ComputeFeatureMasksStep(Step):
         Write a standard MPAS mask dataset.
         """
         write_netcdf(ds_masks, filename, logger=self.logger)
+
+    def _post_process_masks(self, ds_masks, ds_mesh, mask_group):
+        """
+        Post-process computed masks before writing. Default is a no-op.
+        Subclasses may override to augment the dataset.
+        """
+        return ds_masks
 
     def _resolve_runtime_config(self):
         """

--- a/polaris/tasks/mesh/spherical/feature_masks/feature_masks.cfg
+++ b/polaris/tasks/mesh/spherical/feature_masks/feature_masks.cfg
@@ -1,0 +1,40 @@
+# options for creating region or transect masks on an MPAS mesh
+[feature_masks]
+
+# Path to an existing standard MPAS mesh file for configurable use
+mesh_filename = <<<missing>>>
+
+# Mesh name used in output filenames and metadata
+mesh_name = <<<missing>>>
+
+# Any group name supported by geometric_features.get_aggregator_by_name()
+mask_group = Ocean Basins
+
+# Mask types. Use "default" for:
+#   regions: cell vertex
+#   transects: cell edge vertex
+mask_types = default
+
+# Whether transect output should include transectEdgeMaskSigns
+add_edge_sign = False
+
+# Number of MPAS locations processed per chunk
+chunk_size = 1000
+
+# Region polygon subdivision threshold in degrees
+subdivision_threshold = 30.0
+
+# Transect subdivision resolution in meters. None means no subdivision.
+subdivision_resolution = None
+
+# Whether mpas_tools should display progress bars
+show_progress = False
+
+# Python multiprocessing start method: fork, spawn, or forkserver
+multiprocessing_method = forkserver
+
+# number of cores to use if available
+cpus_per_task = 128
+
+# minimum number of cores, below which the step fails
+min_cpus_per_task = 1

--- a/polaris/tasks/mesh/spherical/feature_masks/moc.py
+++ b/polaris/tasks/mesh/spherical/feature_masks/moc.py
@@ -1,0 +1,64 @@
+from mpas_tools.ocean.moc import add_moc_southern_boundary_transects
+
+from polaris.tasks.mesh.spherical.feature_masks.compute import (
+    get_feature_masks_filename,
+)
+
+#: The geometric_features aggregation these helpers apply to
+MOC_MASK_GROUP = 'MOC Basins'
+
+#: The filename prefix E3SM already uses for the staged file, as in
+#: oRRS18to6v3_mocBasinsAndTransects20210623.nc
+MOC_PREFIX = 'mocBasinsAndTransects'
+
+
+def moc_masks_filename(mesh_name, date):
+    """
+    Get the filename for a MOC basin-and-transect mask file.
+
+    Parameters
+    ----------
+    mesh_name : str
+        The mesh name for output filenames and metadata
+
+    date : str
+        The date stamp for the ``'MOC Basins'`` aggregation
+
+    Returns
+    -------
+    filename : str
+        The mask filename
+    """
+    return get_feature_masks_filename(
+        mesh_name=mesh_name, prefix=MOC_PREFIX, date=date
+    )
+
+
+def add_moc_transects(ds_masks, ds_mesh, logger):
+    """
+    Append the southern-boundary transects to MOC basin masks, and drop the
+    string variables that are incompatible with CDF5.
+
+    Parameters
+    ----------
+    ds_masks : xarray.Dataset
+        The MOC basin region masks
+
+    ds_mesh : xarray.Dataset
+        A standard MPAS mesh dataset
+
+    logger : logging.Logger
+        Logger for progress output
+
+    Returns
+    -------
+    ds_masks : xarray.Dataset
+        The masks with southern-boundary transects appended
+    """
+    ds_masks = add_moc_southern_boundary_transects(
+        ds_masks, ds_mesh, logger=logger
+    )
+    to_drop = [v for v in ['history', 'constituents'] if v in ds_masks]
+    if to_drop:
+        ds_masks = ds_masks.drop_vars(to_drop)
+    return ds_masks

--- a/polaris/tasks/mesh/spherical/feature_masks/steps.py
+++ b/polaris/tasks/mesh/spherical/feature_masks/steps.py
@@ -1,0 +1,94 @@
+import os
+
+from geometric_features.aggregation import get_aggregator_by_name
+
+from polaris.config import PolarisConfigParser
+from polaris.tasks.mesh.spherical.feature_masks.compute import (
+    ComputeFeatureMasksStep,
+)
+
+
+def get_feature_mask_steps(
+    mesh_name,
+    mask_group,
+    mesh_step=None,
+    mesh_filename=None,
+    component=None,
+):
+    """
+    Get shared feature-mask steps for one mesh and mask group.
+
+    Parameters
+    ----------
+    mesh_name : str
+        The name of the mesh for output filenames and metadata
+
+    mask_group : str
+        A group name supported by ``get_aggregator_by_name()``
+
+    mesh_step : polaris.Step, optional
+        An upstream step that produces the mesh
+
+    mesh_filename : str, optional
+        The mesh filename from ``mesh_step`` or configurable task config
+
+    component : polaris.Component, optional
+        The component that owns the shared step. Defaults to ``mesh``.
+
+    Returns
+    -------
+    steps : dict of str to polaris.Step
+        The feature-mask step keyed by suggested symlink
+
+    config : polaris.config.PolarisConfigParser
+        The shared feature-mask config
+    """
+    if component is None:
+        from polaris.tasks.mesh import mesh as component
+
+    _, prefix, date = get_aggregator_by_name(mask_group)
+    config_filename = 'feature_masks.cfg'
+    filepath = os.path.join(
+        component.name,
+        'spherical',
+        'feature_masks',
+        mesh_name,
+        f'{prefix}{date}',
+        config_filename,
+    )
+    config = _get_feature_masks_config(component=component, filepath=filepath)
+    config.set('feature_masks', 'mesh_name', mesh_name)
+    config.set('feature_masks', 'mask_group', mask_group)
+    if mesh_filename is not None:
+        config.set('feature_masks', 'mesh_filename', mesh_filename)
+
+    subdir = os.path.join(
+        'spherical',
+        'feature_masks',
+        mesh_name,
+        f'{prefix}{date}',
+        'compute',
+    )
+    step = component.get_or_create_shared_step(
+        step_cls=ComputeFeatureMasksStep,
+        subdir=subdir,
+        config=config,
+        config_filename=config_filename,
+        mesh_step=mesh_step,
+        mesh_filename=mesh_filename,
+        mesh_name=mesh_name,
+        mask_group=mask_group,
+    )
+    return {'feature_masks': step}, config
+
+
+def _get_feature_masks_config(component, filepath):
+    if filepath in component.configs:
+        return component.configs[filepath]
+
+    config = PolarisConfigParser(filepath=filepath)
+    config.add_from_package(
+        'polaris.tasks.mesh.spherical.feature_masks',
+        'feature_masks.cfg',
+    )
+    return config

--- a/polaris/tasks/mesh/spherical/feature_masks/task.py
+++ b/polaris/tasks/mesh/spherical/feature_masks/task.py
@@ -1,0 +1,40 @@
+import os
+
+from polaris.config import PolarisConfigParser
+from polaris.task import Task
+from polaris.tasks.mesh.spherical.feature_masks.compute import (
+    ComputeFeatureMasksStep,
+)
+
+
+class FeatureMasksTask(Task):
+    """
+    A configurable task for creating feature masks on a standard MPAS mesh.
+    """
+
+    def __init__(self, component):
+        """
+        Create a new configurable feature-mask task.
+        """
+        subdir = os.path.join('spherical', 'feature_masks', 'configurable')
+        super().__init__(
+            component=component,
+            name='feature_masks_task',
+            subdir=subdir,
+        )
+
+        config = PolarisConfigParser(
+            filepath=os.path.join(component.name, subdir, 'feature_masks.cfg')
+        )
+        config.add_from_package(
+            'polaris.tasks.mesh.spherical.feature_masks',
+            'feature_masks.cfg',
+        )
+        self.set_shared_config(config, link='feature_masks.cfg')
+
+        step = ComputeFeatureMasksStep(
+            component=component,
+            subdir=os.path.join(subdir, 'compute'),
+        )
+        step.set_shared_config(config, link='feature_masks.cfg')
+        self.add_step(step)

--- a/polaris/tasks/mesh/spherical/feature_masks/tasks.py
+++ b/polaris/tasks/mesh/spherical/feature_masks/tasks.py
@@ -1,0 +1,13 @@
+from polaris.tasks.mesh.spherical.feature_masks.task import FeatureMasksTask
+
+
+def add_feature_mask_tasks(component):
+    """
+    Add configurable feature-mask tasks to the mesh component.
+
+    Parameters
+    ----------
+    component : polaris.Component
+        The mesh component that the tasks will be added to
+    """
+    component.add_task(FeatureMasksTask(component=component))

--- a/polaris/tasks/ocean/add_tasks.py
+++ b/polaris/tasks/ocean/add_tasks.py
@@ -6,6 +6,7 @@ from polaris.tasks.ocean.customizable_viz import add_customizable_viz_tasks
 from polaris.tasks.ocean.external_gravity_wave import (
     add_external_gravity_wave_tasks as add_external_gravity_wave_tasks,
 )
+from polaris.tasks.ocean.feature_masks import add_feature_mask_tasks
 from polaris.tasks.ocean.geostrophic import add_geostrophic_tasks
 from polaris.tasks.ocean.global_ocean import add_global_ocean_tasks
 from polaris.tasks.ocean.horiz_press_grad import add_horiz_press_grad_tasks
@@ -55,6 +56,7 @@ def add_ocean_tasks(component):
     add_customizable_viz_tasks(component=component)
     add_cosine_bell_tasks(component=component)
     add_external_gravity_wave_tasks(component=component)
+    add_feature_mask_tasks(component=component)
     add_geostrophic_tasks(component=component)
     add_global_ocean_tasks(component=component)
     add_isomip_plus_tasks(component=component, mesh_type='spherical')

--- a/polaris/tasks/ocean/add_tasks.py
+++ b/polaris/tasks/ocean/add_tasks.py
@@ -6,6 +6,7 @@ from polaris.tasks.ocean.customizable_viz import add_customizable_viz_tasks
 from polaris.tasks.ocean.external_gravity_wave import (
     add_external_gravity_wave_tasks as add_external_gravity_wave_tasks,
 )
+from polaris.tasks.ocean.feature_masks import add_feature_mask_tasks
 from polaris.tasks.ocean.geostrophic import add_geostrophic_tasks
 from polaris.tasks.ocean.horiz_press_grad import add_horiz_press_grad_tasks
 from polaris.tasks.ocean.ice_shelf_2d import add_ice_shelf_2d_tasks
@@ -55,6 +56,7 @@ def add_ocean_tasks(component):
     add_customizable_viz_tasks(component=component)
     add_cosine_bell_tasks(component=component)
     add_external_gravity_wave_tasks(component=component)
+    add_feature_mask_tasks(component=component)
     add_geostrophic_tasks(component=component)
     add_isomip_plus_tasks(component=component, mesh_type='spherical')
     add_realistic_global_tasks(component=component)

--- a/polaris/tasks/ocean/feature_masks/__init__.py
+++ b/polaris/tasks/ocean/feature_masks/__init__.py
@@ -1,0 +1,9 @@
+from polaris.tasks.ocean.feature_masks.compute import (
+    ComputeOceanFeatureMasksStep as ComputeOceanFeatureMasksStep,
+)
+from polaris.tasks.ocean.feature_masks.task import (
+    OceanFeatureMasksTask as OceanFeatureMasksTask,
+)
+from polaris.tasks.ocean.feature_masks.tasks import (
+    add_feature_mask_tasks as add_feature_mask_tasks,
+)

--- a/polaris/tasks/ocean/feature_masks/compute.py
+++ b/polaris/tasks/ocean/feature_masks/compute.py
@@ -1,6 +1,10 @@
+from geometric_features.aggregation import get_aggregator_by_name
+from mpas_tools.ocean.moc import add_moc_southern_boundary_transects
+
 from polaris.ocean.model.ocean_io_step import OceanIOStep
 from polaris.tasks.mesh.spherical.feature_masks.compute import (
     ComputeFeatureMasksStep,
+    get_feature_masks_filename,
 )
 
 
@@ -9,7 +13,10 @@ class ComputeOceanFeatureMasksStep(ComputeFeatureMasksStep, OceanIOStep):
     A feature-mask step for MPAS-Ocean or Omega mesh files.
 
     Omega-specific input translation belongs in the ocean framework.  The
-    output remains in standard MPAS mask conventions.
+    output remains in standard MPAS mask conventions, except for the
+    'MOC Basins' group, which produces a combined basin-mask and
+    southern-boundary transect file named
+    ``{mesh_name}_mocBasinsAndTransects{date}.nc``.
     """
 
     def _open_mesh_dataset(self, filename):
@@ -29,3 +36,33 @@ class ComputeOceanFeatureMasksStep(ComputeFeatureMasksStep, OceanIOStep):
         """
         ds_masks = self.map_to_native_model_vars(ds_masks)
         super()._write_mask_dataset(ds_masks, filename)
+
+    def _set_output_filenames(self, mesh_name, mask_group):
+        """
+        Set output filenames, using the mocBasinsAndTransects convention
+        for the 'MOC Basins' group.
+        """
+        super()._set_output_filenames(mesh_name, mask_group)
+        if mask_group == 'MOC Basins':
+            _, _, date = get_aggregator_by_name(mask_group)
+            self.output_filename = get_feature_masks_filename(
+                mesh_name=mesh_name,
+                prefix='mocBasinsAndTransects',
+                date=date,
+            )
+            # geojson_filename stays as mocBasins{date}.geojson (set by super)
+
+    def _post_process_masks(self, ds_masks, ds_mesh, mask_group):
+        """
+        For 'MOC Basins', append southern-boundary transects to the mask
+        dataset and drop string variables that are incompatible with CDF5.
+        """
+        if mask_group != 'MOC Basins':
+            return ds_masks
+        ds_masks = add_moc_southern_boundary_transects(
+            ds_masks, ds_mesh, logger=self.logger
+        )
+        to_drop = [v for v in ['history', 'constituents'] if v in ds_masks]
+        if to_drop:
+            ds_masks = ds_masks.drop_vars(to_drop)
+        return ds_masks

--- a/polaris/tasks/ocean/feature_masks/compute.py
+++ b/polaris/tasks/ocean/feature_masks/compute.py
@@ -1,0 +1,31 @@
+from polaris.ocean.model.ocean_io_step import OceanIOStep
+from polaris.tasks.mesh.spherical.feature_masks.compute import (
+    ComputeFeatureMasksStep,
+)
+
+
+class ComputeOceanFeatureMasksStep(ComputeFeatureMasksStep, OceanIOStep):
+    """
+    A feature-mask step for MPAS-Ocean or Omega mesh files.
+
+    Omega-specific input translation belongs in the ocean framework.  The
+    output remains in standard MPAS mask conventions.
+    """
+
+    def _open_mesh_dataset(self, filename):
+        """
+        Open a native ocean mesh and map it to standard MPAS names.
+        """
+        return self.component.open_model_dataset(
+            filename,
+            config=self.config,
+            decode_cf=False,
+            decode_times=False,
+        )
+
+    def _write_mask_dataset(self, ds_masks, filename):
+        """
+        Map a mask dataset to native ocean names and write it.
+        """
+        ds_masks = self.map_to_native_model_vars(ds_masks)
+        super()._write_mask_dataset(ds_masks, filename)

--- a/polaris/tasks/ocean/feature_masks/compute.py
+++ b/polaris/tasks/ocean/feature_masks/compute.py
@@ -1,10 +1,13 @@
 from geometric_features.aggregation import get_aggregator_by_name
-from mpas_tools.ocean.moc import add_moc_southern_boundary_transects
 
 from polaris.ocean.model.ocean_io_step import OceanIOStep
 from polaris.tasks.mesh.spherical.feature_masks.compute import (
     ComputeFeatureMasksStep,
-    get_feature_masks_filename,
+)
+from polaris.tasks.mesh.spherical.feature_masks.moc import (
+    MOC_MASK_GROUP,
+    add_moc_transects,
+    moc_masks_filename,
 )
 
 
@@ -43,13 +46,9 @@ class ComputeOceanFeatureMasksStep(ComputeFeatureMasksStep, OceanIOStep):
         for the 'MOC Basins' group.
         """
         super()._set_output_filenames(mesh_name, mask_group)
-        if mask_group == 'MOC Basins':
+        if mask_group == MOC_MASK_GROUP:
             _, _, date = get_aggregator_by_name(mask_group)
-            self.output_filename = get_feature_masks_filename(
-                mesh_name=mesh_name,
-                prefix='mocBasinsAndTransects',
-                date=date,
-            )
+            self.output_filename = moc_masks_filename(mesh_name, date)
             # geojson_filename stays as mocBasins{date}.geojson (set by super)
 
     def _post_process_masks(self, ds_masks, ds_mesh, mask_group):
@@ -57,12 +56,6 @@ class ComputeOceanFeatureMasksStep(ComputeFeatureMasksStep, OceanIOStep):
         For 'MOC Basins', append southern-boundary transects to the mask
         dataset and drop string variables that are incompatible with CDF5.
         """
-        if mask_group != 'MOC Basins':
+        if mask_group != MOC_MASK_GROUP:
             return ds_masks
-        ds_masks = add_moc_southern_boundary_transects(
-            ds_masks, ds_mesh, logger=self.logger
-        )
-        to_drop = [v for v in ['history', 'constituents'] if v in ds_masks]
-        if to_drop:
-            ds_masks = ds_masks.drop_vars(to_drop)
-        return ds_masks
+        return add_moc_transects(ds_masks, ds_mesh, logger=self.logger)

--- a/polaris/tasks/ocean/feature_masks/task.py
+++ b/polaris/tasks/ocean/feature_masks/task.py
@@ -1,0 +1,40 @@
+import os
+
+from polaris.config import PolarisConfigParser
+from polaris.task import Task
+from polaris.tasks.ocean.feature_masks.compute import (
+    ComputeOceanFeatureMasksStep,
+)
+
+
+class OceanFeatureMasksTask(Task):
+    """
+    A configurable task for creating feature masks on native ocean meshes.
+    """
+
+    def __init__(self, component):
+        """
+        Create a new configurable ocean feature-mask task.
+        """
+        subdir = os.path.join('feature_masks', 'configurable')
+        super().__init__(
+            component=component,
+            name='ocean_feature_masks_task',
+            subdir=subdir,
+        )
+
+        config = PolarisConfigParser(
+            filepath=os.path.join(component.name, subdir, 'feature_masks.cfg')
+        )
+        config.add_from_package(
+            'polaris.tasks.mesh.spherical.feature_masks',
+            'feature_masks.cfg',
+        )
+        self.set_shared_config(config, link='feature_masks.cfg')
+
+        step = ComputeOceanFeatureMasksStep(
+            component=component,
+            subdir=os.path.join(subdir, 'compute'),
+        )
+        step.set_shared_config(config, link='feature_masks.cfg')
+        self.add_step(step)

--- a/polaris/tasks/ocean/feature_masks/tasks.py
+++ b/polaris/tasks/ocean/feature_masks/tasks.py
@@ -1,0 +1,13 @@
+from polaris.tasks.ocean.feature_masks.task import OceanFeatureMasksTask
+
+
+def add_feature_mask_tasks(component):
+    """
+    Add configurable ocean feature-mask tasks to the ocean component.
+
+    Parameters
+    ----------
+    component : polaris.tasks.ocean.Ocean
+        The ocean component that the tasks will be added to
+    """
+    component.add_task(OceanFeatureMasksTask(component=component))

--- a/tests/mesh/spherical/feature_masks/test_feature_masks.py
+++ b/tests/mesh/spherical/feature_masks/test_feature_masks.py
@@ -1,0 +1,370 @@
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import xarray as xr
+from geometric_features import FeatureCollection
+
+from polaris.component import Component
+from polaris.config import PolarisConfigParser
+from polaris.step import Step
+from polaris.tasks.mesh.spherical.feature_masks import (
+    ComputeFeatureMasksStep,
+)
+from polaris.tasks.mesh.spherical.feature_masks import (
+    compute as compute_module,
+)
+from polaris.tasks.mesh.spherical.feature_masks.compute import (
+    compute_feature_masks,
+    get_feature_masks_filename,
+    get_feature_object_type,
+    get_mask_types,
+)
+from polaris.tasks.mesh.spherical.feature_masks.steps import (
+    get_feature_mask_steps,
+)
+
+
+def test_get_feature_object_type_region():
+    fc_mask = _feature_collection('region')
+
+    assert get_feature_object_type(fc_mask) == 'region'
+
+
+def test_get_feature_object_type_transect():
+    fc_mask = _feature_collection('transect')
+
+    assert get_feature_object_type(fc_mask) == 'transect'
+
+
+def test_get_feature_object_type_mixed_raises():
+    fc_mask = FeatureCollection()
+    fc_mask.add_feature(_feature('region', 'Region', _polygon()))
+    fc_mask.add_feature(
+        _feature('transect', 'Transect', _line_string(), component='ocean')
+    )
+
+    with pytest.raises(ValueError, match='single object type'):
+        get_feature_object_type(fc_mask)
+
+
+def test_get_mask_types_defaults():
+    assert get_mask_types('default', 'region') == ('cell', 'vertex')
+    assert get_mask_types('default', 'transect') == (
+        'cell',
+        'edge',
+        'vertex',
+    )
+
+
+def test_get_mask_types_validates():
+    with pytest.raises(ValueError, match='Invalid mask type'):
+        get_mask_types('cell bad', 'region')
+
+
+def test_compute_feature_masks_rejects_region_edge_sign():
+    fc_mask = _feature_collection('region')
+    ds_mesh = xr.Dataset()
+
+    with pytest.raises(ValueError, match='only valid for transect'):
+        compute_feature_masks(
+            ds_mesh=ds_mesh,
+            fc_mask=fc_mask,
+            feature_object_type='region',
+            mask_types=('cell',),
+            logger=None,
+            pool=None,
+            chunk_size=1000,
+            show_progress=False,
+            subdivision_threshold=30.0,
+            subdivision_resolution=None,
+            add_edge_sign=True,
+        )
+
+
+def test_compute_feature_masks_rejects_transect_edge_sign_without_edge():
+    fc_mask = _feature_collection('transect')
+    ds_mesh = xr.Dataset()
+
+    with pytest.raises(ValueError, match='requires edge'):
+        compute_feature_masks(
+            ds_mesh=ds_mesh,
+            fc_mask=fc_mask,
+            feature_object_type='transect',
+            mask_types=('cell',),
+            logger=None,
+            pool=None,
+            chunk_size=1000,
+            show_progress=False,
+            subdivision_threshold=30.0,
+            subdivision_resolution=None,
+            add_edge_sign=True,
+        )
+
+
+def test_feature_masks_filename():
+    filename = get_feature_masks_filename(
+        mesh_name='QU240', prefix='oceanBasins', date='20240830'
+    )
+
+    assert filename == 'QU240_oceanBasins20240830.nc'
+
+
+def test_get_feature_mask_steps_sets_shared_config():
+    component = Component(name='mesh')
+    mesh_step = Step(
+        component=component,
+        name='base_mesh',
+        subdir='spherical/qu/base_mesh/240km',
+    )
+
+    steps, config = get_feature_mask_steps(
+        mesh_name='QU240',
+        mask_group='Ocean Basins',
+        mesh_step=mesh_step,
+        mesh_filename='base_mesh.nc',
+        component=component,
+    )
+
+    step = steps['feature_masks']
+    assert isinstance(step, ComputeFeatureMasksStep)
+    assert step.mesh_step is mesh_step
+    assert step.mesh_filename == 'base_mesh.nc'
+    assert config.get('feature_masks', 'mesh_name') == 'QU240'
+    assert config.get('feature_masks', 'mask_group') == 'Ocean Basins'
+    assert config.get('feature_masks', 'mesh_filename') == 'base_mesh.nc'
+    assert step.subdir == (
+        'spherical/feature_masks/QU240/oceanBasins20240830/compute'
+    )
+
+
+def test_step_setup_configurable_input(tmp_path):
+    mesh_filename = tmp_path / 'mesh.nc'
+    mesh_filename.touch()
+    step = _configured_step(mesh_filename=str(mesh_filename))
+
+    step.setup()
+
+    assert step.input_data[0]['filename'] == 'mesh.nc'
+    assert step.input_data[0]['target'] == str(mesh_filename)
+    assert 'QU240_oceanBasins20240830.nc' in step.outputs
+    assert 'oceanBasins20240830.geojson' in step.outputs
+    assert step.cpus_per_task == 1
+    assert step.min_cpus_per_task == 1
+
+
+def test_step_setup_allows_missing_configurable_options():
+    component = Component(name='mesh')
+    config = PolarisConfigParser()
+    config.add_from_package(
+        'polaris.tasks.mesh.spherical.feature_masks',
+        'feature_masks.cfg',
+    )
+    config.set('feature_masks', 'cpus_per_task', '1')
+    config.set('feature_masks', 'min_cpus_per_task', '1')
+    step = ComputeFeatureMasksStep(
+        component=component,
+        subdir='spherical/feature_masks/configurable/compute',
+    )
+    step.config = config
+
+    step.setup()
+
+    assert step.input_data == []
+    assert step.outputs == []
+    assert step.cpus_per_task == 1
+    assert step.min_cpus_per_task == 1
+
+
+def test_step_runtime_setup_requires_configurable_options(tmp_path):
+    step = _missing_config_step(tmp_path)
+
+    with pytest.raises(
+        ValueError, match=r'\[feature_masks\] mesh_filename must be provided'
+    ):
+        step.runtime_setup()
+
+
+def test_step_runtime_setup_updates_outputs(tmp_path):
+    step = _missing_config_step(tmp_path)
+    step.config.set('feature_masks', 'mesh_filename', 'mesh.nc')
+    step.config.set('feature_masks', 'mesh_name', 'QU240')
+
+    step.runtime_setup()
+
+    assert step.output_filename == 'QU240_oceanBasins20240830.nc'
+    assert step.geojson_filename == 'oceanBasins20240830.geojson'
+    assert step.outputs == [
+        os.path.join(str(tmp_path), 'QU240_oceanBasins20240830.nc'),
+        os.path.join(str(tmp_path), 'oceanBasins20240830.geojson'),
+    ]
+
+
+def test_step_setup_shared_mesh_input():
+    component = Component(name='mesh')
+    mesh_step = Step(
+        component=component,
+        name='base_mesh',
+        subdir='spherical/qu/base_mesh/240km',
+    )
+    step = _configured_step(
+        component=component,
+        mesh_step=mesh_step,
+        mesh_filename='base_mesh.nc',
+    )
+
+    step.setup()
+
+    assert step.input_data[0]['work_dir_target'] == os.path.join(
+        mesh_step.path, 'base_mesh.nc'
+    )
+
+
+def test_step_run_writes_masks_and_geojson(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    xr.Dataset(
+        coords={'nCells': np.arange(1)},
+        data_vars={
+            'lonCell': ('nCells', np.array([0.0])),
+            'latCell': ('nCells', np.array([0.0])),
+        },
+    ).to_netcdf('source_mesh.nc')
+
+    fc_mask = _feature_collection('region')
+
+    def build_mask_feature_collection(mask_group):
+        assert mask_group == 'Ocean Basins'
+        return fc_mask, 'oceanBasins', '20240830'
+
+    def create_mask_pool(process_count, method):
+        assert process_count == 1
+        assert method == 'forkserver'
+        return None
+
+    def fake_compute_feature_masks(**kwargs):
+        assert kwargs['feature_object_type'] == 'region'
+        assert kwargs['mask_types'] == ('cell', 'vertex')
+        return xr.Dataset(
+            data_vars={
+                'regionCellMasks': (
+                    ('nCells', 'nRegions'),
+                    np.ones((1, 1), dtype=np.int32),
+                ),
+                'regionNames': ('nRegions', ['Test Region']),
+            }
+        )
+
+    monkeypatch.setattr(
+        compute_module,
+        'build_mask_feature_collection',
+        build_mask_feature_collection,
+    )
+    monkeypatch.setattr(compute_module, 'create_mask_pool', create_mask_pool)
+    monkeypatch.setattr(
+        compute_module,
+        'compute_feature_masks',
+        fake_compute_feature_masks,
+    )
+
+    step = _configured_step(mesh_filename='source_mesh.nc')
+    step.logger = SimpleNamespace(info=lambda *args, **kwargs: None)
+    step.cpus_per_task = 1
+    step.run()
+
+    assert os.path.exists('QU240_oceanBasins20240830.nc')
+    assert os.path.exists('oceanBasins20240830.geojson')
+    ds_masks = xr.open_dataset('QU240_oceanBasins20240830.nc')
+    assert ds_masks.attrs['mesh_name'] == 'QU240'
+    assert ds_masks.attrs['mask_group'] == 'Ocean Basins'
+    assert ds_masks.attrs['feature_object_type'] == 'region'
+    assert ds_masks.attrs['source_mesh_filename'] == 'source_mesh.nc'
+    assert 'regionCellMasks' in ds_masks
+
+
+def _configured_step(
+    component=None,
+    mesh_step=None,
+    mesh_filename=None,
+):
+    if component is None:
+        component = Component(name='mesh')
+    config = PolarisConfigParser()
+    config.add_from_package(
+        'polaris.tasks.mesh.spherical.feature_masks',
+        'feature_masks.cfg',
+    )
+    config.set('feature_masks', 'mesh_filename', mesh_filename)
+    config.set('feature_masks', 'mesh_name', 'QU240')
+    config.set('feature_masks', 'mask_group', 'Ocean Basins')
+    config.set('feature_masks', 'cpus_per_task', '1')
+    config.set('feature_masks', 'min_cpus_per_task', '1')
+    step = ComputeFeatureMasksStep(
+        component=component,
+        subdir='spherical/feature_masks/configurable/compute',
+        mesh_step=mesh_step,
+        mesh_filename=mesh_filename if mesh_step is not None else None,
+    )
+    step.config = config
+    return step
+
+
+def _missing_config_step(work_dir):
+    component = Component(name='mesh')
+    config = PolarisConfigParser()
+    config.add_from_package(
+        'polaris.tasks.mesh.spherical.feature_masks',
+        'feature_masks.cfg',
+    )
+    config.set('feature_masks', 'cpus_per_task', '1')
+    config.set('feature_masks', 'min_cpus_per_task', '1')
+    step = ComputeFeatureMasksStep(
+        component=component,
+        subdir='spherical/feature_masks/configurable/compute',
+    )
+    step.config = config
+    step.work_dir = str(work_dir)
+    return step
+
+
+def _feature_collection(object_type):
+    geometry = _polygon() if object_type == 'region' else _line_string()
+    fc_mask = FeatureCollection()
+    fc_mask.add_feature(_feature(object_type, 'Test Feature', geometry))
+    return fc_mask
+
+
+def _feature(object_type, name, geometry, component='ocean'):
+    return {
+        'type': 'Feature',
+        'properties': {
+            'name': name,
+            'tags': '',
+            'object': object_type,
+            'component': component,
+            'author': 'Polaris',
+        },
+        'geometry': geometry,
+    }
+
+
+def _polygon():
+    return {
+        'type': 'Polygon',
+        'coordinates': [
+            [
+                [-1.0, -1.0],
+                [1.0, -1.0],
+                [1.0, 1.0],
+                [-1.0, 1.0],
+                [-1.0, -1.0],
+            ]
+        ],
+    }
+
+
+def _line_string():
+    return {
+        'type': 'LineString',
+        'coordinates': [[-1.0, 0.0], [1.0, 0.0]],
+    }

--- a/tests/mesh/spherical/feature_masks/test_moc.py
+++ b/tests/mesh/spherical/feature_masks/test_moc.py
@@ -1,0 +1,175 @@
+import ast
+import inspect
+import logging
+
+import numpy as np
+import pytest
+import xarray as xr
+from geometric_features.aggregation import get_aggregator_by_name
+
+from polaris.component import Component
+from polaris.config import PolarisConfigParser
+from polaris.tasks.mesh.spherical.feature_masks import (
+    ComputeFeatureMasksStep,
+)
+from polaris.tasks.mesh.spherical.feature_masks import moc as moc_module
+from polaris.tasks.mesh.spherical.feature_masks.moc import (
+    MOC_MASK_GROUP,
+    MOC_PREFIX,
+    add_moc_transects,
+    moc_masks_filename,
+)
+
+_TEST_LOGGER = logging.getLogger('test_moc')
+
+
+def test_moc_masks_filename():
+    filename = moc_masks_filename(mesh_name='QU240', date='20210623')
+
+    assert filename == 'QU240_mocBasinsAndTransects20210623.nc'
+    assert MOC_PREFIX in filename
+    assert MOC_MASK_GROUP == 'MOC Basins'
+
+
+def test_add_moc_transects_appends_transects(monkeypatch):
+    ds_mesh = xr.Dataset({'nCells': np.arange(2)})
+    ds_masks = xr.Dataset(
+        {'regionCellMasks': (('nCells', 'nRegions'), np.ones((2, 1)))}
+    )
+    ds_combined = ds_masks.copy()
+    ds_combined['transectEdgeMasks'] = (
+        ('nEdges', 'nTransects'),
+        np.ones((3, 1)),
+    )
+
+    calls = []
+
+    def fake_add_transects(ds_mask, ds_mesh_arg, logger=None):
+        calls.append((ds_mask, ds_mesh_arg))
+        return ds_combined
+
+    monkeypatch.setattr(
+        moc_module,
+        'add_moc_southern_boundary_transects',
+        fake_add_transects,
+    )
+
+    result = add_moc_transects(ds_masks, ds_mesh, logger=_TEST_LOGGER)
+
+    assert len(calls) == 1
+    assert calls[0][0] is ds_masks
+    assert calls[0][1] is ds_mesh
+    assert 'transectEdgeMasks' in result
+
+
+def test_add_moc_transects_drops_problematic_vars(monkeypatch):
+    ds_mesh = xr.Dataset()
+    ds_masks = xr.Dataset({'regionCellMasks': (('nCells',), np.ones(2))})
+    ds_with_extras = ds_masks.copy()
+    ds_with_extras['history'] = xr.DataArray('some history')
+    ds_with_extras['constituents'] = xr.DataArray('some string')
+
+    monkeypatch.setattr(
+        moc_module,
+        'add_moc_southern_boundary_transects',
+        lambda ds, ds_mesh, logger=None: ds_with_extras,
+    )
+
+    result = add_moc_transects(ds_masks, ds_mesh, logger=_TEST_LOGGER)
+
+    assert 'history' not in result
+    assert 'constituents' not in result
+    assert 'regionCellMasks' in result
+
+
+@pytest.mark.parametrize('present_var', ['history', 'constituents'])
+def test_add_moc_transects_tolerates_missing_problematic_vars(
+    monkeypatch, present_var
+):
+    ds_mesh = xr.Dataset()
+    ds_masks = xr.Dataset({'regionCellMasks': (('nCells',), np.ones(2))})
+    # only one of the two problematic vars is present
+    ds_one_extra = ds_masks.copy()
+    ds_one_extra[present_var] = xr.DataArray('value')
+
+    monkeypatch.setattr(
+        moc_module,
+        'add_moc_southern_boundary_transects',
+        lambda ds, ds_mesh, logger=None: ds_one_extra,
+    )
+
+    result = add_moc_transects(ds_masks, ds_mesh, logger=_TEST_LOGGER)
+
+    assert present_var not in result
+    assert 'regionCellMasks' in result
+
+
+def test_moc_module_does_not_depend_on_the_ocean_packages():
+    # the leaf-module property that lets other components reuse the helpers;
+    # importing polaris.tasks anything pulls in every component, so check the
+    # module's own imports rather than sys.modules
+    tree = ast.parse(inspect.getsource(moc_module))
+
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported.add(node.module)
+
+    forbidden = [
+        name
+        for name in imported
+        if name == 'polaris.ocean'
+        or name.startswith('polaris.ocean.')
+        or name == 'polaris.tasks.ocean'
+        or name.startswith('polaris.tasks.ocean.')
+    ]
+
+    assert forbidden == []
+
+
+def test_moc_helpers_work_without_an_ocean_config_section(tmp_path):
+    # a step in another component, whose config has no [ocean] section, can
+    # subclass the model-neutral step and reuse the MOC helpers
+    mesh_filename = tmp_path / 'mesh.nc'
+    mesh_filename.touch()
+
+    component = Component(name='e3sm/init')
+    config = PolarisConfigParser()
+    config.add_from_package(
+        'polaris.tasks.mesh.spherical.feature_masks',
+        'feature_masks.cfg',
+    )
+    config.set('feature_masks', 'mesh_filename', str(mesh_filename))
+    config.set('feature_masks', 'mesh_name', 'QU240')
+    config.set('feature_masks', 'mask_group', MOC_MASK_GROUP)
+    config.set('feature_masks', 'cpus_per_task', '1')
+    config.set('feature_masks', 'min_cpus_per_task', '1')
+
+    step = _MocMasksStep(
+        component=component,
+        subdir='moc_masks',
+    )
+    step.config = config
+
+    step.setup()
+
+    assert not config.has_section('ocean')
+    _, _, date = get_aggregator_by_name(MOC_MASK_GROUP)
+    assert step.output_filename == moc_masks_filename('QU240', date)
+    assert step.output_filename in step.outputs
+
+
+class _MocMasksStep(ComputeFeatureMasksStep):
+    """
+    A stand-in for a MOC mask step in a component other than the ocean.
+    """
+
+    def _set_output_filenames(self, mesh_name, mask_group):
+        super()._set_output_filenames(mesh_name, mask_group)
+        _, _, date = get_aggregator_by_name(mask_group)
+        self.output_filename = moc_masks_filename(mesh_name, date)
+
+    def _post_process_masks(self, ds_masks, ds_mesh, mask_group):
+        return add_moc_transects(ds_masks, ds_mesh, logger=self.logger)

--- a/tests/ocean/feature_masks/test_ocean_feature_masks.py
+++ b/tests/ocean/feature_masks/test_ocean_feature_masks.py
@@ -1,0 +1,81 @@
+import numpy as np
+import xarray as xr
+
+from polaris.tasks.ocean import Ocean
+from polaris.tasks.ocean.feature_masks import ComputeOceanFeatureMasksStep
+
+
+def test_ocean_feature_masks_step_is_ocean_io_step():
+    from polaris.ocean.model.ocean_io_step import OceanIOStep
+
+    component = Ocean()
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+
+    assert isinstance(step, OceanIOStep)
+
+
+def test_ocean_feature_masks_opens_omega_mesh(tmp_path):
+    filename = tmp_path / 'omega_mesh.nc'
+    xr.Dataset(
+        coords={'NCells': np.arange(2)},
+        data_vars={
+            'LatCell': ('NCells', np.array([0.0, 1.0])),
+            'LonCell': ('NCells', np.array([0.0, 1.0])),
+        },
+    ).to_netcdf(filename)
+
+    component = Ocean()
+    component.model = 'omega'
+    component.mpaso_to_omega_dim_map = {'nCells': 'NCells'}
+    component.mpaso_to_omega_var_map = {
+        'latCell': 'LatCell',
+        'lonCell': 'LonCell',
+    }
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+
+    ds_mesh = step._open_mesh_dataset(filename)
+
+    assert 'nCells' in ds_mesh.dims
+    assert 'latCell' in ds_mesh
+    assert 'lonCell' in ds_mesh
+
+
+def test_ocean_feature_masks_writes_omega_mask(tmp_path):
+    filename = tmp_path / 'omega_mask.nc'
+    component = Ocean()
+    component.model = 'omega'
+    component.mpaso_to_omega_dim_map = {
+        'nCells': 'NCells',
+        'nRegions': 'NRegions',
+    }
+    component.mpaso_to_omega_var_map = {
+        'regionCellMasks': 'RegionCellMasks',
+        'regionNames': 'RegionNames',
+    }
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+    ds_masks = xr.Dataset(
+        data_vars={
+            'regionCellMasks': (
+                ('nCells', 'nRegions'),
+                np.ones((2, 1), dtype=np.int32),
+            ),
+            'regionNames': ('nRegions', ['Test Region']),
+        }
+    )
+
+    step._write_mask_dataset(ds_masks, filename)
+
+    ds_native = xr.open_dataset(filename)
+    assert 'NCells' in ds_native.dims
+    assert 'NRegions' in ds_native.dims
+    assert 'RegionCellMasks' in ds_native
+    assert 'RegionNames' in ds_native

--- a/tests/ocean/feature_masks/test_ocean_feature_masks.py
+++ b/tests/ocean/feature_masks/test_ocean_feature_masks.py
@@ -1,8 +1,14 @@
+import logging
+
 import numpy as np
+import pytest
 import xarray as xr
 
 from polaris.tasks.ocean import Ocean
 from polaris.tasks.ocean.feature_masks import ComputeOceanFeatureMasksStep
+from polaris.tasks.ocean.feature_masks import compute as ocean_compute_module
+
+_TEST_LOGGER = logging.getLogger('test_ocean_feature_masks')
 
 
 def test_ocean_feature_masks_step_is_ocean_io_step():
@@ -79,3 +85,150 @@ def test_ocean_feature_masks_writes_omega_mask(tmp_path):
     assert 'NRegions' in ds_native.dims
     assert 'RegionCellMasks' in ds_native
     assert 'RegionNames' in ds_native
+
+
+def test_set_output_filenames_moc_basins():
+    component = Ocean()
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+
+    step._set_output_filenames(mesh_name='QU240', mask_group='MOC Basins')
+
+    assert step.output_filename is not None
+    assert step.geojson_filename is not None
+    assert 'mocBasinsAndTransects' in step.output_filename
+    assert step.output_filename.startswith('QU240_mocBasinsAndTransects')
+    assert step.output_filename.endswith('.nc')
+    assert step.geojson_filename.startswith('mocBasins')
+    assert 'AndTransects' not in step.geojson_filename
+
+
+def test_set_output_filenames_non_moc_uses_normal_naming():
+    component = Ocean()
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+
+    step._set_output_filenames(mesh_name='QU240', mask_group='Ocean Basins')
+
+    assert step.output_filename is not None
+    assert 'mocBasinsAndTransects' not in step.output_filename
+    assert step.output_filename.startswith('QU240_oceanBasins')
+
+
+def test_post_process_masks_moc_calls_transects(monkeypatch):
+    ds_mesh = xr.Dataset({'nCells': np.arange(2)})
+    ds_masks = xr.Dataset(
+        {'regionCellMasks': (('nCells', 'nRegions'), np.ones((2, 1)))}
+    )
+    ds_combined = ds_masks.copy()
+    ds_combined['transectEdgeMasks'] = (
+        ('nEdges', 'nTransects'),
+        np.ones((3, 1)),
+    )
+
+    calls = []
+
+    def fake_add_transects(ds_mask, ds_mesh_arg, logger=None):
+        calls.append((ds_mask, ds_mesh_arg))
+        return ds_combined
+
+    monkeypatch.setattr(
+        ocean_compute_module,
+        'add_moc_southern_boundary_transects',
+        fake_add_transects,
+    )
+
+    component = Ocean()
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+    step.logger = _TEST_LOGGER
+
+    result = step._post_process_masks(ds_masks, ds_mesh, 'MOC Basins')
+
+    assert len(calls) == 1
+    assert 'transectEdgeMasks' in result
+
+
+def test_post_process_masks_drops_problematic_vars(monkeypatch):
+    ds_mesh = xr.Dataset()
+    ds_masks = xr.Dataset({'regionCellMasks': (('nCells',), np.ones(2))})
+    ds_with_extras = ds_masks.copy()
+    ds_with_extras['history'] = xr.DataArray('some history')
+    ds_with_extras['constituents'] = xr.DataArray('some string')
+
+    monkeypatch.setattr(
+        ocean_compute_module,
+        'add_moc_southern_boundary_transects',
+        lambda ds, ds_mesh, logger=None: ds_with_extras,
+    )
+
+    component = Ocean()
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+    step.logger = _TEST_LOGGER
+
+    result = step._post_process_masks(ds_masks, ds_mesh, 'MOC Basins')
+
+    assert 'history' not in result
+    assert 'constituents' not in result
+    assert 'regionCellMasks' in result
+
+
+def test_post_process_masks_non_moc_is_noop(monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        ocean_compute_module,
+        'add_moc_southern_boundary_transects',
+        lambda *a, **kw: called.append(True),
+    )
+
+    ds_mesh = xr.Dataset()
+    ds_masks = xr.Dataset({'regionCellMasks': (('nCells',), np.ones(2))})
+
+    component = Ocean()
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+    step.logger = _TEST_LOGGER
+
+    result = step._post_process_masks(ds_masks, ds_mesh, 'Ocean Basins')
+
+    assert called == []
+    assert result is ds_masks
+
+
+@pytest.mark.parametrize('missing_var', ['history', 'constituents'])
+def test_post_process_masks_tolerates_missing_problematic_vars(
+    monkeypatch, missing_var
+):
+    ds_mesh = xr.Dataset()
+    ds_masks = xr.Dataset({'regionCellMasks': (('nCells',), np.ones(2))})
+    # only one of the two problematic vars is present
+    ds_one_extra = ds_masks.copy()
+    ds_one_extra[missing_var] = xr.DataArray('value')
+
+    monkeypatch.setattr(
+        ocean_compute_module,
+        'add_moc_southern_boundary_transects',
+        lambda ds, ds_mesh, logger=None: ds_one_extra,
+    )
+
+    component = Ocean()
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+    step.logger = _TEST_LOGGER
+
+    result = step._post_process_masks(ds_masks, ds_mesh, 'MOC Basins')
+
+    assert missing_var not in result

--- a/tests/ocean/feature_masks/test_ocean_feature_masks.py
+++ b/tests/ocean/feature_masks/test_ocean_feature_masks.py
@@ -1,9 +1,13 @@
 import logging
 
 import numpy as np
-import pytest
 import xarray as xr
+from geometric_features.aggregation import get_aggregator_by_name
 
+from polaris.tasks.mesh.spherical.feature_masks.moc import (
+    MOC_MASK_GROUP,
+    moc_masks_filename,
+)
 from polaris.tasks.ocean import Ocean
 from polaris.tasks.ocean.feature_masks import ComputeOceanFeatureMasksStep
 from polaris.tasks.ocean.feature_masks import compute as ocean_compute_module
@@ -105,6 +109,20 @@ def test_set_output_filenames_moc_basins():
     assert 'AndTransects' not in step.geojson_filename
 
 
+def test_set_output_filenames_moc_matches_shared_helper():
+    # the delegation to the shared MOC helper cannot silently drift
+    component = Ocean()
+    step = ComputeOceanFeatureMasksStep(
+        component=component,
+        subdir='feature_masks/configurable/compute',
+    )
+
+    step._set_output_filenames(mesh_name='QU240', mask_group=MOC_MASK_GROUP)
+
+    _, _, date = get_aggregator_by_name(MOC_MASK_GROUP)
+    assert step.output_filename == moc_masks_filename('QU240', date)
+
+
 def test_set_output_filenames_non_moc_uses_normal_naming():
     component = Ocean()
     step = ComputeOceanFeatureMasksStep(
@@ -119,7 +137,7 @@ def test_set_output_filenames_non_moc_uses_normal_naming():
     assert step.output_filename.startswith('QU240_oceanBasins')
 
 
-def test_post_process_masks_moc_calls_transects(monkeypatch):
+def test_post_process_masks_moc_delegates_to_shared_helper(monkeypatch):
     ds_mesh = xr.Dataset({'nCells': np.arange(2)})
     ds_masks = xr.Dataset(
         {'regionCellMasks': (('nCells', 'nRegions'), np.ones((2, 1)))}
@@ -132,14 +150,14 @@ def test_post_process_masks_moc_calls_transects(monkeypatch):
 
     calls = []
 
-    def fake_add_transects(ds_mask, ds_mesh_arg, logger=None):
-        calls.append((ds_mask, ds_mesh_arg))
+    def fake_add_moc_transects(ds_mask, ds_mesh_arg, logger=None):
+        calls.append((ds_mask, ds_mesh_arg, logger))
         return ds_combined
 
     monkeypatch.setattr(
         ocean_compute_module,
-        'add_moc_southern_boundary_transects',
-        fake_add_transects,
+        'add_moc_transects',
+        fake_add_moc_transects,
     )
 
     component = Ocean()
@@ -149,44 +167,20 @@ def test_post_process_masks_moc_calls_transects(monkeypatch):
     )
     step.logger = _TEST_LOGGER
 
-    result = step._post_process_masks(ds_masks, ds_mesh, 'MOC Basins')
+    result = step._post_process_masks(ds_masks, ds_mesh, MOC_MASK_GROUP)
 
     assert len(calls) == 1
+    assert calls[0][0] is ds_masks
+    assert calls[0][1] is ds_mesh
+    assert calls[0][2] is _TEST_LOGGER
     assert 'transectEdgeMasks' in result
-
-
-def test_post_process_masks_drops_problematic_vars(monkeypatch):
-    ds_mesh = xr.Dataset()
-    ds_masks = xr.Dataset({'regionCellMasks': (('nCells',), np.ones(2))})
-    ds_with_extras = ds_masks.copy()
-    ds_with_extras['history'] = xr.DataArray('some history')
-    ds_with_extras['constituents'] = xr.DataArray('some string')
-
-    monkeypatch.setattr(
-        ocean_compute_module,
-        'add_moc_southern_boundary_transects',
-        lambda ds, ds_mesh, logger=None: ds_with_extras,
-    )
-
-    component = Ocean()
-    step = ComputeOceanFeatureMasksStep(
-        component=component,
-        subdir='feature_masks/configurable/compute',
-    )
-    step.logger = _TEST_LOGGER
-
-    result = step._post_process_masks(ds_masks, ds_mesh, 'MOC Basins')
-
-    assert 'history' not in result
-    assert 'constituents' not in result
-    assert 'regionCellMasks' in result
 
 
 def test_post_process_masks_non_moc_is_noop(monkeypatch):
     called = []
     monkeypatch.setattr(
         ocean_compute_module,
-        'add_moc_southern_boundary_transects',
+        'add_moc_transects',
         lambda *a, **kw: called.append(True),
     )
 
@@ -204,31 +198,3 @@ def test_post_process_masks_non_moc_is_noop(monkeypatch):
 
     assert called == []
     assert result is ds_masks
-
-
-@pytest.mark.parametrize('missing_var', ['history', 'constituents'])
-def test_post_process_masks_tolerates_missing_problematic_vars(
-    monkeypatch, missing_var
-):
-    ds_mesh = xr.Dataset()
-    ds_masks = xr.Dataset({'regionCellMasks': (('nCells',), np.ones(2))})
-    # only one of the two problematic vars is present
-    ds_one_extra = ds_masks.copy()
-    ds_one_extra[missing_var] = xr.DataArray('value')
-
-    monkeypatch.setattr(
-        ocean_compute_module,
-        'add_moc_southern_boundary_transects',
-        lambda ds, ds_mesh, logger=None: ds_one_extra,
-    )
-
-    component = Ocean()
-    step = ComputeOceanFeatureMasksStep(
-        component=component,
-        subdir='feature_masks/configurable/compute',
-    )
-    step.logger = _TEST_LOGGER
-
-    result = step._post_process_masks(ds_masks, ds_mesh, 'MOC Basins')
-
-    assert missing_var not in result


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
## Summary

This PR adds a shared framework for computing geometric-feature region and transect masks on MPAS meshes, plus configurable mesh and ocean tasks that expose the workflow through Polaris.

## Detailed Description

The PR adds a reusable `ComputeFeatureMasksStep` that builds mask feature collections from `geometric_features`, validates feature object and mask types, computes MPAS region or transect masks with `mpas_tools`, and writes both mask NetCDF output and the source GeoJSON. The workflow supports configurable mesh inputs, mesh metadata, mask groups, mask types, multiprocessing settings, subdivision options, and transect edge signs.

The branch also registers configurable feature-mask tasks under both the mesh and ocean components. The ocean task subclasses the shared step so native MPAS-Ocean or Omega mesh files are opened through the ocean I/O layer before using the same mask-generation logic. `nRegions` and `nTransects` are added to the MPAS-Ocean-to-Omega dimension map so mask output can be written in native Omega names.

`get_feature_mask_steps()` is available for workflows that already have an upstream mesh-producing step; it takes the mesh step and filename explicitly rather than special-casing base or culled meshes.

The "MOC Basins" regions get special treatment. A southern-boundary transect is added for each region, and the combined file is given the `mocBasinsAndTransects` prefix that E3SM and MPAS-Analysis expect.

That MOC behavior lives in `polaris/tasks/mesh/spherical/feature_masks/moc.py`, not in the ocean step. Both pieces of it — the filename convention and appending the transects — are model-agnostic: they operate on standard MPAS meshes and masks, and neither needs a step instance. Keeping them in a leaf module means a step in another component can subclass the model-neutral `ComputeFeatureMasksStep` and reuse them without inheriting the Omega name translation, and so without having to supply an `[ocean]` config section. `ComputeOceanFeatureMasksStep` delegates to the same two functions, so the MOC logic exists in exactly one place. `polaris/tasks/e3sm/init/component_inputs/` is the motivating caller: MPAS-Ocean reads the per-mesh MOC file at run time through its `regionalMasksInput` and `transectMasksInput` streams, so it is a component input rather than an analysis product.

## Testing

Unit tests cover feature object-type detection, mask-type validation, shared-step configuration, configurable setup, output metadata and filenames, and a full step run against a small synthetic mesh.

The MOC helpers are tested directly, including that the module's own imports name neither `polaris.ocean` nor `polaris.tasks.ocean`, and that a step in another component can subclass the model-neutral step, use both helpers, and set up against a config with no `[ocean]` section. On the ocean side the tests cover the Omega name-translation boundary and the delegation to the shared helpers.

`pytest tests/` passes in full (365 tests), and `pre-commit run --all-files` is clean.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
