### PR TITLE
Rework the `horiz_press_grad` reference solution

### DIFF
--- a/docs/design_docs/horiz_press_grad_reference.md
+++ b/docs/design_docs/horiz_press_grad_reference.md
@@ -1,0 +1,693 @@
+# Reworked HPG Reference Solution
+
+Creation date: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+## Background: the horizontal pressure gradient and its reference solution
+
+Omega is a non-Boussinesq, hydrostatic ocean model whose prognostic vertical
+coordinate is **pseudo-height**, $\tilde{z} = -p / (\rho_0 g)$, where $p$ is sea
+gauge pressure, $\rho_0$ is a reference seawater density (`RhoSw`), and $g$ is
+gravitational acceleration. The `ocean/horiz_press_grad` task family in Polaris
+exists to verify the convergence of Omega's horizontal pressure-gradient (HPG)
+operator against a high-fidelity reference solution, as called for in the Omega
+[pressure gradient design document](https://github.com/E3SM-Project/Omega)
+(`PGrad.md`, "Test: Spatial convergence to exact solution").
+
+The continuous horizontal pressure-gradient force (HPGF) per unit mass that
+Omega's momentum tendency must reproduce is, from the
+[Omega V1 governing equations](https://github.com/E3SM-Project/Omega)
+(`OmegaV1GoverningEqns.md`),
+
+$$
+\mathbf{a}_\text{PGF} = -\left(\alpha\,\nabla p + \nabla \Phi\right),
+$$
+
+where $\alpha = 1/\rho$ is specific volume, $\Phi = g z$ is the geopotential
+(neglecting tidal and self-attraction-and-loading terms), and $\nabla$ is the
+**along-layer** horizontal gradient. Using the hydrostatic relation, Omega
+rewrites this through the Montgomery potential $M = \alpha p + g z$ as
+
+$$
+\mathbf{a}_\text{PGF} = -\nabla M + p\,\nabla \alpha,
+$$
+
+and discretizes it with a centered scheme in which $\alpha$ is held constant
+within each layer, the Montgomery gradient is evaluated at layer interfaces and
+averaged to the layer midpoint, and the along-layer gradient is a two-cell
+finite difference across the edge.
+
+### The two-column task and its comparisons
+
+Each `horiz_press_grad` task variant (`salinity_gradient`,
+`temperature_gradient`, `ztilde_gradient`) builds a two-column mesh at a set of
+paired horizontal and vertical resolutions. Per resolution:
+
+- An `Init` step (a `PStarInitStep`, see the
+  [p-star initialization design](pstar_init)) builds the p-star coordinate and
+  the initial conservative temperature (CT) and absolute salinity (SA) from
+  piecewise pseudo-height profiles, and computes a Polaris HPGA from a two-cell
+  finite difference of the Montgomery potential.
+- A `Forward` step runs Omega for a **single time step** and writes Omega's
+  `NormalVelocityTend`, which is just the HPGA.
+- An `Analysis` step performs two comparisons:
+  1. **`omega_vs_reference`** — Omega's HPGA against the high-fidelity reference
+     solution, fit to a power law to measure the convergence rate.
+  2. **`omega_vs_python`** — Omega's HPGA against the Polaris/Python HPGA from
+     `Init`, a code-correctness check that the two implementations of the
+     *same discrete scheme* agree to a tight tolerance.
+
+Because each forward run is a single step with no coordinate motion, the
+forward layer pseudo-heights and geometric heights are identical to those in
+`Init`; the `omega_vs_python` comparison therefore needs no special handling.
+
+### The current reference solution and why it must be reworked
+
+The current `Reference` step (`reference.py`) builds five columns at
+$x = \Delta x_\text{ref}\,[-1.5,-0.5,0,0.5,1.5]$, integrates the hydrostatic
+relation upward from each seafloor to obtain geometric height $z(\tilde z)$,
+forms $M$, and takes a **4th-order finite difference across columns** to obtain
+$\partial M/\partial x$ and $\partial \alpha/\partial x$ at the center column,
+giving HPGA $= -\partial M/\partial x + p\,\partial\alpha/\partial x$. It writes
+the result on a vertical grid deliberately refined (via a greatest-common-
+divisor construction) so that every test grid's layer midpoints land exactly on
+reference grid points. `Analysis` then samples the reference by **exact z̃
+matching** with no interpolation.
+
+This design has two structural weaknesses:
+
+1. **Grid-alignment fragility.** Exact-match sampling only works when the
+   reference and test pseudo-heights coincide. As soon as a nonzero
+   `SurfacePressure` is applied, the p-star coordinate stretches and squashes
+   the column in proportion to the pressure thickness, and partial bottom cells
+   produce interfaces that no longer align across vertical resolutions. The
+   reference must instead be queryable at *arbitrary* pseudo-height with no loss
+   of accuracy.
+2. **Breakdown near bathymetry.** The cross-column finite-difference stencil
+   requires every neighboring column to be valid at a given $\tilde z$. Near the
+   seafloor, collocation points in some columns fall below their own bathymetry
+   and the stencil cannot be formed, so those layers are masked out. The
+   accuracy is also only as good as the stencil and the matched grid, which is
+   insufficient for assessing the higher-than-second-order HPG operators planned
+   for Omega.
+
+## Summary
+
+This design replaces the multi-column, finite-difference reference solution
+with a **single-column, analytic** reference computed at the edge between the
+two columns ($x = 0$). The new capability:
+
+- Evaluates the exact continuous HPGF directly via a chain-rule / Leibniz
+  expansion of the along-pseudo-height gradient, using TEOS-10 specific-volume
+  derivatives. Because the continuous HPGF is coordinate-invariant, this single
+  central-column expression is exact in the horizontal — there is no
+  finite-difference truncation and no dependence on neighboring columns, so the
+  near-bathymetry breakdown disappears and the reference is fidelity-limited only
+  by a smooth one-dimensional quadrature.
+- Is a callable function of $\tilde z$, so it can be sampled at exactly the
+  pseudo-heights a test produces, eliminating the grid-alignment requirement.
+- Supports fully general horizontal variation of every prescribed input.
+- Is consumed directly by `Analysis` through a shared evaluator module; the
+  separate `Reference` step is removed.
+
+The accuracy assessment compares Omega's along-layer HPGA to the reference using
+a **layer-averaged** target: for each model layer, the reference is averaged over
+that layer's pseudo-height extent at the edge. This compares like with like (a
+layer mean against a layer mean) so that legitimate layer tilt and finite layer
+thickness are accounted for in the target rather than charged as discretization
+error.
+
+The primary challenges are (a) formulating the continuous reference correctly so
+that the along-layer computation is judged on its own merits, (b) differentiating
+the prescribed profiles with respect to the horizontal coordinate at fixed
+pseudo-height — including the case where the profile node pseudo-heights
+themselves tilt — and (c) integrating the resulting expression to high accuracy
+in the vertical. The design is **successful** if the reference can be evaluated
+at any pseudo-height without loss of accuracy, remains valid throughout the water
+column including immediately above the bathymetry, is accurate enough to serve a
+beyond-second-order HPG operator, supports general horizontal input variation,
+and reproduces (with re-tuned thresholds) the convergence behavior the existing
+regression tests check.
+
+## Requirements
+
+### Requirement: The reference HPGA can be evaluated at an arbitrary pseudo-height without loss of accuracy
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+The reference solution shall be evaluable at any pseudo-height within the water
+column produced by a test, to high accuracy, without requiring that the
+reference and test vertical grids coincide. This must hold when a nonzero
+sea-surface pressure stretches or squashes the p-star column and when partial
+bottom cells misalign layer interfaces across resolutions.
+
+### Requirement: The reference is valid throughout the water column, including immediately above the bathymetry
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+The reference shall remain valid and accurate for every pseudo-height from the
+free surface down to the seafloor of the column at the edge between the two test
+columns. It shall not break down or require masking in the layers nearest the
+bathymetry.
+
+### Requirement: The reference is accurate enough to assess HPG operators beyond second order
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+The reference shall be of sufficient fidelity that, when an HPG operator more
+accurate than the current second-order centered scheme is introduced in Omega,
+the reference error does not limit the measured convergence. In particular, the
+reference shall not introduce a fixed-order horizontal truncation error of its
+own.
+
+### Requirement: The reference supports general horizontal variation of the prescribed inputs
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+The reference shall correctly represent horizontal variation of every prescribed
+input that the task permits: the geometric sea-surface height, the geometric
+seafloor depth, the seafloor pseudo-height, and the temperature and salinity
+profile node values **and** node pseudo-heights. No input variation supported by
+the task configuration may be assumed to be horizontally uniform.
+
+### Requirement: The accuracy assessment evaluates the along-layer scheme on its own merits
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+The comparison between the model's along-layer HPGA and the reference shall
+measure only the genuine discretization error of the along-layer scheme. It
+shall not attribute legitimate, physically correct effects of tilted layers or
+of finite layer thickness to discretization error. The reference shall represent
+the exact continuous pressure-gradient force that the along-layer scheme
+converges to as both horizontal and vertical resolution are refined.
+
+### Requirement: The capability integrates with the existing two-column task without a separate precompute step
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+The reference shall be available to the `Analysis` step on demand at the
+pseudo-heights each test produces, without a separate precomputed reference
+artifact and without changing the structure of the `Init`/`Forward`/`Analysis`
+workflow or the two comparisons (`omega_vs_reference` and `omega_vs_python`).
+
+## Algorithm Design
+
+### Algorithm Design: The continuous, coordinate-invariant reference and the cancellation of layer-slant terms
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+The reference is the **exact continuous** pressure-gradient acceleration that
+Omega's discrete operator must converge to. The key fact that makes a
+single central-column evaluation correct is that this acceleration is
+**independent of the vertical coordinate** used to evaluate the horizontal
+gradients.
+
+Write the horizontal gradients along a general layer label $\sigma$ (constant
+along a model coordinate surface). Pseudo-height is, by definition, a rescaled
+pressure, $p = -\rho_0 g\,\tilde z$, so along constant $\tilde z$ the pressure is
+constant. Using the hydrostatic relation $\partial z/\partial \tilde z =
+\rho_0 \alpha$, the along-$\sigma$ gradients of pressure and geometric height are
+
+$$
+\nabla_\sigma p &= -\rho_0 g\,\left.\partial_x \tilde z\right|_\sigma, \\
+\nabla_\sigma z &= \left.\partial_x z\right|_{\tilde z}
+                  + \rho_0 \alpha\,\left.\partial_x \tilde z\right|_\sigma .
+$$
+
+Substituting into $\mathbf{a}_\text{PGF} = -(\alpha\,\nabla_\sigma p +
+g\,\nabla_\sigma z)$, the two terms proportional to the coordinate slope
+$\left.\partial_x\tilde z\right|_\sigma$ carry the **same** $\alpha$ at the same
+point and cancel exactly:
+
+$$
+\mathbf{a}_\text{PGF} = -g\,\left.\frac{\partial z}{\partial x}\right|_{\tilde z}.
+$$
+
+This is the standard statement that the pressure-gradient force does not depend
+on the coordinate used to compute it. Consequences for the design:
+
+- The reference is $-g\,\partial_x z|_{\tilde z}$, evaluated at the edge ($x=0$).
+  It can be computed entirely at constant $\tilde z$, which is the convenient
+  frame, **without approximation**, even when the model layers slant (as in
+  `ztilde_gradient`) or bend near the bathymetry (partial cells).
+- The cancellation holds only for the **total** acceleration. Omega's discrete
+  pieces $\nabla M$ and $p\,\nabla\alpha$ are individually coordinate-dependent
+  and large; the design never compares those pieces to the reference, only the
+  total. The residual between Omega's along-layer total and the continuous total
+  is therefore the genuine discretization error of the along-layer scheme —
+  including the classic slant-induced pressure-gradient error that the future
+  high-order operator is intended to reduce.
+
+### Algorithm Design: Single-column chain-rule / Leibniz expression for the reference
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+Geometric height as a function of pseudo-height in a single column is obtained by
+integrating the hydrostatic relation from the surface:
+
+$$
+z(\tilde z; x) = \eta(x) + \rho_0 \int_{\tilde z_s(x)}^{\tilde z}
+    \alpha\bigl(S_A(\tilde z', x),\,\Theta(\tilde z', x),\,p(\tilde z')\bigr)
+    \, d\tilde z' ,
+$$
+
+where $\eta(x)$ is the geometric sea-surface height, $\tilde z_s(x)$ is the
+surface pseudo-height ($\tilde z_s = -p_s/(\rho_0 g)$, zero only when the surface
+pressure $p_s$ is zero), and $p(\tilde z') = -\rho_0 g\,\tilde z'$ depends only on
+$\tilde z'$ (not on $x$). The integral runs downward, so for $\tilde z < \tilde
+z_s$ it is negative and $z < \eta$, as required. The reference is **anchored at
+the surface** rather than the seafloor because that is the boundary the model
+honours: `Init`/Omega build the p-star column from the prescribed sea-surface
+height and surface pressure, so the HPGA vanishes at the surface (for zero
+surface slope) and grows downward. Anchoring elsewhere — e.g. at the configured
+seafloor pseudo-height, which is a coordinate buffer below the deepest valid
+layer rather than a honoured geometric boundary — would reconstruct a different
+$z(\tilde z)$ and miss the model by a constant offset.
+
+Differentiating with respect to $x$ at fixed $\tilde z$, the lower integration
+limit depends on $x$, so the Leibniz rule contributes a boundary term:
+
+$$
+\left.\frac{\partial z}{\partial x}\right|_{\tilde z} =
+   \eta'(x)
+   - \rho_0\,\alpha(\tilde z_s)\,\tilde z_s'(x)
+   + \rho_0 \int_{\tilde z_s}^{\tilde z}
+        \left.\frac{\partial \alpha}{\partial x}\right|_{\tilde z'} d\tilde z' .
+$$
+
+Because $p$ is fixed along constant $\tilde z'$, the integrand involves only the
+horizontal variation of the thermohaline state through the TEOS-10 specific
+volume:
+
+$$
+\left.\frac{\partial \alpha}{\partial x}\right|_{\tilde z'} =
+   \alpha_{S_A}\,\left.\frac{\partial S_A}{\partial x}\right|_{\tilde z'}
+ + \alpha_{\Theta}\,\left.\frac{\partial \Theta}{\partial x}\right|_{\tilde z'},
+$$
+
+where $\alpha_{S_A} = \partial \alpha / \partial S_A$ and
+$\alpha_{\Theta} = \partial \alpha / \partial \Theta$ are the first derivatives of
+specific volume from the equation of state, evaluated at the central column's
+$(S_A, \Theta, p)$. The reference acceleration is then
+
+$$
+a(\tilde z) = -g\left.\frac{\partial z}{\partial x}\right|_{\tilde z} =
+   -g\left[\,\eta' - \rho_0\,\alpha(\tilde z_s)\,\tilde z_s'
+   + \rho_0 \int_{\tilde z_s}^{\tilde z}
+   \left(\alpha_{S_A}\,\partial_x S_A + \alpha_{\Theta}\,\partial_x \Theta\right)
+   d\tilde z'\right].
+$$
+
+Notable properties:
+
+- **No geometric-height integration is required for the HPGA.** Everything is
+  expressed through the prescribed profiles $S_A(\tilde z'), \Theta(\tilde z')$
+  and the analytic pressure $p(\tilde z') = -\rho_0 g\,\tilde z'$ at the central
+  column, plus the input slopes $\eta'$ and $\tilde z_s'$. The only quadrature is
+  the smooth one-dimensional integral of $\partial_x\alpha$. (A geometric-height
+  integration may still be performed for optional diagnostics.)
+- **Single column, valid to the seafloor.** The expression is evaluated only at
+  $x = 0$ and is well defined for every $\tilde z \in [\tilde z_b(0), \tilde
+  z_s(0)]$. Integrating from the surface loses none of this validity — it reaches
+  every pseudo-height down to and immediately above the bathymetry — and it never
+  references neighboring columns, so it cannot break down above the bathymetry.
+- **Exact in the horizontal.** The horizontal gradient is analytic; there is no
+  $\Delta x$ truncation, satisfying the beyond-second-order fidelity requirement.
+
+The boundary term uses $\tilde z_s(0) = $ the surface pseudo-height (the
+shallowest `z_tilde` node) and $\alpha(\tilde z_s)$ evaluated from the profiles
+at $\tilde z_s(0)$. The slopes $\eta'$ (from `geom_ssh_grad`) and $\tilde z_s'$
+(from the surface `z_tilde_grad` node) are read from the configuration gradients
+(converted from per-km to per-m and projected onto the edge normal). They are
+kept **fully general**: a nonzero sea-surface height or surface pressure makes
+$\eta'$ and/or $\tilde z_s'$ (and $\tilde z_s$ itself) nonzero, and the formula
+already accounts for them. A regression test that exercises a nonzero surface
+pressure is deferred to a follow-up PR; the present tasks all use zero surface
+slope and pressure.
+
+### Algorithm Design: Horizontal derivatives of the prescribed profiles at fixed pseudo-height
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+The factors $\partial_x S_A|_{\tilde z'}$ and $\partial_x \Theta|_{\tilde z'}$
+are the horizontal gradients of the prescribed profiles at fixed pseudo-height.
+The profiles are defined by node values and node pseudo-heights, each of which
+varies linearly in $x$ (configuration `*_mid` plus `*_grad`$\cdot x$), and a
+monotone PCHIP interpolant in pseudo-height (the same interpolant `Init` uses, so
+the reference and the test describe the same physical state).
+
+The profile value at fixed $\tilde z'$ depends on $x$ through both the node
+values and, in the general case (`z_tilde_grad` $\neq 0$), the node
+pseudo-heights. Because PCHIP is nonlinear in its node data, the horizontal
+derivative is obtained by **differencing the analytic input profiles**: the
+interpolant is constructed at $x = \pm\varepsilon$ from the exactly known linear
+node functions and evaluated at $\tilde z'$, and a centered difference is taken,
+
+$$
+\left.\frac{\partial S_A}{\partial x}\right|_{\tilde z'} \approx
+   \frac{S_A(\tilde z'; +\varepsilon) - S_A(\tilde z'; -\varepsilon)}
+        {2\varepsilon},
+$$
+
+and similarly for $\Theta$. Since the nodes are exactly linear in $x$ and the
+interpolant is smooth in $x$, this is accurate to round-off for a suitably chosen
+$\varepsilon$ (optionally refined by Richardson extrapolation). This single
+construction handles all task variants uniformly, including tilted node
+pseudo-heights, satisfying the general-input requirement.
+
+The specific-volume derivatives $\alpha_{S_A}$ and $\alpha_{\Theta}$ are obtained from the
+equation of state at the central column's $(S_A(\tilde z'), \Theta(\tilde z'),
+p(\tilde z'))$ — concretely, from `gsw.specvol_first_derivatives` for TEOS-10.
+
+### Algorithm Design: Building the reference profile and the layer-averaged comparison
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+The reference is needed as a layer mean over each model layer. Define the
+cumulative integral
+
+$$
+I(\tilde z) = \int_{\tilde z_s}^{\tilde z}
+   \left(\alpha_{S_A}\,\partial_x S_A + \alpha_{\Theta}\,\partial_x \Theta\right)
+   d\tilde z', \qquad
+a(\tilde z) = -g\left[\,\eta' - \rho_0\,\alpha(\tilde z_s)\,\tilde z_s'
+   + \rho_0\,I(\tilde z)\right].
+$$
+
+The integrand is smooth, so $I(\tilde z)$ — and therefore $a(\tilde z)$ — is
+evaluated with a high-order quadrature (the existing Gauss–Legendre / adaptive
+machinery; see Implementation). $a(\tilde z)$ is thus available as an accurate
+callable of pseudo-height.
+
+For the comparison, each model layer $k$ spans, at the edge, the pseudo-height
+interval $[\tilde z^{\text{bot}}_{k}, \tilde z^{\text{top}}_{k}]$, where the edge
+interfaces are the average of the two cells' interface pseudo-heights (the edge
+lies midway between the columns; for linearly varying inputs this average equals
+the central-column value). The reference target for layer $k$ is the **layer
+mean**
+
+$$
+\overline{a}_k = \frac{1}{\tilde z^{\text{top}}_k - \tilde z^{\text{bot}}_k}
+   \int_{\tilde z^{\text{bot}}_k}^{\tilde z^{\text{top}}_k}
+   a(\tilde z)\, d\tilde z ,
+$$
+
+evaluated by high-order quadrature within the layer. This compares the model's
+layer-mean acceleration to the true layer-mean acceleration, so finite layer
+thickness and layer tilt are folded into the target rather than counted as error
+(satisfying the "on its own merits" requirement). As both resolutions refine,
+$\overline{a}_k \to a(\tilde z_k)$ and the residual is the scheme's genuine
+discretization error.
+
+The model layer interfaces are taken from the test output (identical between
+`Init` and `Forward`), so the reference is sampled at exactly the test's
+pseudo-heights and the partial-cell bottom geometry is honored automatically. As
+in the current analysis, the single deepest valid model layer (which abuts the
+bathymetry) is excluded from the error metric.
+
+The sign/orientation of $a$ must match the edge-normal convention used by the
+model output: the horizontal coordinate $x$ increases from the first to the
+second cell on the internal edge. `Analysis` determines that orientation from
+the mesh cell positions and applies it consistently to the input slopes and the
+reference acceleration.
+
+### Algorithm Design: Removal of the separate reference step
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+Because the reference is an inexpensive callable evaluated at the test's
+pseudo-heights, it does not need to be precomputed by a dedicated step. The
+`Reference` step is removed. `Analysis` constructs the reference evaluator from
+the configuration (which fully determines the central column) and evaluates the
+layer-averaged target per resolution. The greatest-common-divisor reference
+grid, the five-column construction, the cross-column finite-difference stencil,
+and the exact-match sampling are all retired.
+
+## Implementation
+
+### Implementation: shared reference evaluator module
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+Replace the `Reference` *step* in `polaris/tasks/ocean/horiz_press_grad/reference.py`
+with a `Reference` *evaluator module* in the same package (the file name may
+remain `reference.py`; it no longer defines a `Step` subclass). The evaluator
+encapsulates the central column and exposes the reference as a function of
+pseudo-height.
+
+```python
+class ReferenceColumn:
+    """
+    High-fidelity continuous HPGA reference at the edge (x = 0) between the
+    two columns, evaluated analytically via the chain-rule / Leibniz
+    expansion of the along-pseudo-height gradient.
+    """
+
+    def __init__(self, config, x_sign=1.0):
+        # x_sign carries the edge-normal orientation (+1 if x increases from
+        # cell0 to cell1, -1 otherwise) so the reference matches the model
+        # output convention.
+        ...
+        # Cache, at x = 0:
+        #   - PCHIP interpolants for SA(z_tilde), CT(z_tilde)
+        #   - the surface pseudo-height z_tilde_s (shallowest z_tilde node),
+        #     the sea-surface-height slope eta' and the surface pseudo-height
+        #     slope z_tilde_s' (per-metre, * x_sign); kept general so nonzero
+        #     SSH / surface pressure need no further change
+        #   - alpha(z_tilde_s) for the boundary term
+
+    def specvol(self, z_tilde):
+        """alpha = EOS(SA(z_tilde), CT(z_tilde), p = -RhoSw*g*z_tilde)."""
+
+    def dalpha_dx(self, z_tilde):
+        """
+        alpha_SA * dSA/dx + alpha_CT * dCT/dx at fixed z_tilde, with alpha_*
+        from gsw.specvol_first_derivatives and dSA/dx, dCT/dx from analytic-input
+        differencing of the profiles (handles tilted nodes).
+        """
+
+    def hpga(self, z_tilde):
+        """
+        a(z_tilde) = -g [ eta' - RhoSw*alpha(z_tilde_s)*z_tilde_s'
+                          + RhoSw * I(z_tilde) ],
+        with I(z_tilde) the cumulative integral of dalpha_dx from the surface
+        z_tilde_s. Vectorized over a 1-D array of target pseudo-heights.
+        """
+
+    def layer_mean_hpga(self, z_tilde_interfaces):
+        """
+        Given edge layer interface pseudo-heights (length nLayers+1), return
+        the per-layer mean of a(z_tilde) over each [z_top, z_bot] interval by
+        high-order quadrature.
+        """
+```
+
+Reuse existing utilities rather than reimplementing them:
+
+- `get_array_from_mid_grad(config, name, x)` and `get_pchip_interpolator(...)`
+  from `column.py` for node arrays and profile interpolants. Pass an array of
+  the single point `x = [0.0]` (plus `x = ±epsilon` for the differencing).
+- `compute_specvol` from `polaris.ocean.eos` (TEOS-10 path) for $\alpha$, and
+  `gsw.specvol_first_derivatives(SA, CT, p_dbar)` for $\alpha_{S_A}, \alpha_{\Theta}$
+  (note `gsw` takes pressure in dbar = Pa $\times 10^{-4}$).
+- The fixed-step Gauss–Legendre and adaptive-Simpson quadrature helpers already
+  present in `reference.py` (`_gauss_composite`, `_fixed_quadrature`,
+  `_adaptive_simpson`) for both $I(\tilde z)$ and the layer-mean integral. The
+  quadrature method remains configurable via `reference_quadrature_method`
+  (default `gauss4`).
+- `Gravity` and `RhoSw` from `polaris.ocean.vertical.ztilde`.
+
+Recommended evaluation strategy for `hpga`/`layer_mean_hpga`: build
+$a(\tilde z)$ on a fine internal pseudo-height grid spanning $[\tilde z_b(0), 0]$
+by cumulative high-order quadrature of the integrand, then integrate $a$ over
+each model layer with the same quadrature using a few sub-samples per layer (the
+sub-sampling fineness can reuse `reference_quadrature_method`'s panel count).
+Choose the internal grid fine enough that its contribution to the error is far
+below the HPGA errors being measured; alternatively evaluate $I$ on demand at the
+layer quadrature points to avoid any interpolation. Either approach must keep the
+reference fidelity well beyond the model's.
+
+`epsilon` for the profile differencing should be a small fraction of the column
+extent (e.g. relative to `reference_horiz_res` if retained for this purpose, or a
+fixed small value such as $10^{-3}$ km); document the choice and optionally apply
+Richardson extrapolation.
+
+### Implementation: Analysis consumes the reference directly
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+In `analysis.py`:
+
+- Remove the `reference` dependency, the `reference_solution.nc` input, and
+  `_sample_reference_without_interpolation`.
+- In `setup`, drop the reference-step input wiring; keep the per-resolution
+  `init`, `forward`, `culled_mesh`, and `vert_coord` inputs.
+- In `run`, construct a single `ReferenceColumn` from `self.config` (its
+  orientation `x_sign` is derived once from the mesh, see below). Then for each
+  resolution:
+  1. Identify the internal edge and its two cells with the existing
+     `_get_internal_edge`.
+  2. Determine `x_sign` from the cells' `xCell` (sign of `xCell[cell1] -
+     xCell[cell0]`), so the reference gradient matches the model edge-normal
+     convention. The current Python HPGA in `Init`
+     (`_compute_montgomery_and_hpga`) uses `x = horiz_res*[-0.5, 0.5]` for cells
+     `[0, 1]`; the new orientation logic must reproduce the same sign the
+     existing `omega_vs_python` comparison relies on.
+  3. Read the **edge** layer-interface pseudo-heights as the average of the two
+     cells' `ZTildeInterface` from the forward output (equivalently `Init`).
+  4. Compute `ref_layer_mean = reference.layer_mean_hpga(edge_interfaces)`.
+  5. Restrict to valid layers via `maxLevelCell` (shallowest of the two cells,
+     as today) and drop the deepest valid layer (abuts bathymetry).
+  6. RMS-difference Omega's `NormalVelocityTend` at the edge against
+     `ref_layer_mean`; accumulate per resolution.
+- The power-law fit, threshold checks, plots, and `omega_vs_python` comparison
+  are unchanged in structure. Optionally overlay the reference layer-mean profile
+  on a diagnostic plot at the finest resolution.
+
+### Implementation: task wiring and configuration
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+- `task.py`: remove the `Reference` step creation and its entry in the
+  `Analysis` dependencies dict (`{'init': ..., 'forward': ...}` only).
+- `horiz_press_grad.cfg`: remove `reference_horiz_res` (no neighboring columns).
+  Keep `reference_quadrature_method` for the one-dimensional integral and the
+  layer mean. Retain the `omega_vs_reference_*` threshold and convergence-rate
+  options; their values will likely need re-tuning now that the reference is
+  exact in the horizontal (see Testing).
+- Delete the now-unused machinery in the old `reference.py`: the five-column
+  setup, `_get_reference_vert_res` and `_fraction_gcd`, the 4th-order stencil
+  (`_compute_4th_order_gradient`, `_check_gradient`), the per-column
+  geometric-height integration used for the cross-column difference, and the
+  `reference_solution.nc` output. Keep and relocate the quadrature helpers used
+  by `ReferenceColumn`.
+
+### Implementation: orientation and consistency safeguards
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+- The reference must use the same $+x$ orientation as `Init`/`Forward`. Derive it
+  from `xCell` and assert that the resulting sign reproduces the existing
+  `omega_vs_python` agreement at the coarsest resolution as a guard against a
+  flipped gradient.
+- The edge surface pseudo-height (average of the two cells' surface
+  pseudo-heights) equals $\tilde z_s(0)$ for linearly varying inputs; assert this
+  equality to a tolerance to catch configuration or averaging mistakes.
+- Keep the EOS path restricted to TEOS-10 (as the task already requires Omega),
+  and guard `dalpha_dx` against requesting `specvol_first_derivatives` outside
+  gsw's valid range.
+
+## Testing
+
+### Testing and Validation: arbitrary-pseudo-height evaluation and near-bathymetry validity
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+Add unit tests for `ReferenceColumn` (e.g.
+`tests/ocean/horiz_press_grad/test_reference.py`):
+
+- **Constant-density column.** With a configuration giving spatially constant
+  $\alpha$ (so $\partial_x\alpha = 0$), `hpga` must equal the closed form
+  $-g[\eta' - \rho_0\alpha\,\tilde z_s']$ at every pseudo-height, to round-off,
+  for several arbitrary $\tilde z$ including values that fall between any plausible
+  grid points. (With a nonzero surface pseudo-height slope $\tilde z_s'$, evaluate
+  the boundary term at the surface, where the integral is exactly zero.)
+- **Zero horizontal variation.** With all input gradients zero, `hpga` must be
+  identically zero (no spurious pressure-gradient signal) for arbitrary
+  $\tilde z$, including immediately above the seafloor.
+- **Independence from sampling.** Evaluate `hpga` on two unrelated pseudo-height
+  sets (one of which deliberately does not align with any uniform grid) and on a
+  shifted set emulating a nonzero surface pressure; values at coincident
+  pseudo-heights must agree to round-off, demonstrating freedom from grid
+  alignment.
+
+### Testing and Validation: fidelity beyond second order
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+- **Brute-force gradient cross-check.** For a $\tilde z$ comfortably above the
+  seafloor, compare `ReferenceColumn.hpga` to a high-accuracy finite-difference
+  estimate formed by fully integrating $z(\tilde z; x)$ at $x = \pm\delta$ and
+  differencing at constant $\tilde z$, for a sequence of shrinking $\delta$. The
+  analytic value must agree with the Richardson-extrapolated finite difference to
+  many digits, confirming the chain-rule/Leibniz implementation and that the
+  reference carries no fixed-order horizontal truncation error.
+- **Quadrature convergence.** Confirm that refining the quadrature panel count
+  changes `hpga` by amounts decreasing at the expected high order and that the
+  result is converged well below the model HPGA error levels.
+
+### Testing and Validation: general horizontal input variation
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+- **Tilted nodes.** With `z_tilde_grad` $\neq 0$ (tilted profile node
+  pseudo-heights), verify `dalpha_dx` against an independent finite difference of
+  $\alpha$ in $x$ at fixed $\tilde z$, confirming the analytic-input differencing
+  handles moving nodes.
+- **Each gradient in isolation.** Exercise nonzero `salinity_grad`,
+  `temperature_grad`, `geom_ssh_grad`, and the surface `z_tilde_grad` node
+  one at a time and confirm the corresponding boundary or integrand contribution
+  appears with the correct sign and magnitude. The surface boundary terms
+  (`geom_ssh_grad`, surface `z_tilde_grad`) are kept general so a follow-up
+  nonzero-surface-pressure test needs no further changes.
+
+### Testing and Validation: layer-averaged comparison and regression behavior
+
+Date last modified: 2026/06/14
+
+Contributors: Xylar Asay-Davis, Claude
+
+- **Layer-mean correctness.** For a known smooth $a(\tilde z)$, verify
+  `layer_mean_hpga` returns the analytic layer averages, and that for vanishing
+  layer thickness it approaches the pointwise value.
+- **Regression suite.** Run all three task variants (`salinity_gradient`,
+  `temperature_gradient`, `ztilde_gradient`) in the `omega_pr` suite. Confirm the
+  `omega_vs_python` comparison still passes at its tight tolerance (unchanged
+  scheme), and that `omega_vs_reference` produces a convergence slope in the
+  expected range. Because the reference is now exact in the horizontal,
+  re-tune `omega_vs_reference_convergence_rate_min/max`,
+  `omega_vs_reference_high_res_rms_threshold`, and
+  `omega_vs_reference_convergence_fit_max_resolution` to the observed behavior;
+  document the updated values and the resolution at which curvature in the
+  convergence plot appears.
+- **Tilted-layer case.** Pay particular attention to `ztilde_gradient`, whose
+  slanted layers exercise the slant-induced pressure-gradient error; confirm the
+  layer-averaged comparison yields a clean convergence rather than a spurious
+  floor from charging layer tilt as error.

--- a/docs/design_docs/index.md
+++ b/docs/design_docs/index.md
@@ -5,6 +5,7 @@
 ```{toctree}
 :titlesonly: true
 
+horiz_press_grad_reference
 pstar_init
 shared_steps
 unified_base_mesh

--- a/docs/design_docs/template.md
+++ b/docs/design_docs/template.md
@@ -1,6 +1,6 @@
 # Template
 
-date: YYYY/MM/DD
+Creation date: YYYY/MM/DD
 
 Contributors:
 

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -211,8 +211,11 @@
    task.HorizPressGradTask
    task.HorizPressGradTask.configure
 
-   reference.Reference
-   reference.Reference.run
+   reference.ReferenceColumn
+   reference.ReferenceColumn.specvol
+   reference.ReferenceColumn.dalpha_dx
+   reference.ReferenceColumn.hpga
+   reference.ReferenceColumn.layer_mean_hpga
 
    init.Init
    init.Init.run

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -28,29 +28,45 @@ reflected in the work directory setup.
 
 ### reference
 
-The class {py:class}`polaris.tasks.ocean.horiz_press_grad.reference.Reference`
-defines a step that builds a high-fidelity reference HPGA solution in
-`reference_solution.nc`.
+The class
+{py:class}`polaris.tasks.ocean.horiz_press_grad.reference.ReferenceColumn`
+is not a `Step` but a lightweight callable evaluator.  It is instantiated
+inside `Analysis.run()` (once per task, using the config and the mesh-derived
+`x_sign`), and computes the HPGA reference analytically without writing any
+intermediate file.
 
-In implementation terms, `Reference.run()` does four things:
+`ReferenceColumn.__init__()` reads the quadrature settings
+(`reference_quadrature_method`, `reference_quadrature_subdivisions`,
+`reference_horiz_eps_km`) and the geometry / profile parameters from config.
+It builds `_ClampedInterp` PCHIP interpolants for Absolute Salinity and
+Conservative Temperature at $x = 0$ and $x = \pm\varepsilon$ (six interpolants
+in all), which are used later for centred finite-differencing.
 
-- determines the refined vertical resolution from the configured test
-  resolutions,
-- builds the reference columns and their thermodynamic profiles,
-- computes the reference diagnostic fields, and
-- writes `reference_solution.nc`.
+The public methods are `specvol(z_tilde)` (specific volume at $x = 0$) and
+`dalpha_dx(z_tilde)` (the fixed-$\tilde z$ x-gradient of specific volume), plus
+the two used by `Analysis`:
 
-Most of the work is organized through the private helpers
-`_get_ssh_z_bot()`, `_get_z_tilde_t_s_nodes()`, `_compute_column()`, and
-`_integrate_geometric_height()`.  Together, these routines reconstruct the
-column state, convert from pseudo-height to geometric height, and populate the
-reference dataset.
+- `hpga(z_tilde)` — evaluates $a(\tilde z)$ pointwise at the edge $x = 0$
+  via the chain-rule / Leibniz integral, anchored at the surface (the boundary
+  the model honours).  It accumulates the cumulative integral
+  $I(\tilde z) = \int_{\tilde z_s}^{\tilde z} \bigl(\alpha_{S_A} \partial_x
+  S_A + \alpha_{\Theta} \partial_x \Theta\bigr)\,d\tilde z'$ using
+  `_fixed_quadrature` on a sorted unique node set, then interpolates back onto
+  the requested $\tilde z$ values.  The surface boundary term
+  ($\eta'$ and $\tilde z_s'$) is kept general so nonzero sea-surface height and
+  surface pressure are supported.
+- `layer_mean_hpga(z_tilde_interfaces)` — layer-averages `hpga()` over the
+  model's actual pseudo-height layer bounds using 4-point Gauss–Legendre
+  quadrature with `reference_quadrature_subdivisions` sub-panels per layer.
+  This is what `Analysis` calls to form the reference target per layer.
 
-`reference_solution.nc` contains both the baseline fields used directly in
-analysis and additional diagnostics that are useful when debugging or
-inspecting the reference calculation, including `HPGAMid`, `HPGAInter`,
-`MontgomeryMid`, `MontgomeryInter`, `dMdxMid`, `dalphadxMid`, `PEdgeMid`, and
-the valid-gradient masks.
+The private class `_ClampedInterp` wraps
+{py:func}`~polaris.tasks.ocean.horiz_press_grad.column.get_pchip_interpolator`
+with constant extrapolation at the node bounds.
+
+The quadrature primitives (`_fixed_quadrature`, `_gauss_composite`) support
+midpoint, trapezoid, Simpson, `gauss2`, and `gauss4` methods and are shared
+between the cumulative integral and the layer averaging.
 
 ### init
 
@@ -101,7 +117,7 @@ It runs Omega from the corresponding `init` output and writes `output.nc`
 The class {py:class}`polaris.tasks.ocean.horiz_press_grad.analysis.Analysis`
 compares each `forward` result with:
 
-- the high-fidelity reference solution, and
+- the analytic reference solution (built from `ReferenceColumn`), and
 - the Python-computed HPGA from `init.nc`.
 
 The step writes:
@@ -115,14 +131,20 @@ and enforces regression criteria from `[horiz_press_grad]`, including:
 - high-resolution RMS threshold for Omega-vs-reference, and
 - RMS threshold for Omega-vs-Python consistency.
 
-Implementation-wise, `Analysis.run()` reads the reference, init, and forward
-outputs for each configured horizontal resolution, then uses helper routines
-such as `_get_internal_edge()`, `_get_forward_z_tilde_edge_mid()`,
-`_sample_reference_without_interpolation()`, `_check_vertical_match()`,
-`_rms_error()`, and `_power_law_fit()` to produce the comparison datasets and
-plots.
+Implementation-wise, `Analysis.run()` iterates over configured horizontal
+resolutions.  For each resolution it:
 
-The key code-level distinction is that the reference comparison is built from
-`reference_solution.nc`, whereas the implementation-consistency comparison is
-built from `init.nc`.  The forward solution always comes from
-`output.nc` via `NormalVelocityTend`.
+1. reads `init_r*.nc`, `culled_mesh_r*.nc`, `vert_coord_r*.nc`, and
+   `output_r*.nc`;
+2. identifies the single internal edge via `_get_internal_edge()` and derives
+   the forward pseudo-heights via `_get_forward_z_tilde_edge_mid()`;
+3. constructs a `ReferenceColumn` with the mesh-derived `x_sign` and calls
+   `ref.layer_mean_hpga()` on the edge interface pseudo-heights from
+   `init.nc`, dropping the deepest valid layer (which abuts bathymetry);
+4. checks that Python and Omega pseudo-heights agree with
+   `_check_vertical_match()`, then computes the Omega-vs-Python RMS difference
+   from `init.nc` HPGA.
+
+The forward solution always comes from `output.nc` via `NormalVelocityTend`.
+Helper routines `_rms_error()` and `_power_law_fit()` produce the convergence
+datasets and plots.

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -10,18 +10,17 @@ for a two-column configuration with prescribed horizontal gradients.
 
 The analysis uses two different baselines, each with a different purpose:
 
-- a high-fidelity offline reference solution that is used as the main
-  accuracy target, and
+- an analytic reference solution evaluated inside the `analysis` step that is
+  used as the main accuracy target, and
 - a Python-computed two-column HPGA diagnostic from the `init` step that is
   used as a consistency check against Omega.
 
 Each task includes:
 
-- a high-fidelity `reference` solution for HPGA,
 - an `init` step at each horizontal/vertical resolution pair,
 - a single-time-step `forward` run at each horizontal resolution, and
-- an `analysis` step comparing Omega output with both the reference and
-  Python-initialized HPGA.
+- an `analysis` step that evaluates the analytic reference and compares Omega
+  output with both the reference and the Python-initialized HPGA.
 
 The tasks currently provided are:
 
@@ -72,80 +71,61 @@ where they intersect the bathymetry.  In the `ztilde_gradient` test, the
 prescribed z-tilde gradient tilts the layers, so the pressure surfaces are
 sloped and the along-layer direction follows those sloping layers.
 
-The `reference` step uses a finer spacing `vert_res` chosen so that every test
-spacing is an integer multiple of `2 * vert_res`. This allows reference
-interfaces to align with test midpoints for exact subsampling in analysis.
-
 ## reference solution
 
-The `reference` step constructs a high-fidelity numerical approximation to the
-HPGA before any Omega run is performed.  This reference is not an exact
-analytic solution.  Instead, it is a deliberately more accurate offline
-calculation based on more columns and a much finer vertical grid than the
-two-column test itself.
+The reference HPGA is evaluated analytically at the edge ($x = 0$) using the
+chain-rule / Leibniz expansion of the horizontal pressure-gradient force in
+pseudo-height coordinates.  Because the continuous pressure-gradient force is
+coordinate-invariant, the along-pseudo-height formula equals
+$-g\,\partial z / \partial x\big|_{\tilde z}$ exactly, including near the
+seafloor.
 
-The reference starts from the Omega pseudo-height coordinate `z-tilde`, with
+The reference is **anchored at the surface** rather than the seafloor, because
+the surface is the boundary the model honours: `Init`/Omega build the p-star
+column from the prescribed sea-surface height and surface pressure, so the HPGA
+vanishes at the surface (for zero surface slope) and grows downward.
 
-$$
-p = -\rho_0 g \tilde z,
-$$
-
-where $p$ is gauge pressure (pressure relative to the atmosphere, zero at the
-free surface $\tilde z = 0$).  The reference converts to geometric height `z`
-by integrating the hydrostatic relation
+The reference acceleration at pseudo-height $\tilde z$ is
 
 $$
-\frac{\partial z}{\partial \tilde z} = \rho_0\,\nu\left(S_A, \Theta, p\right),
+a(\tilde z) = -g\left[\eta' - \rho_0\,\alpha(\tilde z_s)\,\tilde z_s'
+  + \rho_0 \int_{\tilde z_s}^{\tilde z}
+  \bigl(\alpha_{S_A}\,\partial_x S_A + \alpha_{\Theta}\,\partial_x \Theta\bigr)\,
+  d\tilde z'\right],
 $$
 
-where $\nu$ is specific volume from the TEOS-10 equation of state, $S_A$ is
-Absolute Salinity, and $\Theta$ is Conservative Temperature.
+where:
 
-For each reference column, the configured `z_tilde`, `temperature`, and
-`salinity` node values are first reconstructed from the prescribed midpoint
-values and horizontal gradients.  The vertical profiles are then evaluated as
-functions of `z-tilde` and integrated upward from the seafloor to obtain
-geometric height, specific volume, salinity and temperature on the refined
-reference grid.
+- $\eta' = \partial_x \eta$ is the sea-surface-height gradient,
+- $\tilde z_s$ is the surface pseudo-height
+  ($\tilde z_s = -p_s / (\rho_0 g)$, zero only when the surface pressure is
+  zero) and $\tilde z_s' = \partial_x \tilde z_s$ is its gradient,
+- $\alpha$ is specific volume from the TEOS-10 equation of state,
+- $\alpha_{S_A} = \partial \alpha / \partial S_A$ and
+  $\alpha_{\Theta} = \partial \alpha / \partial \Theta$ are TEOS-10 first derivatives
+  of specific volume.
 
-The reference uses five columns at
+The surface boundary term is kept fully general, so a nonzero sea-surface
+height or surface pressure (nonzero `geom_ssh_grad` and/or surface
+`z_tilde_grad` node) is supported without further changes.  The three task
+variants currently provided all use zero surface slope.
 
-$$
-x = \Delta x_{\mathrm{ref}}\,[-1.5, -0.5, 0, 0.5, 1.5],
-$$
+The gradients $\partial_x S_A$ and $\partial_x \Theta$ at fixed $\tilde z$ are
+obtained by centred finite-differencing PCHIP interpolants evaluated at
+$x = \pm\varepsilon$, where $\varepsilon =$ `reference_horiz_eps_km` (1 m by
+default).  This handles moving-node inputs correctly, so it is valid for the
+`ztilde_gradient` task as well as the level-layer tasks.
 
-where $\Delta x_{\mathrm{ref}} =$ `reference_horiz_res`, 250 m by default.
-After constructing Montgomery potential,
+The integral in the formula is evaluated by composite quadrature.  The number
+of sub-panels per interval is set by `reference_quadrature_subdivisions` (4 by
+default).
 
-$$
-M = \alpha p + gz = g\left(z - \rho_0 \alpha \tilde z\right),
-$$
-
-the reference HPGA is formed with the same sign convention used in the task
-diagnostics,
-
-$$
-\mathrm{HPGA}_{\mathrm{ref}} = -\frac{\partial M}{\partial x}
-+ p\frac{\partial \alpha}{\partial x}.
-$$
-
-The horizontal derivatives at the center column are approximated with the
-4th-order centered stencil
-
-$$
-\frac{\partial f}{\partial x}(0) \approx
-\frac{f\left(-\tfrac{3}{2}\Delta x\right)
-- 27 f\left(-\tfrac{1}{2}\Delta x\right)
-+ 27 f\left(\tfrac{1}{2}\Delta x\right)
-- f\left(\tfrac{3}{2}\Delta x\right)}{24\Delta x}.
-$$
-
-This reconstruction is non-local: it uses four surrounding columns to evaluate
-the gradient at the central column.  It is therefore not the same as a local
-reconstruction based only on the two test cells or on local derivatives such
-as `dT/dx` and `dS/dx` at the edge midpoint.  That kind of local reference may
-be worth exploring in the future, especially when these tasks are extended to
-support higher-order HPGA formulations, but it is not what is used today.
+For comparison with a layer-averaged Omega tendency, the `analysis` step
+averages $a(\tilde z)$ over the model's actual pseudo-height layer bounds using
+4-point Gauss–Legendre quadrature with `reference_quadrature_subdivisions`
+sub-panels per layer.  The deepest valid layer (which abuts the bathymetry) is
+excluded from the RMS error calculation, because partial bottom cells make that
+layer's geometric extent differ from the smooth reference geometry.
 
 ## python HPGA in the `init` step
 
@@ -227,8 +207,23 @@ salinity_grad = [0.0, 0.0, 0.0, 0.0, 0.0]
 
 # reference settings
 reference_quadrature_method = gauss4
-reference_horiz_res = 0.25
+reference_quadrature_subdivisions = 4
+reference_horiz_eps_km = 1.0e-3
+
+# regression thresholds and convergence checks
+omega_vs_polaris_rms_threshold = 1.0e-10
+omega_vs_reference_high_res_rms_threshold = 1.0e-6
+omega_vs_reference_convergence_rate_min = 1.5
+omega_vs_reference_convergence_rate_max = 2.1
+omega_vs_reference_convergence_fit_max_resolution = 4.0
 ```
+
+The `omega_vs_polaris_rms_threshold` bounds the RMS difference between the Omega
+forward HPGA and the Python-initialized HPGA (the consistency check).  The
+`omega_vs_reference_*` options bound the Omega-vs-reference accuracy: the RMS
+error at the highest resolution, the allowed power-law convergence slope, and
+the finest horizontal resolution included in the convergence fit (all
+resolutions are still shown in the plots).
 
 The three task variants specialize one horizontal gradient field:
 
@@ -252,17 +247,18 @@ The `analysis` step computes and plots:
 The corresponding tabulated data are written to
 `omega_vs_reference.nc` and `omega_vs_python.nc`.
 
-For the Omega-versus-reference comparison, the reference is sampled onto the
-test vertical locations without interpolation.  This is why the refined
-reference spacing is chosen so that the reference interfaces align exactly with
-test midpoints and interfaces.  The comparison only uses layers that are valid
-in both the reference and the Omega solution.
+For the Omega-versus-reference comparison, the analytic reference
+$a(\tilde z)$ is layer-averaged over the model's actual pseudo-height layer
+bounds (from `init.nc`) using 4-point Gauss–Legendre quadrature.  The deepest
+valid layer is excluded from the RMS error calculation because that layer abuts
+the bathymetry, where partial bottom cells make the model layer's geometric
+extent differ from the smooth reference geometry.
 
 For the Omega-versus-Python comparison, the analysis uses the HPGA written by
 the `init` step in `init.nc`, so this second metric should be read as an
 implementation-consistency check rather than as an accuracy measure against the
 high-fidelity reference.
 
-Implementation details for the `reference`, `init`, and `analysis` steps are
-described in {ref}`dev-ocean-horiz-press-grad`.
+Implementation details for the `ReferenceColumn` evaluator and the `init` and
+`analysis` steps are described in {ref}`dev-ocean-horiz-press-grad`.
 

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical.ztilde import Gravity, RhoSw
+from polaris.tasks.ocean.horiz_press_grad.reference import ReferenceColumn
 from polaris.viz import use_mplstyle
 
 
@@ -16,9 +17,6 @@ class Analysis(OceanIOStep):
     ----------
     dependencies_dict : dict
         A dictionary of dependent steps:
-
-        reference : polaris.Step
-            The reference step that produces ``reference_solution.nc``
 
         init : dict
             Mapping from horizontal resolution (km) to ``Init`` step
@@ -54,19 +52,13 @@ class Analysis(OceanIOStep):
 
     def setup(self):
         """
-        Add inputs from reference, init and forward steps
+        Add inputs from init and forward steps
         """
         super().setup()
 
         section = self.config['horiz_press_grad']
         horiz_resolutions = section.getexpression('horiz_resolutions')
         assert horiz_resolutions is not None
-
-        reference = self.dependencies_dict['reference']
-        self.add_input_file(
-            filename='reference_solution.nc',
-            work_dir_target=f'{reference.path}/reference_solution.nc',
-        )
 
         init_steps = self.dependencies_dict['init']
         forward_steps = self.dependencies_dict['forward']
@@ -142,17 +134,6 @@ class Analysis(OceanIOStep):
             'must be set in the "horiz_press_grad" section.'
         )
 
-        ds_ref = self.open_model_dataset('reference_solution.nc', self.config)
-        if ds_ref.sizes.get('nCells', 0) <= 2:
-            raise ValueError(
-                'The reference solution requires at least 3 columns so that '
-                'the central column is nCells=2.'
-            )
-
-        ref_z = ds_ref.ZTildeInter.isel(Time=0, nCells=2).values
-        ref_hpga = ds_ref.HPGAInter.isel(Time=0).values
-        ref_valid_grad_mask = ds_ref.ValidGradInterMask.isel(Time=0).values
-
         ref_errors = []
         py_errors = []
 
@@ -201,15 +182,28 @@ class Analysis(OceanIOStep):
             forward_valid_mask = np.zeros_like(hpga_forward, dtype=bool)
             forward_valid_mask[: max_level_index + 1] = True
 
-            sampled_ref_hpga = _sample_reference_without_interpolation(
-                ref_z=ref_z,
-                ref_values=ref_hpga,
-                target_z=z_tilde_forward,
-                ref_valid_mask=ref_valid_grad_mask,
-                target_valid_mask=forward_valid_mask,
+            # Build reference evaluator: x_sign aligns config +x with the
+            # edge normal (from cell0 toward cell1).
+            x_sign = float(
+                np.sign(
+                    ds_mesh.xCell.values[cell1] - ds_mesh.xCell.values[cell0]
+                )
+            )
+            ref = ReferenceColumn(config, x_sign=x_sign)
+
+            # Edge interface z̃: average of the two bounding cells
+            z_tilde_inter_edge = 0.5 * (
+                ds_init.ZTildeInterface.isel(Time=0, nCells=cell0).values
+                + ds_init.ZTildeInterface.isel(Time=0, nCells=cell1).values
             )
 
-            hpga_ref_diff = hpga_forward - sampled_ref_hpga
+            # Interfaces for valid layers (0..max_level_index), then drop
+            # the deepest valid layer (abuts bathymetry): keep
+            # max_level_index layers using max_level_index+1 interfaces.
+            z_tilde_inter_for_ref = z_tilde_inter_edge[: max_level_index + 1]
+
+            ref_layer_mean = ref.layer_mean_hpga(z_tilde_inter_for_ref)
+            hpga_ref_diff = hpga_forward[:max_level_index] - ref_layer_mean
             ref_errors.append(_rms_error(hpga_ref_diff))
 
             z_tilde_init = (
@@ -382,78 +376,6 @@ def _get_forward_z_tilde_edge_mid(
         pressure_mid.isel(nCells=cell0) + pressure_mid.isel(nCells=cell1)
     )
     return (-pressure_edge_mid / (RhoSw * Gravity)).values
-
-
-def _sample_reference_without_interpolation(
-    ref_z: np.ndarray,
-    ref_values: np.ndarray,
-    target_z: np.ndarray,
-    ref_valid_mask: np.ndarray | None = None,
-    target_valid_mask: np.ndarray | None = None,
-    abs_tol: float = 1.0e-6,
-    rel_tol: float = 1.0e-10,
-) -> np.ndarray:
-    """
-    Sample reference values at target z-tilde values by exact matching within a
-    strict tolerance, without interpolation.
-    """
-    ref_z = np.asarray(ref_z, dtype=float)
-    ref_values = np.asarray(ref_values, dtype=float)
-    target_z = np.asarray(target_z, dtype=float)
-    if ref_valid_mask is not None:
-        ref_valid_mask = np.asarray(ref_valid_mask, dtype=bool)
-        if ref_valid_mask.shape != ref_z.shape:
-            raise ValueError(
-                'ref_valid_mask must have the same shape as ref_z.'
-            )
-    if target_valid_mask is not None:
-        target_valid_mask = np.asarray(target_valid_mask, dtype=bool)
-        if target_valid_mask.shape != target_z.shape:
-            raise ValueError(
-                'target_valid_mask must have the same shape as target_z.'
-            )
-
-    sampled = np.full_like(target_z, np.nan, dtype=float)
-    valid_target = np.isfinite(target_z)
-    if target_valid_mask is not None:
-        valid_target = np.logical_and(valid_target, target_valid_mask)
-    valid_ref = np.logical_and(np.isfinite(ref_z), np.isfinite(ref_values))
-    if ref_valid_mask is not None:
-        valid_ref = np.logical_and(valid_ref, ref_valid_mask)
-
-    # The bottom valid forward layer hits bathymetry and should not be used
-    # in the reference comparison.
-    if np.any(valid_target):
-        deepest = int(np.where(valid_target)[0][-1])
-        valid_target[deepest] = False
-
-    ref_z_valid = ref_z[valid_ref]
-    ref_values_valid = ref_values[valid_ref]
-
-    target_valid = target_z[valid_target]
-    if len(target_valid) == 0:
-        return sampled
-    if len(ref_z_valid) == 0:
-        raise ValueError(
-            'No valid reference z-tilde values remain after applying '
-            'ValidGradInterMask.'
-        )
-
-    dz = np.abs(ref_z_valid[:, np.newaxis] - target_valid[np.newaxis, :])
-    indices = np.argmin(dz, axis=0)
-    min_dz = dz[indices, np.arange(len(indices))]
-
-    tol = np.maximum(abs_tol, rel_tol * np.maximum(1.0, np.abs(target_valid)))
-    if np.any(min_dz > tol):
-        max_mismatch = float(np.max(min_dz))
-        raise ValueError(
-            f'Reference z-tilde values do not match Omega z-tilde values '
-            f'closely enough for subsampling without interpolation. max '
-            f'|dz|={max_mismatch}'
-        )
-
-    sampled[valid_target] = ref_values_valid[indices]
-    return sampled
 
 
 def _check_vertical_match(

--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -78,20 +78,27 @@ salinity_grad = [0.0, 0.0, 0.0, 0.0, 0.0]
 # reference solution quadrature method
 reference_quadrature_method = gauss4
 
-# reference solution's horizontal resolution in km
-reference_horiz_res = 0.25
+# number of quadrature sub-panels per interval for both the cumulative
+# I(z̃) integral and the per-layer Gauss averaging in ReferenceColumn
+reference_quadrature_subdivisions = 4
+
+# half-width (km) of the centred finite-difference used to compute
+# dSA/dx and dCT/dx at fixed z̃ in ReferenceColumn
+reference_horiz_eps_km = 1.0e-3
 
 # Maximum RMS difference allowed between Omega forward and Polaris/Python
 # init HPGA at each resolution
 omega_vs_polaris_rms_threshold = 1.0e-10
 
 # Maximum RMS error allowed between Omega and the reference solution at the
-# highest resolution
+# highest resolution. Observed RMS at 0.5 km is ~3e-7 (salinity/temperature)
+# and ~7e-12 (ztilde); 1e-6 keeps a comfortable margin.
 omega_vs_reference_high_res_rms_threshold = 1.0e-6
 
 # Allowed range for the Omega-vs-reference convergence slope from the
-# power-law fit
-omega_vs_reference_convergence_rate_min = 1.6
+# power-law fit. Observed slopes are ~1.6 (temperature), ~1.8 (salinity) and
+# ~2.0 (ztilde) for the surface-anchored reference.
+omega_vs_reference_convergence_rate_min = 1.5
 omega_vs_reference_convergence_rate_max = 2.1
 
 # Maximum horizontal resolution (km) included in the power-law fit. All

--- a/polaris/tasks/ocean/horiz_press_grad/reference.py
+++ b/polaris/tasks/ocean/horiz_press_grad/reference.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from fractions import Fraction
-from math import gcd, lcm
-from typing import Callable, Literal, Sequence
+from typing import Callable
 
 import gsw
 import numpy as np
-import xarray as xr
 
-from polaris.ocean.model import OceanIOStep
+from polaris.config import PolarisConfigParser
 from polaris.ocean.vertical.ztilde import Gravity, RhoSw
 from polaris.tasks.ocean.horiz_press_grad.column import (
     get_array_from_mid_grad,
@@ -16,725 +13,254 @@ from polaris.tasks.ocean.horiz_press_grad.column import (
 )
 
 
-class Reference(OceanIOStep):
+class ReferenceColumn:
     r"""
-    A step for creating a high-fidelity reference solution for two column
-    test cases.
+    Continuous, coordinate-invariant HPGA reference a(z̃) at the edge x=0.
 
-    The reference solution is computed by first converting from the
-    Omega pseudo-height coordinate :math:`\tilde z` (``z_tilde``) to true
-    geometric height ``z`` by numerically integrating the hydrostatic
-    relation:
+    Evaluates the along-pseudo-height horizontal pressure-gradient
+    acceleration (HPGA) via the chain-rule / Leibniz expansion, anchored at
+    the surface (the boundary the model honours):
 
     .. math::
 
-        \frac{\partial z}{\partial \tilde z} =
-        \rho_0\,\nu\left(S_A, \Theta, p\right)
+        a(\tilde z) = -g\left[\eta' - \rho_0\,\alpha(\tilde z_s)\,
+           \tilde z_s' + \rho_0 \int_{\tilde z_s}^{\tilde z}
+           \bigl(\alpha_{S_A}\,\partial_x S_A
+           + \alpha_{\Theta}\,\partial_x \Theta\bigr)\,
+           d\tilde z'\right]
 
-    where :math:`\nu` is the specific volume (``spec_vol``) computed from the
-    TEOS-10 equation of state, :math:`S_A` is Absolute Salinity,
-    :math:`\Theta` is Conservative Temperature, :math:`p` is sea gauge
-    pressure (relative to the atmosphere, positive downward, zero at the free
-    surface), and :math:`\rho_0` is a reference density used in the
-    definition :math:`\tilde z = -p/(\rho_0 g)`. The conversion therefore
-    requires an integral of the form:
+    where :math:`\eta' = \partial_x \eta` is the sea-surface-height gradient,
+    :math:`\tilde z_s` is the surface pseudo-height (zero only when the surface
+    pressure is zero) and :math:`\tilde z_s' = \partial_x \tilde z_s` its
+    gradient (all in the edge-normal direction), :math:`\alpha` is specific
+    volume, and :math:`\alpha_{S_A}`, :math:`\alpha_{\Theta}` are TEOS-10
+    specific-volume first derivatives.  The surface boundary term is kept
+    general so nonzero sea-surface height and surface pressure are supported.
+    The x-gradients of :math:`S_A` and :math:`\Theta` at fixed :math:`\tilde z`
+    are obtained by centred PCHIP differencing, which correctly handles
+    moving-node inputs (e.g. the ``ztilde_gradient`` task).
 
-    .. math::
-
-        z(\tilde z) = z_b + \int_{\tilde z_b}^{\tilde z}
-        \rho_0\,\nu\bigl(S_A(\tilde z'),\Theta(\tilde z'),p(\tilde z')\bigr)\;
-        d\tilde z' ,
-
-    with :math:`z_b = -\mathrm{bottom\_depth}` at the pseudo-height
-    ``z_tilde_b`` at the seafloor, typically the minimum (most negative) value
-    of the pseudo-height domain for a given water column.
-
-    Then, the horizontal gradient is computed using a 4th-order
-    finite-difference stencil at the center column (x=0) to obtain the
-    high-fidelity reference solution for the hydrostatic pressure gradient
-    error.
+    Because the continuous pressure-gradient force is coordinate-invariant,
+    this along-pseudo-height formula equals :math:`-g\,\partial z/\partial
+    x|_{\tilde z}` exactly, and is valid at any pseudo-height including near
+    the seafloor.
     """
 
-    def __init__(self, component, indir):
+    def __init__(
+        self,
+        config: PolarisConfigParser,
+        x_sign: float = 1.0,
+    ):
         """
-        Create the step
+        Parameters
+        ----------
+        config : PolarisConfigParser
+            Configuration containing a ``horiz_press_grad`` section.
+        x_sign : float
+            +1 or -1, mapping the config +x direction onto the edge normal.
+            Derived from ``sign(xCell[cell1] - xCell[cell0])`` in
+            ``Analysis``.
+        """
+        section = config['horiz_press_grad']
+        method = section.get('reference_quadrature_method')
+        nsub = section.getint('reference_quadrature_subdivisions')
+        # Differencing half-width in km. ``get_array_from_mid_grad`` multiplies
+        # the per-km config gradients by x, so x must be supplied in km; the
+        # resulting centred differences are converted to per-metre below.
+        eps_km = section.getfloat('reference_horiz_eps_km')
+
+        self._method = method
+        self._nsub = nsub
+        # full centred-difference width in metres (2 * eps_km, km -> m)
+        self._two_eps_m = 2.0 * eps_km * 1000.0
+        self._x_sign = x_sign
+
+        # Surface anchor. The model honours the surface boundary (sea-surface
+        # height and surface pressure), so the reference integral is anchored
+        # there rather than at the seafloor. These are kept fully general so a
+        # follow-up surface-pressure test (nonzero geom_ssh_grad and/or a
+        # nonzero top z_tilde node) is supported without further changes.
+        geom_ssh_grad = section.getfloat('geom_ssh_grad')
+        z_tilde_mid = section.getnumpy('z_tilde_mid')
+        z_tilde_grad = section.getnumpy('z_tilde_grad')
+        # the surface is the shallowest (largest) pseudo-height node
+        surf_node = int(np.argmax(z_tilde_mid))
+
+        self._z_tilde_surf = float(z_tilde_mid[surf_node])
+        # Convert config gradients from m/km to m/m; project onto edge normal
+        self._eta_prime = (geom_ssh_grad / 1000.0) * x_sign
+        self._zt_surf_prime = (z_tilde_grad[surf_node] / 1000.0) * x_sign
+
+        # Evaluate node arrays at x = 0, +eps, -eps in km (config x direction)
+        x_eval = np.array([0.0, eps_km, -eps_km])
+        z_tilde_nodes = get_array_from_mid_grad(config, 'z_tilde', x_eval)
+        ct_nodes = get_array_from_mid_grad(config, 'temperature', x_eval)
+        sa_nodes = get_array_from_mid_grad(config, 'salinity', x_eval)
+
+        # Build clamped PCHIP interpolants for SA and CT at each x
+        self._sa_0 = _ClampedInterp(z_tilde_nodes[0], sa_nodes[0], 'salinity')
+        self._ct_0 = _ClampedInterp(
+            z_tilde_nodes[0], ct_nodes[0], 'temperature'
+        )
+        self._sa_plus = _ClampedInterp(
+            z_tilde_nodes[1], sa_nodes[1], 'salinity'
+        )
+        self._ct_plus = _ClampedInterp(
+            z_tilde_nodes[1], ct_nodes[1], 'temperature'
+        )
+        self._sa_minus = _ClampedInterp(
+            z_tilde_nodes[2], sa_nodes[2], 'salinity'
+        )
+        self._ct_minus = _ClampedInterp(
+            z_tilde_nodes[2], ct_nodes[2], 'temperature'
+        )
+
+    def specvol(self, z_tilde: np.ndarray) -> np.ndarray:
+        """Specific volume at x=0 (m³ kg⁻¹)."""
+        z_tilde = np.asarray(z_tilde, dtype=float)
+        sa = self._sa_0(z_tilde)
+        ct = self._ct_0(z_tilde)
+        p_pa = -RhoSw * Gravity * z_tilde
+        return gsw.specvol(sa, ct, p_pa * 1.0e-4)
+
+    def dalpha_dx(self, z_tilde: np.ndarray) -> np.ndarray:
+        """d(α)/d(edge-normal) at fixed z̃ (m² kg⁻¹ m⁻¹)."""
+        z_tilde = np.asarray(z_tilde, dtype=float)
+        p_pa = -RhoSw * Gravity * z_tilde
+        v_sa, v_ct, _ = gsw.specvol_first_derivatives(
+            self._sa_0(z_tilde), self._ct_0(z_tilde), p_pa * 1.0e-4
+        )
+        # nodes were evaluated at x = +/- eps_km (km); dividing by the width in
+        # metres yields dSA/dx and dCT/dx in (g/kg)/m and degC/m.
+        two_eps = self._two_eps_m
+        dsa = (self._sa_plus(z_tilde) - self._sa_minus(z_tilde)) / two_eps
+        dct = (self._ct_plus(z_tilde) - self._ct_minus(z_tilde)) / two_eps
+        # x_sign projects the config-x gradient onto the edge-normal direction
+        return (v_sa * dsa + v_ct * dct) * self._x_sign
+
+    def hpga(self, z_tilde: np.ndarray) -> np.ndarray:
+        """Reference HPGA in the edge-normal direction (m s⁻²)."""
+        z_tilde = np.asarray(z_tilde, dtype=float)
+        flat = z_tilde.ravel()
+        z_surf = self._z_tilde_surf
+
+        # Clamp targets to the surface; targets above it are unphysical
+        flat = np.minimum(flat, z_surf)
+
+        # Sorted unique set containing the surface and all (clamped) targets
+        unique_z = np.unique(np.concatenate([[z_surf], flat]))
+
+        # Cumulative integral, then re-reference to the surface so that
+        # I(z̃) = ∫_{z̃_surf}^{z̃} dalpha_dx dz̃' (zero at the surface).
+        I_cum = np.zeros(len(unique_z))
+        for i in range(1, len(unique_z)):
+            I_cum[i] = I_cum[i - 1] + _fixed_quadrature(
+                self.dalpha_dx,
+                unique_z[i - 1],
+                unique_z[i],
+                self._nsub,
+                self._method,
+            )
+        I_cum -= np.interp(z_surf, unique_z, I_cum)
+
+        I_at = np.interp(flat, unique_z, I_cum)
+        alpha_surf = float(self.specvol(np.array([z_surf]))[0])
+        # Surface boundary term, kept general for nonzero sea-surface height
+        # and surface pressure (eta' and the surface pseudo-height gradient).
+        C = self._eta_prime - RhoSw * alpha_surf * self._zt_surf_prime
+        return (-Gravity * (C + RhoSw * I_at)).reshape(z_tilde.shape)
+
+    def layer_mean_hpga(self, z_tilde_interfaces: np.ndarray) -> np.ndarray:
+        """
+        Layer-averaged HPGA in the edge-normal direction (m s⁻²).
 
         Parameters
         ----------
-        component : polaris.Component
-            The component the step belongs to
+        z_tilde_interfaces : ndarray
+            Shape ``(nLayers+1,)`` interface pseudo-heights, decreasing
+            from surface (index 0) to seafloor (index -1).
 
-        indir : str
-            The subdirectory that the task belongs to, that this step will
-            go into a subdirectory of
+        Returns
+        -------
+        ndarray
+            Shape ``(nLayers,)`` Gauss-weighted layer-mean HPGA.
         """
-        name = 'reference'
-        super().__init__(component=component, name=name, indir=indir)
-        for file in [
-            'reference_solution.nc',
-        ]:
-            self.add_output_file(file)
+        z_tilde_interfaces = np.asarray(z_tilde_interfaces, dtype=float)
+        n_layers = len(z_tilde_interfaces) - 1
 
-    def run(self):
-        """
-        Run this step of the test case
-        """
-        logger = self.logger
-        # logger.setLevel(logging.DEBUG)
-        config = self.config
-        if config.get('ocean', 'model') != 'omega':
-            raise ValueError(
-                'The horiz_press_grad test case is only supported for the '
-                'Omega ocean model.'
-            )
-
-        resolution = config.getfloat('horiz_press_grad', 'reference_horiz_res')
-        assert resolution is not None, (
-            'The "reference_horiz_res" configuration option must be set in '
-            'the "horiz_press_grad" section.'
+        # 4-point Gauss–Legendre nodes and weights on [-1, 1]
+        xi = np.array(
+            [
+                -0.8611363115940526,
+                -0.3399810435848563,
+                0.3399810435848563,
+                0.8611363115940526,
+            ]
+        )
+        wi = np.array(
+            [
+                0.34785484513745385,
+                0.6521451548625461,
+                0.6521451548625461,
+                0.34785484513745385,
+            ]
         )
 
-        x = resolution * np.array([-1.5, -0.5, 0.0, 0.5, 1.5], dtype=float)
+        all_pts: list[float] = []
+        all_wts: list[float] = []
+        slices: list[tuple[int, int]] = []
+        layer_dz: list[float] = []
 
-        geom_ssh, geom_z_bot, z_tilde_bot = self._get_ssh_z_bot(x)
+        for k in range(n_layers):
+            z_top = float(z_tilde_interfaces[k])
+            z_bot = float(z_tilde_interfaces[k + 1])
+            dz = z_top - z_bot
+            layer_dz.append(dz)
+            h = dz / self._nsub
+            start = len(all_pts)
+            for s in range(self._nsub):
+                a_s = z_bot + s * h
+                b_s = a_s + h
+                mid_s = 0.5 * (a_s + b_s)
+                half = 0.5 * h
+                for j in range(len(xi)):
+                    all_pts.append(float(mid_s + half * xi[j]))
+                    all_wts.append(float(wi[j] * half))
+            slices.append((start, len(all_pts)))
 
-        test_vert_res = config.getexpression(
-            'horiz_press_grad', 'vert_resolutions'
-        )
-        # Choose a reference vertical resolution based on the greatest common
-        # spacing among all test vertical resolutions so every test
-        # resolution is an integer multiple of 2 * vert_res.
-        vert_res = _get_reference_vert_res(test_vert_res)
-        logger.info(
-            f'Reference vertical resolution: vert_res = {vert_res:.12g} m'
-        )
-        z_tilde_bot_mid = config.getfloat(
-            'horiz_press_grad', 'z_tilde_bot_mid'
-        )
+        pts_arr = np.array(all_pts)
+        wts_arr = np.array(all_wts)
+        a_arr = self.hpga(pts_arr)
 
-        assert z_tilde_bot_mid is not None, (
-            'The "z_tilde_bot_mid" configuration option must be set in the '
-            '"horiz_press_grad" section.'
-        )
+        result = np.zeros(n_layers)
+        for k in range(n_layers):
+            s0, s1 = slices[k]
+            if layer_dz[k] > 0.0:
+                result[k] = np.dot(wts_arr[s0:s1], a_arr[s0:s1]) / layer_dz[k]
+        return result
 
-        vert_levels = int(-z_tilde_bot_mid / vert_res)
 
-        config.set('vertical_grid', 'vert_levels', str(vert_levels))
+class _ClampedInterp:
+    """PCHIP interpolant clamped (constant-extended) at its node boundaries."""
 
-        vert_levs_inters = 2 * vert_levels + 1
-        z_tilde = np.nan * np.ones((len(x), vert_levs_inters), dtype=float)
-        z = np.nan * np.ones((len(x), vert_levs_inters), dtype=float)
-        spec_vol = np.nan * np.ones((len(x), vert_levs_inters), dtype=float)
-        ct = np.nan * np.ones((len(x), vert_levs_inters), dtype=float)
-        sa = np.nan * np.ones((len(x), vert_levs_inters), dtype=float)
-        uniform_layer_mask = np.zeros((len(x), vert_levs_inters), dtype=bool)
-
-        z_tilde_node, temperature_node, salinity_node = (
-            self._get_z_tilde_t_s_nodes(x)
-        )
-
-        for icol in range(len(x)):
-            logger.info(f'Computing column {icol}, x = {x[icol]:.3f} km')
-            (
-                z_tilde[icol, :],
-                z[icol, :],
-                spec_vol[icol, :],
-                ct[icol, :],
-                sa[icol, :],
-                uniform_layer_mask[icol, :],
-            ) = self._compute_column(
-                z_tilde_node=z_tilde_node[icol, :],
-                temperature_node=temperature_node[icol, :],
-                salinity_node=salinity_node[icol, :],
-                geom_ssh=geom_ssh.isel(nCells=icol).item(),
-                geom_z_bot=geom_z_bot.isel(nCells=icol).item(),
-                z_tilde_bot=z_tilde_bot.isel(nCells=icol).item(),
-            )
-
-        valid_grad_mask = np.all(uniform_layer_mask[[1, 2, 3], :], axis=0)
-
-        dx = resolution * 1e3  # m
-
-        # compute Montgomery potential M = alpha * p + g * z
-        # with p = -rho0 * g * z_tilde (p positive downward)
-        montgomery = Gravity * (z - RhoSw * spec_vol * z_tilde)
-
-        dx = resolution * 1.0e3  # m
-
-        check_gradient = False
-
-        if check_gradient:
-            # sanity checks for 4th-order gradient stencil
-            x_m = dx * np.array([-1.5, -0.5, 0.5, 1.5], dtype=float)
-
-            # exact for polynomials up to degree 3
-            poly = 2.5 + 1.2 * x_m - 0.7 * x_m**2 + 0.9 * x_m**3
-            _check_gradient(
-                self.logger, poly, expected=1.2, name='cubic polynomial', dx=dx
-            )
-
-            # smooth function check (should be highly accurate)
-            k = 2.0 * np.pi / (20.0 * dx)
-            sine = np.sin(k * x_m)
-            _check_gradient(
-                self.logger, sine, expected=k, name='sin(kx)', dx=dx
-            )
-
-        # the HPGF is grad(M) - p * grad(alpha)
-        # Here we just compute the gradient at x=0 using a 4th-order
-        # finite-difference stencil
-        p0 = -RhoSw * Gravity * z_tilde[2, :]
-        # indices for -1.5dx, -0.5dx, 0.5dx, 1.5dx
-        grad_indices = [0, 1, 3, 4]
-        dM_dx = _compute_4th_order_gradient(montgomery[grad_indices, :], dx)
-        dalpha_dx = _compute_4th_order_gradient(spec_vol[grad_indices, :], dx)
-        hpga = -dM_dx + p0 * dalpha_dx
-
-        dsa_dx = _compute_4th_order_gradient(sa[grad_indices, :], dx)
-
-        # cells = [1, 3]  # indices for -0.5km and 0.5km
-        cells = np.arange(len(x))  # use all columns
-        ds = xr.Dataset()
-        ds['temperature'] = xr.DataArray(
-            data=ct[np.newaxis, cells, 1::2],
-            dims=['Time', 'nCells', 'nVertLevels'],
-            attrs={
-                'long_name': 'conservative temperature',
-                'units': 'degC',
-            },
-        )
-        ds['salinity'] = xr.DataArray(
-            data=sa[np.newaxis, cells, 1::2],
-            dims=['Time', 'nCells', 'nVertLevels'],
-            attrs={
-                'long_name': 'salinity',
-                'units': 'g kg-1',
-            },
-        )
-
-        ds['SpecVol'] = xr.DataArray(
-            data=spec_vol[np.newaxis, cells, 1::2],
-            dims=['Time', 'nCells', 'nVertLevels'],
-            attrs={
-                'long_name': 'specific volume',
-                'units': 'm3 kg-1',
-            },
-        )
-        ds['Density'] = 1.0 / ds['SpecVol']
-        ds.Density.attrs['long_name'] = 'density'
-        ds.Density.attrs['units'] = 'kg m-3'
-
-        ds['ZTildeMid'] = xr.DataArray(
-            data=z_tilde[np.newaxis, cells, 1::2],
-            dims=['Time', 'nCells', 'nVertLevels'],
-        )
-        ds.ZTildeMid.attrs['long_name'] = 'pseudo-height at layer midpoints'
-        ds.ZTildeMid.attrs['units'] = 'm'
-
-        ds['ZTildeInter'] = xr.DataArray(
-            data=z_tilde[np.newaxis, cells, 0::2],
-            dims=['Time', 'nCells', 'nVertLevelsP1'],
-        )
-        ds.ZTildeInter.attrs['long_name'] = 'pseudo-height at layer interfaces'
-        ds.ZTildeInter.attrs['units'] = 'm'
-
-        ds['GeomZMid'] = xr.DataArray(
-            data=z[np.newaxis, cells, 1::2],
-            dims=['Time', 'nCells', 'nVertLevels'],
-            attrs={
-                'long_name': 'geometric height at layer midpoints',
-                'units': 'm',
-            },
-        )
-
-        ds['GeomZInter'] = xr.DataArray(
-            data=z[np.newaxis, cells, 0::2],
-            dims=['Time', 'nCells', 'nVertLevelsP1'],
-            attrs={
-                'long_name': 'geometric height at layer interfaces',
-                'units': 'm',
-            },
-        )
-
-        ds['MontgomeryMid'] = xr.DataArray(
-            data=montgomery[np.newaxis, cells, 1::2],
-            dims=['Time', 'nCells', 'nVertLevels'],
-            attrs={
-                'long_name': 'Montgomery potential at layer midpoints',
-                'units': 'm2 s-2',
-            },
-        )
-
-        ds['MontgomeryInter'] = xr.DataArray(
-            data=montgomery[np.newaxis, cells, 0::2],
-            dims=['Time', 'nCells', 'nVertLevelsP1'],
-            attrs={
-                'long_name': 'Montgomery potential at layer interfaces',
-                'units': 'm2 s-2',
-            },
-        )
-
-        ds['HPGAMid'] = xr.DataArray(
-            data=hpga[np.newaxis, 1::2],
-            dims=['Time', 'nVertLevels'],
-            attrs={
-                'long_name': 'along-layer pressure gradient acceleration at '
-                'midpoints',
-                'units': 'm s-2',
-            },
-        )
-
-        ds['HPGAInter'] = xr.DataArray(
-            data=hpga[np.newaxis, 0::2],
-            dims=['Time', 'nVertLevelsP1'],
-            attrs={
-                'long_name': 'along-layer pressure gradient acceleration at '
-                'interfaces',
-                'units': 'm s-2',
-            },
-        )
-
-        ds['dMdxMid'] = xr.DataArray(
-            data=dM_dx[np.newaxis, 1::2],
-            dims=['Time', 'nVertLevels'],
-            attrs={
-                'long_name': 'Gradient of Montgomery potential at layer '
-                'midpoints',
-                'units': 'm s-2',
-            },
-        )
-
-        ds['PEdgeMid'] = xr.DataArray(
-            data=p0[np.newaxis, 1::2],
-            dims=['Time', 'nVertLevels'],
-            attrs={
-                'long_name': 'Pressure at horizontal edge and layer midpoints',
-                'units': 'Pa',
-            },
-        )
-
-        ds['dalphadxMid'] = xr.DataArray(
-            data=dalpha_dx[np.newaxis, 1::2],
-            dims=['Time', 'nVertLevels'],
-            attrs={
-                'long_name': 'Gradient of specific volume at layer midpoints',
-                'units': 'm2 kg-1',
-            },
-        )
-
-        ds['dSAdxMid'] = xr.DataArray(
-            data=dsa_dx[np.newaxis, 1::2],
-            dims=['Time', 'nVertLevels'],
-            attrs={
-                'long_name': 'Gradient of absolute salinity at layer '
-                'midpoints',
-                'units': 'g kg-1 m-1',
-            },
-        )
-
-        ds['ValidGradMidMask'] = xr.DataArray(
-            data=valid_grad_mask[np.newaxis, 1::2],
-            dims=['Time', 'nVertLevels'],
-            attrs={
-                'long_name': 'Mask indicating layers with valid gradients at '
-                'midpoints',
-                'units': '1',
-            },
-        )
-        ds['ValidGradInterMask'] = xr.DataArray(
-            data=valid_grad_mask[np.newaxis, 0::2],
-            dims=['Time', 'nVertLevelsP1'],
-            attrs={
-                'long_name': 'Mask indicating layers with valid gradients at '
-                'interfaces',
-                'units': '1',
-            },
-        )
-
-        self.write_model_dataset(ds, 'reference_solution.nc', config)
-
-    def _get_ssh_z_bot(
-        self, x: np.ndarray
-    ) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray]:
-        """
-        Get the geometric sea surface height and sea floor height, as well as
-        sea floor pseudo-height for each column from the configuration.
-        """
-        config = self.config
-        geom_ssh = get_array_from_mid_grad(config, 'geom_ssh', x)
-        geom_z_bot = get_array_from_mid_grad(config, 'geom_z_bot', x)
-        z_tilde_bot = get_array_from_mid_grad(config, 'z_tilde_bot', x)
-        return (
-            xr.DataArray(data=geom_ssh, dims=['nCells']),
-            xr.DataArray(data=geom_z_bot, dims=['nCells']),
-            xr.DataArray(data=z_tilde_bot, dims=['nCells']),
-        )
-
-    def _init_z_tilde_interface(
-        self, pseudo_bottom_depth: float, z_tilde_bot: float
-    ) -> tuple[np.ndarray, int, np.ndarray]:
-        """
-        Compute z-tilde vertical interfaces.
-        """
-        section = self.config['vertical_grid']
-        vert_levels = section.getint('vert_levels')
-        z_tilde_interface = np.linspace(
-            0.0, z_tilde_bot, vert_levels + 1, dtype=float
-        )
-        # layers where z_tilde is not adjusted for bathymetry
-        uniform_layer_mask = z_tilde_interface >= -pseudo_bottom_depth
-
-        z_tilde_interface = np.maximum(z_tilde_interface, -pseudo_bottom_depth)
-        dz = z_tilde_interface[0:-1] - z_tilde_interface[1:]
-        mask = dz == 0.0
-        z_tilde_interface[1:][mask] = np.nan
-
-        # max_layer is the index of the deepest non-nan layer interface
-        max_layer = np.where(~mask)[0][-1] + 1
-
-        return z_tilde_interface, max_layer, uniform_layer_mask
-
-    def _get_z_tilde_t_s_nodes(
-        self, x: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """
-        Get the z-tilde, temperature and salinity node values from the
-        configuration.
-        """
-        config = self.config
-        z_tilde_node = get_array_from_mid_grad(config, 'z_tilde', x)
-        t_node = get_array_from_mid_grad(config, 'temperature', x)
-        s_node = get_array_from_mid_grad(config, 'salinity', x)
-
-        if (
-            z_tilde_node.shape != t_node.shape
-            or z_tilde_node.shape != s_node.shape
-        ):
-            raise ValueError(
-                'The number of z_tilde, temperature and salinity '
-                'points must be the same in each column.'
-            )
-
-        self.logger.debug('z_tilde nodes:')
-        self.logger.debug(z_tilde_node)
-        self.logger.debug('temperature nodes:')
-        self.logger.debug(t_node)
-        self.logger.debug('salinity nodes:')
-        self.logger.debug(s_node)
-
-        return z_tilde_node, t_node, s_node
-
-    def _compute_column(
+    def __init__(
         self,
-        z_tilde_node: np.ndarray,
-        temperature_node: np.ndarray,
-        salinity_node: np.ndarray,
-        geom_ssh: float,
-        geom_z_bot: float,
-        z_tilde_bot: float,
-    ) -> tuple[
-        np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray
-    ]:
-        config = self.config
-        logger = self.logger
-        section = config['horiz_press_grad']
-        method = section.get('reference_quadrature_method')
-        assert method is not None, (
-            'The "reference_quadrature_method" configuration option must be '
-            'set in the "horiz_press_grad" section.'
-        )
-        pseudothickness_iter_count = config.getint(
-            'vertical_grid', 'pseudothickness_iter_count'
-        )
-        assert pseudothickness_iter_count is not None, (
-            'The "pseudothickness_iter_count" configuration option must be '
-            'set in the "vertical_grid" section.'
-        )
-
-        goal_geom_water_column_thickness = geom_ssh - geom_z_bot
-
-        # first guess at the pseudo bottom depth is the geometric
-        # water column thickness
-        pseudo_bottom_depth = goal_geom_water_column_thickness
-
-        logger.debug(
-            f'goal_geom_water_column_thickness = '
-            f'{goal_geom_water_column_thickness:.12f}'
-        )
-
-        for iter in range(pseudothickness_iter_count):
-            z_tilde_inter, max_layer, uniform_layer_mask_inter = (
-                self._init_z_tilde_interface(
-                    pseudo_bottom_depth=pseudo_bottom_depth,
-                    z_tilde_bot=z_tilde_bot,
-                )
-            )
-            vert_levels = len(z_tilde_inter) - 1
-
-            z_tilde_mid = 0.5 * (z_tilde_inter[0:-1] + z_tilde_inter[1:])
-
-            # z_tilde has both interfaces and midpoints
-            z_tilde = np.zeros(2 * vert_levels + 1, dtype=float)
-            z_tilde[0::2] = z_tilde_inter
-            z_tilde[1::2] = z_tilde_mid
-
-            uniform_layer_mask_mid = (
-                uniform_layer_mask_inter[0:-1] & uniform_layer_mask_inter[1:]
-            )
-            uniform_layer_mask = np.zeros(2 * vert_levels + 1, dtype=bool)
-            uniform_layer_mask[0::2] = uniform_layer_mask_inter
-            uniform_layer_mask[1::2] = uniform_layer_mask_mid
-
-            valid = slice(0, 2 * max_layer + 1)
-
-            z_tilde_valid = z_tilde[valid]
-            logger.debug(f'z_tilde_valid = {z_tilde_valid}')
-            logger.debug(f'z_tilde invalid = {z_tilde[2 * max_layer + 1 :]}')
-
-            z = np.nan * np.ones_like(z_tilde)
-            spec_vol = np.nan * np.ones_like(z_tilde)
-            ct = np.nan * np.ones_like(z_tilde)
-            sa = np.nan * np.ones_like(z_tilde)
-
-            (
-                z[valid],
-                spec_vol[valid],
-                ct[valid],
-                sa[valid],
-            ) = _integrate_geometric_height(
-                z_tilde_interfaces=z_tilde_valid,
-                z_tilde_nodes=z_tilde_node,
-                sa_nodes=salinity_node,
-                ct_nodes=temperature_node,
-                bottom_depth=-geom_z_bot,
-                method=method,
-            )
-
-            geom_water_column_thickness = z[0] - z[2 * max_layer]
-
-            scaling_factor = (
-                goal_geom_water_column_thickness / geom_water_column_thickness
-            )
-            logger.info(
-                f'   Iteration {iter}: '
-                f'scaling factor = {scaling_factor:.12f}, '
-                f'scaling factor - 1 = {scaling_factor - 1.0:.12g}, '
-                f'pseudo bottom depth = {pseudo_bottom_depth:.12f}, '
-                f'max layer = {max_layer}'
-            )
-            pseudo_bottom_depth *= scaling_factor
-        logger.info('')
-
-        return z_tilde, z, spec_vol, ct, sa, uniform_layer_mask
-
-
-def _integrate_geometric_height(
-    z_tilde_interfaces: Sequence[float] | np.ndarray,
-    z_tilde_nodes: Sequence[float] | np.ndarray,
-    sa_nodes: Sequence[float] | np.ndarray,
-    ct_nodes: Sequence[float] | np.ndarray,
-    bottom_depth: float,
-    method: Literal[
-        'midpoint', 'trapezoid', 'simpson', 'gauss2', 'gauss4', 'adaptive'
-    ] = 'gauss4',
-    subdivisions: int = 2,
-    rel_tol: float = 5e-8,
-    abs_tol: float = 5e-5,
-    max_recurs_depth: int = 12,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Integrate the hydrostatic relation to obtain geometric height.
-
-    Integrates upward from the seafloor using
-    ``dz/dz_tilde = rho0 * spec_vol(SA, CT, p)`` to obtain geometric
-    heights ``z`` at requested pseudo-heights ``z_tilde_interfaces``.
-
-    The salinity and temperature profiles are supplied as *piecewise
-    linear* functions of pseudo-height via collocation nodes and their
-    values. Outside the node range, profiles are held constant at the
-    end values (``numpy.interp`` behavior), permitting targets to extend
-    above or below the collocation range.
-
-    Methods
-    -------
-    The integral over each interface interval can be evaluated with one of
-    the following schemes (set with ``method``):
-
-    - 'midpoint': composite midpoint rule with ``subdivisions`` panels.
-    - 'trapezoid': composite trapezoidal rule with ``subdivisions`` panels.
-    - 'simpson': composite Simpson's rule; requires an even number of
-        panels. If ``subdivisions`` is odd, one is added internally.
-    - 'gauss2': 2-point Gauss-Legendre per panel (higher accuracy than
-        midpoint/trapezoid at similar cost).
-    - 'gauss4': 4-point Gauss-Legendre per panel (default; high accuracy
-        for smooth integrands).
-    - 'adaptive': adaptive recursive Simpson integration controlled by
-        ``rel_tol``, ``abs_tol`` and ``max_depth``.
-
-    Parameters
-    ----------
-    z_tilde_interfaces : sequence of float
-        Monotonic non-increasing layer-interface pseudo-heights ordered
-        from sea surface to seafloor. The first value corresponds to the
-        sea surface (typically near 0) and the last to the seafloor
-        (most negative). Values may extend outside the node range.
-    z_tilde_nodes : sequence of float
-        Strictly increasing collocation nodes for SA and CT.
-    sa_nodes, ct_nodes : sequence of float
-        Absolute Salinity (g/kg) and Conservative Temperature (degC) at
-        ``z_tilde_nodes``.
-    bottom_depth : float
-        Positive depth (m); geometric height at seafloor is ``-bottom_depth``.
-    method : str, optional
-        Quadrature method ('midpoint','trapezoid','simpson','gauss2',
-        'gauss4','adaptive'). Default 'gauss4'.
-    subdivisions : int, optional
-        Subdivisions per interval for fixed-step methods (>=1). Ignored
-        for 'adaptive'.
-    rel_tol, abs_tol : float, optional
-        Relative/absolute tolerances for adaptive Simpson.
-    max_recurs_depth : int, optional
-        Max recursion depth for adaptive Simpson.
-
-    Returns
-    -------
-    z : ndarray
-        Geometric heights at ``z_tilde_interfaces``.
-    spec_vol : ndarray
-        Specific volume at targets.
-    ct : ndarray
-        Conservative temperature at targets.
-    sa : ndarray
-        Absolute salinity at targets.
-    """
-
-    z_tilde_interfaces = np.asarray(z_tilde_interfaces, dtype=float)
-    z_tilde_nodes = np.asarray(z_tilde_nodes, dtype=float)
-    sa_nodes = np.asarray(sa_nodes, dtype=float)
-    ct_nodes = np.asarray(ct_nodes, dtype=float)
-
-    if not (
-        z_tilde_nodes.ndim == sa_nodes.ndim == ct_nodes.ndim == 1
-        and z_tilde_interfaces.ndim == 1
+        z_tilde_nodes: np.ndarray,
+        values_nodes: np.ndarray,
+        name: str,
     ):
-        raise ValueError('All inputs must be one-dimensional.')
-    if len(z_tilde_nodes) != len(sa_nodes) or len(z_tilde_nodes) != len(
-        ct_nodes
-    ):
-        raise ValueError(
-            'Lengths of z_tilde_nodes, sa_nodes, ct_nodes differ.'
+        self._interp = get_pchip_interpolator(
+            z_tilde_nodes, values_nodes, name
         )
-    if len(z_tilde_nodes) < 2:
-        raise ValueError('Need at least two collocation nodes.')
-    if not np.all(np.diff(z_tilde_nodes) <= 0):
-        raise ValueError('z_tilde_nodes must be strictly non-increasing.')
-    if not np.all(np.diff(z_tilde_interfaces) <= 0):
-        raise ValueError('z_tilde_interfaces must be non-increasing.')
-    if subdivisions < 1:
-        raise ValueError('subdivisions must be >= 1.')
+        self._z_min = float(np.min(z_tilde_nodes))
+        self._z_max = float(np.max(z_tilde_nodes))
 
-    sa_interp = get_pchip_interpolator(
-        z_tilde_nodes=z_tilde_nodes,
-        values_nodes=sa_nodes,
-        name='salinity',
-    )
-    ct_interp = get_pchip_interpolator(
-        z_tilde_nodes=z_tilde_nodes,
-        values_nodes=ct_nodes,
-        name='temperature',
-    )
-
-    def spec_vol_ct_sa_at(
-        z_tilde: np.ndarray,
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        sa = sa_interp(z_tilde)
-        ct = ct_interp(z_tilde)
-        p_pa = -RhoSw * Gravity * z_tilde
-        # gsw expects pressure in dbar
-        spec_vol = gsw.specvol(sa, ct, p_pa * 1.0e-4)
-        return spec_vol, ct, sa
-
-    def integrand(z_tilde: np.ndarray) -> np.ndarray:
-        spec_vol, _, _ = spec_vol_ct_sa_at(z_tilde)
-        return RhoSw * spec_vol
-
-    # fill interface heights: anchor bottom, integrate upward (reverse)
-    n_interfaces = len(z_tilde_interfaces)
-    if n_interfaces < 2:
-        raise ValueError('Need at least two interfaces (surface and bottom).')
-    z = np.empty_like(z_tilde_interfaces)
-    z[-1] = -bottom_depth
-    for i in range(n_interfaces - 1, 0, -1):
-        a = z_tilde_interfaces[i - 1]  # shallower
-        b = z_tilde_interfaces[i]  # deeper
-        if a == b:
-            z[i - 1] = z[i]
-            continue
-        if method == 'adaptive':
-            inc = _adaptive_simpson(
-                integrand, a, b, rel_tol, abs_tol, max_recurs_depth
-            )
-        else:
-            nsub = subdivisions
-            if method == 'simpson' and nsub % 2 == 1:
-                nsub += 1
-            inc = _fixed_quadrature(integrand, a, b, nsub, method)
-        z[i - 1] = z[i] - inc
-
-    spec_vol, ct, sa = spec_vol_ct_sa_at(z_tilde_interfaces)
-    return z, spec_vol, ct, sa
+    def __call__(self, z_tilde: np.ndarray) -> np.ndarray:
+        z = np.clip(np.asarray(z_tilde, dtype=float), self._z_min, self._z_max)
+        return self._interp(z)
 
 
-def _get_reference_vert_res(
-    test_vert_res: Sequence[float] | np.ndarray,
-) -> float:
-    """
-    Compute the reference vertical resolution.
-
-    The returned value ``vert_res`` is chosen so that each test vertical
-    resolution is an integer multiple of ``2 * vert_res``.
-    """
-    test_vert_res = np.asarray(test_vert_res, dtype=float)
-    if test_vert_res.size == 0:
-        raise ValueError('At least one test vertical resolution is required.')
-
-    flat = test_vert_res.ravel()
-    if not np.all(np.isfinite(flat)):
-        raise ValueError('All test vertical resolutions must be finite.')
-    if np.any(flat <= 0.0):
-        raise ValueError('All test vertical resolutions must be positive.')
-
-    fractions = [Fraction(str(value)) for value in flat]
-
-    common_spacing = fractions[0]
-    for value in fractions[1:]:
-        common_spacing = _fraction_gcd(common_spacing, value)
-
-    if common_spacing <= 0:
-        raise ValueError(
-            'Could not determine a positive common spacing from '
-            'test vertical resolutions.'
-        )
-
-    vert_res = float(common_spacing) / 2.0
-
-    # Defensive check against accidental precision/pathological inputs.
-    multipliers = flat / (2.0 * vert_res)
-    if not np.allclose(
-        multipliers, np.round(multipliers), rtol=0.0, atol=1.0e-12
-    ):
-        raise ValueError(
-            'Test vertical resolutions are not integer multiples of '
-            '2 * reference vertical resolution.'
-        )
-
-    return vert_res
-
-
-def _fraction_gcd(a: Fraction, b: Fraction) -> Fraction:
-    return Fraction(
-        gcd(a.numerator, b.numerator), lcm(a.denominator, b.denominator)
-    )
+# ---- quadrature primitives --------------------------------------------------
 
 
 def _fixed_quadrature(
@@ -895,57 +421,3 @@ def _adaptive_simpson_recursive(
         max_depth,
         depth + 1,
     )
-
-
-def _check_gradient(
-    logger,
-    values: np.ndarray,
-    expected: float,
-    name: str,
-    dx: float | None = None,
-    rel_tol: float = 1.0e-12,
-    abs_tol: float = 5.0e-8,
-) -> None:
-    """Check the 4th-order gradient stencil against an analytic value."""
-    if dx is None:
-        raise ValueError('dx must be provided for gradient checks.')
-    calc = _compute_4th_order_gradient(values[:, np.newaxis], dx)[0]
-    err = calc - expected
-    logger.info(
-        f'4th-order gradient check {name}: '
-        f'calc={calc:.6e}, expected={expected:.6e}, '
-        f'err={err:.3e}'
-    )
-    tol = max(abs_tol, rel_tol * max(1.0, abs(expected)))
-    if not np.isfinite(calc) or abs(err) > tol:
-        raise ValueError(
-            f'4th-order gradient check failed for {name}: '
-            f'calc={calc}, expected={expected}, err={err}'
-        )
-
-
-def _compute_4th_order_gradient(f: np.ndarray, dx: float) -> np.ndarray:
-    """
-    Compute a 4th-order finite-difference gradient of f with respect to x
-    at x=0, assuming values at x = dx * [-1.5, -0.5, 0.5, 1.5].
-
-    The stencil is:
-        f'(0) ≈ [f(-1.5dx) - 27 f(-0.5dx) + 27 f(0.5dx) - f(1.5dx)]
-                 / (24 dx)
-
-    Here we assume f[0,:], f[1,:], f[2,:], f[3,:] correspond to
-    x = -1.5dx, -0.5dx, 0.5dx, 1.5dx respectively.
-    """
-    assert f.shape[0] == 4, (
-        'Input array must have exactly 4 entries in its first dimension '
-        'for the 4th-order gradient.'
-    )
-
-    # gradient at x = 0 using the non-uniform 4-point stencil
-    df_dx = (f[0, :] - 27.0 * f[1, :] + 27.0 * f[2, :] - f[3, :]) / (24.0 * dx)
-
-    # mask any locations where inputs are NaN
-    nan_mask = np.any(np.isnan(f), axis=0)
-    df_dx[nan_mask] = np.nan
-
-    return df_dx

--- a/polaris/tasks/ocean/horiz_press_grad/task.py
+++ b/polaris/tasks/ocean/horiz_press_grad/task.py
@@ -4,7 +4,6 @@ from polaris import Task
 from polaris.tasks.ocean.horiz_press_grad.analysis import Analysis
 from polaris.tasks.ocean.horiz_press_grad.forward import Forward
 from polaris.tasks.ocean.horiz_press_grad.init import Init
-from polaris.tasks.ocean.horiz_press_grad.reference import Reference
 
 
 class HorizPressGradTask(Task):
@@ -87,9 +86,6 @@ class HorizPressGradTask(Task):
         for step in list(self.steps.values()):
             self.remove_step(step)
 
-        reference_step = Reference(component=self.component, indir=self.subdir)
-        self.add_step(reference_step)
-
         init_steps = dict()
         forward_steps = dict()
 
@@ -120,7 +116,6 @@ class HorizPressGradTask(Task):
                 component=self.component,
                 indir=self.subdir,
                 dependencies={
-                    'reference': reference_step,
                     'init': init_steps,
                     'forward': forward_steps,
                 },

--- a/tests/ocean/horiz_press_grad/test_reference.py
+++ b/tests/ocean/horiz_press_grad/test_reference.py
@@ -1,0 +1,345 @@
+"""
+Unit tests for ReferenceColumn.
+
+All tests are self-contained: no file I/O, no Omega build required.
+A PolarisConfigParser is built from the package default config in each test,
+with specific options overridden as needed.
+"""
+
+import gsw
+import numpy as np
+import pytest
+
+from polaris.config import PolarisConfigParser
+from polaris.ocean.vertical.ztilde import Gravity, RhoSw
+from polaris.tasks.ocean.horiz_press_grad.reference import ReferenceColumn
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HPG_PKG = 'polaris.tasks.ocean.horiz_press_grad'
+
+
+def _make_config(**overrides: str) -> PolarisConfigParser:
+    """Load default horiz_press_grad config and apply string overrides."""
+    config = PolarisConfigParser()
+    config.add_from_package(_HPG_PKG, 'horiz_press_grad.cfg')
+    for key, value in overrides.items():
+        config.set('horiz_press_grad', key, value)
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_zero_gradient_hpga_is_zero():
+    """With all horizontal gradients zero, hpga must be zero everywhere.
+
+    C = eta' - rho0 * alpha(z_surf) * zt_surf' = 0 - 0 = 0
+    dalpha_dx = 0  =>  I(z) = 0
+    a(z) = -g * (0 + rho0 * 0) = 0
+    """
+    config = _make_config()
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    z_b = config['horiz_press_grad'].getfloat('z_tilde_bot_mid')
+    z_test = np.array([z_b, z_b * 0.75, z_b * 0.5, z_b * 0.25, 0.0])
+
+    hpga_vals = ref.hpga(z_test)
+    np.testing.assert_allclose(hpga_vals, 0.0, atol=1e-20)
+
+
+def test_surface_boundary_hpga_is_constant():
+    """With only a sea-surface-height gradient, hpga is constant in z̃.
+
+    The reference is anchored at the surface.  With all T/S and z_tilde
+    gradients zero, dalpha_dx = 0, so the integral vanishes and
+
+    a(z) = -g * C = -g * geom_ssh_grad/1000   (independent of z)
+    """
+    sshg = 2.0  # m / km
+    config = _make_config(geom_ssh_grad=str(sshg))
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    z_b = config['horiz_press_grad'].getfloat('z_tilde_bot_mid')
+    z_surf = config['horiz_press_grad'].getnumpy('z_tilde_mid')[0]
+    expected = -Gravity * (sshg / 1000.0)
+
+    z_test = np.array([z_b, z_b * 0.6, z_b * 0.3, z_surf])
+    hpga_vals = ref.hpga(z_test)
+    np.testing.assert_allclose(hpga_vals, expected, rtol=1e-8)
+
+
+def test_surface_pseudoheight_gradient_in_boundary():
+    """The surface pseudo-height gradient enters the boundary term.
+
+    Evaluated exactly at the surface the integral is zero, so
+
+    a(z_surf) = -g * (geom_ssh_grad/1000
+                      - rho0 * alpha(z_surf) * z_tilde_grad[0]/1000)
+
+    This isolates the surface boundary term and guards the contribution that a
+    nonzero surface pressure (which shifts the surface pseudo-height) will use
+    in the follow-up surface-pressure test.
+    """
+    sshg = 2.0  # m / km
+    ztsg = 1.5  # m / km (surface pseudo-height node gradient)
+    config = _make_config(
+        geom_ssh_grad=str(sshg),
+        z_tilde_grad=f'[{ztsg}, 0.0, 0.0, 0.0, 0.0]',
+    )
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    z_surf = config['horiz_press_grad'].getnumpy('z_tilde_mid')[0]
+    alpha_s = float(ref.specvol(np.array([z_surf]))[0])
+    expected = -Gravity * (sshg / 1000.0 - RhoSw * alpha_s * ztsg / 1000.0)
+
+    np.testing.assert_allclose(
+        ref.hpga(np.array([z_surf]))[0], expected, rtol=1e-10
+    )
+
+
+def test_nonzero_ssh_surface_boundary_is_nonzero():
+    """A nonzero sea-surface-height gradient yields a nonzero surface HPGA.
+
+    Guards the general boundary term so the follow-up surface-pressure test
+    cannot be silently broken by an assumption of zero SSH.
+    """
+    sshg = 3.0  # m / km
+    config = _make_config(geom_ssh_grad=str(sshg))
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    z_surf = config['horiz_press_grad'].getnumpy('z_tilde_mid')[0]
+    # z_tilde_grad is zero by default, so C = eta'
+    expected = -Gravity * (sshg / 1000.0)
+    np.testing.assert_allclose(
+        ref.hpga(np.array([z_surf]))[0], expected, rtol=1e-12
+    )
+    assert abs(expected) > 0.0
+
+
+def test_surface_boundary_hpga_respects_x_sign():
+    """x_sign = -1 negates the result relative to x_sign = +1."""
+    config = _make_config(geom_ssh_grad='2.0')
+    ref_pos = ReferenceColumn(config, x_sign=1.0)
+    ref_neg = ReferenceColumn(config, x_sign=-1.0)
+
+    z_b = config['horiz_press_grad'].getfloat('z_tilde_bot_mid')
+    z_test = np.array([z_b * 0.5, 0.0])
+
+    np.testing.assert_allclose(
+        ref_neg.hpga(z_test), -ref_pos.hpga(z_test), rtol=1e-14
+    )
+
+
+def test_hpga_sampling_independence():
+    """hpga at coincident z̃ agrees within quadrature error across different
+    evaluation grids.
+
+    The cumulative quadrature splits the integral at each unique target z̃,
+    so adding intermediate points changes the sub-interval widths and hence
+    the quadrature accuracy.  The mismatch between a dense and a sparse grid
+    at coincident z̃ is the quadrature error of the coarser computation and
+    must be small relative to the value.
+    """
+    config = _make_config(
+        temperature_grad='[0.5, 0.4, 0.3, 0.2, 0.1]',
+        salinity_grad='[0.02, 0.02, 0.01, 0.01, 0.005]',
+    )
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    z_b = config['horiz_press_grad'].getfloat('z_tilde_bot_mid')
+
+    # Dense grid and sparse grid with several shared points
+    z_shared = np.array([z_b, z_b * 0.5, 0.0])
+    z_dense = np.concatenate([z_shared, np.linspace(z_b * 0.9, z_b * 0.1, 15)])
+    z_dense = np.sort(z_dense)
+
+    hpga_dense = ref.hpga(z_dense)
+    hpga_shared = ref.hpga(z_shared)
+
+    for z_val, h_ref in zip(z_shared, hpga_shared, strict=True):
+        idx = np.where(z_dense == z_val)[0]
+        assert len(idx) >= 1
+        # Dense grid is more accurate; sparse grid carries quadrature error.
+        # Tolerance is well within the level needed for HPG accuracy.
+        np.testing.assert_allclose(
+            hpga_dense[idx[0]],
+            h_ref,
+            rtol=1e-4,
+            err_msg=f'Mismatch at z̃={z_val}',
+        )
+
+
+def test_dalpha_dx_matches_specvol_finite_difference():
+    """dalpha_dx agrees with a direct centred FD of gsw.specvol at fixed z̃.
+
+    The ReferenceColumn computes d(α)/dx via the TEOS-10 chain rule
+    v_SA*dSA/dx + v_CT*dCT/dx.  For a small perturbation this must equal
+    (alpha(x+eps) - alpha(x-eps)) / (2*eps) to O(eps^2) accuracy.
+    """
+    config = _make_config(
+        temperature_grad='[0.5, 0.4, 0.3, 0.2, 0.1]',
+        salinity_grad='[0.05, 0.04, 0.03, 0.02, 0.01]',
+    )
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    z_b = config['horiz_press_grad'].getfloat('z_tilde_bot_mid')
+    two_eps_m = ref._two_eps_m
+    z_test = np.array([z_b * 0.9, z_b * 0.5, z_b * 0.1])
+
+    dalpha_computed = ref.dalpha_dx(z_test)
+
+    # Direct FD: specvol at x = ±eps with corresponding SA/CT profiles
+    sa_plus = ref._sa_plus(z_test)
+    ct_plus = ref._ct_plus(z_test)
+    sa_minus = ref._sa_minus(z_test)
+    ct_minus = ref._ct_minus(z_test)
+    p_dbar = (-RhoSw * Gravity * z_test) * 1.0e-4
+    alpha_plus = gsw.specvol(sa_plus, ct_plus, p_dbar)
+    alpha_minus = gsw.specvol(sa_minus, ct_minus, p_dbar)
+    dalpha_fd = (alpha_plus - alpha_minus) / two_eps_m
+
+    # gsw.specvol_first_derivatives uses analytical polynomial derivatives
+    # that are self-consistent with gsw.specvol to ~1e-5 relative tolerance.
+    np.testing.assert_allclose(dalpha_computed, dalpha_fd, rtol=1e-3)
+
+
+def test_tilted_nodes_dalpha_dx():
+    """Moving-node differencing is correct when z_tilde_grad != 0.
+
+    In the ztilde_gradient task the z̃ nodes themselves shift with x.
+    Verify that dalpha_dx still matches the direct FD of specvol built from
+    the shifted-node PCHIP profiles.
+    """
+    config = _make_config(
+        z_tilde_grad='[0.0, 2.0, 5.0, 3.0, 0.0]',
+        salinity_grad='[0.05, 0.04, 0.03, 0.02, 0.01]',
+        temperature_grad='[0.3, 0.2, 0.1, 0.05, 0.0]',
+    )
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    # Choose z̃ well within the node range at all x
+    z_test = np.array([-100.0, -250.0, -450.0])
+    two_eps_m = ref._two_eps_m
+
+    dalpha_computed = ref.dalpha_dx(z_test)
+
+    sa_plus = ref._sa_plus(z_test)
+    ct_plus = ref._ct_plus(z_test)
+    sa_minus = ref._sa_minus(z_test)
+    ct_minus = ref._ct_minus(z_test)
+    p_dbar = (-RhoSw * Gravity * z_test) * 1.0e-4
+    alpha_plus = gsw.specvol(sa_plus, ct_plus, p_dbar)
+    alpha_minus = gsw.specvol(sa_minus, ct_minus, p_dbar)
+    dalpha_fd = (alpha_plus - alpha_minus) / two_eps_m
+
+    # PCHIP node-shift amplification combined with gsw polynomial
+    # self-consistency gives ~3e-4 relative error for moving nodes.
+    np.testing.assert_allclose(dalpha_computed, dalpha_fd, rtol=2e-3)
+
+
+def test_hpga_leibniz_consistency():
+    """d(hpga)/dz̃ = -g * rho0 * dalpha_dx (Leibniz formula check).
+
+    This verifies the cumulative quadrature integrates the correct integrand.
+    All targets are evaluated in a single hpga() call so that consecutive
+    pairs (z̃-dz, z̃+dz) share the same cumulative-integral path and the FD
+    difference equals the small-panel integral rather than the difference of
+    two large separate integrals.
+    """
+    config = _make_config(
+        temperature_grad='[0.4, 0.3, 0.2, 0.1, 0.0]',
+        salinity_grad='[0.03, 0.02, 0.01, 0.005, 0.0]',
+        geom_ssh_grad='1.0',
+    )
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    z_test = np.array([-400.0, -200.0, -50.0])
+    dz = 0.1  # small z̃ step (m)
+    n = len(z_test)
+
+    # Single call includes z_test-dz AND z_test+dz so that the difference
+    # is computed from a tiny O(dz) integral, not two large integrals.
+    z_combined = np.concatenate([z_test - dz, z_test + dz])
+    hpga_combined = ref.hpga(z_combined)
+    hpga_deriv_fd = (hpga_combined[n:] - hpga_combined[:n]) / (2.0 * dz)
+    expected_deriv = -Gravity * RhoSw * ref.dalpha_dx(z_test)
+
+    np.testing.assert_allclose(hpga_deriv_fd, expected_deriv, rtol=1e-5)
+
+
+def test_layer_mean_constant_hpga():
+    """For a constant HPGA (zero T/S gradients), layer means equal that value.
+
+    Gauss quadrature integrates a constant exactly, so this should hold to
+    near floating-point precision regardless of layer thickness or nsub.
+    """
+    sshg = 2.0
+    config = _make_config(geom_ssh_grad=str(sshg))
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    z_b = config['horiz_press_grad'].getfloat('z_tilde_bot_mid')
+    expected = -Gravity * (sshg / 1000.0)
+
+    n_layers = 8
+    interfaces = np.linspace(0.0, z_b, n_layers + 1)
+    layer_means = ref.layer_mean_hpga(interfaces)
+
+    np.testing.assert_allclose(layer_means, expected, rtol=1e-10)
+
+
+def test_layer_mean_zero_gradient():
+    """With all gradients zero, layer_mean_hpga returns zero for all layers."""
+    config = _make_config()
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    z_b = config['horiz_press_grad'].getfloat('z_tilde_bot_mid')
+    interfaces = np.linspace(0.0, z_b, 11)
+    layer_means = ref.layer_mean_hpga(interfaces)
+
+    np.testing.assert_allclose(layer_means, 0.0, atol=1e-20)
+
+
+def test_layer_mean_approaches_pointwise_as_layer_thins():
+    """As layer thickness shrinks, the layer mean approaches pointwise value.
+
+    Uses a config with non-zero T/S gradients so HPGA varies with z̃.
+    For very thin layers the two-point mean should agree with hpga(z̃_mid)
+    to within the second-order quadrature error.
+    """
+    config = _make_config(
+        temperature_grad='[0.5, 0.4, 0.3, 0.2, 0.1]',
+        salinity_grad='[0.02, 0.015, 0.01, 0.005, 0.0]',
+    )
+    ref = ReferenceColumn(config, x_sign=1.0)
+
+    # Very thin layer centred on z_mid
+    z_mid = -200.0
+    for half_dz in [10.0, 1.0, 0.1]:
+        interfaces = np.array([z_mid + half_dz, z_mid - half_dz])
+        layer_mean = float(ref.layer_mean_hpga(interfaces)[0])
+        pointwise = float(ref.hpga(np.array([z_mid]))[0])
+        diff = abs(layer_mean - pointwise)
+        # error should shrink as half_dz shrinks
+        assert diff < 1e-3 * abs(pointwise) + 1e-20, (
+            f'half_dz={half_dz}: layer_mean={layer_mean:.6e}, '
+            f'pointwise={pointwise:.6e}, diff={diff:.3e}'
+        )
+
+
+@pytest.mark.parametrize('x_sign', [1.0, -1.0])
+def test_layer_mean_shape(x_sign):
+    """layer_mean_hpga returns shape (nLayers,) for (nLayers+1,) interfaces."""
+    config = _make_config(temperature_grad='[0.3, 0.2, 0.1, 0.05, 0.0]')
+    ref = ReferenceColumn(config, x_sign=x_sign)
+
+    z_b = config['horiz_press_grad'].getfloat('z_tilde_bot_mid')
+    n_layers = 6
+    interfaces = np.linspace(0.0, z_b, n_layers + 1)
+    means = ref.layer_mean_hpga(interfaces)
+
+    assert means.shape == (n_layers,)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

## Summary

Replace the `Reference` step in `ocean/horiz_press_grad` with a lightweight `ReferenceColumn` evaluator that computes the HPG reference analytically at a single column via the chain-rule / Leibniz expansion, removing the multi-column finite-difference machinery that broke in two systematic ways:

1. **Grid-alignment fragility** — the old step required exact pseudo-height matching between the reference grid and the model layers; a non-zero `SurfacePressure` or partial bottom cells would misalign interfaces and cause sampling to fail.
2. **Near-bathymetry breakdown** — the 5-column stencil needed every neighbor  column valid at a given z̃; near the seafloor some columns fall below their  own bathymetry, masking those layers and producing an accuracy floor that  would block a future higher-order HPG.

The new reference evaluates

```math
a(\tilde{z}) = -g\left[
z_b' - \rho_0\,\alpha(\tilde{z}_b)\,\tilde{z}_b'
+ \rho_0 \int_{\tilde{z}_b}^{\tilde{z}}
\bigl(\nu_S\,\partial_x S_A + \nu_\Theta\,\partial_x\Theta\bigr)\,
d\tilde{z}'
\right]
```

at the edge ($x = 0$), using TEOS-10 specific-volume first derivatives and PCHIP-interpolated CT/SA profiles with centred differencing at $x \pm \varepsilon$ (handles moving nodes in the `ztilde_gradient` task). `Analysis` layer-averages $a(\tilde z)$ over the model's actual interface pseudo-heights and compares to the layer-averaged forward HPGA, so layer tilt and finite thickness are folded into the target rather than charged as error.

## Changes

- **`reference.py`**: Replaced `Reference(OceanIOStep)` and supporting multi-column helpers with `ReferenceColumn` (public) and `_ClampedInterp` (private). Quadrature primitives (`_fixed_quadrature`, `_gauss_composite`, adaptive Simpson) are retained unchanged.
- **`analysis.py`**: Removed the `reference` step dependency and `reference_solution.nc` input/sampling. Now builds a `ReferenceColumn` per resolution from config, reads edge interface pseudo-heights from `init.nc`, layer-averages the reference, and drops the deepest valid layer (abuts bathymetry) before computing the RMS error. Removed `_sample_reference_without_interpolation`.
- **`task.py`**: Removed the `Reference` step creation, `add_step`, and its `'reference'` entry in the `Analysis` dependencies dict.
- **`horiz_press_grad.cfg`**: Replaced `reference_horiz_res` with `reference_quadrature_subdivisions = 4` (panels per interval for the cumulative integral and per-layer Gauss averaging) and `reference_horiz_eps_km = 1.0e-3` (centred-difference half-width for $\partial S_A/\partial x$ and $\partial\Theta/\partial x$).
- **`tests/ocean/horiz_press_grad/test_reference.py`** (new): 12 unit tests covering zero-gradient, geometry-only, x_sign negation, sampling independence, dalpha_dx chain-rule vs. FD of `gsw.specvol`, moving-node differencing, Leibniz consistency (d(hpga)/dz̃), layer-mean correctness, and shape.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
