### PR TITLE
Fix model in horiz_press_grad task family

### DIFF
--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -17,7 +17,8 @@ min_pc_fraction = 0.1
 # Options related the ocean component
 [ocean]
 # Which model, MPAS-Ocean or Omega, is used
-model = mpas-ocean
+# These test rely on the z-tilde coordinate only suported in Omega.
+model = omega
 
 # Equation of state type, defaults to mpas-ocean default
 eos_type = teos-10


### PR DESCRIPTION
It was set to `mpas-ocean`, whereas it should be set to `omega` since these tasks only support Omega.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #600 