### PR TITLE
Fix vert_coord inputs for viz/analysis steps

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -600,6 +600,14 @@
 
    OceanIOStep
    OceanIOStep.setup
+   OceanIOStep.process_inputs_and_outputs
+   OceanIOStep.add_horiz_mesh_input_file
+   OceanIOStep.add_vert_coord_input_file
+   OceanIOStep.add_init_input_file
+   OceanIOStep.get_horiz_mesh_filename
+   OceanIOStep.get_vert_coord_filename
+   OceanIOStep.get_init_filename
+   OceanIOStep.open_vert_coord_dataset
    OceanIOStep.map_to_native_model_vars
    OceanIOStep.write_model_dataset
    OceanIOStep.map_from_native_model_vars
@@ -612,6 +620,8 @@
    OceanModelStep.compute_cell_count
    OceanModelStep.map_yaml_options
    OceanModelStep.map_yaml_configs
+
+   OceanModelFilesMixin
 
    get_days_since_start
    get_time_interval_string

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -39,6 +39,76 @@ should be added to the `variables` section in the
 [mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml)
 file.
 
+#### Canonical staged files
+
+The three files that flow through the ocean pipeline — horizontal mesh,
+vertical coordinate, and initial state — have canonical local filenames
+defined in the `[ocean_staged_files]` config section (in
+`polaris/ocean/ocean.cfg`):
+
+```ini
+[ocean_staged_files]
+horiz_mesh_filename = mesh.nc
+vert_coord_filename = vert_coord.nc
+init_filename = init.nc
+```
+
+These filenames are shared by all pipeline stages: init steps write them as
+outputs, model steps link them as inputs, and viz/analysis steps also link
+from upstream using the same names.
+
+Both {py:class}`polaris.ocean.model.OceanIOStep` and
+{py:class}`polaris.ocean.model.OceanModelStep` inherit these conveniences from
+{py:class}`polaris.ocean.model.OceanModelFilesMixin`:
+
+- **Getters** — `get_horiz_mesh_filename()`, `get_vert_coord_filename()`,
+  `get_init_filename()` — read the current values from config.
+- **Input-file registration** — `add_horiz_mesh_input_file(**kwargs)`,
+  `add_vert_coord_input_file(filename=None, **kwargs)`,
+  `add_init_input_file(**kwargs)` — all safe to call from `__init__()`.
+  The model check is deferred to `process_inputs_and_outputs()`, so no
+  `if model == 'omega':` guards are needed in `__init__()`.
+  `add_vert_coord_input_file()` is a no-op for MPAS-Ocean when the default
+  placeholder is used.  When an explicit `filename=` is given (for
+  per-resolution files such as `'vert_coord_r04.nc'`), it must be called
+  from `setup()` or later because `self.config` is required.
+
+A typical viz or analysis step that reads vert-coord variables:
+
+```python
+class Viz(OceanIOStep):
+    def __init__(self, component, indir, init):
+        super().__init__(component=component, name='viz', indir=indir)
+        self.add_input_file(filename='mesh.nc',
+                            work_dir_target=f'{init.path}/culled_mesh.nc')
+        self.add_input_file(filename='init.nc',
+                            work_dir_target=f'{init.path}/init.nc')
+        # registers vert_coord.nc for Omega; no-op for MPAS-Ocean
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc')
+        self.add_input_file(filename='output.nc', target='../forward/output.nc')
+
+    def run(self):
+        ds_init = self.open_model_dataset('init.nc', self.config)
+        # returns ds_init for MPAS-Ocean; opens vert_coord.nc for Omega
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
+        ...
+        compute_transect(
+            ...,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
+        )
+```
+
+`open_vert_coord_dataset(ds_init, vert_coord_filename=None)` returns
+the subset of variables associated with the veritcal coordinate taken from
+`ds_init` for MPAS-Ocean (the vert-coord variables live in `init.nc`) and
+opens the separate `vert_coord.nc` file for Omega, mapping
+Omega variable names to MPAS-Ocean equivalents via `open_model_dataset()`.
+Pass an explicit `vert_coord_filename=` when using per-resolution files
+(e.g. from a `ConvergenceAnalysis` subclass).
+
 ### Running an E3SM component
 
 Steps that run either Omega or MPAS-Ocean should descend from the

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -159,6 +159,10 @@ class ConvergenceAnalysis(OceanIOStep):
                 filename=f'init_r{refinement_factor:02g}.nc',
                 work_dir_target=f'{init.path}/init.nc',
             )
+            self.add_vert_coord_input_file(
+                filename=f'vert_coord_r{refinement_factor:02g}.nc',
+                work_dir_target=f'{init.path}/vert_coord.nc',
+            )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',
                 work_dir_target=f'{forward.path}/output.nc',

--- a/polaris/ocean/model/__init__.py
+++ b/polaris/ocean/model/__init__.py
@@ -1,4 +1,7 @@
 from polaris.ocean.model.ocean_io_step import OceanIOStep as OceanIOStep
+from polaris.ocean.model.ocean_model_files_mixin import (
+    OceanModelFilesMixin as OceanModelFilesMixin,
+)
 from polaris.ocean.model.ocean_model_step import (
     OceanModelStep as OceanModelStep,
 )

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -1,6 +1,9 @@
 from typing import TYPE_CHECKING
 
+import xarray as xr
+
 from polaris import Step
+from polaris.ocean.model.ocean_model_files_mixin import OceanModelFilesMixin
 
 if TYPE_CHECKING:
     # Keep Ocean as a type-only import. Importing it at runtime pulls
@@ -9,7 +12,7 @@ if TYPE_CHECKING:
     from polaris.tasks.ocean import Ocean
 
 
-class OceanIOStep(Step):
+class OceanIOStep(Step, OceanModelFilesMixin):
     """
     A step that writes input and/or output files for Omega or MPAS-Ocean
     """
@@ -20,6 +23,15 @@ class OceanIOStep(Step):
 
     def __init__(self, component: 'Ocean', **kwargs):
         super().__init__(component=component, **kwargs)
