### PR TITLE
Explicitly add Omega debug tracers to tasks that need them

### DIFF
--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -76,6 +76,8 @@ Omega:
     TracerHorzAdvTendencyEnable : true
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
+  Tracers:
+    Debug: [Debug1]
   IOStreams:
     InitialState:
       Contents:

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -84,6 +84,8 @@ Omega:
     ThicknessVertAdvTendencyEnable: false
     VelocityVertAdvTendencyEnable: false
     TracerVertAdvTendencyEnable: true
+  Tracers:
+    Debug: [Debug1, Debug2, Debug3]
   IOStreams:
     InitialVertCoord:
       UsePointerFile: false

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -75,6 +75,8 @@ Omega:
     TracerHorzAdvTendencyEnable : true
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
+  Tracers:
+    Debug: [Debug1, Debug2, Debug3]
   IOStreams:
     InitialState:
       Contents:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
Some tests currently rely on the default setting in Omega:
```
  Tracers:
    Debug: [Debug1, Debug2, Debug3]
```
But we want to drop that default, see https://github.com/E3SM-Project/Omega/issues/406.  Tests that need debug tracers declare them in this PR.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
