### PR TITLE
Add overflow tests using higher order advection

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -380,7 +380,7 @@
 
    add_overflow_tasks
 
-   default.Default
+   smoke_test.SmokeTest
 
    forward.Forward
    forward.Forward.dynamic_model_config

--- a/docs/developers_guide/ocean/tasks/overflow.md
+++ b/docs/developers_guide/ocean/tasks/overflow.md
@@ -2,10 +2,10 @@
 
 # overflow
 
-The overflow task group is currently comprised of one `default` task for quick
-testing, particularly against a baseline, and one `rpe` test which shows how
-the resting potential energy changes across forward runs with different
-viscosities.
+The overflow task group is currently comprised of three `smoke_test` tasks
+for quick testing (one for each horizontal advection order: 2, 3, and 4),
+and one `rpe` test which shows how the resting potential energy changes across
+forward runs with different viscosities.
 
 ## framework
 
@@ -42,7 +42,7 @@ tasks have as their target and minimum (if the resources are not explicitly
 prescribed).  For MPAS-Ocean, PIO namelist options are modified and a
 graph partition is generated as part of `runtime_setup()`.  Next, the ocean
 model is run. The duration is set by `run_duration` in the config section
-corresponding to the task (`overflow_default` or `overflow_rpe`). Finally,
+corresponding to the task (`overflow_smoke_test` or `overflow_rpe`). Finally,
 validation of `layerThickness`, `temperature` and `normalVelocity` in the
 `output.nc` file are performed against a baseline if one is provided when
 calling {ref}`dev-polaris-setup`.
@@ -52,12 +52,16 @@ calling {ref}`dev-polaris-setup`.
 The {py:class}`polaris.tasks.ocean.overflow.viz.Viz` plots the initial and
 final temperature along a transect perpendicular to the continental slope.
 
-(dev-ocean-overflow-default)=
+(dev-ocean-overflow-smoke-test)=
 
-## default
+## smoke_test
 
-The {py:class}`polaris.tasks.ocean.overflow.default.Default`
-test runs the `init` step, a short `forward` step, and the `viz` step.
+The {py:class}`polaris.tasks.ocean.overflow.smoke_test.SmokeTest`
+task runs the `init` step, a short `forward` step, and (optionally, not run
+by default) the `viz` step. Three instances are created, one for each
+horizontal advection order (2, 3, and 4), producing tasks named
+`smoke_test_horiz_adv_order_2`, `smoke_test_horiz_adv_order_3`, and
+`smoke_test_horiz_adv_order_4`.
 
 ## rpe
 

--- a/docs/users_guide/ocean/tasks/overflow.md
+++ b/docs/users_guide/ocean/tasks/overflow.md
@@ -5,7 +5,7 @@
 The ``ocean/overflow`` test group induces a density current flowing down a
 continental slope and includes two test cases.
 
-## suppported models
+## supported models
 
 These tasks support MPAS-Ocean and Omega.
 
@@ -94,8 +94,11 @@ These config options are common to all overflow tests:
 # Options related to the overflow case
 [overflow]
 
+# Time integration scheme
+time_integrator = RK4
+
 # Timestep per km horizontal resolution (s)
-dt_per_km = 10.
+dt_per_km = 7.5
 
 # Barotropic timestep per km horizontal resolution (s)
 btr_dt_per_km = 2.5
@@ -138,6 +141,12 @@ lower_temperature = 10.0
 
 # Higher temperature (deg C)
 higher_temperature = 20.0
+
+# Default viscosity (m^2/s)
+default_viscosity = 1000.0
+
+# Default horizontal advection order
+default_horiz_adv_order = 2
 ```
 
 The linear EOS is used because it is convenient for computing RPE. The
@@ -149,12 +158,17 @@ namelist parameters for the linear EOS can be altered using config options
 The number of cores is determined by `goal_cells_per_core` and
 `max_cells_per_core` in the `ocean` section of the config file.
 
-## default
+## smoke_test
 
 ### description
 
-The default case is the same as described above except the run is stopped
-before it is allowed to reach equilibrium to facilitate rapid testing.
+There are three smoke test cases corresponding to horizontal advection orders
+2, 3, and 4: `smoke_test_horiz_adv_order_2`, `smoke_test_horiz_adv_order_3`,
+and `smoke_test_horiz_adv_order_4`. Each smoke test is the same as described
+above except the run is stopped before it is allowed to reach equilibrium to
+facilitate rapid testing. The horizontal advection order is controlled by the
+`horiz_adv_order` argument to the `SmokeTest` task and passed through to the
+forward step.
 
 ### mesh
 
@@ -175,23 +189,25 @@ See {ref}`ocean-overflow`.
 ### time step and run duration
 
 The time step for forward integration is set by `dt_per_km` and the model
-resolution. The barotropic time step is 15s. The run duration is 12 minutes.
+resolution. The run duration is 12 minutes.
 
 ### config options
 
-The config options specific to the default case are:
+The config options specific to the smoke test cases are:
 
 ```cfg