+
+    def process_inputs_and_outputs(self) -> None:
+        """
+        Resolve ``<<<placeholder>>>`` filenames to configured names and drop
+        ``<<<vert_coord>>>`` entries for MPAS-Ocean before delegating to
+        the base :py:class:`~polaris.Step` processing.
+        """
+        self._resolve_model_file_placeholders()
+        super().process_inputs_and_outputs()
 
     def add_output_files_for_ocean_model_input(
         self,
@@ -37,16 +49,16 @@ class OceanIOStep(Step):
         ----------
         horiz_mesh_filename : str, optional
             Local filename for the horizontal mesh output; defaults to the
-            ``horiz_mesh_filename`` option in ``[ocean_model_files]``.
+            ``horiz_mesh_filename`` option in ``[ocean_staged_files]``.
 
         vert_coord_filename : str, optional
             Local filename for the vertical-coordinate output (Omega only);
             defaults to the ``vert_coord_filename`` option in
-            ``[ocean_model_files]``.
+            ``[ocean_staged_files]``.
 
         init_filename : str, optional
             Local filename for the initial-state output; defaults to the
-            ``init_filename`` option in ``[ocean_model_files]``.
+            ``init_filename`` option in ``[ocean_staged_files]``.
 
         base_mesh_filename : str, optional
             If provided, also register this filename as an output (used when
@@ -61,15 +73,11 @@ class OceanIOStep(Step):
         model = config.get('ocean', 'model')
 
         if horiz_mesh_filename is None:
-            horiz_mesh_filename = config.get(
-                'ocean_model_files', 'horiz_mesh_filename'
-            )
+            horiz_mesh_filename = self.get_horiz_mesh_filename()
         if vert_coord_filename is None:
-            vert_coord_filename = config.get(
-                'ocean_model_files', 'vert_coord_filename'
-            )
+            vert_coord_filename = self.get_vert_coord_filename()
         if init_filename is None:
-            init_filename = config.get('ocean_model_files', 'init_filename')
+            init_filename = self.get_init_filename()
 
         if base_mesh_filename is not None:
             self.add_output_file(filename=base_mesh_filename)
@@ -79,6 +87,60 @@ class OceanIOStep(Step):
             self.add_output_file(filename=vert_coord_filename)
         if model == 'mpas-ocean' and graph_filename is not None:
             self.add_output_file(filename=graph_filename)
+
+    def open_vert_coord_dataset(
+        self, ds_init, vert_coord_filename=None, **kwargs
+    ):
+        """
+        Return the dataset containing vertical-coordinate variables
+        (``bottomDepth``, ``minLevelCell``, ``maxLevelCell``,
+        ``vertCoordMovementWeights`` and either ``restingThickness`` or
+        ``RefPseudoThickness``).
+
+        For Omega: opens *vert_coord_filename* (defaults to
+        :py:meth:`get_vert_coord_filename`) via
+        :py:meth:`open_model_dataset` so Omega variable names are mapped to
+        their MPAS-Ocean equivalents.
+
+        For MPAS-Ocean: returns the set of vertical-coordinate variables from
+        *ds_init* (those variables live in the initial state file).
+
+        Parameters
+        ----------
+        ds_init : xarray.Dataset
+            The already-opened initial-condition dataset.
+        vert_coord_filename : str, optional
+            Local filename of the vertical-coordinate file.  Defaults to
+            :py:meth:`get_vert_coord_filename`.  Pass an explicit name when
+            using per-resolution files (e.g. ``'vert_coord_r04.nc'``).
+        **kwargs
+            Forwarded to :py:meth:`open_model_dataset`.
+        """
+        model = self.config.get('ocean', 'model')
+        if model == 'omega':
+            if vert_coord_filename is None:
+                vert_coord_filename = self.get_vert_coord_filename()
+            ds_vert_coord = self.open_model_dataset(
+                vert_coord_filename, config=self.config, **kwargs
+            )
+        elif model == 'mpas-ocean':
+            ds_vert_coord = xr.Dataset()
+            if self.component.vert_coord_vars is None:
+                raise ValueError(
+                    'Vertical coordinate variables not defined in the Ocean '
+                    'component'
+                )
+            for var in self.component.vert_coord_vars:
+                if var not in ds_init:
+                    raise ValueError(
+                        f"Expected vertical coordinate variable '{var}' not "
+                        'found in initial condition dataset'
+                    )
+                ds_vert_coord[var] = ds_init[var]
+        else:
+            raise ValueError(f'Unsupported ocean model: {model}')
+
+        return ds_vert_coord
 
     def map_to_native_model_vars(self, ds):
         """

--- a/polaris/ocean/model/ocean_model_files_mixin.py
+++ b/polaris/ocean/model/ocean_model_files_mixin.py
@@ -1,0 +1,167 @@
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from polaris.config import PolarisConfigParser
+    from polaris.tasks.ocean import Ocean
+
+# Maps placeholder filenames to their [ocean_staged_files] config option names.
+_PLACEHOLDER_MAP = {
+    '<<<horiz_mesh>>>': 'horiz_mesh_filename',
+    '<<<vert_coord>>>': 'vert_coord_filename',
+    '<<<init>>>': 'init_filename',
+}
+
+
+class OceanModelFilesMixin:
+    """
+    Mixin providing access to the ``[ocean_staged_files]`` config section and
+    the shared placeholder mechanism for the three canonical ocean dataset
+    files (horizontal mesh, vertical coordinate, initial state).
+
+    Must be combined with a Step subclass that sets ``self.config`` and
+    provides ``self.add_input_file()``.  The ``add_*_input_file()`` methods
+    are safe to call from ``__init__()`` because the model check is deferred
+    to :py:meth:`_resolve_model_file_placeholders`, which is called at
+    ``process_inputs_and_outputs()`` time.
+    """
+
+    component: 'Ocean'
+    # These attributes and methods are provided by the Step base class:
+    config: 'PolarisConfigParser'
+    input_data: list[dict[str, Any]]
+
+    def add_input_file(
+        self,
+        filename=None,
+        target=None,
+        database=None,
+        database_component=None,
+        url=None,
+        work_dir_target=None,
+        package=None,
+        copy=False,
+    ) -> None:
+        """Provided by :py:class:`polaris.Step`."""
+        raise NotImplementedError
+
+    # --- filename getters ---
+
+    def get_horiz_mesh_filename(self) -> str:
+        """
+        Get the configured local filename for the horizontal mesh file.
+        """
+        return self._get_model_input_filename('horiz_mesh_filename')
+
+    def get_vert_coord_filename(self) -> str:
+        """
+        Get the configured local filename for the vertical coordinate file.
+        """
+        return self._get_model_input_filename('vert_coord_filename')
+
+    def get_init_filename(self) -> str:
+        """
+        Get the configured local filename for the initial-condition file.
+        """
+        return self._get_model_input_filename('init_filename')
+
+    # --- input file registration ---
+
+    def add_horiz_mesh_input_file(self, **kwargs) -> None:
+        """
+        Add the horizontal-mesh input file using a placeholder that is
+        resolved to the configured filename at
+        :py:meth:`process_inputs_and_outputs` time.  Safe to call from
+        ``__init__()``.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional keyword arguments forwarded to
+            :py:meth:`polaris.Step.add_input_file`.
+        """
+        self.add_input_file(filename='<<<horiz_mesh>>>', **kwargs)
+
+    def add_vert_coord_input_file(self, filename=None, **kwargs) -> None:
+        """
+        Add the vertical-coordinate input file.
+
+        When *filename* is ``None`` (the default), the
+        ``'<<<vert_coord>>>'`` placeholder is used.  The placeholder is
+        resolved at :py:meth:`process_inputs_and_outputs` time and silently
+        dropped for MPAS-Ocean (no separate vert_coord file exists).  Safe
+        to call from ``__init__()``.
+
+        When *filename* is provided explicitly (e.g. ``'vert_coord_r04.nc'``
+        for multi-resolution steps), the entry is added directly for Omega
+        only and must be called from ``setup()`` or later (requires
+        ``self.config``).
+
+        Parameters
+        ----------
+        filename : str, optional
+            Explicit local filename, overriding the placeholder.
+        **kwargs
+            Additional keyword arguments forwarded to
+            :py:meth:`polaris.Step.add_input_file`.
+        """
+        if filename is None:
+            self.add_input_file(filename='<<<vert_coord>>>', **kwargs)
+        else:
+            model = self.config.get('ocean', 'model')
+            if model == 'omega':
+                self.add_input_file(filename=filename, **kwargs)
+
+    def add_init_input_file(self, **kwargs) -> None:
+        """
+        Add the initial-condition input file using a placeholder that is
+        resolved to the configured filename at
+        :py:meth:`process_inputs_and_outputs` time.  Safe to call from
+        ``__init__()``.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional keyword arguments forwarded to
+            :py:meth:`polaris.Step.add_input_file`.
+        """
+        self.add_input_file(filename='<<<init>>>', **kwargs)
+
+    # --- shared placeholder resolution ---
+
+    def _resolve_model_file_placeholders(self) -> None:
+        """
+        Scan ``self.input_data``, replace placeholder filenames with the
+        configured names from ``[ocean_staged_files]``, and drop
+        ``'<<<vert_coord>>>'`` entries for MPAS-Ocean.  Called at the top of
+        :py:meth:`process_inputs_and_outputs` by both
+        :py:class:`~polaris.ocean.model.OceanModelStep` and
+        :py:class:`~polaris.ocean.model.OceanIOStep`.
+        """
+        model = self.config.get('ocean', 'model')
+        keep = []
+        for entry in self.input_data:
+            fn = entry['filename']
+            if fn == '<<<vert_coord>>>' and model != 'omega':
+                continue
+            if fn in _PLACEHOLDER_MAP:
+                entry['filename'] = self._get_model_input_filename(
+                    _PLACEHOLDER_MAP[fn]
+                )
+            keep.append(entry)
+        self.input_data = keep
+
+    # --- private helper ---
+
+    def _get_model_input_filename(self, option: str) -> str:
+        section = 'ocean_staged_files'
+        if not self.config.has_section(section):
+            raise ValueError(
+                f'Config section [{section}] is required to determine model '
+                f'input filenames, but it was not found.'
+            )
+        if not self.config.has_option(section, option):
+            raise ValueError(
+                f'Config option {option!r} is required to determine model '
+                f'input filenames, but it was not found in [{section}].'
+            )
+        return self.config.get(section, option)

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -12,6 +12,7 @@ from polaris.ocean.conservation import (
     compute_total_salt,
     compute_total_tracer,
 )
+from polaris.ocean.model.ocean_model_files_mixin import OceanModelFilesMixin
 
 if TYPE_CHECKING:
     # Keep Ocean as a type-only import. Importing it at runtime pulls
@@ -33,7 +34,7 @@ ConfigsType = Dict[
 ]
 
 
-class OceanModelStep(ModelStep):
+class OceanModelStep(ModelStep, OceanModelFilesMixin):
     """
     An Omega or MPAS-Ocean step
 
@@ -52,14 +53,6 @@ class OceanModelStep(ModelStep):
         The name of the graph partition file to link to (relative to the base
         working directory)
     """
-
-    # a mapping from placeholder filenames to config options used to
-    # determine the actual filenames at runtime
-    _MODEL_INPUT_OPTIONS = {
-        '<<<horiz_mesh>>>': 'horiz_mesh_filename',
-        '<<<vert_coord>>>': 'vert_coord_filename',
-        '<<<init>>>': 'init_filename',
-    }
 
     # make sure component is of type Ocean, using a string to avoid circular
     # imports
@@ -266,81 +259,13 @@ class OceanModelStep(ModelStep):
         self._set_gpus_per_task()
         super().constrain_resources(available_cores)
 
-    def add_horiz_mesh_input_file(self, **kwargs) -> None:
-        """
-        Add a horizontal-mesh input file using the configured local filename.
-
-        Parameters
-        ----------
-        **kwargs
-            Additional keyword arguments to pass to
-            :py:meth:`polaris.Step.add_input_file()`
-        """
-        self.add_input_file(filename='<<<horiz_mesh>>>', **kwargs)
-
-    def add_vert_coord_input_file(self, **kwargs) -> None:
-        """
-        Add a vertical-coordinate input file using the configured local
-        filename.  For MPAS-Ocean this entry is silently skipped at runtime
-        (no separate vert_coord file is written).
-
-        Parameters
-        ----------
-        **kwargs
-            Additional keyword arguments to pass to
-            :py:meth:`polaris.Step.add_input_file()`
-        """
-        self.add_input_file(filename='<<<vert_coord>>>', **kwargs)
-
-    def add_init_input_file(self, **kwargs) -> None:
-        """
-        Add an initial-condition input file using the configured local
-        filename.
-
-        Parameters
-        ----------
-        **kwargs
-            Additional keyword arguments to pass to
-            :py:meth:`polaris.Step.add_input_file()`
-        """
-        self.add_input_file(filename='<<<init>>>', **kwargs)
-
-    def get_horiz_mesh_filename(self) -> str:
-        """
-        Get the configured local filename for the horizontal mesh file.
-        """
-        return self._get_model_input_filename('horiz_mesh_filename')
-
-    def get_vert_coord_filename(self) -> str:
-        """
-        Get the configured local filename for the vertical coordinate file.
-        """
-        return self._get_model_input_filename('vert_coord_filename')
-
-    def get_init_filename(self) -> str:
-        """
-        Get the configured local filename for the initial-condition file.
-        """
-        return self._get_model_input_filename('init_filename')
-
     def process_inputs_and_outputs(self) -> None:
         """
         Process the model and any configured model-input placeholders.
         For MPAS-Ocean, ``<<<vert_coord>>>`` entries are removed because no
         separate vert coord file is written for that model.
         """
-        model = self.component.model
-        keep = []
-        for entry in self.input_data:
-            fn = entry['filename']
-            if fn == '<<<vert_coord>>>' and model != 'omega':
-                continue
-            if fn in self._MODEL_INPUT_OPTIONS:
-                entry['filename'] = self._get_model_input_filename(
-                    self._MODEL_INPUT_OPTIONS[fn]
-                )
-            keep.append(entry)
-        self.input_data = keep
+        self._resolve_model_file_placeholders()
         super().process_inputs_and_outputs()
 
     def compute_cell_count(self) -> Optional[int]:
@@ -665,20 +590,6 @@ class OceanModelStep(ModelStep):
         self.min_tasks = max(
             1, 4 * round(cell_count / (4 * max_cells_per_core))
         )
-
-    def _get_model_input_filename(self, option: str) -> str:
-        section = 'ocean_model_files'
-        if not self.config.has_section(section):
-            raise ValueError(
-                f'Config section {section} is required to determine model '
-                f'input filenames, but it was not found.'
-            )
-        if not self.config.has_option(section, option):
-            raise ValueError(
-                f'Config option {option} is required to determine model input '
-                f'filenames, but it was not found in section {section}.'
-            )
-        return self.config.get(section, option)
 
     def _get_model_input_replacements(self) -> Dict[str, str]:
         return {

--- a/polaris/ocean/ocean.cfg
+++ b/polaris/ocean/ocean.cfg
@@ -33,10 +33,12 @@ goal_cells_per_gpu = 8000
 # few GPUs are available)
 max_cells_per_gpu = 80000
 
-# Local filenames Polaris stages for ocean model inputs. These are setup-time
-# conventions rather than science options. Changing them after setup can break
-# staged inputs and stream filenames.
-[ocean_model_files]
+# Canonical local filenames for the three ocean datasets shared across the
+# pipeline: horizontal mesh, vertical coordinate, and initial state. Init steps
+# write these names as outputs; model steps link them as inputs; viz and analysis
+# steps also link from upstream using the same names. Changing these after setup
+# breaks staged symlinks and model stream filenames.
+[ocean_staged_files]
 horiz_mesh_filename = mesh.nc
 vert_coord_filename = vert_coord.nc
 init_filename = init.nc

--- a/polaris/ocean/rpe.py
+++ b/polaris/ocean/rpe.py
@@ -7,26 +7,40 @@ from polaris.constants import get_constant
 from polaris.ocean.model import get_days_since_start
 
 
-def compute_rpe(ds_mesh, ds_init, ds_outputs, config=None):
+def compute_rpe(ds_mesh, ds_init, ds_outputs, config=None, ds_vert_coord=None):
     """
     Computes the reference (resting) potential energy for the whole domain
 
     Parameters
     ----------
-    mesh_filename : str
-        Name of the netCDF file containing the MPAS horizontal mesh variables
+    ds_mesh : xarray.Dataset
+        Dataset containing MPAS horizontal mesh variables
 
-    initial_state_filename : str
-        Name of the netCDF file containing the initial state
+    ds_init : xarray.Dataset
+        Dataset containing the initial state
 
-    output_filenames : list
-        List of netCDF files containing output of forward steps
+    ds_outputs : list of xarray.Dataset
+        Datasets containing output of forward steps
+
+    config : polaris.config.PolarisConfigParser, optional
+        Configuration for the task
+
+    ds_vert_coord : xarray.Dataset, optional
+        Dataset containing vertical-coordinate variables (``bottomDepth``,
+        ``minLevelCell``, ``maxLevelCell``).  For Omega this is the separate
+        ``vert_coord.nc`` dataset opened via
+        :py:meth:`~polaris.ocean.model.OceanIOStep.open_vert_coord_dataset`.
+        Defaults to *ds_init* when not provided (correct for MPAS-Ocean).
 
     Returns
     -------
     rpe : numpy.ndarray
-        the reference potential energy of size ``Time`` x ``len(output_files)``
+        the reference potential energy of size ``len(output_files)`` x
+        ``Time``
     """
+    if ds_vert_coord is None:
+        ds_vert_coord = ds_init
+
     num_files = len(ds_outputs)
     if num_files == 0:
         raise ValueError('Must provide at least one output filename')
@@ -36,9 +50,9 @@ def compute_rpe(ds_mesh, ds_init, ds_outputs, config=None):
     xEdge = ds_mesh.xEdge
     yEdge = ds_mesh.yEdge
     areaCell = ds_mesh.areaCell
-    minLevelCell = ds_init.minLevelCell - 1
-    maxLevelCell = ds_init.maxLevelCell - 1
-    bottomDepth = ds_init.bottomDepth
+    minLevelCell = ds_vert_coord.minLevelCell - 1
+    maxLevelCell = ds_vert_coord.maxLevelCell - 1
+    bottomDepth = ds_vert_coord.bottomDepth
     nVertLevels = ds_init.sizes['nVertLevels']
 
     areaCellMatrix = np.tile(areaCell, (nVertLevels, 1)).transpose()

--- a/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
+++ b/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
@@ -1,14 +1,13 @@
 import cmocean  # noqa: F401
 import matplotlib.pyplot as plt
 import numpy as np
-import xarray as xr
 
-from polaris import Step
+from polaris.ocean.model import OceanIOStep, get_days_since_start
 from polaris.ocean.rpe import compute_rpe
 from polaris.viz import plot_horiz_field, use_mplstyle
 
 
-class Analysis(Step):
+class Analysis(OceanIOStep):
     """
     A step for plotting the results of a series of baroclinic channel RPE runs
 
@@ -44,6 +43,7 @@ class Analysis(Step):
         )
 
         self.add_input_file(target='../../init/init.nc')
+        self.add_vert_coord_input_file(target='../../init/vert_coord.nc')
 
         for nu in nus:
             self.add_input_file(
@@ -67,13 +67,18 @@ class Analysis(Step):
         nus = self.nus
         section = self.config['baroclinic_channel_rpe']
 
-        ds_mesh = xr.open_dataset(mesh_filename)
-        ds_init = xr.open_dataset(init_filename)
-        ds_outputs = [xr.open_dataset(i) for i in self.inputs[2:]]
+        ds_mesh = self.open_model_dataset(mesh_filename, self.config)
+        ds_init = self.open_model_dataset(init_filename, self.config)
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
+        ds_outputs = [
+            self.open_model_dataset(f'output_nu_{nu:g}.nc', self.config)
+            for nu in nus
+        ]
         rpe = compute_rpe(
             ds_mesh,
             ds_init,
             ds_outputs,
+            ds_vert_coord=ds_vert_coord,
         )
 
         plt.switch_backend('Agg')
@@ -82,8 +87,10 @@ class Analysis(Step):
         min_temp = section.getfloat('min_temp')
         max_temp = section.getfloat('max_temp')
 
-        ds = xr.open_dataset(f'output_nu_{nus[0]:g}.nc', decode_times=False)
-        times = ds.daysSinceStartOfSim.values
+        ds = self.open_model_dataset(
+            f'output_nu_{nus[0]:g}.nc', self.config, decode_times=True
+        )
+        times = get_days_since_start(ds)
 
         use_mplstyle()
         fig = plt.figure()
@@ -102,12 +109,14 @@ class Analysis(Step):
 
         for row_index, nu in enumerate(nus):
             ax = axes[row_index]
-            ds = xr.open_dataset(f'output_nu_{nu:g}.nc', decode_times=False)
+            ds = self.open_model_dataset(
+                f'output_nu_{nu:g}.nc', self.config, decode_times=True
+            )
             ds = ds.isel(nVertLevels=0)
-            times = ds.daysSinceStartOfSim.values
+            times = get_days_since_start(ds)
             time_index = np.argmin(np.abs(times - time))
 
-            cell_mask = ds_init.maxLevelCell >= 1
+            cell_mask = ds_vert_coord.maxLevelCell >= 1
             plot_horiz_field(
                 ds_mesh,
                 ds['temperature'],

--- a/polaris/tasks/ocean/baroclinic_channel/viz.py
+++ b/polaris/tasks/ocean/baroclinic_channel/viz.py
@@ -72,14 +72,10 @@ class Viz(OceanIOStep):
         self.add_input_file(
             filename='mesh.nc', work_dir_target=f'{mesh.path}/culled_mesh.nc'
         )
-        self.add_input_file(
-            filename='init.nc', work_dir_target=f'{init.path}/init.nc'
+        self.add_init_input_file(work_dir_target=f'{init.path}/init.nc')
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc'
         )
-        if self.component.model == 'omega':
-            self.add_input_file(
-                filename='vert_coord.nc',
-                work_dir_target=f'{init.path}/vert_coord.nc',
-            )
         self.add_input_file(
             filename='output.nc', work_dir_target=f'{forward.path}/output.nc'
         )
@@ -91,10 +87,7 @@ class Viz(OceanIOStep):
         config = self.config
         ds_mesh = self.open_model_dataset('mesh.nc', config=config)
         ds_init = self.open_model_dataset('init.nc', config=config)
-        if self.component.model == 'omega':
-            ds_vert = self.open_model_dataset('vert_coord.nc', config=config)
-        else:
-            ds_vert = ds_init
+        ds_vert = self.open_vert_coord_dataset(ds_init)
         ds = self.open_model_dataset('output.nc', config=config)
 
         t_index = ds.sizes['Time'] - 1

--- a/polaris/tasks/ocean/barotropic_channel/viz.py
+++ b/polaris/tasks/ocean/barotropic_channel/viz.py
@@ -29,6 +29,7 @@ class Viz(OceanIOStep):
             filename='mesh.nc', target='../init/culled_mesh.nc'
         )
         self.add_input_file(filename='init.nc', target='../init/init.nc')
+        self.add_vert_coord_input_file(target='../init/vert_coord.nc')
         self.add_input_file(
             filename='output.nc', target='../forward/output.nc'
         )
@@ -39,10 +40,11 @@ class Viz(OceanIOStep):
         """
         ds_mesh = self.open_model_dataset('mesh.nc', self.config)
         ds_init = self.open_model_dataset('init.nc', self.config)
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
         ds_out = self.open_model_dataset('output.nc', self.config)
 
-        cell_mask = ds_init.maxLevelCell >= 1
-        vertex_mask = ds_init.boundaryVertex == 0
+        cell_mask = ds_vert_coord.maxLevelCell >= 1
+        vertex_mask = ds_mesh.boundaryVertex == 0
 
         # Uncomment these lines to get 10 evenly spaced time slices
         # nt = ds_out.sizes['Time']

--- a/polaris/tasks/ocean/geostrophic/analysis.py
+++ b/polaris/tasks/ocean/geostrophic/analysis.py
@@ -1,5 +1,3 @@
-import xarray as xr
-
 from polaris.ocean.convergence.analysis import ConvergenceAnalysis
 from polaris.tasks.ocean.geostrophic.exact_solution import (
     compute_exact_solution,
@@ -131,8 +129,14 @@ class Analysis(ConvergenceAnalysis):
                 zidx=zidx,
             )
         else:
-            ds_init = xr.open_dataset(f'init_r{refinement_factor:02g}.nc')
-            bottom_depth = ds_init.bottomDepth
+            ds_init = self.open_model_dataset(
+                f'init_r{refinement_factor:02g}.nc', self.config
+            )
+            ds_vert_coord = self.open_vert_coord_dataset(
+                ds_init,
+                vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
+            )
+            bottom_depth = ds_vert_coord.bottomDepth
             ssh = super().get_output_field(
                 refinement_factor=refinement_factor,
                 field_name='ssh',

--- a/polaris/tasks/ocean/geostrophic/viz.py
+++ b/polaris/tasks/ocean/geostrophic/viz.py
@@ -1,11 +1,10 @@
 import cmocean  # noqa: F401
-import xarray as xr
 
-from polaris import Step
+from polaris.ocean.model import OceanIOStep
 from polaris.viz import plot_global_mpas_field
 
 
-class Viz(Step):
+class Viz(OceanIOStep):
     """
     A step for plotting fields from the cosine bell output
 
@@ -53,6 +52,9 @@ class Viz(Step):
             filename='initial_state.nc',
             work_dir_target=f'{init.path}/init.nc',
         )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc',
+        )
         self.add_input_file(
             filename='output.nc', work_dir_target=f'{forward.path}/output.nc'
         )
