### PR TITLE
Add `surfacePressure` to Omega initial conditions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,8 +86,7 @@ intersphinx_mapping = {
     'mosaic': ('https://docs.e3sm.org/mosaic', None),
     'numpy': ('https://numpy.org/doc/stable', None),
     'python': ('https://docs.python.org', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
-    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
+"sphinx": ("https://www.sphinx-doc.org/en/master", None),
     'xarray': ('https://xarray.pydata.org/en/stable', None),
     'tranche': ('https://xylar.github.io/tranche/', None),
 }

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -676,8 +676,8 @@ For workflows that need pseudo-height/pressure conversion, the
   between pseudo-height and pressure.
 - {py:func}`polaris.ocean.vertical.ztilde.pressure_from_geom_thickness()` and
   {py:func}`polaris.ocean.vertical.ztilde.pressure_and_spec_vol_from_state_at_geom_height()`
-  compute hydrostatic pressure (and specific volume) from geometric layer
-  thickness and state variables.
+  compute hydrostatic gauge pressure (and specific volume) from geometric
+  layer thickness and state variables.
 - {py:func}`polaris.ocean.vertical.ztilde.geom_height_from_pseudo_height()`
   reconstructs geometric layer-interface and midpoint heights from
   pseudo-thickness and specific volume.

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -34,8 +34,14 @@ reconstruction coefficient files. In addition,
 is not present in the dataset. This provides a way of using the same initial
 conditions for MPAS-Ocean and Omega when the geometric thickness is the state
 variable for MPAS-Ocean and the pseudo-thickness is the state variable for
-Omega. As new variables are added to Omega, they
-should be added to the `variables` section in the
+Omega. Similarly,
+{py:meth}`polaris.ocean.model.OceanIOStep.write_initial_state_dataset()`
+ensures that `surfacePressure` is present in initial conditions written for
+Omega, adding it initialized to zero if it is not already set.  This allows
+tasks to share the same initial-state dataset between MPAS-Ocean and Omega
+without needing to explicitly include a `surfacePressure` field. As new
+variables are added to Omega, they should be added to the `variables` section
+in the
 [mpaso_to_omega.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/mpaso_to_omega.yaml)
 file.
 

--- a/docs/developers_guide/ocean/tasks/manufactured_solution.md
+++ b/docs/developers_guide/ocean/tasks/manufactured_solution.md
@@ -17,7 +17,9 @@ The config options for the `manufactured_solution` test are described in
 Additionally, the test uses a `forward.yaml` file with
 a few common model config options related to run duration and default
 horizontal  and vertical momentum and tracer diffusion, as well as defining
-`mesh`, `input`, `restart`, and `output` streams.
+`mesh`, `input`, `restart`, and `output` streams for MPAS-Ocean.  For Omega,
+the file defines an `InitialState` stream (reading `NormalVelocity`,
+`PseudoThickness`, and `SurfacePressure`) and a `History` stream.
 
 ### exact_solution
 

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -89,7 +89,9 @@ $$
 p = -\rho_0 g \tilde z,
 $$
 
-and converts to geometric height `z` by integrating the hydrostatic relation
+where $p$ is gauge pressure (pressure relative to the atmosphere, zero at the
+free surface $\tilde z = 0$).  The reference converts to geometric height `z`
+by integrating the hydrostatic relation
 
 $$
 \frac{\partial z}{\partial \tilde z} = \rho_0\,\nu\left(S_A, \Theta, p\right),

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -73,6 +73,7 @@ variables:
   normalVelocity: NormalVelocity
   # Note: vertVelocityTop in MPAS-Ocean has no Omega equivalent and
   #       VerticalPseudoVelocity in Omega has no MPAS-Ocean equivalent
+  surfacePressure: SurfacePressure
 
   # auxiliary state
   ssh: SshCell

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -3,7 +3,8 @@ Conversions between Omega pseudo-height and pressure.
 
 Omega's vertical coordinate is pseudo-height
     z_tilde = -p / (RhoSw * g)
-with z_tilde positive upward. Here, ``p`` is sea pressure in Pascals (Pa),
+with z_tilde positive upward. Here, ``p`` is sea gauge pressure (pressure
+relative to the atmosphere, zero at the free surface) in Pascals (Pa),
 ``RhoSw`` is a reference density (kg m^-3), and ``g`` is gravitational
 acceleration as defined by ``polaris.constants`` via the Physical Constants
 Dictionary.
@@ -36,14 +37,14 @@ def pseudothickness_from_pressure(
     p: xr.DataArray,
 ) -> xr.DataArray:
     """
-    Convert sea pressure to pseudo-thickness.
+    Convert sea gauge pressure to pseudo-thickness.
 
     z_tilde = -p / (RhoSw * g)
 
     Parameters
     ----------
     p : xarray.DataArray
-        Sea pressure in Pascals (Pa) at layer interfaces.
+        Sea gauge pressure in Pascals (Pa) at layer interfaces.
 
     Returns
     -------
@@ -71,14 +72,14 @@ def pseudothickness_from_pressure(
 
 def z_tilde_from_pressure(p: xr.DataArray) -> xr.DataArray:
     """
-    Convert sea pressure to pseudo-height.
+    Convert sea gauge pressure to pseudo-height.
 
     z_tilde = -p / (RhoSw * g)
 
     Parameters
     ----------
     p : xarray.DataArray
-        Sea pressure in Pascals (Pa).
+        Sea gauge pressure in Pascals (Pa).
 
     Returns
     -------
@@ -98,9 +99,12 @@ def z_tilde_from_pressure(p: xr.DataArray) -> xr.DataArray:
 
 def pressure_from_z_tilde(z_tilde: xr.DataArray) -> xr.DataArray:
     """
-    Convert pseudo-height to sea pressure.
+    Convert pseudo-height to sea gauge pressure.
 
     p = -z_tilde * (RhoSw * g)
+
+    Pressure here is gauge pressure (relative to the atmosphere), which is
+    zero at the free surface (z_tilde = 0) and positive downward.
 
     Parameters
     ----------
@@ -110,13 +114,14 @@ def pressure_from_z_tilde(z_tilde: xr.DataArray) -> xr.DataArray:
     Returns
     -------
     xarray.DataArray
-        Sea pressure with the same shape and coords as ``z_tilde`` (Pa).
+        Sea gauge pressure with the same shape and coords as ``z_tilde``
+        (Pa).
     """
 
     p = -(z_tilde) * (RhoSw * Gravity)
     return p.assign_attrs(
         {
-            'long_name': 'sea pressure',
+            'long_name': 'sea gauge pressure',
             'units': 'Pa',
             'note': 'p = -RhoSw * g * z_tilde',
         }
@@ -129,14 +134,15 @@ def pressure_from_geom_thickness(
     spec_vol: xr.DataArray,
 ) -> tuple[xr.DataArray, xr.DataArray]:
     """
-    Compute the pressure at layer interfaces and midpoints given surface
-    pressure, geometric layer thicknesses, and specific volume. This
+    Compute gauge pressure at layer interfaces and midpoints given surface
+    gauge pressure, geometric layer thicknesses, and specific volume. This
     calculation assumes a constant specific volume within each layer.
 
     Parameters
     ----------
     surf_pressure : xarray.DataArray
-        The surface pressure at the top of the water column.
+        The surface gauge pressure at the top of the water column (zero for
+        a free surface open to the atmosphere).
 
     geom_layer_thickness : xarray.DataArray
         The geometric thickness of each layer, set to zero for invalid layers.
@@ -147,10 +153,10 @@ def pressure_from_geom_thickness(
     Returns
     -------
     p_interface : xarray.DataArray
-        The pressure at layer interfaces.
+        The gauge pressure at layer interfaces.
 
     p_mid : xarray.DataArray
-        The pressure at layer midpoints.
+        The gauge pressure at layer midpoints.
     """
 
     dp = Gravity / spec_vol * geom_layer_thickness
@@ -186,12 +192,12 @@ def pressure_and_spec_vol_from_state_at_geom_height(
     logger: logging.Logger | None = None,
 ) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray]:
     """
-    Compute the pressure at layer interfaces and midpoints, as well as the
+    Compute gauge pressure at layer interfaces and midpoints, as well as the
     specific volume at midpoints given geometric layer thicknesses,
     temperature and salinity at layer midpoints (i.e. constant in geometric
-    height, not pseudo-height), and surface pressure. The solution is found
-    iteratively starting from a specific volume calculated from the reference
-    density.
+    height, not pseudo-height), and surface gauge pressure. The solution is
+    found iteratively starting from a specific volume calculated from the
+    reference density.
 
     Requires config options needed by
     {py:func}`polaris.ocean.eos.compute_specvol()`.
@@ -211,7 +217,8 @@ def pressure_and_spec_vol_from_state_at_geom_height(
         The salinity at layer midpoints.
 
     surf_pressure : xarray.DataArray
-        The surface pressure at the top of the water column.
+        The surface gauge pressure at the top of the water column (zero for
+        a free surface open to the atmosphere).
 
     iter_count : int
         The number of iterations to perform.
@@ -222,10 +229,10 @@ def pressure_and_spec_vol_from_state_at_geom_height(
     Returns
     -------
     p_interface : xarray.DataArray
-        The pressure at layer interfaces.
+        The gauge pressure at layer interfaces.
 
     p_mid : xarray.DataArray
-        The pressure at layer midpoints.
+        The gauge pressure at layer midpoints.
 
     spec_vol : xarray.DataArray
         The specific volume at layer midpoints.

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -2,6 +2,7 @@ import importlib.resources as imp_res
 import os
 from typing import Dict, Tuple, Union
 
+import numpy as np
 import xarray as xr
 from mpas_tools.io import write_netcdf
 from mpas_tools.vector.reconstruct import reconstruct_variable
@@ -362,6 +363,14 @@ class Ocean(Component):
         ds = self.remove_horiz_mesh_vars(ds)
         if self.model == 'omega':
             ds = self.remove_vert_coord_vars(ds)
+
+            # make sure surfacePressure is present for Omega
+            if 'surfacePressure' not in ds and 'SurfacePressure' not in ds:
+                ds['surfacePressure'] = xr.DataArray(
+                    data=np.zeros((1, ds.sizes['nCells']), dtype=float),
+                    dims=['Time', 'nCells'],
+                    attrs={'units': 'Pa', 'long_name': 'Surface Pressure'},
+                )
         self.write_model_dataset(ds, filename, config)
 
     def map_from_native_model_vars(self, ds):

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -314,7 +314,7 @@ class Init(OceanIOStep):
             data=np.zeros((1, ncells), dtype=float),
             dims=['Time', 'nCells'],
             attrs={
-                'long_name': 'surface pressure',
+                'long_name': 'sea surface gauge pressure',
                 'units': 'Pa',
             },
         )
@@ -327,7 +327,7 @@ class Init(OceanIOStep):
         ds.bottomDepth.attrs['units'] = 'm'
 
         ds['pressure'] = p_mid
-        ds.pressure.attrs['long_name'] = 'pressure at layer midpoints'
+        ds.pressure.attrs['long_name'] = 'gauge pressure at layer midpoints'
         ds.pressure.attrs['units'] = 'Pa'
 
         ds['Density'] = 1.0 / ds['SpecVol']
@@ -465,7 +465,8 @@ class Init(OceanIOStep):
             ds.salinity.isel(nCells=1) - ds.salinity.isel(nCells=0)
         ) / dx
 
-        # Pressure (positive downward), averaged to the edge between columns
+        # Gauge pressure (positive downward), averaged to the edge between
+        # columns
         p_edge_mid = 0.5 * (p_mid.isel(nCells=0) + p_mid.isel(nCells=1))
 
         hpga_mid = -dM_dx_mid + p_edge_mid * dalpha_dx_mid
@@ -498,7 +499,9 @@ class Init(OceanIOStep):
 
         ds['PEdgeMid'] = p_edge_mid
         ds.PEdgeMid.attrs = {
-            'long_name': 'Pressure at horizontal edge and layer midpoints',
+            'long_name': (
+                'Gauge pressure at horizontal edge and layer midpoints'
+            ),
             'units': 'Pa',
         }
 
@@ -559,11 +562,11 @@ class Init(OceanIOStep):
         ds = ds_mesh.copy()
 
         ds['BottomPressure'] = bottom_pressure
-        ds.BottomPressure.attrs['long_name'] = 'seafloor pressure'
+        ds.BottomPressure.attrs['long_name'] = 'seafloor gauge pressure'
         ds.BottomPressure.attrs['units'] = 'Pa'
-        # the surface pressure is always zero
+        # gauge pressure is zero at the free surface
         ds['SurfacePressure'] = xr.zeros_like(bottom_pressure)
-        ds.SurfacePressure.attrs['long_name'] = 'sea surface pressure'
+        ds.SurfacePressure.attrs['long_name'] = 'sea surface gauge pressure'
         ds.SurfacePressure.attrs['units'] = 'Pa'
         ds_list: list[xr.Dataset] = []
         for icell in range(ds.sizes['nCells']):

--- a/polaris/tasks/ocean/horiz_press_grad/reference.py
+++ b/polaris/tasks/ocean/horiz_press_grad/reference.py
@@ -33,8 +33,9 @@ class Reference(OceanIOStep):
 
     where :math:`\nu` is the specific volume (``spec_vol``) computed from the
     TEOS-10 equation of state, :math:`S_A` is Absolute Salinity,
-    :math:`\Theta` is Conservative Temperature, :math:`p` is sea pressure
-    (positive downward), and :math:`\rho_0` is a reference density used in the
+    :math:`\Theta` is Conservative Temperature, :math:`p` is sea gauge
+    pressure (relative to the atmosphere, positive downward, zero at the free
+    surface), and :math:`\rho_0` is a reference density used in the
     definition :math:`\tilde z = -p/(\rho_0 g)`. The conversion therefore
     requires an integral of the form:
 


### PR DESCRIPTION
Adds `surfacePressure` to Omega initial conditions but does not add it to yaml files. Thus, `surfacePressure` is not used by the model. This relies on https://github.com/E3SM-Project/Omega/pull/433. Adding `surfacePressure` to the yaml files for Omega-supported tests (that do not use `State`) will be done in a further PR.

This PR also adds `surfacePressure` --> `SurfacePressure` mapping from MPAS-Ocean --> Omega.

We need to add `SurfacePressure` explicitly to to manufactured solution initial state, since it does not use the `State` field group.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