-[overflow_default]
+[overflow_smoke_test]
 
-# Run duration (minutes)
+# Run duration
 run_duration = 12.
 
-# Output interval (seconds)
-output_interval = 1.
-```
+run_duration_units = minutes
 
-Include here any further description of each of the config options.
+# Output interval
+output_interval = 1.
+
+output_interval_units = seconds
+```
 
 ### cores
 
@@ -201,7 +217,7 @@ See {ref}`ocean-overflow`.
 
 ### description
 
-The `rpe` case is the same as the default except it runs to 40 days by which
+The `rpe` case is similar to the smoke tests except it runs to 40 days by which
 time the dense blob is mostly at depth. It also includs several forward runs
 corresponding to different values of the laplacian viscosity specified by the
 config option `overflow_rpe:viscosities`. The analysis step is a substitute for the viz step as
@@ -226,11 +242,15 @@ The config options specific to the RPE case are:
 ```cfg
 [overflow_rpe]
 
-# Run duration (days)
+# Run duration
 run_duration = 40.
 
-# Output interval (days)
+run_duration_units = days
+
+# Output interval
 output_interval = 1.
+
+output_interval_units = hours
 
 # Viscosity values to test for rpe test case
 viscosities = 1, 5, 10, 100, 1000

--- a/docs/users_guide/ocean/tasks/overflow.md
+++ b/docs/users_guide/ocean/tasks/overflow.md
@@ -3,7 +3,7 @@
 # overflow
 
 The ``ocean/overflow`` test group induces a density current flowing down a
-continental slope and includes two test cases.
+continental slope and includes four test cases.
 
 ## supported models
 
@@ -218,8 +218,8 @@ See {ref}`ocean-overflow`.
 ### description
 
 The `rpe` case is similar to the smoke tests except it runs to 40 days by which
-time the dense blob is mostly at depth. It also includs several forward runs
-corresponding to different values of the laplacian viscosity specified by the
+time the dense blob is mostly at depth. It also includes several forward runs
+corresponding to different values of the Laplacian viscosity specified by the
 config option `overflow_rpe:viscosities`. The analysis step is a substitute for the viz step as
 it includes the same cross-section visualizations of temperature but also
 includes a computation and plot of the evolution of the Resting Potential

--- a/polaris/suites/ocean/mpaso_pr.txt
+++ b/polaris/suites/ocean/mpaso_pr.txt
@@ -9,7 +9,9 @@ ocean/planar/internal_wave/standard/default
 ocean/planar/internal_wave/vlr/default
 # ocean/planar/manufactured_solution/convergence_both
 ocean/planar/merry_go_round/default
-ocean/planar/overflow/default
+ocean/planar/overflow/smoke_test_horiz_adv_order_2
+ocean/planar/overflow/smoke_test_horiz_adv_order_3
+ocean/planar/overflow/smoke_test_horiz_adv_order_4
 ocean/single_column/cvmix
 ocean/single_column/ekman
 ocean/single_column/ideal_age

--- a/polaris/suites/ocean/omega_nightly.txt
+++ b/polaris/suites/ocean/omega_nightly.txt
@@ -8,6 +8,9 @@ ocean/planar/manufactured_solution/convergence_both/del4
 ocean/planar/merry_go_round/default
 ocean/planar/merry_go_round/convergence_both_order2
 ocean/planar/merry_go_round/convergence_both_order4
+ocean/planar/overflow/smoke_test_horiz_adv_order_2
+ocean/planar/overflow/smoke_test_horiz_adv_order_3
+ocean/planar/overflow/smoke_test_horiz_adv_order_4
 ocean/spherical/icos/correlated_tracers_2d
 ocean/spherical/icos/cosine_bell/decomp
 ocean/spherical/icos/cosine_bell/restart

--- a/polaris/suites/ocean/omega_pr.txt
+++ b/polaris/suites/ocean/omega_pr.txt
@@ -4,7 +4,9 @@ ocean/planar/manufactured_solution/convergence_both/default
 ocean/planar/manufactured_solution/convergence_both/del2
 ocean/planar/manufactured_solution/convergence_both/del4
 ocean/planar/merry_go_round/default
-ocean/planar/overflow/default
+ocean/planar/overflow/smoke_test_horiz_adv_order_2
+ocean/planar/overflow/smoke_test_horiz_adv_order_3
+ocean/planar/overflow/smoke_test_horiz_adv_order_4
 ocean/spherical/icos/cosine_bell/decomp
 ocean/spherical/icos/cosine_bell/restart
 

--- a/polaris/tasks/ocean/overflow/__init__.py
+++ b/polaris/tasks/ocean/overflow/__init__.py
@@ -1,9 +1,9 @@
 import os
 
 from polaris.config import PolarisConfigParser as PolarisConfigParser
-from polaris.tasks.ocean.overflow.default import Default as Default
-from polaris.tasks.ocean.overflow.init import Init as Init
-from polaris.tasks.ocean.overflow.rpe import Rpe as Rpe
+from polaris.tasks.ocean.overflow.init import Init
+from polaris.tasks.ocean.overflow.rpe import Rpe
+from polaris.tasks.ocean.overflow.smoke_test import SmokeTest
 
 
 def add_overflow_tasks(component):
@@ -25,9 +25,15 @@ def add_overflow_tasks(component):
     init_step = Init(component=component, name='init', indir=taskdir)
     init_step.set_shared_config(config, link=config_filename)
 
-    default = Default(component=component, indir=taskdir, init=init_step)
-    default.set_shared_config(config, link=config_filename)
-    component.add_task(default)
+    for horiz_adv_order in [2, 3, 4]:
+        smoke_test = SmokeTest(
+            component=component,
+            indir=taskdir,
+            init=init_step,
+            horiz_adv_order=horiz_adv_order,
+        )
+        smoke_test.set_shared_config(config, link=config_filename)
+        component.add_task(smoke_test)
 
     component.add_task(
         Rpe(

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -45,7 +45,6 @@ class Forward(OceanModelStep):
         name : str
             the name of the task
 
-
         init : polaris.ocean.tasks.internal_wave.init.Init
             the initial state step
 

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -9,13 +9,14 @@ class Forward(OceanModelStep):
 
     Attributes
     ----------
-    task_name : str
-       The name of the task that this step belongs to
+    config_section : str
+        The section in the config file for this test case, used to get
+        the run duration and output interval
 
-    yaml_filename : str
-       The name of the yaml file for this forward step
+    horiz_adv_order : int or None
+        The horizontal advection order for the test case
 
-    nu : float
+    nu : float or None
        The Laplacian viscosity to use for this forward step
     """
 
@@ -23,15 +24,15 @@ class Forward(OceanModelStep):
         self,
         component,
         init,
-        yaml_filename='forward.yaml',
+        config_section,
         name='forward',
-        task_name='default',
         subdir=None,
         indir=None,
         ntasks=None,
         min_tasks=None,
         openmp_threads=1,
-        nu=1000.0,
+        horiz_adv_order=None,
+        nu=None,
     ):
         """
         Create a new test case
@@ -47,11 +48,12 @@ class Forward(OceanModelStep):
         task_name : str
            The name of the task that this step belongs to
 
-        yaml_filename : str
-           The name of the yaml file for this forward step
-
         init : polaris.ocean.tasks.internal_wave.init.Init
             the initial state step
+
+        config_section : str
+            The section in the config file for this test case, used to get
+            the run duration and output interval
 
         subdir : str, optional
             the subdirectory for the step.  The default is ``name``
@@ -67,6 +69,10 @@ class Forward(OceanModelStep):
 
         openmp_threads : int, optional
             the number of OpenMP threads the step will use
+
+        horiz_adv_order : int, optional
+            The horizontal advection order for the test case (if different
+            from the default for the test group)
 
         nu : float, optional
             the viscosity (if different from the default for the test group)
@@ -84,8 +90,8 @@ class Forward(OceanModelStep):
             update_eos=True,
             graph_target=f'{init.path}/culled_graph.info',
         )
-        self.task_name = task_name
-        self.yaml_filename = yaml_filename
+        self.config_section = config_section
+        self.horiz_adv_order = horiz_adv_order
         self.nu = nu
 
         # make sure output is double precision
@@ -119,36 +125,25 @@ class Forward(OceanModelStep):
         btr_dt_str = get_time_interval_string(
             seconds=btr_dt_per_km * resolution
         )
-        section = config[f'overflow_{self.task_name}']
+        if self.nu is None:
+            self.nu = config.getfloat('overflow', 'default_viscosity')
+
+        if self.horiz_adv_order is None:
+            self.horiz_adv_order = config.getint(
+                'overflow', 'default_horiz_adv_order'
+            )
+        section = config[self.config_section]
         run_duration = section.getfloat('run_duration')
         run_duration_units = section.get('run_duration_units')
         output_interval = section.getfloat('output_interval')
         output_units = section.get('output_interval_units')
         output_freq = int(output_interval)
-        if run_duration_units == 'days':
-            run_duration_str = get_time_interval_string(days=run_duration)
-        elif run_duration_units == 'hours':
-            run_duration_str = get_time_interval_string(
-                seconds=run_duration * 3600.0
-            )
-        elif run_duration_units == 'minutes':
-            run_duration_str = get_time_interval_string(
-                seconds=run_duration * 60.0
-            )
-        elif run_duration_units == 'seconds':
-            run_duration_str = get_time_interval_string(seconds=run_duration)
-        else:
-            raise ValueError(
-                f'Unknown run duration units: {run_duration_units}'
-            )
-        if self.task_name == 'rpe':
-            output_interval_str = get_time_interval_string(
-                days=output_interval
-            )
-        else:
-            output_interval_str = get_time_interval_string(
-                seconds=output_interval
-            )
+        run_duration_str = self._interval_to_string(
+            run_duration, run_duration_units
+        )
+        output_interval_str = self._interval_to_string(
+            output_interval, output_units
+        )
 
         time_integrator = config.get('overflow', 'time_integrator')
         time_integrator_map = dict([('RK4', 'RungeKutta4')])
@@ -173,10 +168,11 @@ class Forward(OceanModelStep):
             nu=self.nu,
             output_freq=f'{output_freq}',
             output_freq_units=output_units,
+            horiz_adv_order=self.horiz_adv_order,
         )
         self.add_yaml_file(
             'polaris.tasks.ocean.overflow',
-            self.yaml_filename,
+            'forward.yaml',
             template_replacements=replacements,
         )
 
@@ -197,3 +193,20 @@ class Forward(OceanModelStep):
         nx, ny = compute_planar_hex_nx_ny(lx, ly, resolution)
         cell_count = nx * ny
         return cell_count
+
+    @staticmethod
+    def _interval_to_string(interval, units):
+        """
+        Convert a time interval to a string in the format "DDDD_HH:MM:SS.SS"
+        """
+        if units == 'days':
+            interval_str = get_time_interval_string(days=interval)
+        elif units == 'hours':
+            interval_str = get_time_interval_string(seconds=interval * 3600.0)
+        elif units == 'minutes':
+            interval_str = get_time_interval_string(seconds=interval * 60.0)
+        elif units == 'seconds':
+            interval_str = get_time_interval_string(seconds=interval)
+        else:
+            raise ValueError(f'Unexpected time interval units: {units}')
+        return interval_str

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -45,8 +45,6 @@ class Forward(OceanModelStep):
         name : str
             the name of the task
 
-        task_name : str
-           The name of the task that this step belongs to
 
         init : polaris.ocean.tasks.internal_wave.init.Init
             the initial state step

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -19,6 +19,8 @@ ocean:
     config_cvmix_background_viscosity: 0.0
   bottom_drag:
     config_explicit_bottom_drag_coeff: 0.01
+  advection:
+    config_horiz_tracer_adv_order: {{ horiz_adv_order }}
 
 mpas-ocean:
   io:

--- a/polaris/tasks/ocean/overflow/overflow.cfg
+++ b/polaris/tasks/ocean/overflow/overflow.cfg
@@ -72,7 +72,13 @@ lower_temperature = 10.0
 # Higher temperature (deg C)
 higher_temperature = 20.0
 
-[overflow_default]
+# Default viscosity (m^2/s)
+default_viscosity = 1000.0
+
+# Default horizontal advection order
+default_horiz_adv_order = 2
+
+[overflow_smoke_test]
 
 # Run duration
 run_duration = 12.

--- a/polaris/tasks/ocean/overflow/overflow.cfg
+++ b/polaris/tasks/ocean/overflow/overflow.cfg
@@ -98,7 +98,7 @@ run_duration = 40.
 run_duration_units = days
 
 # Output interval
-output_interval = 1.
+output_interval = 6.
 
 output_interval_units = hours
 

--- a/polaris/tasks/ocean/overflow/rpe/__init__.py
+++ b/polaris/tasks/ocean/overflow/rpe/__init__.py
@@ -68,8 +68,8 @@ class Rpe(Task):
             step = Forward(
                 component=component,
                 name=name,
-                task_name='rpe',
                 init=init,
+                config_section='overflow_rpe',
                 indir=self.subdir,
                 ntasks=None,
                 min_tasks=None,

--- a/polaris/tasks/ocean/overflow/smoke_test.py
+++ b/polaris/tasks/ocean/overflow/smoke_test.py
@@ -6,13 +6,13 @@ from polaris.tasks.ocean.overflow.forward import Forward as Forward
 from polaris.tasks.ocean.overflow.viz import Viz as Viz
 
 
-class Default(Task):
+class SmokeTest(Task):
     """
-    The default overflow test case simply creates the mesh and
+    The short overflow smoke test simply creates the mesh and
     initial condition, then performs a short forward run on 4 cores.
     """
 
-    def __init__(self, component, indir, init):
+    def __init__(self, component, indir, init, horiz_adv_order):
         """
         Create the test case
 
@@ -26,8 +26,11 @@ class Default(Task):
 
         init : polaris.tasks.ocean.overflow.init.Init
             A shared step for creating the initial state
+
+        horiz_adv_order : int
+            The horizontal advection order for the test case
         """
-        task_name = 'default'
+        task_name = f'smoke_test_horiz_adv_order_{horiz_adv_order}'
         super().__init__(component=component, name=task_name, indir=indir)
 
         self.add_step(init, symlink='init')
@@ -35,9 +38,10 @@ class Default(Task):
         forward_step = Forward(
             component=component,
             init=init,
-            task_name=task_name,
+            config_section='overflow_smoke_test',
             name='forward',
             indir=self.subdir,
+            horiz_adv_order=horiz_adv_order,
         )
         self.add_step(forward_step)
 

--- a/polaris/tasks/ocean/overflow/viz.py
+++ b/polaris/tasks/ocean/overflow/viz.py
@@ -73,6 +73,11 @@ class Viz(OceanIOStep):
             filename='mesh.nc',
             work_dir_target=f'{mesh.path}/culled_mesh.nc',
         )
+        if self.component.model == 'omega':
+            self.add_input_file(
+                filename='vert_coord.nc',
+                work_dir_target=f'{init.path}/vert_coord.nc',
+            )
         self.add_input_file(
             filename='init.nc',
             work_dir_target=f'{init.path}/init.nc',
@@ -89,6 +94,13 @@ class Viz(OceanIOStep):
         config = self.config
         ds_mesh = self.open_model_dataset('mesh.nc', config=config)
         ds_init = self.open_model_dataset('init.nc', config=config)
+        model = self.component.model
+        if model == 'omega':
+            ds_vert_coord = self.open_model_dataset(
+                'vert_coord.nc', config=config
+            )
+        else:
+            ds_vert_coord = ds_init
         ds = self.open_model_dataset('output.nc', config=config)
 
         x_min = ds_mesh.xVertex.min().values
@@ -104,9 +116,9 @@ class Viz(OceanIOStep):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds_init.layerThickness.isel(Time=t_index),
-            bottom_depth=ds_init.bottomDepth,
-            min_level_cell=ds_init.minLevelCell - 1,
-            max_level_cell=ds_init.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 
@@ -134,9 +146,9 @@ class Viz(OceanIOStep):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds.layerThickness.isel(Time=t_index),
-            bottom_depth=ds_init.bottomDepth,
-            min_level_cell=ds_init.minLevelCell - 1,
-            max_level_cell=ds_init.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge replaces the `default` overflow test with:
```
  ocean/planar/overflow/smoke_test_horiz_adv_order_2
  ocean/planar/overflow/smoke_test_horiz_adv_order_3
  ocean/planar/overflow/smoke_test_horiz_adv_order_4
```
The first is the same as the old `default`, while the other 2 can be used to detect regression in higher order horizontal advection of tracers in combination with variable bathymetry.

This PR also updates the Omega submodule to bring in https://github.com/E3SM-Project/Omega/pull/403.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