@@ -74,8 +76,9 @@ class Viz(Step):
             v='geostrophic_viz_vel',
         )
 
-        ds_init = xr.open_dataset('initial_state.nc')
-        bottom_depth = ds_init.bottomDepth
+        ds_init = self.open_model_dataset('initial_state.nc', config)
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
+        bottom_depth = ds_vert_coord.bottomDepth
         ds_init = self._process_ds(ds_init, bottom_depth, time_index=0)
         ds_init.to_netcdf('remapped_init.nc')
 
@@ -91,7 +94,7 @@ class Viz(Step):
                 plot_land=False,
             )
 
-        ds_out = xr.open_dataset('output.nc')
+        ds_out = self.open_model_dataset('output.nc', config)
         ds_out = self._process_ds(ds_out, bottom_depth, time_index=-1)
         ds_out.to_netcdf('remapped_final.nc')
 

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -68,7 +68,6 @@ class Analysis(OceanIOStep):
             work_dir_target=f'{reference.path}/reference_solution.nc',
         )
 
-        model = self.config.get('ocean', 'model')
         init_steps = self.dependencies_dict['init']
         forward_steps = self.dependencies_dict['forward']
         for resolution in horiz_resolutions:
@@ -86,11 +85,10 @@ class Analysis(OceanIOStep):
                 filename=f'culled_mesh_r{resolution:02g}.nc',
                 work_dir_target=f'{init.path}/culled_mesh.nc',
             )
