### PR TITLE
Extract ocean model I/O into the ocean framework

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -380,7 +380,7 @@
 
    add_overflow_tasks
 
-   default.Default
+   smoke_test.SmokeTest
 
    forward.Forward
    forward.Forward.dynamic_model_config

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -7,12 +7,6 @@
    :toctree: generated/
 
    Ocean
-   Ocean.map_to_native_model_vars
-   Ocean.map_var_list_to_native_model
-   Ocean.write_model_dataset
-   Ocean.map_from_native_model_vars
-   Ocean.map_var_list_from_native_model
-   Ocean.open_model_dataset
 
    add_tasks.add_ocean_tasks
 ```
@@ -615,6 +609,27 @@
 
    get_days_since_start
    get_time_interval_string
+```
+
+### Ocean Model I/O
+
+```{eval-rst}
+.. currentmodule:: polaris.ocean.model
+
+.. autosummary::
+   :toctree: generated/
+
+   map_to_native_model_vars
+   map_from_native_model_vars
+   map_var_list_to_native_model
+   map_var_list_from_native_model
+   write_model_dataset
+   write_horiz_mesh_dataset
+   remove_horiz_mesh_vars
+   write_vert_coord_dataset
+   remove_vert_coord_vars
+   write_initial_state_dataset
+   open_model_dataset
 ```
 
 ### Equations of state (EOS)

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -12,30 +12,52 @@ The `ocean` component contains an ever expanding set of shared framework code.
 
 Steps that write input files for or read output files from either Omega or
 MPAS-Ocean should descend from the {py:class}`polaris.ocean.model.OceanIOStep`
-class.  Methods in this class facilitate mapping between MPAS-Ocean variable
-names (used in Polaris) and Omega variable names for tasks that will run Omega.
+class.  This class facilitates mapping between MPAS-Ocean variable names (used
+in Polaris) and Omega variable names for tasks that will run Omega.
 
-To map a dataset between MPAS-Ocean variable names and those appropriate for
-the model being run, use the methods
-{py:meth}`polaris.ocean.model.OceanIOStep.map_to_native_model_vars()` and
-{py:meth}`polaris.ocean.model.OceanIOStep.map_from_native_model_vars()`. These
-methods should be called in Polaris immediatly before writing out input files
-and immediately after opening in output files, respectively. To make opening
-and writing easier, we also provide
-{py:meth}`polaris.ocean.model.OceanIOStep.write_model_dataset()` and
-{py:meth}`polaris.ocean.model.OceanIOStep.open_model_dataset()`, which take
-care of of the mapping in addition to writing and opening a dataset,
-respectively. The `open_model_dataset()` method also supports reconstructing
-normal vector components to their zonal and meridional equivalents by passing
-a list of variable names to
-{py:class}`mpas_tools.vector.reconstruct.reconstruct_variables`, along with the mesh and
-reconstruction coefficient files. In addition,
-`open_model_dataset()` derives `PseudoThickness` from the ocean state when it
-is not present in the dataset. This provides a way of using the same initial
-conditions for MPAS-Ocean and Omega when the geometric thickness is the state
-variable for MPAS-Ocean and the pseudo-thickness is the state variable for
-Omega. As new variables are added to Omega, they
-should be added to the `variables` section in the
+The I/O functions themselves live in the `polaris.ocean.model` module (backed
+by `polaris.ocean.model.io`) and can be called directly when you have a `model`
+string available:
+
+- {py:func}`polaris.ocean.model.map_to_native_model_vars()` and
+  {py:func}`polaris.ocean.model.map_from_native_model_vars()` rename dimensions
+  and variables in a dataset between MPAS-Ocean and Omega conventions.  These
+  should be called immediately before writing input files and immediately after
+  opening output files, respectively.
+- {py:func}`polaris.ocean.model.map_var_list_to_native_model()` and
+  {py:func}`polaris.ocean.model.map_var_list_from_native_model()` perform the
+  same renaming on plain Python lists of variable names (e.g. for validation).
+- {py:func}`polaris.ocean.model.write_model_dataset()` maps names then writes
+  a dataset to NetCDF.
+- {py:func}`polaris.ocean.model.write_horiz_mesh_dataset()` validates that all
+  expected horizontal mesh variables are present before writing.
+- {py:func}`polaris.ocean.model.remove_horiz_mesh_vars()` drops horizontal mesh
+  variables from a dataset.
+- {py:func}`polaris.ocean.model.write_vert_coord_dataset()` writes a separate
+  vertical-coordinate file for Omega's ``InitialVertCoord`` stream (a no-op for
+  MPAS-Ocean, which keeps these fields in the initial-state file).
+- {py:func}`polaris.ocean.model.remove_vert_coord_vars()` drops vertical
+  coordinate variables from a dataset.
+- {py:func}`polaris.ocean.model.write_initial_state_dataset()` removes
+  horizontal mesh fields (and for Omega, vertical coordinate fields) then writes
+  the initial-state file.
+- {py:func}`polaris.ocean.model.open_model_dataset()` opens a NetCDF file,
+  maps variable names from Omega back to MPAS-Ocean conventions, and optionally
+  reconstructs normal vector components to their zonal and meridional
+  equivalents by passing a list of variable names along with the mesh and
+  reconstruction coefficient files.  It also derives `layerThickness` from
+  `PseudoThickness` and `SpecVol` when those are present in an Omega output
+  file, providing a unified interface for both models.
+
+When writing a step that descends from {py:class}`polaris.ocean.model.OceanIOStep`,
+you can call these same functions through the equivalent instance methods
+(`self.map_to_native_model_vars()`, `self.write_model_dataset()`,
+`self.open_model_dataset()`, etc.), which internally call `_effective_model()`
+to determine the active model from `self.model` (if set on the step) or from
+`config['ocean']['model']` (set during {py:meth}`polaris.tasks.ocean.Ocean.configure`).
+
+As new variables are added to Omega, they should be added to the `variables`
+section in the
 [mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml)
 file.
 

--- a/docs/developers_guide/ocean/tasks/overflow.md
+++ b/docs/developers_guide/ocean/tasks/overflow.md
@@ -2,10 +2,10 @@
 
 # overflow
 
-The overflow task group is currently comprised of one `default` task for quick
-testing, particularly against a baseline, and one `rpe` test which shows how
-the resting potential energy changes across forward runs with different
-viscosities.
+The overflow task group is currently comprised of three `smoke_test` tasks
+for quick testing (one for each horizontal advection order: 2, 3, and 4),
+and one `rpe` test which shows how the resting potential energy changes across
+forward runs with different viscosities.
 
 ## framework
 
@@ -42,7 +42,7 @@ tasks have as their target and minimum (if the resources are not explicitly
 prescribed).  For MPAS-Ocean, PIO namelist options are modified and a
 graph partition is generated as part of `runtime_setup()`.  Next, the ocean
 model is run. The duration is set by `run_duration` in the config section
-corresponding to the task (`overflow_default` or `overflow_rpe`). Finally,
+corresponding to the task (`overflow_smoke_test` or `overflow_rpe`). Finally,
 validation of `layerThickness`, `temperature` and `normalVelocity` in the
 `output.nc` file are performed against a baseline if one is provided when
 calling {ref}`dev-polaris-setup`.
@@ -52,12 +52,16 @@ calling {ref}`dev-polaris-setup`.
 The {py:class}`polaris.tasks.ocean.overflow.viz.Viz` plots the initial and
 final temperature along a transect perpendicular to the continental slope.
 
-(dev-ocean-overflow-default)=
+(dev-ocean-overflow-smoke-test)=
 
-## default
+## smoke_test
 
-The {py:class}`polaris.tasks.ocean.overflow.default.Default`
-test runs the `init` step, a short `forward` step, and the `viz` step.
+The {py:class}`polaris.tasks.ocean.overflow.smoke_test.SmokeTest`
+task runs the `init` step, a short `forward` step, and (optionally, not run
+by default) the `viz` step. Three instances are created, one for each
+horizontal advection order (2, 3, and 4), producing tasks named
+`smoke_test_horiz_adv_order_2`, `smoke_test_horiz_adv_order_3`, and
+`smoke_test_horiz_adv_order_4`.
 
 ## rpe
 

--- a/docs/users_guide/ocean/tasks/overflow.md
+++ b/docs/users_guide/ocean/tasks/overflow.md
@@ -5,7 +5,7 @@
 The ``ocean/overflow`` test group induces a density current flowing down a
 continental slope and includes two test cases.
 
-## suppported models
+## supported models
 
 These tasks support MPAS-Ocean and Omega.
 
@@ -94,8 +94,11 @@ These config options are common to all overflow tests:
 # Options related to the overflow case
 [overflow]
 
+# Time integration scheme
+time_integrator = RK4
+
 # Timestep per km horizontal resolution (s)
-dt_per_km = 10.
+dt_per_km = 7.5
 
 # Barotropic timestep per km horizontal resolution (s)
 btr_dt_per_km = 2.5
@@ -138,6 +141,12 @@ lower_temperature = 10.0
 
 # Higher temperature (deg C)
 higher_temperature = 20.0
+
+# Default viscosity (m^2/s)
+default_viscosity = 1000.0
+
+# Default horizontal advection order
+default_horiz_adv_order = 2
 ```
 
 The linear EOS is used because it is convenient for computing RPE. The
@@ -149,12 +158,17 @@ namelist parameters for the linear EOS can be altered using config options
 The number of cores is determined by `goal_cells_per_core` and
 `max_cells_per_core` in the `ocean` section of the config file.
 
-## default
+## smoke_test
 
 ### description
 
-The default case is the same as described above except the run is stopped
-before it is allowed to reach equilibrium to facilitate rapid testing.
+There are three smoke test cases corresponding to horizontal advection orders
+2, 3, and 4: `smoke_test_horiz_adv_order_2`, `smoke_test_horiz_adv_order_3`,
+and `smoke_test_horiz_adv_order_4`. Each smoke test is the same as described
+above except the run is stopped before it is allowed to reach equilibrium to
+facilitate rapid testing. The horizontal advection order is controlled by the
+`horiz_adv_order` argument to the `SmokeTest` task and passed through to the
+forward step.
 
 ### mesh
 
@@ -175,23 +189,25 @@ See {ref}`ocean-overflow`.
 ### time step and run duration
 
 The time step for forward integration is set by `dt_per_km` and the model
-resolution. The barotropic time step is 15s. The run duration is 12 minutes.
+resolution. The run duration is 12 minutes.
 
 ### config options
 
-The config options specific to the default case are:
+The config options specific to the smoke test cases are:
 
 ```cfg
-[overflow_default]
+[overflow_smoke_test]
 
