### PR TITLE
renamed windForcing to match upcoming omega options 

### DIFF
--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -77,8 +77,8 @@ variables:
 
   # auxiliary state
   ssh: SshCell
-  windStressZonal: WindStressZonal
-  windStressMeridional: WindStressMeridional
+  windStressZonal: SfcStressZonal
+  windStressMeridional: SfcStressMeridional
   relativeVorticity: RelVortVertex
 
   # vertical coordinate diagnostics
@@ -150,7 +150,7 @@ config:
 - section:
     forcing: Tendencies
   options:
-    config_use_bulk_wind_stress: WindForcingTendencyEnable
+    config_use_bulk_wind_stress: SfcStressForcingTendencyEnable
 
 - section:
     debug: Tendencies

--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -97,8 +97,8 @@ Omega:
       Contents:
       - State
       - Base
-      - WindStressZonal
-      - WindStressMeridional
+      - SfcStressZonal
+      - SfcStressMeridional
     RestartRead:
       UsePointerFile: true
       PointerFilename: ocn.pointer

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -70,8 +70,8 @@ Omega:
       Mode: read
       Contents:
       - State
-      - WindStressZonal
-      - WindStressMeridional
+      - SfcStressZonal
+      - SfcStressMeridional
     History:
       UsePointerFile: false
       Filename: output.nc

--- a/polaris/tasks/ocean/horiz_press_grad/forward.yaml
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.yaml
@@ -10,7 +10,7 @@ Omega:
     SSHTendencyEnable: false
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false
-    WindForcingTendencyEnable: false
+    SfcStressForcingTendencyEnable: false
     BottomDragTendencyEnable: false
     TracerHorzAdvTendencyEnable: false
     TracerDiffTendencyEnable: false


### PR DESCRIPTION
This is an update to Polaris which will be needed once the Forcing class is merged to Omega (and/or alongside it).  

This is because the Forcing class includes a rename of the WindForcingTendencyEnable flag. 
I also renamed the `WindStressZonal/WindStressMeridional` fields to align with the naming in Omega, but push back on this if need be. Polaris is standalone ocean so the surface stress forcing can technically be wind forcing only, let me know what you think. Do we have any polaris case where we read the forcing from file? If so, this renaming would require file changes. If we always set up the forcing locally, this should have changes the field name consistently. 

The renaming is pretty minimal and should not affect test behavior. 
I successfully ran an omega_pr suite using my [omega branch](https://github.com/alicebarthel/E3SM/tree/omega/add-forcing-class) on pm-cpu. 
Let me know what extra tests I should run. 

Leaving at draft for now since we don't want to change polaris before the omega merge. 