-            if model == 'omega':
-                self.add_input_file(
-                    filename=f'vert_coord_r{resolution:02g}.nc',
-                    work_dir_target=f'{init.path}/vert_coord.nc',
-                )
+            self.add_vert_coord_input_file(
+                filename=f'vert_coord_r{resolution:02g}.nc',
+                work_dir_target=f'{init.path}/vert_coord.nc',
+            )
 
     def run(self):
         """
@@ -155,7 +153,6 @@ class Analysis(OceanIOStep):
         ref_hpga = ds_ref.HPGAInter.isel(Time=0).values
         ref_valid_grad_mask = ds_ref.ValidGradInterMask.isel(Time=0).values
 
-        model = self.config.get('ocean', 'model')
         ref_errors = []
         py_errors = []
 
@@ -187,17 +184,13 @@ class Analysis(OceanIOStep):
             # maxLevelCell is one-based (Fortran indexing), convert to
             # zero-based and use the shallowest valid bottom among the two
             # cells that bound the internal edge.
-            if model == 'omega':
-                ds_vc = self.open_model_dataset(
-                    f'vert_coord_r{resolution:02g}.nc', self.config
-                )
-                max_level_cells = ds_vc.maxLevelCell.isel(
-                    nCells=[cell0, cell1]
-                ).values.astype(int)
-            else:
-                max_level_cells = ds_init.maxLevelCell.isel(
-                    nCells=[cell0, cell1]
-                ).values.astype(int)
+            ds_vc = self.open_vert_coord_dataset(
+                ds_init,
+                vert_coord_filename=f'vert_coord_r{resolution:02g}.nc',
+            )
+            max_level_cells = ds_vc.maxLevelCell.isel(
+                nCells=[cell0, cell1]
+            ).values.astype(int)
             max_level_index = int(np.min(max_level_cells) - 1)
             if max_level_index < 0:
                 raise ValueError(

--- a/polaris/tasks/ocean/ice_shelf_2d/viz.py
+++ b/polaris/tasks/ocean/ice_shelf_2d/viz.py
@@ -5,12 +5,12 @@ import pandas as pd
 import xarray as xr
 from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 
-from polaris import Step
 from polaris.mpas import cell_mask_to_edge_mask
+from polaris.ocean.model import OceanIOStep
 from polaris.viz import plot_horiz_field
 
 
-class Viz(Step):
+class Viz(OceanIOStep):
     """
     A step for visualizing a cross-section and horizontal planes through the
     ice shelf
