### PR TITLE
Update to v1.0.0-alpha.9 and mache v3.7.1

### DIFF
--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "polaris",
-    "mache_version": "3.7.0",
+    "mache_version": "3.7.1",
     "description": "Deploy polaris environment"
   },
   "arguments": [

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -3,7 +3,7 @@
 bootstrap_python = 3.14
 python = 3.14
 geometric_features = 1.6.3
-mache = 3.7.0
+mache = 3.7.1
 mpas_tools = 1.6.0
 otps = 2021.10
 parallelio = 2.6.9

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.0-alpha.8'
+__version__ = '1.0.0-alpha.9'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This mache version brings in https://github.com/E3SM-Project/mache/pull/437, which fixes version detection and the location of pixi cache files.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