-# Run duration (minutes)
+# Run duration
 run_duration = 12.
 
-# Output interval (seconds)
-output_interval = 1.
-```
+run_duration_units = minutes
 
-Include here any further description of each of the config options.
+# Output interval
+output_interval = 1.
+
+output_interval_units = seconds
+```
 
 ### cores
 
@@ -201,7 +217,7 @@ See {ref}`ocean-overflow`.
 
 ### description
 
-The `rpe` case is the same as the default except it runs to 40 days by which
+The `rpe` case is similar to the smoke tests except it runs to 40 days by which
 time the dense blob is mostly at depth. It also includs several forward runs
 corresponding to different values of the laplacian viscosity specified by the
 config option `overflow_rpe:viscosities`. The analysis step is a substitute for the viz step as
@@ -226,11 +242,15 @@ The config options specific to the RPE case are:
 ```cfg
 [overflow_rpe]
 
-# Run duration (days)
+# Run duration
 run_duration = 40.
 
-# Output interval (days)
+run_duration_units = days
+
+# Output interval
 output_interval = 1.
+
+output_interval_units = hours
 
 # Viscosity values to test for rpe test case
 viscosities = 1, 5, 10, 100, 1000

--- a/polaris/ocean/model/__init__.py
+++ b/polaris/ocean/model/__init__.py
@@ -1,3 +1,32 @@
+from polaris.ocean.model.io import (
+    map_from_native_model_vars as map_from_native_model_vars,
+)
+from polaris.ocean.model.io import (
+    map_to_native_model_vars as map_to_native_model_vars,
+)
+from polaris.ocean.model.io import (
+    map_var_list_from_native_model as map_var_list_from_native_model,
+)
+from polaris.ocean.model.io import (
+    map_var_list_to_native_model as map_var_list_to_native_model,
+)
+from polaris.ocean.model.io import open_model_dataset as open_model_dataset
+from polaris.ocean.model.io import (
+    remove_horiz_mesh_vars as remove_horiz_mesh_vars,
+)
+from polaris.ocean.model.io import (
+    remove_vert_coord_vars as remove_vert_coord_vars,
+)
+from polaris.ocean.model.io import (
+    write_horiz_mesh_dataset as write_horiz_mesh_dataset,
+)
+from polaris.ocean.model.io import (
+    write_initial_state_dataset as write_initial_state_dataset,
+)
+from polaris.ocean.model.io import write_model_dataset as write_model_dataset
+from polaris.ocean.model.io import (
+    write_vert_coord_dataset as write_vert_coord_dataset,
+)
 from polaris.ocean.model.ocean_io_step import OceanIOStep as OceanIOStep
 from polaris.ocean.model.ocean_model_step import (
     OceanModelStep as OceanModelStep,

--- a/polaris/ocean/model/io.py
+++ b/polaris/ocean/model/io.py
@@ -1,0 +1,504 @@
+import importlib.resources as imp_res
+from typing import Optional, Tuple
+
+import xarray as xr
+from mpas_tools.io import write_netcdf
+from mpas_tools.vector.reconstruct import reconstruct_variable
+from ruamel.yaml import YAML
+
+from polaris.ocean.vertical.diagnostics import (
+    geom_thickness_from_ds,
+    pseudothickness_from_ds,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level lazy caches (populated on first use)
+# ---------------------------------------------------------------------------
+
+_var_maps: Optional[Tuple[dict, dict]] = None  # (dim_map, var_map)
+# keyed by model string -> (horiz_mesh_vars, vert_coord_vars)
+_variable_lists: dict = {}
+
+
+def _get_var_maps() -> Tuple[dict, dict]:
+    """Return (mpaso_to_omega_dim_map, mpaso_to_omega_var_map)."""
+    global _var_maps
+    if _var_maps is None:
+        package = 'polaris.ocean.model'
+        yaml_file = 'mpaso_to_omega.yaml'
+        text = imp_res.files(package).joinpath(yaml_file).read_text()
+        yaml_data = YAML(typ='rt')
+        nested_dict = yaml_data.load(text)
+        _var_maps = (nested_dict['dimensions'], nested_dict['variables'])
+    return _var_maps
+
+
+def _get_variable_lists(model: str) -> Tuple[list, list]:
+    """Return (horiz_mesh_vars, vert_coord_vars) for the given model."""
+    global _variable_lists
+    if model not in _variable_lists:
+        package = 'polaris.ocean.model'
+        text = imp_res.files(package).joinpath('variables.yaml').read_text()
+        yaml_data = YAML(typ='rt')
+        nested_dict = yaml_data.load(text)
+        horiz_mesh_vars = nested_dict['ocean']['horiz_mesh_variables']
+        vert_coord_vars = list(nested_dict['ocean']['vert_coord_variables'])
+        model_section_map = {'mpas-ocean': 'mpas-ocean', 'omega': 'Omega'}
+        model_key = model_section_map.get(model or '')
+        if model_key:
+            extra = nested_dict.get(model_key, {}).get(
+                'vert_coord_variables', []
+            )
+            vert_coord_vars.extend(extra)
+        _variable_lists[model] = (horiz_mesh_vars, vert_coord_vars)
+    return _variable_lists[model]
+
+
+def _check_vars_present(ds, native_vars, context):
+    """Raise ValueError if any variable in native_vars is absent from ds."""
+    missing = [v for v in native_vars if v not in ds]
+    if missing:
+        raise ValueError(
+            f'{context} requires the following variables that are '
+            'missing from the dataset: ' + ', '.join(missing)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public I/O functions
+# ---------------------------------------------------------------------------
+
+
+def map_to_native_model_vars(ds, model):
+    """
+    If the model is Omega, rename dimensions and variables in a dataset
+    from their MPAS-Ocean names to the Omega equivalent (appropriate for
+    input datasets like an initial condition).
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset containing MPAS-Ocean variable names
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        The same dataset with variables renamed as appropriate for the
+        ocean model being run
+    """
+    if model == 'omega':
+        dim_map, var_map = _get_var_maps()
+        rename = {k: v for k, v in dim_map.items() if k in ds.dims}
+        rename_vars = {k: v for k, v in var_map.items() if k in ds}
+        rename.update(rename_vars)
+        ds = ds.rename(rename)
+    return ds
+
+
+def map_from_native_model_vars(ds, model):
+    """
+    If the model is Omega, rename dimensions and variables in a dataset
+    from their Omega names to the MPAS-Ocean equivalent (appropriate for
+    datasets that are output from the model).
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset containing variable names native to either ocean model
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        The same dataset with variables named as expected in MPAS-Ocean
+    """
+    if model == 'omega':
+        dim_map, var_map = _get_var_maps()
+        rename = {k: v for v, k in dim_map.items() if k in ds.dims}
+        rename_vars = {k: v for v, k in var_map.items() if k in ds}
+        rename.update(rename_vars)
+        ds = ds.rename(rename)
+    return ds
+
+
+def map_var_list_to_native_model(var_list, model):
+    """
+    If the model is Omega, rename variables from their MPAS-Ocean names to
+    the Omega equivalent (appropriate for validation variable lists).
+
+    Parameters
+    ----------
+    var_list : list of str
+        A list of MPAS-Ocean variable names
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+
+    Returns
+    -------
+    renamed_vars : list of str
+        The same list with variables renamed as appropriate for the
+        ocean model being run
+    """
+    if model == 'omega':
+        _, var_map = _get_var_maps()
+        return [var_map.get(v, v) for v in var_list]
+    return var_list
+
+
+def map_var_list_from_native_model(var_list, model):
+    """
+    If the model is Omega, rename variables from their Omega names to
+    the MPAS-Ocean equivalent.
+
+    Parameters
+    ----------
+    var_list : list of str
+        A list of variable names in native model form
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+
+    Returns
+    -------
+    renamed_vars : list of str
+        The same list with variables renamed back to MPAS-Ocean names
+    """
+    if model == 'omega':
+        _, var_map = _get_var_maps()
+        # invert: omega name -> mpaso name
+        return [v for v, k in var_map.items() if k in var_list]
+    return var_list
+
+
+def write_model_dataset(ds, filename, config, model):
+    """
+    Write out the given dataset, mapping dimension and variable names from
+    MPAS-Ocean to Omega names if appropriate.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset containing MPAS-Ocean variable names
+
+    filename : str
+        The path for the NetCDF file to write
+
+    config : polaris.config.PolarisConfigParser
+        Configuration for the task; used when the model is Omega to
+        convert geometric layer thickness to pseudo-thickness before
+        writing.
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+    """
+    if model == 'omega':
+        mpas_to_omega_vars = {
+            'layerThickness': 'PseudoThickness',
+            'restingThickness': 'RefPseudoThickness',
+        }
+        for mpas_var, omega_var in mpas_to_omega_vars.items():
+            if mpas_var in ds.keys() and omega_var not in ds.keys():
+                pseudothickness, spec_vol = pseudothickness_from_ds(
+                    ds, config=config, src_var_name=mpas_var
+                )
+                if pseudothickness is not None and spec_vol is not None:
+                    ds[omega_var] = pseudothickness
+                    if mpas_var == 'layerThickness':
+                        ds['SpecVol'] = spec_vol
+
+    ds = map_to_native_model_vars(ds, model)
+    write_netcdf(ds=ds, fileName=filename)
+
+
+def write_horiz_mesh_dataset(ds, filename, config, model):
+    """
+    Write a horizontal mesh dataset, validating that all expected mesh
+    variables are present.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset containing MPAS-Ocean or native model variable names
+        including all horizontal mesh variables
+
+    filename : str
+        The path for the NetCDF file to write
+
+    config : polaris.config.PolarisConfigParser
+        Not used; retained for API compatibility.
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+    """
+    horiz_mesh_vars, _ = _get_variable_lists(model)
+    ds = map_to_native_model_vars(ds, model)
+    native_vars = map_var_list_to_native_model(horiz_mesh_vars, model)
+    _check_vars_present(ds, native_vars, 'write_horiz_mesh_dataset')
+    write_netcdf(ds=ds, fileName=filename)
+
+
+def remove_horiz_mesh_vars(ds, model):
+    """
+    Remove horizontal mesh variables from a dataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset containing MPAS-Ocean variable names
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        The same dataset without horizontal mesh variables
+    """
+    horiz_mesh_vars, _ = _get_variable_lists(model)
+    drop = [v for v in horiz_mesh_vars if v in ds]
+    if drop:
+        ds = ds.drop_vars(drop)
+    return ds
+
+
+def write_vert_coord_dataset(ds, filename, config, model):
+    """
+    Write a vertical-coordinate dataset for Omega's ``InitialVertCoord``
+    stream.  This is a no-op for MPAS-Ocean (vertical coordinate fields
+    stay in the initial state file).
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset containing MPAS-Ocean or native model variable names,
+        including the vertical coordinate variables and the
+        temperature/salinity/ssh fields needed for pseudo-thickness
+        conversion.
+
+    filename : str
+        The path for the NetCDF file to write
+
+    config : polaris.config.PolarisConfigParser
+        Configuration for the task; used when converting
+        ``restingThickness`` to ``RefPseudoThickness``.
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+    """
+    _, vert_coord_vars = _get_variable_lists(model)
+    native_vars = map_var_list_to_native_model(vert_coord_vars, model)
+
+    if model != 'omega':
+        _check_vars_present(ds, native_vars, 'write_vert_coord_dataset')
+        return
+
+    ds_vc = ds.copy()
+
+    if 'restingThickness' in ds_vc and 'RefPseudoThickness' not in ds_vc:
+        pseudothickness, _ = pseudothickness_from_ds(
+            ds_vc, config=config, src_var_name='restingThickness'
+        )
+        if pseudothickness is not None:
+            if 'Time' in pseudothickness.dims:
+                pseudothickness = pseudothickness.isel(Time=0)
+            ds_vc['RefPseudoThickness'] = pseudothickness
+
+    ds_vc = map_to_native_model_vars(ds_vc, model)
+    _check_vars_present(ds_vc, native_vars, 'write_vert_coord_dataset')
+    ds_vc = ds_vc[native_vars]
+    write_netcdf(ds=ds_vc, fileName=filename)
+
+
+def remove_vert_coord_vars(ds, model):
+    """
+    Remove vertical coordinate variables from a dataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset containing MPAS-Ocean variable names
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        The same dataset without vertical coordinate variables
+    """
+    _, vert_coord_vars = _get_variable_lists(model)
+    drop = [v for v in vert_coord_vars if v in ds]
+    if drop:
+        ds = ds.drop_vars(drop)
+    return ds
+
+
+def write_initial_state_dataset(ds, filename, config, model):
+    """
+    Write an initial-state dataset, omitting horizontal mesh fields and
+    (for Omega) vertical coordinate fields.
+
+    For MPAS-Ocean the vertical coordinate variables remain in the initial
+    state file.  For Omega they are written separately via
+    :py:func:`write_vert_coord_dataset`.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset containing MPAS-Ocean variable names
+
+    filename : str
+        The path for the NetCDF file to write
+
+    config : polaris.config.PolarisConfigParser
+        Configuration for the task; forwarded to
+        :py:func:`write_model_dataset`.
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+    """
+    ds = remove_horiz_mesh_vars(ds, model)
+    if model == 'omega':
+        ds = remove_vert_coord_vars(ds, model)
+    write_model_dataset(ds, filename, config, model)
+
+
+def open_model_dataset(
+    filename,
+    config,
+    model,
+    mesh_filename=None,
+    reconstruct_variables=None,
+    coeffs_filename=None,
+    **kwargs,
+):
+    """
+    Open the given dataset, mapping variable and dimension names from Omega
+    to MPAS-Ocean names if appropriate.
+
+    Parameters
+    ----------
+    filename : str
+        The path for the NetCDF file to open
+
+    config : polaris.config.PolarisConfigParser
+        Configuration for the task; used when the model is Omega to
+        compute geometric layer thickness from pseudo-thickness.
+
+    model : str
+        The ocean model: ``'omega'`` or ``'mpas-ocean'``
+
+    mesh_filename : str, optional
+        Path to the mesh NetCDF file.
+
+    reconstruct_variables : list of str, optional
+        List of variable names to reconstruct in the dataset.
+
+    coeffs_filename : str, optional
+        Path to the coefficients NetCDF file.
+
+    kwargs
+        keyword arguments passed to `xarray.open_dataset()`
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        The dataset with variables named as expected in MPAS-Ocean
+    """
+    ds = xr.open_dataset(filename, **kwargs)
+    if (
+        model == 'omega'
+        and 'layerThickness' not in ds.keys()
+        and 'PseudoThickness' in ds.keys()
+        and 'SpecVol' in ds.keys()
+    ):
+        ds['layerThickness'] = geom_thickness_from_ds(ds, config=config)
+    ds = map_from_native_model_vars(ds, model)
+    ds = _add_reconstructed_variables_to_dataset(
+        ds, reconstruct_variables, mesh_filename, coeffs_filename
+    )
+    return ds
+
+
+def _add_reconstructed_variables_to_dataset(
+    ds, reconstruct_variables, mesh_filename, coeffs_filename
+):
+    """
+    Add reconstructed vector variables to the dataset if requested.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset to add reconstructed variables to.
+
+    reconstruct_variables : list of str or None
+        List of variable names to reconstruct.
+
+    mesh_filename : str
+        Path to the mesh NetCDF file.
+
+    coeffs_filename : str
+        Path to the coefficients NetCDF file.
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        The dataset with reconstructed variables added.
+    """
+    if reconstruct_variables is None:
+        return ds
+
+    if mesh_filename is None:
+        raise ValueError(
+            'mesh_filename must be provided to open_model_dataset for '
+            'variable reconstruction'
+        )
+    if coeffs_filename is None:
+        raise ValueError(
+            'coeffs_filename must be provided to open_model_dataset for '
+            'variable reconstruction'
+        )
+
+    for variable in reconstruct_variables:
+        if variable not in ds:
+            raise ValueError(
+                f"User requested vector reconstruction for '{variable}' "
+                "but it isn't present in the dataset."
+            )
+
+        out_var_name = (
+            variable.replace('normal', '').lower()
+            if 'normal' in variable
+            else variable
+        )
+
+        if f'{out_var_name}Zonal' in ds and f'{out_var_name}Meridional' in ds:
+            continue
+
+        ds_mesh = xr.open_dataset(mesh_filename)
+        ds_coeff = xr.open_dataset(coeffs_filename)
+        coeffs_reconstruct = ds_coeff.coeffs_reconstruct
+
+        if ds_coeff.sizes['nCells'] != ds_mesh.sizes['nCells']:
+            print(
+                f'The sizes of coefficient dataset do not match mesh '
+                f'dataset; exiting without reconstructing {out_var_name}'
+            )
+            continue
+
+        reconstruct_variable(
+            out_var_name,
+            ds[variable],
+            ds_mesh,
+            coeffs_reconstruct,
+            ds,
+            quiet=True,
+        )
+
+    return ds

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -1,12 +1,5 @@
-from typing import TYPE_CHECKING
-
 from polaris import Step
-
-if TYPE_CHECKING:
-    # Keep Ocean as a type-only import. Importing it at runtime pulls
-    # polaris.tasks.ocean back into polaris.ocean.model while that package is
-    # still importing these step classes, creating a circular import.
-    from polaris.tasks.ocean import Ocean
+from polaris.ocean.model import io
 
 
 class OceanIOStep(Step):
@@ -14,12 +7,21 @@ class OceanIOStep(Step):
     A step that writes input and/or output files for Omega or MPAS-Ocean
     """
 
-    # make sure component is of type Ocean, using a string to avoid circular
-    # imports
-    component: 'Ocean'
-
-    def __init__(self, component: 'Ocean', **kwargs):
+    def __init__(self, component, **kwargs):
         super().__init__(component=component, **kwargs)
+
+    def _effective_model(self) -> str:
+        """
+        Return the ocean model for this step.
+
+        If the step (or a subclass) has set ``self.model`` explicitly (e.g.
+        :py:class:`.InitialStateStep`), that value is used.  Otherwise the
+        model is read from ``config['ocean']['model']``, which is the
+        globally-configured model set during :py:meth:`.Ocean.configure`.
+        """
+        return getattr(self, 'model', None) or self.config.get(
+            'ocean', 'model'
+        )
 
     def add_output_files_for_ocean_model_input(
         self,
@@ -58,7 +60,7 @@ class OceanIOStep(Step):
             only (e.g. ``'culled_graph.info'``).  Ignored for Omega.
         """
         config = self.config
-        model = config.get('ocean', 'model')
+        model = self._effective_model()
 
         if horiz_mesh_filename is None:
             horiz_mesh_filename = config.get(
@@ -97,7 +99,7 @@ class OceanIOStep(Step):
             The same dataset with variables renamed as appropriate for the
             ocean model being run
         """
-        return self.component.map_to_native_model_vars(ds)
+        return io.map_to_native_model_vars(ds, model=self._effective_model())
 
     def write_model_dataset(self, ds, filename, config):
         """
@@ -113,9 +115,11 @@ class OceanIOStep(Step):
             The path for the NetCDF file to write
 
         config : polaris.config.PolarisConfigParser
-            Configuration for the task; forwarded to the Ocean component.
+            Configuration for the task; forwarded to the I/O module.
         """
-        self.component.write_model_dataset(ds, filename, config=config)
+        io.write_model_dataset(
+            ds, filename, config, model=self._effective_model()
+        )
 
     def write_horiz_mesh_dataset(self, ds, filename, config):
         """
@@ -132,9 +136,11 @@ class OceanIOStep(Step):
             The path for the NetCDF file to write
 
         config : polaris.config.PolarisConfigParser
-            Configuration for the task; forwarded to the Ocean component.
+            Configuration for the task; forwarded to the I/O module.
         """
-        self.component.write_horiz_mesh_dataset(ds, filename, config)
+        io.write_horiz_mesh_dataset(
+            ds, filename, config, model=self._effective_model()
+        )
 
     def write_vert_coord_dataset(self, ds, filename, config):
         """
@@ -150,9 +156,11 @@ class OceanIOStep(Step):
             The path for the NetCDF file to write
 
         config : polaris.config.PolarisConfigParser
-            Configuration for the task; forwarded to the Ocean component.
+            Configuration for the task; forwarded to the I/O module.
         """
-        self.component.write_vert_coord_dataset(ds, filename, config)
+        io.write_vert_coord_dataset(
+            ds, filename, config, model=self._effective_model()
+        )
 
     def write_initial_state_dataset(self, ds, filename, config):
         """
@@ -168,9 +176,11 @@ class OceanIOStep(Step):
             The path for the NetCDF file to write
 
         config : polaris.config.PolarisConfigParser
-            Configuration for the task; forwarded to the Ocean component.
+            Configuration for the task; forwarded to the I/O module.
         """
-        self.component.write_initial_state_dataset(ds, filename, config)
+        io.write_initial_state_dataset(
+            ds, filename, config, model=self._effective_model()
+        )
 
     def map_from_native_model_vars(self, ds):
         """
@@ -188,7 +198,7 @@ class OceanIOStep(Step):
         ds : xarray.Dataset
             The same dataset with variables named as expected in MPAS-Ocean
         """
-        return self.component.map_from_native_model_vars(ds)
+        return io.map_from_native_model_vars(ds, model=self._effective_model())
 
     def open_model_dataset(self, filename, config, **kwargs):
         """
@@ -201,7 +211,7 @@ class OceanIOStep(Step):
             The path for the NetCDF file to open
 
         config : polaris.config.PolarisConfigParser
-            Configuration for the task; forwarded to the Ocean component.
+            Configuration for the task; forwarded to the I/O module.
 
         kwargs
             keyword arguments passed to `xarray.open_dataset()`
@@ -211,6 +221,6 @@ class OceanIOStep(Step):
         ds : xarray.Dataset
             The dataset with variables named as expected in MPAS-Ocean
         """
-        return self.component.open_model_dataset(
-            filename, config=config, **kwargs
+        return io.open_model_dataset(
+            filename, config, model=self._effective_model(), **kwargs
         )

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from polaris import Step
 from polaris.ocean.model import io
 
@@ -5,7 +7,16 @@ from polaris.ocean.model import io
 class OceanIOStep(Step):
     """
     A step that writes input and/or output files for Omega or MPAS-Ocean
+
+    Attributes
+    ----------
+    model : str or None
+        The ocean model (``'omega'`` or ``'mpas-ocean'``) if fixed at
+        construction time, or ``None`` to read from
+        ``config['ocean']['model']`` at run time.
     """
+
+    model: Optional[str] = None
 
     def __init__(self, component, **kwargs):
         super().__init__(component=component, **kwargs)
@@ -18,10 +29,21 @@ class OceanIOStep(Step):
         :py:class:`.InitialStateStep`), that value is used.  Otherwise the
         model is read from ``config['ocean']['model']``, which is the
         globally-configured model set during :py:meth:`.Ocean.configure`.
+
+        Raises
+        ------
+        ValueError
+            If the resolved model is not ``'omega'`` or ``'mpas-ocean'``,
+            indicating the user needs to pass ``--model`` to ``polaris setup``.
         """
-        return getattr(self, 'model', None) or self.config.get(
-            'ocean', 'model'
-        )
+        model = self.model or self.config.get('ocean', 'model')
+        if model not in ('omega', 'mpas-ocean'):
+            raise ValueError(
+                f'Step "{self.name}" requires the ocean model to be set to '
+                f'"omega" or "mpas-ocean", but got "{model}". Pass '
+                f'--model omega or --model mpas-ocean to polaris setup.'
+            )
+        return model
 
     def add_output_files_for_ocean_model_input(
         self,

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -12,6 +12,7 @@ from polaris.ocean.conservation import (
     compute_total_salt,
     compute_total_tracer,
 )
+from polaris.ocean.model import io
 
 if TYPE_CHECKING:
     # Keep Ocean as a type-only import. Importing it at runtime pulls
@@ -530,10 +531,12 @@ class OceanModelStep(ModelStep):
                 self.work_dir, self.get_horiz_mesh_filename()
             )
             this_filename = os.path.join(self.work_dir, filename)
-            ds_mesh = self.component.open_model_dataset(
-                mesh_filename, self.config
+            ds_mesh = io.open_model_dataset(
+                mesh_filename, self.config, model=self.component.model
             )
-            ds = self.component.open_model_dataset(this_filename, self.config)
+            ds = io.open_model_dataset(
+                this_filename, self.config, model=self.component.model
+            )
             if 'tracer conservation' in properties:
                 # All tracers in mpaso_to_omega.yaml
                 tracers_to_check = [

--- a/polaris/suites/ocean/mpaso_pr.txt
+++ b/polaris/suites/ocean/mpaso_pr.txt
@@ -9,7 +9,9 @@ ocean/planar/internal_wave/standard/default
 ocean/planar/internal_wave/vlr/default
 # ocean/planar/manufactured_solution/convergence_both
 ocean/planar/merry_go_round/default
-ocean/planar/overflow/default
+ocean/planar/overflow/smoke_test_horiz_adv_order_2
+ocean/planar/overflow/smoke_test_horiz_adv_order_3
+ocean/planar/overflow/smoke_test_horiz_adv_order_4
 ocean/single_column/cvmix
 ocean/single_column/ekman
 ocean/single_column/ideal_age

--- a/polaris/suites/ocean/omega_nightly.txt
+++ b/polaris/suites/ocean/omega_nightly.txt
@@ -8,6 +8,9 @@ ocean/planar/manufactured_solution/convergence_both/del4
 ocean/planar/merry_go_round/default
 ocean/planar/merry_go_round/convergence_both_order2
 ocean/planar/merry_go_round/convergence_both_order4
+ocean/planar/overflow/smoke_test_horiz_adv_order_2
+ocean/planar/overflow/smoke_test_horiz_adv_order_3
+ocean/planar/overflow/smoke_test_horiz_adv_order_4
 ocean/spherical/icos/correlated_tracers_2d
 ocean/spherical/icos/cosine_bell/decomp
 ocean/spherical/icos/cosine_bell/restart

--- a/polaris/suites/ocean/omega_pr.txt
+++ b/polaris/suites/ocean/omega_pr.txt
@@ -4,7 +4,9 @@ ocean/planar/manufactured_solution/convergence_both/default
 ocean/planar/manufactured_solution/convergence_both/del2
 ocean/planar/manufactured_solution/convergence_both/del4
 ocean/planar/merry_go_round/default
-ocean/planar/overflow/default
+ocean/planar/overflow/smoke_test_horiz_adv_order_2
+ocean/planar/overflow/smoke_test_horiz_adv_order_3
+ocean/planar/overflow/smoke_test_horiz_adv_order_4
 ocean/spherical/icos/cosine_bell/decomp
 ocean/spherical/icos/cosine_bell/restart
 

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -1,17 +1,7 @@
-import importlib.resources as imp_res
 import os
-from typing import Dict, Tuple, Union
-
-import xarray as xr
-from mpas_tools.io import write_netcdf
-from mpas_tools.vector.reconstruct import reconstruct_variable
-from ruamel.yaml import YAML
+from typing import Union
 
 from polaris import Component
-from polaris.ocean.vertical.diagnostics import (
-    geom_thickness_from_ds,
-    pseudothickness_from_ds,
-)
 
 
 class Ocean(Component):
@@ -21,22 +11,10 @@ class Ocean(Component):
     Attributes
     ----------
     model : str
-        The ocean model being used, either 'mpas-ocean', 'omega', or
-        'unknown' if no OceanModelStep or OceanIOStep is present in any task
-
-    mpaso_to_omega_dim_map : dict
-        A map from MPAS-Ocean dimension names to their Omega equivalents
-
-    mpaso_to_omega_var_map : dict
-        A map from MPAS-Ocean variable names to their Omega equivalents
-
-    horiz_mesh_vars : list of str
-        Variables that belong in the horizontal mesh file rather than the
-        initial condition file
-
-    vert_coord_vars : list of str
-        Variables that belong in the vertical coordinate file (Omega only)
-        rather than the initial condition file
+        The ocean model being used, either ``'mpas-ocean'``, ``'omega'``, or
+        ``'unknown'`` if no ``OceanModelStep`` or ``OceanIOStep`` is present
+        in any task, or if only model-fixed ``OceanIOStep`` instances are
+        present (steps that set ``self.model`` explicitly at construction time)
     """
 
     def __init__(self):
@@ -45,10 +23,6 @@ class Ocean(Component):
         """
         super().__init__(name='ocean')
         self.model: Union[None, str] = None
-        self.mpaso_to_omega_dim_map: Union[None, Dict[str, str]] = None
-        self.mpaso_to_omega_var_map: Union[None, Dict[str, str]] = None
-        self.horiz_mesh_vars: Union[None, list[str]] = None
-        self.vert_coord_vars: Union[None, list[str]] = None
 
     def configure(self, config, tasks):
         """
@@ -64,10 +38,10 @@ class Ocean(Component):
         """
         section = config['ocean']
         model = section.get('model')
-        has_ocean_io_steps, has_ocean_model_steps = (
+        has_ocean_model_steps, has_fixed_io, has_agnostic_io = (
             self._has_ocean_io_model_steps(tasks)
         )
-        if not (has_ocean_model_steps or has_ocean_io_steps):
+        if not (has_ocean_model_steps or has_fixed_io or has_agnostic_io):
             # No ocean I/O or model steps, so no model detection or build
             # needed.
             if model == 'detect':
@@ -75,426 +49,67 @@ class Ocean(Component):
             self.model = model
             return
 
-        if model == 'detect':
-            model = self._detect_model(config)
-            print('Detected ocean model:', model)
-            config.set('ocean', 'model', model)
+        model_cfgs = {'mpas-ocean': 'mpas_ocean.cfg', 'omega': 'omega.cfg'}
 
-        configs = {'mpas-ocean': 'mpas_ocean.cfg', 'omega': 'omega.cfg'}
+        if has_ocean_model_steps or has_agnostic_io:
+            # Need a single global model: either a binary is required, or
+            # model-agnostic IO steps need the model from config.
+            if model == 'detect':
+                model = self._detect_model(config)
+                print('Detected ocean model:', model)
+                config.set('ocean', 'model', model)
+            if model not in model_cfgs:
+                raise ValueError(f'Unknown ocean model {model}')
+            config.add_from_package('polaris.ocean', model_cfgs[model])
+            if has_ocean_model_steps:
+                # Try to detect the model build; trigger a build if absent
+                component_path = config.get('paths', 'component_path')
+                if model == 'omega':
+                    detected = self._detect_omega_build(component_path)
+                else:
+                    detected = self._detect_mpas_ocean_build(component_path)
+                if not detected:
+                    build = config.getboolean('build', 'build')
+                    if not build:
+                        print(
+                            f'Ocean model {model} not found in '
+                            f'{component_path}, setting build option to True'
+                        )
+                        config.set('build', 'build', 'True', user=True)
+            self.model = model
+        else:
+            # Only model-fixed IO steps; each step knows its own model.
+            # Load config for every model referenced by those steps.
+            from polaris.ocean.model.ocean_io_step import OceanIOStep
 
-        if model not in configs:
-            raise ValueError(f'Unknown ocean model {model}')
-
-        config.add_from_package('polaris.ocean', configs[model])
-
-        component_path = config.get('paths', 'component_path')
-        if has_ocean_model_steps:
-            # we need to try to detect the model and build it if needed
-            if model == 'omega':
-                detected = self._detect_omega_build(component_path)
-            else:
-                detected = self._detect_mpas_ocean_build(component_path)
-
-            if not detected:
-                # looks like we need to build the model
-                build = config.getboolean('build', 'build')
-                if not build:
-                    print(
-                        f'Ocean model {model} not found in '
-                        f'{component_path}, setting build option to True'
-                    )
-                    config.set('build', 'build', 'True', user=True)
-
-        self.model = model
-        if model == 'omega':
-            self._read_var_map()
-
-    def map_to_native_model_vars(self, ds):
-        """
-        If the model is Omega, rename dimensions and variables in a dataset
-        from their MPAS-Ocean names to the Omega equivalent (appropriate for
-        input datasets like an initial condition)
-
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            A dataset containing MPAS-Ocean variable names
-
-        Returns
-        -------
-        ds : xarray.Dataset
-            The same dataset with variables renamed as appropriate for the
-            ocean model being run
-        """
-        model = self.model
-        if model == 'omega':
-            assert self.mpaso_to_omega_dim_map is not None
-            rename = {
-                k: v
-                for k, v in self.mpaso_to_omega_dim_map.items()
-                if k in ds.dims
+            fixed_models = {
+                step.model
+                for task in tasks
+                for step in task.steps.values()
+                if isinstance(step, OceanIOStep) and step.model is not None
             }
-            assert self.mpaso_to_omega_var_map is not None
-            rename_vars = {
-                k: v for k, v in self.mpaso_to_omega_var_map.items() if k in ds
-            }
-            rename.update(rename_vars)
-            ds = ds.rename(rename)
-        return ds
+            for m in sorted(fixed_models):
+                if m not in model_cfgs:
+                    raise ValueError(f'Unknown ocean model {m}')
+                config.add_from_package('polaris.ocean', model_cfgs[m])
+            self.model = model if model != 'detect' else 'unknown'
 
-    def map_var_list_to_native_model(self, var_list):
-        """
-        If the model is Omega, rename variables from their MPAS-Ocean names to
-        the Omega equivalent (appropriate for validation variable lists)
-
-        Parameters
-        ----------
-        var_list : list of str
-            A list of MPAS-Ocean variable names
-
-        Returns
-        -------
-        renamed_vars : list of str
-            The same list with variables renamed as appropriate for the
-            ocean model being run
-        """
-        renamed_vars = var_list
-        model = self.model
-        if model == 'omega':
-            assert self.mpaso_to_omega_var_map is not None
-            renamed_vars = [
-                self.mpaso_to_omega_var_map.get(v, v) for v in var_list
-            ]
-        return renamed_vars
-
-    def write_model_dataset(self, ds, filename, config):
-        """
-        Write out the given dataset, mapping dimension and variable names from
-        MPAS-Ocean to Omega names if appropriate
-
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            A dataset containing MPAS-Ocean variable names
-
-        filename : str
-            The path for the NetCDF file to write
-
-        config : polaris.config.PolarisConfigParser
-            Configuration for the task; used when the model is Omega to
-            convert geometric layer thickness to pseudo-thickness before
-            writing.
-        """
-        if self.model == 'omega':
-            # fields to be converted from geometric to pseudo thickness
-            mpas_to_omega_vars = {
-                'layerThickness': 'PseudoThickness',
-                'restingThickness': 'RefPseudoThickness',
-            }
-            for mpas_var, omega_var in mpas_to_omega_vars.items():
-                if mpas_var in ds.keys() and omega_var not in ds.keys():
-                    pseudothickness, spec_vol = pseudothickness_from_ds(
-                        ds, config=config, src_var_name=mpas_var
-                    )
-                    if pseudothickness is not None and spec_vol is not None:
-                        ds[omega_var] = pseudothickness
-                        if mpas_var == 'layerThickness':
-                            ds['SpecVol'] = spec_vol
-
-        # After map_to_native_model_vars, the dataset contains
-        # LayerThickness and PseudoThickness which are both
-        # pseudo-thickness
-        ds = self.map_to_native_model_vars(ds)
-
-        write_netcdf(ds=ds, fileName=filename)
-
-    def write_horiz_mesh_dataset(self, ds, filename, config):
-        """
-        Write a horizontal mesh dataset, validating that all expected mesh
-        variables are present.
-
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            A dataset containing MPAS-Ocean or native model variable names
-            including all horizontal mesh variables
-
-        filename : str
-            The path for the NetCDF file to write
-
-        config : polaris.config.PolarisConfigParser
-            Not used; retained for API compatibility.
-        """
-        if self.horiz_mesh_vars is None:
-            self._read_variables_yaml()
-        if self.model == 'omega' and self.mpaso_to_omega_var_map is None:
-            self._read_var_map()
-        assert self.horiz_mesh_vars is not None
-        ds = self.map_to_native_model_vars(ds)
-        native_vars = self.map_var_list_to_native_model(self.horiz_mesh_vars)
-        self._check_vars_present(ds, native_vars, 'write_horiz_mesh_dataset')
-        write_netcdf(ds=ds, fileName=filename)
-
-    def remove_horiz_mesh_vars(self, ds):
-        """
-        Remove horizontal mesh variables from a dataset.
-
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            A dataset containing MPAS-Ocean variable names
-
-        Returns
-        -------
-        ds : xarray.Dataset
-            The same dataset without horizontal mesh variables
-        """
-        if self.horiz_mesh_vars is None:
-            self._read_variables_yaml()
-
-        assert self.horiz_mesh_vars is not None
-        drop = [v for v in self.horiz_mesh_vars if v in ds]
-        if drop:
-            ds = ds.drop_vars(drop)
-        return ds
-
-    def write_vert_coord_dataset(self, ds, filename, config):
-        """
-        Write a vertical-coordinate dataset for Omega's ``InitialVertCoord``
-        stream.  This is a no-op for MPAS-Ocean (vertical coordinate fields
-        stay in the initial state file).
-
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            A dataset containing MPAS-Ocean or native model variable names,
-            including the vertical coordinate variables and the
-            temperature/salinity/ssh fields needed for pseudo-thickness
-            conversion.
-
-        filename : str
-            The path for the NetCDF file to write
-
-        config : polaris.config.PolarisConfigParser
-            Configuration for the task; used when converting
-            ``restingThickness`` to ``RefPseudoThickness``.
-        """
-        if self.vert_coord_vars is None:
-            self._read_variables_yaml()
-        if self.model == 'omega' and self.mpaso_to_omega_var_map is None:
-            self._read_var_map()
-        assert self.vert_coord_vars is not None
-
-        native_vars = self.map_var_list_to_native_model(self.vert_coord_vars)
-
-        if self.model != 'omega':
-            self._check_vars_present(
-                ds, native_vars, 'write_vert_coord_dataset'
-            )
-            return
-
-        ds_vc = ds.copy()
-
-        # Convert restingThickness (geometric) to RefPseudoThickness (pseudo)
-        if 'restingThickness' in ds_vc and 'RefPseudoThickness' not in ds_vc:
-            pseudothickness, _ = pseudothickness_from_ds(
-                ds_vc, config=config, src_var_name='restingThickness'
-            )
-            if pseudothickness is not None:
-                # VertCoordInit stream is time-independent; drop Time dim
-                if 'Time' in pseudothickness.dims:
-                    pseudothickness = pseudothickness.isel(Time=0)
-                ds_vc['RefPseudoThickness'] = pseudothickness
-
-        ds_vc = self.map_to_native_model_vars(ds_vc)
-        # native_vars for Omega: [MinLayerCell, MaxLayerCell,
-        #   BottomGeomDepth, VertCoordMovementWeights, RefPseudoThickness]
-        self._check_vars_present(
-            ds_vc, native_vars, 'write_vert_coord_dataset'
-        )
-        ds_vc = ds_vc[native_vars]
-        write_netcdf(ds=ds_vc, fileName=filename)
-
-    def remove_vert_coord_vars(self, ds):
-        """
-        Remove vertical coordinate variables from a dataset.
-
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            A dataset containing MPAS-Ocean variable names
-
-        Returns
-        -------
-        ds : xarray.Dataset
-            The same dataset without vertical coordinate variables
-        """
-        if self.vert_coord_vars is None:
-            self._read_variables_yaml()
-
-        assert self.vert_coord_vars is not None
-        drop = [v for v in self.vert_coord_vars if v in ds]
-        if drop:
-            ds = ds.drop_vars(drop)
-        return ds
-
-    def write_initial_state_dataset(self, ds, filename, config):
-        """
-        Write an initial-state dataset, omitting horizontal mesh fields and
-        (for Omega) vertical coordinate fields.
-
-        For MPAS-Ocean the vertical coordinate variables remain in the initial
-        state file.  For Omega they are written separately via
-        :py:meth:`write_vert_coord_dataset`.
-
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            A dataset containing MPAS-Ocean variable names
-
-        filename : str
-            The path for the NetCDF file to write
-
-        config : polaris.config.PolarisConfigParser
-            Configuration for the task; forwarded to
-            :py:meth:`write_model_dataset`.
-        """
-        ds = self.remove_horiz_mesh_vars(ds)
-        if self.model == 'omega':
-            ds = self.remove_vert_coord_vars(ds)
-        self.write_model_dataset(ds, filename, config)
-
-    def map_from_native_model_vars(self, ds):
-        """
-        If the model is Omega, rename dimensions and variables in a dataset
-        from their Omega names to the MPAS-Ocean equivalent (appropriate for
-        datasets that are output from the model)
-
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            A dataset containing variable names native to either ocean model
-
-        Returns
-        -------
-        ds : xarray.Dataset
-            The same dataset with variables named as expected in MPAS-Ocean
-        """
-        model = self.model
-        if model == 'omega':
-            # switch keys and values in mpaso_to_omega maps to get
-            # omega to mpaso maps
-            assert self.mpaso_to_omega_dim_map is not None
-            rename = {
-                k: v
-                for v, k in self.mpaso_to_omega_dim_map.items()
-                if k in ds.dims
-            }
-            assert self.mpaso_to_omega_var_map is not None
-            rename_vars = {
-                k: v for v, k in self.mpaso_to_omega_var_map.items() if k in ds
-            }
-            rename.update(rename_vars)
-            ds = ds.rename(rename)
-        return ds
-
-    def map_var_list_from_native_model(self, var_list):
-        """
-        If the model is Omega, rename variables from their Omega names to
-        the MPAS-Ocean equivalent
-
-        Parameters
-        ----------
-        var_list : list of str
-            A list of MPAS-Ocean variable names
-
-        Returns
-        -------
-        renamed_vars : list of str
-            The same list with variables renamed as appropriate for the
-            ocean model being run
-        """
-        renamed_vars = var_list
-        model = self.model
-        if model == 'omega':
-            # switch keys and values in mpaso_to_omega maps to get
-            # omega to mpaso maps
-            assert self.mpaso_to_omega_var_map is not None
-            renamed_vars = [
-                v
-                for v, k in self.mpaso_to_omega_var_map.items()
-                if k in var_list
-            ]
-        return renamed_vars
-
-    def open_model_dataset(
-        self,
-        filename,
-        config,
-        mesh_filename=None,
-        reconstruct_variables=None,
-        coeffs_filename=None,
-        **kwargs,
-    ):
-        """
-        Open the given dataset, mapping variable and dimension names from Omega
-        to MPAS-Ocean names if appropriate
-
-        Parameters
-        ----------
-        filename : str
-            The path for the NetCDF file to open
-
-        config : polaris.config.PolarisConfigParser
-            Configuration for the task; used when the model is Omega to
-            compute geometric layer thickness from pseudo-thickness.
-
-        mesh_filename : str, optional
-            Path to the mesh NetCDF file.
-
-        reconstruct_variables : list of str, optional
-            List of variable names to reconstruct in the dataset.
-
-        coeffs_filename : str, optional
-            Path to the coefficients NetCDF file.
-
-        kwargs
-            keyword arguments passed to `xarray.open_dataset()`
-
-        Returns
-        -------
-        ds : xarray.Dataset
-            The dataset with variables named as expected in MPAS-Ocean
-        """
-        ds = xr.open_dataset(filename, **kwargs)
-        if (
-            self.model == 'omega'
-            and 'layerThickness' not in ds.keys()
-            and 'PseudoThickness' in ds.keys()
-            and 'SpecVol' in ds.keys()
-        ):
-            ds['layerThickness'] = geom_thickness_from_ds(ds, config=config)
-        ds = self.map_from_native_model_vars(ds)
-        ds = _add_reconstructed_variables_to_dataset(
-            ds, reconstruct_variables, mesh_filename, coeffs_filename
-        )
-        return ds
-
-    def _check_vars_present(self, ds, native_vars, context):
-        """
-        Raise ValueError if any variable in native_vars is absent from ds.
-        """
-        missing = [v for v in native_vars if v not in ds]
-        if missing:
-            raise ValueError(
-                f'{context} requires the following variables that are '
-                'missing from the dataset: ' + ', '.join(missing)
-            )
-
-    def _has_ocean_io_model_steps(self, tasks) -> Tuple[bool, bool]:
+    def _has_ocean_io_model_steps(self, tasks) -> tuple[bool, bool, bool]:
         """
         Determine if any steps in this component descend from OceanIOStep or
-        OceanModelStep
+        OceanModelStep, and distinguish model-fixed from model-agnostic IO
+        steps.
+
+        Returns
+        -------
+        has_ocean_model_steps : bool
+            True if any step is an ``OceanModelStep`` (needs a model binary).
+        has_model_fixed_io_steps : bool
+            True if any ``OceanIOStep`` has ``self.model`` set explicitly at
+            construction time (does not need global model detection).
+        has_model_agnostic_io_steps : bool
+            True if any ``OceanIOStep`` does *not* have ``self.model`` set
+            (reads the model from config; requires global model detection).
         """
         # local import to avoid circular imports
         from polaris.ocean.model.ocean_io_step import OceanIOStep
@@ -505,56 +120,22 @@ class Ocean(Component):
             for task in tasks
             for step in task.steps.values()
         )
-        has_ocean_io_steps = any(
-            isinstance(step, OceanIOStep)
+        has_model_fixed_io_steps = any(
+            isinstance(step, OceanIOStep) and step.model is not None
+            for task in tasks
+            for step in task.steps.values()
+        )
+        has_model_agnostic_io_steps = any(
+            isinstance(step, OceanIOStep) and step.model is None
             for task in tasks
             for step in task.steps.values()
         )
 
-        return has_ocean_io_steps, has_ocean_model_steps
-
-    def _read_variables_yaml(self):
-        """
-        Read horiz_mesh_vars and vert_coord_vars from variables.yaml
-        """
-        if (
-            self.horiz_mesh_vars is not None
-            and self.vert_coord_vars is not None
-        ):
-            return
-        package = 'polaris.ocean.model'
-        filename = 'variables.yaml'
-        text = imp_res.files(package).joinpath(filename).read_text()
-        yaml_data = YAML(typ='rt')
-        nested_dict = yaml_data.load(text)
-        self.horiz_mesh_vars = nested_dict['ocean']['horiz_mesh_variables']
-        self.vert_coord_vars = list(
-            nested_dict['ocean']['vert_coord_variables']
+        return (
+            has_ocean_model_steps,
+            has_model_fixed_io_steps,
+            has_model_agnostic_io_steps,
         )
-        model_section_map = {'mpas-ocean': 'mpas-ocean', 'omega': 'Omega'}
-        model_key = model_section_map.get(self.model or '')
-        if model_key:
-            extra = nested_dict.get(model_key, {}).get(
-                'vert_coord_variables', []
-            )
-            self.vert_coord_vars.extend(extra)
-
-    def _read_var_map(self):
-        """
-        Read the map from MPAS-Ocean to Omega dimension and variable names
-        """
-        if self.mpaso_to_omega_var_map is not None:
-            return
-        package = 'polaris.ocean.model'
-
-        filename = 'mpaso_to_omega.yaml'
-        text = imp_res.files(package).joinpath(filename).read_text()
-        yaml_data = YAML(typ='rt')
-        nested_dict = yaml_data.load(text)
-        self.mpaso_to_omega_dim_map = nested_dict['dimensions']
-        self.mpaso_to_omega_var_map = nested_dict['variables']
-
-        self._read_variables_yaml()
 
     def _detect_model(self, config) -> str:
         """
@@ -621,84 +202,6 @@ class Ocean(Component):
                 all_found = False
                 break
         return all_found
-
-
-def _add_reconstructed_variables_to_dataset(
-    ds, reconstruct_variables, mesh_filename, coeffs_filename
-):
-    """
-    Add reconstructed vector variables to the dataset if requested.
-
-    Parameters
-    ----------
-    ds : xarray.Dataset
-        The dataset to add reconstructed variables to.
-
-    reconstruct_variables : list of str or None
-        List of variable names to reconstruct.
-
-    mesh_filename : str
-        Path to the mesh NetCDF file.
-
-    coeffs_filename : str
-        Path to the coefficients NetCDF file.
-
-    Returns
-    -------
-    ds : xarray.Dataset
-        The dataset with reconstructed variables added.
-    """
-    if reconstruct_variables is None:
-        return ds
-
-    if mesh_filename is None:
-        raise ValueError(
-            'mesh_filename must be provided to open_model_dataset for '
-            'variable reconstruction'
-        )
-    if coeffs_filename is None:
-        raise ValueError(
-            'coeffs_filename must be provided to open_model_dataset for '
-            'variable reconstruction'
-        )
-
-    for variable in reconstruct_variables:
-        if variable not in ds:
-            raise ValueError(
-                f"User requested vector reconstruction for '{variable}' "
-                "but it isn't present in the dataset."
-            )
-
-        out_var_name = (
-            variable.replace('normal', '').lower()
-            if 'normal' in variable
-            else variable
-        )
-
-        if f'{out_var_name}Zonal' in ds and f'{out_var_name}Meridional' in ds:
-            continue
-
-        ds_mesh = xr.open_dataset(mesh_filename)
-        ds_coeff = xr.open_dataset(coeffs_filename)
-        coeffs_reconstruct = ds_coeff.coeffs_reconstruct
-
-        if ds_coeff.sizes['nCells'] != ds_mesh.sizes['nCells']:
-            print(
-                f'The sizes of coefficient dataset do not match mesh '
-                f'dataset; exiting without reconstructing {out_var_name}'
-            )
-            continue
-
-        reconstruct_variable(
-            out_var_name,
-            ds[variable],
-            ds_mesh,
-            coeffs_reconstruct,
-            ds,
-            quiet=True,
-        )
-
-    return ds
 
 
 # create a single module-level instance available to other components

--- a/polaris/tasks/ocean/overflow/__init__.py
+++ b/polaris/tasks/ocean/overflow/__init__.py
@@ -1,9 +1,9 @@
 import os
 
 from polaris.config import PolarisConfigParser as PolarisConfigParser
-from polaris.tasks.ocean.overflow.default import Default as Default
-from polaris.tasks.ocean.overflow.init import Init as Init
-from polaris.tasks.ocean.overflow.rpe import Rpe as Rpe
+from polaris.tasks.ocean.overflow.init import Init
+from polaris.tasks.ocean.overflow.rpe import Rpe
+from polaris.tasks.ocean.overflow.smoke_test import SmokeTest
 
 
 def add_overflow_tasks(component):
@@ -25,9 +25,15 @@ def add_overflow_tasks(component):
     init_step = Init(component=component, name='init', indir=taskdir)
     init_step.set_shared_config(config, link=config_filename)
 
-    default = Default(component=component, indir=taskdir, init=init_step)
-    default.set_shared_config(config, link=config_filename)
-    component.add_task(default)
+    for horiz_adv_order in [2, 3, 4]:
+        smoke_test = SmokeTest(
+            component=component,
+            indir=taskdir,
+            init=init_step,
+            horiz_adv_order=horiz_adv_order,
+        )
+        smoke_test.set_shared_config(config, link=config_filename)
+        component.add_task(smoke_test)
 
     component.add_task(
         Rpe(

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -9,13 +9,14 @@ class Forward(OceanModelStep):
 
     Attributes
     ----------
-    task_name : str
-       The name of the task that this step belongs to
+    config_section : str
+        The section in the config file for this test case, used to get
+        the run duration and output interval
 
-    yaml_filename : str
-       The name of the yaml file for this forward step
+    horiz_adv_order : int or None
+        The horizontal advection order for the test case
 
-    nu : float
+    nu : float or None
        The Laplacian viscosity to use for this forward step
     """
 
@@ -23,15 +24,15 @@ class Forward(OceanModelStep):
         self,
         component,
         init,
-        yaml_filename='forward.yaml',
+        config_section,
         name='forward',
-        task_name='default',
         subdir=None,
         indir=None,
         ntasks=None,
         min_tasks=None,
         openmp_threads=1,
-        nu=1000.0,
+        horiz_adv_order=None,
+        nu=None,
     ):
         """
         Create a new test case
@@ -47,11 +48,12 @@ class Forward(OceanModelStep):
         task_name : str
            The name of the task that this step belongs to
 
-        yaml_filename : str
-           The name of the yaml file for this forward step
-
         init : polaris.ocean.tasks.internal_wave.init.Init
             the initial state step
+
+        config_section : str
+            The section in the config file for this test case, used to get
+            the run duration and output interval
 
         subdir : str, optional
             the subdirectory for the step.  The default is ``name``
@@ -67,6 +69,10 @@ class Forward(OceanModelStep):
 
         openmp_threads : int, optional
             the number of OpenMP threads the step will use
+
+        horiz_adv_order : int, optional
+            The horizontal advection order for the test case (if different
+            from the default for the test group)
 
         nu : float, optional
             the viscosity (if different from the default for the test group)
@@ -84,8 +90,8 @@ class Forward(OceanModelStep):
             update_eos=True,
             graph_target=f'{init.path}/culled_graph.info',
         )
-        self.task_name = task_name
-        self.yaml_filename = yaml_filename
+        self.config_section = config_section
+        self.horiz_adv_order = horiz_adv_order
         self.nu = nu
 
         # make sure output is double precision
@@ -119,36 +125,25 @@ class Forward(OceanModelStep):
         btr_dt_str = get_time_interval_string(
             seconds=btr_dt_per_km * resolution
         )
-        section = config[f'overflow_{self.task_name}']
+        if self.nu is None:
+            self.nu = config.getfloat('overflow', 'default_viscosity')
+
+        if self.horiz_adv_order is None:
+            self.horiz_adv_order = config.getint(
+                'overflow', 'default_horiz_adv_order'
+            )
+        section = config[self.config_section]
         run_duration = section.getfloat('run_duration')
         run_duration_units = section.get('run_duration_units')
         output_interval = section.getfloat('output_interval')
         output_units = section.get('output_interval_units')
         output_freq = int(output_interval)
-        if run_duration_units == 'days':
-            run_duration_str = get_time_interval_string(days=run_duration)
-        elif run_duration_units == 'hours':
-            run_duration_str = get_time_interval_string(
-                seconds=run_duration * 3600.0
-            )
-        elif run_duration_units == 'minutes':
-            run_duration_str = get_time_interval_string(
-                seconds=run_duration * 60.0
-            )
-        elif run_duration_units == 'seconds':
-            run_duration_str = get_time_interval_string(seconds=run_duration)
-        else:
-            raise ValueError(
-                f'Unknown run duration units: {run_duration_units}'
-            )
-        if self.task_name == 'rpe':
-            output_interval_str = get_time_interval_string(
-                days=output_interval
-            )
-        else:
-            output_interval_str = get_time_interval_string(
-                seconds=output_interval
-            )
+        run_duration_str = self._interval_to_string(
+            run_duration, run_duration_units
+        )
+        output_interval_str = self._interval_to_string(
+            output_interval, output_units
+        )
 
         time_integrator = config.get('overflow', 'time_integrator')
         time_integrator_map = dict([('RK4', 'RungeKutta4')])
@@ -173,10 +168,11 @@ class Forward(OceanModelStep):
             nu=self.nu,
             output_freq=f'{output_freq}',
             output_freq_units=output_units,
+            horiz_adv_order=self.horiz_adv_order,
         )
         self.add_yaml_file(
             'polaris.tasks.ocean.overflow',
-            self.yaml_filename,
+            'forward.yaml',
             template_replacements=replacements,
         )
 
@@ -197,3 +193,20 @@ class Forward(OceanModelStep):
         nx, ny = compute_planar_hex_nx_ny(lx, ly, resolution)
         cell_count = nx * ny
         return cell_count
+
+    @staticmethod
+    def _interval_to_string(interval, units):
+        """
+        Convert a time interval to a string in the format "DDDD_HH:MM:SS.SS"
+        """
+        if units == 'days':
+            interval_str = get_time_interval_string(days=interval)
+        elif units == 'hours':
+            interval_str = get_time_interval_string(seconds=interval * 3600.0)
+        elif units == 'minutes':
+            interval_str = get_time_interval_string(seconds=interval * 60.0)
+        elif units == 'seconds':
+            interval_str = get_time_interval_string(seconds=interval)
+        else:
+            raise ValueError(f'Unexpected time interval units: {units}')
+        return interval_str

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -19,6 +19,8 @@ ocean:
     config_cvmix_background_viscosity: 0.0
   bottom_drag:
     config_explicit_bottom_drag_coeff: 0.01
+  advection:
+    config_horiz_tracer_adv_order: {{ horiz_adv_order }}
 
 mpas-ocean:
   io:

--- a/polaris/tasks/ocean/overflow/overflow.cfg
+++ b/polaris/tasks/ocean/overflow/overflow.cfg
@@ -72,7 +72,13 @@ lower_temperature = 10.0
 # Higher temperature (deg C)
 higher_temperature = 20.0
 
-[overflow_default]
+# Default viscosity (m^2/s)
+default_viscosity = 1000.0
+
+# Default horizontal advection order
+default_horiz_adv_order = 2
+
+[overflow_smoke_test]
 
 # Run duration
 run_duration = 12.

--- a/polaris/tasks/ocean/overflow/rpe/__init__.py
+++ b/polaris/tasks/ocean/overflow/rpe/__init__.py
@@ -68,8 +68,8 @@ class Rpe(Task):
             step = Forward(
                 component=component,
                 name=name,
-                task_name='rpe',
                 init=init,
+                config_section='overflow_rpe',
                 indir=self.subdir,
                 ntasks=None,
                 min_tasks=None,

--- a/polaris/tasks/ocean/overflow/smoke_test.py
+++ b/polaris/tasks/ocean/overflow/smoke_test.py
@@ -6,13 +6,13 @@ from polaris.tasks.ocean.overflow.forward import Forward as Forward
 from polaris.tasks.ocean.overflow.viz import Viz as Viz
 
 
-class Default(Task):
+class SmokeTest(Task):
     """
-    The default overflow test case simply creates the mesh and
+    The short overflow smoke test simply creates the mesh and
     initial condition, then performs a short forward run on 4 cores.
     """
 
-    def __init__(self, component, indir, init):
+    def __init__(self, component, indir, init, horiz_adv_order):
         """
         Create the test case
 
@@ -26,8 +26,11 @@ class Default(Task):
 
         init : polaris.tasks.ocean.overflow.init.Init
             A shared step for creating the initial state
+
+        horiz_adv_order : int
+            The horizontal advection order for the test case
         """
-        task_name = 'default'
+        task_name = f'smoke_test_horiz_adv_order_{horiz_adv_order}'
         super().__init__(component=component, name=task_name, indir=indir)
 
         self.add_step(init, symlink='init')
@@ -35,9 +38,10 @@ class Default(Task):
         forward_step = Forward(
             component=component,
             init=init,
-            task_name=task_name,
+            config_section='overflow_smoke_test',
             name='forward',
             indir=self.subdir,
+            horiz_adv_order=horiz_adv_order,
         )
         self.add_step(forward_step)
 

--- a/polaris/tasks/ocean/overflow/viz.py
+++ b/polaris/tasks/ocean/overflow/viz.py
@@ -73,6 +73,11 @@ class Viz(OceanIOStep):
             filename='mesh.nc',
             work_dir_target=f'{mesh.path}/culled_mesh.nc',
         )
+        if self.component.model == 'omega':
+            self.add_input_file(
+                filename='vert_coord.nc',
+                work_dir_target=f'{init.path}/vert_coord.nc',
+            )
         self.add_input_file(
             filename='init.nc',
             work_dir_target=f'{init.path}/init.nc',
@@ -89,6 +94,13 @@ class Viz(OceanIOStep):
         config = self.config
         ds_mesh = self.open_model_dataset('mesh.nc', config=config)
         ds_init = self.open_model_dataset('init.nc', config=config)
+        model = self.component.model
+        if model == 'omega':
+            ds_vert_coord = self.open_model_dataset(
+                'vert_coord.nc', config=config
+            )
+        else:
+            ds_vert_coord = ds_init
         ds = self.open_model_dataset('output.nc', config=config)
 
         x_min = ds_mesh.xVertex.min().values
@@ -104,9 +116,9 @@ class Viz(OceanIOStep):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds_init.layerThickness.isel(Time=t_index),
-            bottom_depth=ds_init.bottomDepth,
-            min_level_cell=ds_init.minLevelCell - 1,
-            max_level_cell=ds_init.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 
@@ -134,9 +146,9 @@ class Viz(OceanIOStep):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds.layerThickness.isel(Time=t_index),
-            bottom_depth=ds_init.bottomDepth,
-            min_level_cell=ds_init.minLevelCell - 1,
-            max_level_cell=ds_init.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 

--- a/tests/ocean/test_mesh_init_split.py
+++ b/tests/ocean/test_mesh_init_split.py
@@ -6,7 +6,7 @@ import pytest
 import xarray as xr
 
 from polaris.model_step import ModelStep
-from polaris.ocean.model import OceanIOStep, OceanModelStep
+from polaris.ocean.model import OceanIOStep, OceanModelStep, io
 from polaris.tasks.ocean import Ocean
 from polaris.yaml import PolarisYaml
 
@@ -25,10 +25,6 @@ def _make_config(
 
 
 def test_write_initial_state_dataset_omega_drops_horiz_mesh_vars(tmp_path):
-    component = Ocean()
-    component.model = 'omega'
-    component._read_var_map()
-
     config = MagicMock()
 
     ds = xr.Dataset(
@@ -41,7 +37,7 @@ def test_write_initial_state_dataset_omega_drops_horiz_mesh_vars(tmp_path):
     )
 
     filename = tmp_path / 'initial_state.nc'
-    component.write_initial_state_dataset(ds, str(filename), config)
+    io.write_initial_state_dataset(ds, str(filename), config, model='omega')
 
     ds_out = xr.open_dataset(filename)
     assert 'Temperature' in ds_out
@@ -51,10 +47,6 @@ def test_write_initial_state_dataset_omega_drops_horiz_mesh_vars(tmp_path):
 
 
 def test_write_initial_state_dataset_omega_drops_vert_coord_vars(tmp_path):
-    component = Ocean()
-    component.model = 'omega'
-    component._read_var_map()
-
     config = MagicMock()
 
     ds = xr.Dataset(
@@ -69,7 +61,7 @@ def test_write_initial_state_dataset_omega_drops_vert_coord_vars(tmp_path):
     )
 
     filename = tmp_path / 'initial_state.nc'
-    component.write_initial_state_dataset(ds, str(filename), config)
+    io.write_initial_state_dataset(ds, str(filename), config, model='omega')
 
     ds_out = xr.open_dataset(filename)
     assert 'Temperature' in ds_out
@@ -82,10 +74,6 @@ def test_write_initial_state_dataset_omega_drops_vert_coord_vars(tmp_path):
 def test_write_initial_state_dataset_mpas_ocean_keeps_vert_coord_vars(
     tmp_path,
 ):
-    component = Ocean()
-    component.model = 'mpas-ocean'
-    component._read_var_map()
-
     config = MagicMock()
 
     ds = xr.Dataset(
@@ -100,7 +88,9 @@ def test_write_initial_state_dataset_mpas_ocean_keeps_vert_coord_vars(
     )
 
     filename = tmp_path / 'initial_state.nc'
-    component.write_initial_state_dataset(ds, str(filename), config)
+    io.write_initial_state_dataset(
+        ds, str(filename), config, model='mpas-ocean'
+    )
 
     ds_out = xr.open_dataset(filename)
     assert 'temperature' in ds_out
@@ -111,10 +101,6 @@ def test_write_initial_state_dataset_mpas_ocean_keeps_vert_coord_vars(
 
 
 def test_write_vert_coord_dataset_noop_for_mpas_ocean(tmp_path):
-    component = Ocean()
-    component.model = 'mpas-ocean'
-    component._read_var_map()
-
     config = MagicMock()
 
     ds = xr.Dataset(
@@ -128,7 +114,7 @@ def test_write_vert_coord_dataset_noop_for_mpas_ocean(tmp_path):
     )
 
     filename = tmp_path / 'vert_coord.nc'
-    component.write_vert_coord_dataset(ds, str(filename), config)
+    io.write_vert_coord_dataset(ds, str(filename), config, model='mpas-ocean')
 
     assert not filename.exists()
 
@@ -143,10 +129,6 @@ def test_write_vert_coord_dataset_noop_for_mpas_ocean(tmp_path):
 def test_write_vert_coord_dataset_raises_on_missing_vars(
     tmp_path, model, missing_var
 ):
-    component = Ocean()
-    component.model = model
-    component._read_var_map()
-
     config = MagicMock()
 
     # omit the model-specific thickness var and vertCoordMovementWeights
@@ -160,23 +142,18 @@ def test_write_vert_coord_dataset_raises_on_missing_vars(
 
     filename = tmp_path / 'vert_coord.nc'
     with pytest.raises(ValueError, match=missing_var):
-        component.write_vert_coord_dataset(ds, str(filename), config)
+        io.write_vert_coord_dataset(ds, str(filename), config, model=model)
 
 
-def _make_horiz_mesh_ds(component):
+def _make_horiz_mesh_ds(model):
     """Build a minimal dataset with all horiz_mesh_vars as dummy data."""
+    horiz_mesh_vars, _ = io._get_variable_lists(model)
     return xr.Dataset(
-        data_vars={
-            v: ('nCells', [0.0, 1.0]) for v in component.horiz_mesh_vars
-        }
+        data_vars={v: ('nCells', [0.0, 1.0]) for v in horiz_mesh_vars}
     )
 
 
 def test_write_horiz_mesh_dataset_raises_on_missing_vars(tmp_path):
-    component = Ocean()
-    component.model = 'mpas-ocean'
-    component._read_var_map()
-
     config = MagicMock()
 
     # dataset is missing most horiz_mesh_vars
@@ -184,19 +161,17 @@ def test_write_horiz_mesh_dataset_raises_on_missing_vars(tmp_path):
 
     filename = tmp_path / 'mesh.nc'
     with pytest.raises(ValueError, match='indexToCellID'):
-        component.write_horiz_mesh_dataset(ds, str(filename), config)
+        io.write_horiz_mesh_dataset(
+            ds, str(filename), config, model='mpas-ocean'
+        )
 
 
 def test_write_horiz_mesh_dataset_writes_mpas_ocean(tmp_path):
-    component = Ocean()
-    component.model = 'mpas-ocean'
-    component._read_var_map()
-
     config = MagicMock()
-    ds = _make_horiz_mesh_ds(component)
+    ds = _make_horiz_mesh_ds('mpas-ocean')
 
     filename = tmp_path / 'mesh.nc'
-    component.write_horiz_mesh_dataset(ds, str(filename), config)
+    io.write_horiz_mesh_dataset(ds, str(filename), config, model='mpas-ocean')
 
     ds_out = xr.open_dataset(filename)
     assert 'xCell' in ds_out
@@ -204,15 +179,11 @@ def test_write_horiz_mesh_dataset_writes_mpas_ocean(tmp_path):
 
 
 def test_write_horiz_mesh_dataset_writes_omega(tmp_path):
-    component = Ocean()
-    component.model = 'omega'
-    component._read_var_map()
-
     config = MagicMock()
-    ds = _make_horiz_mesh_ds(component)
+    ds = _make_horiz_mesh_ds('omega')
 
     filename = tmp_path / 'mesh.nc'
-    component.write_horiz_mesh_dataset(ds, str(filename), config)
+    io.write_horiz_mesh_dataset(ds, str(filename), config, model='omega')
 
     ds_out = xr.open_dataset(filename)
     assert 'XCell' in ds_out
@@ -310,6 +281,106 @@ def test_dynamic_model_config_uses_model_input_filename_replacements():
     assert yaml.streams['HorzMeshIn']['Filename'] == 'custom_mesh.nc'
     assert yaml.streams['InitialVertCoord']['Filename'] == 'custom_vc.nc'
     assert yaml.streams['InitialState']['Filename'] == 'custom_init.nc'
+
+
+def _make_tasks(steps):
+    """Return a list of one mock task containing the given steps."""
+    task = MagicMock()
+    task.steps = {s.name: s for s in steps}
+    return [task]
+
+
+def _make_agnostic_io_step(name='io_step'):
+    """OceanIOStep with no self.model (agnostic — reads from config)."""
+    component = Ocean()
+    step = OceanIOStep(component=component, name=name)
+    return step
+
+
+def _make_fixed_io_step(model, name='fixed_step'):
+    """OceanIOStep with self.model set at construction time."""
+    component = Ocean()
+    step = OceanIOStep(component=component, name=name)
+    step.model = model
+    return step
+
+
+class TestOceanConfigure:
+    """Tests for Ocean.configure() model-detection enforcement."""
+
+    def _config(self, model='detect'):
+        cfg = MagicMock()
+        cfg.__getitem__ = lambda self_, key: MagicMock(
+            **{'get.return_value': model}
+        )
+        cfg.get = MagicMock(return_value=model)
+        return cfg
+
+    def test_no_ocean_steps_detect_becomes_unknown(self):
+        ocean = Ocean()
+        plain_step = MagicMock()
+        plain_step.name = 'plain'
+        # plain_step is not an OceanIOStep or OceanModelStep
+        tasks = _make_tasks([plain_step])
+        cfg = self._config(model='detect')
+        ocean.configure(cfg, tasks)
+        assert ocean.model == 'unknown'
+
+    def test_agnostic_io_step_with_explicit_model_succeeds(self):
+        ocean = Ocean()
+        step = _make_agnostic_io_step()
+        tasks = _make_tasks([step])
+        # model='omega' skips the detect branch entirely
+        cfg = self._config(model='omega')
+        cfg.add_from_package = MagicMock()
+        ocean.configure(cfg, tasks)
+        assert ocean.model == 'omega'
+        cfg.add_from_package.assert_called_once_with(
+            'polaris.ocean', 'omega.cfg'
+        )
+
+    def test_agnostic_io_step_no_model_raises(self, monkeypatch):
+        """When --model is not given and only agnostic IO steps exist,
+        configure() must raise (via _detect_model) rather than return
+        silently with model='unknown'."""
+        ocean = Ocean()
+        step = _make_agnostic_io_step()
+        tasks = _make_tasks([step])
+        cfg = self._config(model='detect')
+        cfg.add_from_package = MagicMock()
+
+        # Simulate no binary found for either model
+        monkeypatch.setattr(
+            ocean.__class__, '_detect_omega_build', lambda self_, p: False
+        )
+        monkeypatch.setattr(
+            ocean.__class__,
+            '_detect_mpas_ocean_build',
+            lambda self_, p: False,
+        )
+        # _detect_model reads component_path from copies of config;
+        # patch copy() to return a simple mock that exposes get()
+        cfg_copy = MagicMock()
+        cfg_copy.get = MagicMock(return_value='/fake/path')
+        cfg.copy = MagicMock(return_value=cfg_copy)
+        cfg_copy.add_from_package = MagicMock()
+
+        with pytest.raises(ValueError, match='Could not detect ocean model'):
+            ocean.configure(cfg, tasks)
+
+    def test_fixed_io_step_no_model_flag_succeeds(self, monkeypatch):
+        """When only model-fixed IO steps exist, configure() must succeed
+        without requiring --model, and self.model is set to 'unknown'."""
+        ocean = Ocean()
+        step = _make_fixed_io_step(model='omega')
+        tasks = _make_tasks([step])
+        cfg = self._config(model='detect')
+        cfg.add_from_package = MagicMock()
+        ocean.configure(cfg, tasks)
+        assert ocean.model == 'unknown'
+        cfg.add_from_package.assert_called_once_with(
+            'polaris.ocean', 'omega.cfg'
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary

Previously, all model-specific I/O logic (variable renaming, pseudo-thickness conversion, dataset splitting) lived inside the `Ocean` component class.  Steps reached this logic only by delegating through `self.component`, which meant the component had to hold a single globally-configured model (`'omega'` or `'mpas-ocean'`).  That global model was enforced at `polaris setup` time via model detection, so any task containing an I/O step required `--model` to be passed — even if no model binary was needed.

This PR moves the I/O logic out of the component and into standalone functions in the ocean framework.  Each function takes an explicit `model` argument rather than reading from component state.  A new `_effective_model()` helper on the base I/O step class resolves the model in priority order: the step's own `model` attribute (if set by a subclass) first, then the globally-configured model from config.

`Ocean.configure()` now distinguishes three kinds of steps:

- **`OceanModelStep`** — needs a model binary; triggers global model detection (unchanged from before).
- **Model-agnostic `OceanIOStep`** (step leaves `self.model = None`) — reads the model from config at run time; also triggers global model detection and raises a clear error at `polaris setup` time if `--model` is not resolvable. This is the common case for most existing I/O steps.
- **Model-fixed `OceanIOStep`** (step sets `self.model` explicitly at construction time) — knows its own model without a global setting; global detection is skipped and the appropriate model config file is loaded per step. This enables a future step subclass to fix its model independently and coexist with steps targeting a different model, without requiring `--model`.

Tests that exercised the I/O logic through the component are updated to call the framework functions directly, and new tests cover all four `configure()` paths (no ocean steps; agnostic IO with explicit model; agnostic IO with no
model, which must raise at setup time; fixed IO with no model, which must succeed).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