@@ -42,6 +42,9 @@ class Viz(Step):
         self.add_input_file(
             filename='init.nc', work_dir_target=f'{init.path}/init.nc'
         )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc'
+        )
         self.add_input_file(
             filename='adjusted_init.nc', target='../forward/init.nc'
         )
@@ -57,11 +60,12 @@ class Viz(Step):
         """
         Run this step of the test case
         """
-        ds_mesh = xr.load_dataset('mesh.nc')
-        ds_init = xr.load_dataset('init.nc')
-        ds_adj_init = xr.load_dataset('adjusted_init.nc')
-        ds = xr.load_dataset('output.nc')
-        ds_ice = xr.load_dataset('land_ice_fluxes.nc')
+        ds_mesh = self.open_model_dataset('mesh.nc', self.config)
+        ds_init = self.open_model_dataset('init.nc', self.config)
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
+        ds_adj_init = self.open_model_dataset('adjusted_init.nc', self.config)
+        ds = self.open_model_dataset('output.nc', self.config)
+        ds_ice = self.open_model_dataset('land_ice_fluxes.nc', self.config)
 
         x_mid = ds_mesh.xCell.median()
         y_min = ds_mesh.yCell.min()
@@ -84,7 +88,11 @@ class Viz(Step):
         plt.close()
 
         ds_horiz = self._process_ds(
-            ds_init, ds_ice, ds_adj_init, ds_init.bottomDepth, time_index=0
+            ds_init,
+            ds_ice,
+            ds_adj_init,
+            ds_vert_coord.bottomDepth,
+            time_index=0,
         )
         vmin_del_ssh = np.min(ds_horiz.delSsh.values)
         vmax_del_ssh = np.max(ds_horiz.delSsh.values)
@@ -103,9 +111,9 @@ class Viz(Step):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds_init.layerThickness.isel(Time=time_index),
-            bottom_depth=ds_init.bottomDepth,
-            min_level_cell=ds_init.minLevelCell - 1,
-            max_level_cell=ds_init.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 
@@ -132,8 +140,8 @@ class Viz(Step):
         )
 
         # Plot water column thickness horizontal ds_init
-        cell_mask = ds_init.maxLevelCell >= 1
-        edge_mask = cell_mask_to_edge_mask(ds_init, cell_mask)
+        cell_mask = ds_vert_coord.maxLevelCell >= 1
+        edge_mask = cell_mask_to_edge_mask(ds_mesh, cell_mask)
         plot_horiz_field(
             ds_mesh,
             ds_horiz['columnThickness'],
@@ -144,7 +152,11 @@ class Viz(Step):
 
         time_index = -1  # Plot the final state
         ds_horiz = self._process_ds(
-            ds, ds_ice, ds_init, ds_init.bottomDepth, time_index=time_index
+            ds,
+            ds_ice,
+            ds_init,
+            ds_vert_coord.bottomDepth,
+            time_index=time_index,
         )
         vmin_del_ssh = np.min(ds_horiz.delSsh.values)
         vmax_del_ssh = np.max(ds_horiz.delSsh.values)
@@ -205,9 +217,9 @@ class Viz(Step):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds.layerThickness.isel(Time=time_index),
-            bottom_depth=ds_init.bottomDepth,
-            min_level_cell=ds_init.minLevelCell - 1,
-            max_level_cell=ds_init.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 

--- a/polaris/tasks/ocean/inertial_gravity_wave/viz.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/viz.py
@@ -1,22 +1,20 @@
-import datetime
-
 import cmocean  # noqa: F401
 import matplotlib.pyplot as plt
 import numpy as np
-import xarray as xr
 
-from polaris import Step
+from polaris.mpas import time_since_start
 from polaris.ocean.convergence import (
     get_resolution_for_task,
     get_timestep_for_task,
 )
+from polaris.ocean.model import OceanIOStep
 from polaris.tasks.ocean.inertial_gravity_wave.exact_solution import (
     ExactSolution,
 )
 from polaris.viz import plot_horiz_field, use_mplstyle
 
 
-class Viz(Step):
+class Viz(OceanIOStep):
     """
     A step for visualizing the output from the inertial gravity wave
     test case
@@ -115,6 +113,10 @@ class Viz(Step):
                 filename=f'init_r{refinement_factor:02g}.nc',
                 work_dir_target=f'{init.path}/init.nc',
             )
+            self.add_vert_coord_input_file(
+                filename=f'vert_coord_r{refinement_factor:02g}.nc',
+                work_dir_target=f'{init.path}/vert_coord.nc',
+            )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',
                 work_dir_target=f'{forward.path}/output.nc',
@@ -137,6 +139,8 @@ class Viz(Step):
         section = config['inertial_gravity_wave']
         eta0 = section.getfloat('ssh_amplitude')
 
+        model = config.get('ocean', 'model')
+
         use_mplstyle()
         fig, axes = plt.subplots(nrows=nres, ncols=3, figsize=(12, 2 * nres))
         rmse = []
@@ -145,18 +149,27 @@ class Viz(Step):
             resolution = get_resolution_for_task(
                 config, refinement_factor, refinement=self.refinement
             )
-            ds_mesh = xr.open_dataset(f'mesh_r{refinement_factor:02g}.nc')
-            ds_init = xr.open_dataset(f'init_r{refinement_factor:02g}.nc')
-            ds = xr.open_dataset(f'output_r{refinement_factor:02g}.nc')
-            exact = ExactSolution(ds_init, config)
+            ds_mesh = self.open_model_dataset(
+                f'mesh_r{refinement_factor:02g}.nc', config
+            )
+            ds_init = self.open_model_dataset(
+                f'init_r{refinement_factor:02g}.nc', config
+            )
+            ds_vert_coord = self.open_vert_coord_dataset(
+                ds_init,
+                vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
+            )
+            ds = self.open_model_dataset(
+                f'output_r{refinement_factor:02g}.nc', config
+            )
+            exact = ExactSolution(ds_mesh, config)
 
-            t0 = datetime.datetime.strptime(
-                ds.xtime.values[0].decode(), '%Y-%m-%d_%H:%M:%S'
-            )
-            tf = datetime.datetime.strptime(
-                ds.xtime.values[-1].decode(), '%Y-%m-%d_%H:%M:%S'
-            )
-            t = (tf - t0).total_seconds()
+            if model == 'mpas-o':
+                dt = time_since_start(ds.xtime.values)
+                t = float(dt[-1])
+            else:
+                # time is seconds since the start of the simulation in Omega
+                t = float(ds.Time.values[-1])
             ssh_model = ds.ssh.values[-1, :]
             rmse.append(
                 np.sqrt(np.mean((ssh_model - exact.ssh(t).values) ** 2))
@@ -168,7 +181,7 @@ class Viz(Step):
             if error_range is None:
                 error_range = np.max(np.abs(ds.ssh_error.values))
 
-            cell_mask = ds_init.maxLevelCell >= 1
+            cell_mask = ds_vert_coord.maxLevelCell >= 1
             descriptor = plot_horiz_field(
                 ds_mesh,
                 ds['ssh'],

--- a/polaris/tasks/ocean/internal_wave/rpe/analysis.py
+++ b/polaris/tasks/ocean/internal_wave/rpe/analysis.py
@@ -4,12 +4,12 @@ import numpy as np
 import xarray as xr
 from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 
-from polaris import Step
+from polaris.ocean.model import OceanIOStep, get_days_since_start
 from polaris.ocean.rpe import compute_rpe
 from polaris.viz import use_mplstyle
 
 
-class Analysis(Step):
+class Analysis(OceanIOStep):
     """
     A step for plotting the results of a series of internal wave RPE runs
 
@@ -42,6 +42,7 @@ class Analysis(Step):
         )
 
         self.add_input_file(filename='init.nc', target='../../../init/init.nc')
+        self.add_vert_coord_input_file(target='../../../init/vert_coord.nc')
 
         for nu in nus:
             self.add_input_file(
@@ -63,13 +64,18 @@ class Analysis(Step):
         nus = self.nus
         section = self.config['internal_wave_rpe']
 
-        ds_mesh = xr.open_dataset(mesh_filename)
-        ds_init = xr.open_dataset(init_filename)
-        ds_outputs = [xr.open_dataset(i) for i in self.inputs[2:]]
+        ds_mesh = self.open_model_dataset(mesh_filename, self.config)
+        ds_init = self.open_model_dataset(init_filename, self.config)
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
+        ds_outputs = [
+            self.open_model_dataset(f'output_nu_{nu:g}.nc', self.config)
+            for nu in nus
+        ]
         rpe = compute_rpe(
             ds_mesh,
             ds_init,
             ds_outputs,
+            ds_vert_coord=ds_vert_coord,
         )
 
         plt.switch_backend('Agg')
@@ -78,8 +84,10 @@ class Analysis(Step):
         min_temp = section.getfloat('min_temp')
         max_temp = section.getfloat('max_temp')
 
-        ds = xr.open_dataset(f'output_nu_{nus[0]:g}.nc', decode_times=False)
-        times = ds.daysSinceStartOfSim.values
+        ds = self.open_model_dataset(
+            f'output_nu_{nus[0]:g}.nc', self.config, decode_times=True
+        )
+        times = get_days_since_start(ds)
 
         use_mplstyle()
         fig = plt.figure()
@@ -107,17 +115,19 @@ class Analysis(Step):
         y = xr.DataArray(data=[y_min, y_max], dims=('nPoints',))
         for row_index, nu in enumerate(nus):
             ax = axes[row_index]
-            ds = xr.open_dataset(f'output_nu_{nu:g}.nc', decode_times=False)
-            times = ds.daysSinceStartOfSim.values
+            ds = self.open_model_dataset(
+                f'output_nu_{nu:g}.nc', self.config, decode_times=True
+            )
+            times = get_days_since_start(ds)
             time_index = np.argmin(np.abs(times - time))
             ds_transect = compute_transect(
                 x=x,
                 y=y,
                 ds_horiz_mesh=ds_mesh,
                 layer_thickness=ds.layerThickness.isel(Time=time_index),
-                bottom_depth=ds_init.bottomDepth,
-                min_level_cell=ds_init.minLevelCell - 1,
-                max_level_cell=ds_init.maxLevelCell - 1,
+                bottom_depth=ds_vert_coord.bottomDepth,
+                min_level_cell=ds_vert_coord.minLevelCell - 1,
+                max_level_cell=ds_vert_coord.maxLevelCell - 1,
                 spherical=False,
             )
 

--- a/polaris/tasks/ocean/internal_wave/viz.py
+++ b/polaris/tasks/ocean/internal_wave/viz.py
@@ -3,10 +3,10 @@ import numpy as np
 import xarray as xr
 from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 
-from polaris import Step
+from polaris.ocean.model import OceanIOStep
 
 
-class Viz(Step):
+class Viz(OceanIOStep):
     """
     A step for visualizing a cross-section through the internal wave
     """
@@ -25,6 +25,7 @@ class Viz(Step):
             filename='mesh.nc', target='../../../init/culled_mesh.nc'
         )
         self.add_input_file(filename='init.nc', target='../../../init/init.nc')
+        self.add_vert_coord_input_file(target='../../../init/vert_coord.nc')
         self.add_input_file(
             filename='output.nc', target='../forward/output.nc'
         )
@@ -33,9 +34,10 @@ class Viz(Step):
         """
         Run this step of the test case
         """
-        ds_mesh = xr.load_dataset('init.nc')
-        ds_init = ds_mesh
-        ds = xr.load_dataset('output.nc')
+        ds_mesh = self.open_model_dataset('mesh.nc', self.config)
+        ds_init = self.open_model_dataset('init.nc', self.config)
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
+        ds = self.open_model_dataset('output.nc', self.config)
 
         x_mid = ds_mesh.xCell.median()
         y_min = ds_mesh.yCell.min()
@@ -53,9 +55,9 @@ class Viz(Step):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds_init.layerThickness.isel(Time=tidx),
-            bottom_depth=ds_mesh.bottomDepth,
-            min_level_cell=ds_mesh.minLevelCell - 1,
-            max_level_cell=ds_mesh.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 
@@ -77,9 +79,9 @@ class Viz(Step):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds.layerThickness.isel(Time=tidx),
-            bottom_depth=ds_mesh.bottomDepth,
-            min_level_cell=ds_mesh.minLevelCell - 1,
-            max_level_cell=ds_mesh.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 

--- a/polaris/tasks/ocean/manufactured_solution/viz.py
+++ b/polaris/tasks/ocean/manufactured_solution/viz.py
@@ -114,6 +114,10 @@ class Viz(OceanIOStep):
                 filename=f'init_r{refinement_factor:02g}.nc',
                 work_dir_target=f'{init.path}/init.nc',
             )
+            self.add_vert_coord_input_file(
+                filename=f'vert_coord_r{refinement_factor:02g}.nc',
+                work_dir_target=f'{init.path}/vert_coord.nc',
+            )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',
                 work_dir_target=f'{forward.path}/output.nc',
@@ -154,13 +158,17 @@ class Viz(OceanIOStep):
             ds_init = self.open_model_dataset(
                 f'init_r{refinement_factor:02g}.nc', config
             )
+            ds_vert_coord = self.open_vert_coord_dataset(
+                ds_init,
+                vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
+            )
             ds = self.open_model_dataset(
                 f'output_r{refinement_factor:02g}.nc',
                 config,
                 decode_times=False,
             )
 
-            exact = ExactSolution(config, ds_init)
+            exact = ExactSolution(config, ds_mesh)
 
             if model == 'mpas-o':
                 dt = time_since_start(ds.xtime.values)
@@ -181,14 +189,12 @@ class Viz(OceanIOStep):
             if error_range is None:
                 error_range = np.max(np.abs(ds.ssh_error.values))
 
-            cell_mask = ds_init.maxLevelCell >= 1
+            cell_mask = ds_vert_coord.maxLevelCell >= 1
             descriptor = plot_horiz_field(
-                ds,
                 ds_mesh,
-                'ssh',
+                ssh_model,
                 ax=axes[i, 0],
                 cmap='cmo.balance',
-                t_index=ds.sizes['Time'] - 1,
                 vmin=-eta0,
                 vmax=eta0,
                 cmap_title='SSH',

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -63,6 +63,9 @@ class Viz(OceanIOStep):
             filename='init.nc',
             work_dir_target=f'{init.path}/init.nc',
         )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc',
+        )
         self.add_input_file(
             filename='output.nc',
             work_dir_target=f'{forward.path}/output.nc',
@@ -95,6 +98,7 @@ class Viz(OceanIOStep):
 
         ds_mesh = self.open_model_dataset('mesh.nc', config)
         ds_init = self.open_model_dataset('init.nc', config)
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
         ds = self.open_model_dataset('output.nc', config, decode_times=False)
 
         x_min = ds_mesh.xVertex.min().values
@@ -116,9 +120,9 @@ class Viz(OceanIOStep):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds_init.layerThickness.isel(Time=0),
-            bottom_depth=ds_init.bottomDepth,
-            min_level_cell=ds_init.minLevelCell - 1,
-            max_level_cell=ds_init.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 

--- a/polaris/tasks/ocean/merry_go_round/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/viz.py
@@ -113,6 +113,10 @@ class Viz(OceanIOStep):
                 filename=f'init_r{refinement_factor:02g}.nc',
                 work_dir_target=f'{init.path}/init.nc',
             )
+            self.add_vert_coord_input_file(
+                filename=f'vert_coord_r{refinement_factor:02g}.nc',
+                work_dir_target=f'{init.path}/vert_coord.nc',
+            )
             self.add_input_file(
                 filename=f'output_r{refinement_factor:02g}.nc',
                 work_dir_target=f'{forward.path}/output.nc',
@@ -166,6 +170,10 @@ class Viz(OceanIOStep):
             ds_init = self.open_model_dataset(
                 f'init_r{refinement_factor:02g}.nc', config
             )
+            ds_vert_coord = self.open_vert_coord_dataset(
+                ds_init,
+                vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
+            )
             ds = self.open_model_dataset(
                 f'output_r{refinement_factor:02g}.nc',
                 config,
@@ -195,9 +203,9 @@ class Viz(OceanIOStep):
                 y=y,
                 ds_horiz_mesh=ds_mesh,
                 layer_thickness=ds_init.layerThickness.isel(Time=0),
-                bottom_depth=ds_init.bottomDepth,
-                min_level_cell=ds_init.minLevelCell - 1,
-                max_level_cell=ds_init.maxLevelCell - 1,
+                bottom_depth=ds_vert_coord.bottomDepth,
+                min_level_cell=ds_vert_coord.minLevelCell - 1,
+                max_level_cell=ds_vert_coord.maxLevelCell - 1,
                 spherical=False,
             )
 

--- a/polaris/tasks/ocean/overflow/rpe/analysis.py
+++ b/polaris/tasks/ocean/overflow/rpe/analysis.py
@@ -47,6 +47,9 @@ class Analysis(OceanIOStep):
         self.add_input_file(
             filename='init.nc', work_dir_target=f'{init.path}/init.nc'
         )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc'
+        )
 
         # for nu in nus:
         #    self.add_input_file(
@@ -70,6 +73,7 @@ class Analysis(OceanIOStep):
 
         ds_mesh = self.open_model_dataset(mesh_filename, config=self.config)
         ds_init = self.open_model_dataset(init_filename, config=self.config)
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
 
         rpe = compute_rpe(
             ds_mesh,
@@ -83,6 +87,7 @@ class Analysis(OceanIOStep):
                 for nu in nus
             ],
             config=self.config,
+            ds_vert_coord=ds_vert_coord,
         )
 
         plt.switch_backend('Agg')
@@ -134,9 +139,9 @@ class Analysis(OceanIOStep):
                 y=y,
                 ds_horiz_mesh=ds_mesh,
                 layer_thickness=ds.layerThickness.isel(Time=time_index),
-                bottom_depth=ds_init.bottomDepth,
-                min_level_cell=ds_init.minLevelCell - 1,
-                max_level_cell=ds_init.maxLevelCell - 1,
+                bottom_depth=ds_vert_coord.bottomDepth,
+                min_level_cell=ds_vert_coord.minLevelCell - 1,
+                max_level_cell=ds_vert_coord.maxLevelCell - 1,
                 spherical=False,
             )
 

--- a/polaris/tasks/ocean/overflow/viz.py
+++ b/polaris/tasks/ocean/overflow/viz.py
@@ -73,11 +73,9 @@ class Viz(OceanIOStep):
             filename='mesh.nc',
             work_dir_target=f'{mesh.path}/culled_mesh.nc',
         )
-        if self.component.model == 'omega':
-            self.add_input_file(
-                filename='vert_coord.nc',
-                work_dir_target=f'{init.path}/vert_coord.nc',
-            )
+        self.add_vert_coord_input_file(
+            work_dir_target=f'{init.path}/vert_coord.nc',
+        )
         self.add_input_file(
             filename='init.nc',
             work_dir_target=f'{init.path}/init.nc',
@@ -94,13 +92,7 @@ class Viz(OceanIOStep):
         config = self.config
         ds_mesh = self.open_model_dataset('mesh.nc', config=config)
         ds_init = self.open_model_dataset('init.nc', config=config)
-        model = self.component.model
-        if model == 'omega':
-            ds_vert_coord = self.open_model_dataset(
-                'vert_coord.nc', config=config
-            )
-        else:
-            ds_vert_coord = ds_init
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
         ds = self.open_model_dataset('output.nc', config=config)
 
         x_min = ds_mesh.xVertex.min().values

--- a/polaris/tasks/ocean/seamount/viz.py
+++ b/polaris/tasks/ocean/seamount/viz.py
@@ -31,6 +31,7 @@ class Viz(OceanIOStep):
             filename='mesh.nc', target='../../init/culled_mesh.nc'
         )
         self.add_input_file(filename='init.nc', target='../../init/init.nc')
+        self.add_vert_coord_input_file(target='../../init/vert_coord.nc')
         self.add_input_file(
             filename='output.nc', target='../forward/output.nc'
         )
@@ -41,6 +42,7 @@ class Viz(OceanIOStep):
         """
         ds_mesh = self.open_model_dataset('mesh.nc', self.config)
         ds_init = self.open_model_dataset('init.nc', self.config)
+        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
         ds = self.open_model_dataset(
             'output.nc', self.config, decode_times=True
         )
@@ -58,9 +60,9 @@ class Viz(OceanIOStep):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds_init.layerThickness.isel(Time=t_index),
-            bottom_depth=ds_init.bottomDepth,
-            min_level_cell=ds_init.minLevelCell - 1,
-            max_level_cell=ds_init.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 
@@ -70,9 +72,9 @@ class Viz(OceanIOStep):
             y=y,
             ds_horiz_mesh=ds_mesh,
             layer_thickness=ds.layerThickness.isel(Time=t_index),
-            bottom_depth=ds_init.bottomDepth,
-            min_level_cell=ds_init.minLevelCell - 1,
-            max_level_cell=ds_init.maxLevelCell - 1,
+            bottom_depth=ds_vert_coord.bottomDepth,
+            min_level_cell=ds_vert_coord.minLevelCell - 1,
+            max_level_cell=ds_vert_coord.maxLevelCell - 1,
             spherical=False,
         )
 
@@ -95,8 +97,8 @@ class Viz(OceanIOStep):
         )
 
         field_name = 'normalVelocity'
-        cell_mask = ds_init.maxLevelCell >= 1
-        edge_mask = cell_mask_to_edge_mask(ds_init, cell_mask)
+        cell_mask = ds_vert_coord.maxLevelCell >= 1
+        edge_mask = cell_mask_to_edge_mask(ds_mesh, cell_mask)
         mpas_field = ds[field_name].isel(Time=t_index)
         max_velocity = np.max(np.abs(mpas_field.values))
         plot_horiz_field(

--- a/tests/ocean/test_mesh_init_split.py
+++ b/tests/ocean/test_mesh_init_split.py
@@ -15,12 +15,19 @@ def _make_config(
     horiz_mesh_filename='mesh.nc',
     vert_coord_filename='vert_coord.nc',
     init_filename='init.nc',
+    model='omega',
 ):
     config = ConfigParser()
-    config.add_section('ocean_model_files')
-    config.set('ocean_model_files', 'horiz_mesh_filename', horiz_mesh_filename)
-    config.set('ocean_model_files', 'vert_coord_filename', vert_coord_filename)
-    config.set('ocean_model_files', 'init_filename', init_filename)
+    config.add_section('ocean')
+    config.set('ocean', 'model', model)
+    config.add_section('ocean_staged_files')
+    config.set(
+        'ocean_staged_files', 'horiz_mesh_filename', horiz_mesh_filename
+    )
+    config.set(
+        'ocean_staged_files', 'vert_coord_filename', vert_coord_filename
+    )
+    config.set('ocean_staged_files', 'init_filename', init_filename)
     return config
 
 
@@ -268,7 +275,7 @@ def test_vert_coord_placeholder_skipped_for_mpas_ocean(monkeypatch):
         min_tasks=1,
     )
 
-    step.config = _make_config()
+    step.config = _make_config(model='mpas-ocean')
     step.add_vert_coord_input_file(work_dir_target='vc_target.nc')
 
     monkeypatch.setattr(


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
### Motivation

Omega stores vertical coordinate variables (`bottomDepth`, `minLevelCell`, `maxLevelCell`, `vertCoordMovementWeights`) in a separate `vert_coord.nc` file rather than in the initial condition file. Many viz and analysis steps were reading these variables directly from `ds_init`, which worked for MPAS-Ocean but produced errors with Omega. At the same time, `OceanModelStep` already had a clean mechanism for handling the three canonical ocean dataset files (`mesh.nc`, `vert_coord.nc`, `init.nc`) via a placeholder system and a dedicated config section (PR #544)— but `OceanIOStep` (the base class for viz/analysis steps) had no equivalent, forcing task developers to write their own `if model == 'omega':` guards. This PR fixes both problems by extracting the shared file-handling logic into a [mixin](https://en.wikipedia.org/wiki/Mixin), extending it to `OceanIOStep`, and updating all affected steps to read vert-coord variables from the correct dataset.

### Summary

- **Rename** `[ocean_model_files]` config section → `[ocean_staged_files]` and update its comment to reflect that these canonical filenames (`mesh.nc`, `vert_coord.nc`, `init.nc`) govern the entire pipeline — init outputs, model inputs, and viz/analysis inputs — not just model runs.
- **Create** `polaris/ocean/model/ocean_model_files_mixin.py`: a new mixin class (`OceanModelFilesMixin`) that provides the shared placeholder mechanism (`<<<horiz_mesh>>>`, `<<<vert_coord>>>`, `<<<init>>>`), `add_*_input_file()` methods (all safe to call from `__init__()` because the model check is deferred to `process_inputs_and_outputs()`), `get_*_filename()` getters, and `_resolve_model_file_placeholders()`.
- **Refactor** `OceanModelStep` to inherit from the mixin (removes ~70 lines of duplicated code).
- **Extend** `OceanIOStep` with the same mixin plus `process_inputs_and_outputs()` and `open_vert_coord_dataset()`. The new `open_vert_coord_dataset(ds_init, vert_coord_filename=None)` method returns the vertical coordinate variables from `ds_init` for MPAS-Ocean and opens the separate `vert_coord.nc` file for Omega (with variable-name mapping).
- **Update** `compute_rpe()` with a new optional `ds_vert_coord` parameter (defaults to `ds_init` for backward compatibility).
- **Update** `ConvergenceAnalysis.setup()` to register per-resolution `vert_coord_r{rf:02g}.nc` input files for Omega.
- **Fix 14 viz/analysis steps** that were reading `bottomDepth`, `minLevelCell`, `maxLevelCell` from `ds_init` (wrong for Omega — those variables live in `vert_coord.nc`). Steps are converted from bare `Step` to `OceanIOStep` as needed and now use `open_vert_coord_dataset()` for correct dataset selection per model.
- **Simplify** two already-fixed steps (`overflow/viz.py`, `horiz_press_grad/analysis.py`) to use the new mixin methods instead of manual `if model == 'omega':` guards.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #604 