### PR TITLE
Require state vars in `write_initial_state_dataset`, including surface pressure

### DIFF
--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -40,6 +40,7 @@ class OceanIOStep(OceanModelFilesMixin, Step):
         init_filename=None,
         base_mesh_filename=None,
         graph_filename=None,
+        skip_validation=False,
     ):
         """
         Register output files that will be consumed by the ocean model as
@@ -82,9 +83,19 @@ class OceanIOStep(OceanModelFilesMixin, Step):
         if base_mesh_filename is not None:
             self.add_output_file(filename=base_mesh_filename)
         self.add_output_file(filename=horiz_mesh_filename)
-        self.add_output_file(filename=init_filename)
+        if skip_validation:
+            self.add_output_file(filename=init_filename)
+        else:
+            self.add_output_file(
+                filename=init_filename, validate_class='state'
+            )
         if model == 'omega':
-            self.add_output_file(filename=vert_coord_filename)
+            if skip_validation:
+                self.add_output_file(filename=vert_coord_filename)
+            else:
+                self.add_output_file(
+                    filename=vert_coord_filename, validate_class='vert_coord'
+                )
         if model == 'mpas-ocean' and graph_filename is not None:
             self.add_output_file(filename=graph_filename)
 

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -278,3 +278,56 @@ class OceanIOStep(Step, OceanModelFilesMixin):
         return self.component.open_model_dataset(
             filename, config=config, **kwargs
         )
+
+    def add_output_file(
+        self,
+        filename,
+        validate_vars=None,
+        check_properties=None,
+        validate_class=None,
+    ):
+        """
+        Add an output file, optionally resolving ``validate_class`` to a
+        pre-defined list of variables from the Ocean component.
+
+        Parameters
+        ----------
+        filename : str
+            The output filename to register.
+
+        validate_vars : list of str, optional
+            Explicit list of variable names to validate against a baseline.
+            Mutually exclusive with ``validate_class``.
+
+        validate_class : str, optional
+            A named class of variables to validate.  Currently only
+            ``'state'`` is supported, which resolves to
+            ``self.component.state_vars`` mapped to the native model's
+            variable names.
+
+        **kwargs
+            Forwarded to :py:meth:`polaris.Step.add_output_file`.
+        """
+        if validate_class is not None:
+            if validate_class == 'state':
+                if self.component.state_vars is None:
+                    self.component._read_variables_yaml()
+                assert self.component.state_vars is not None
+                validate_vars = list(
+                    dict.fromkeys(
+                        self.component.map_var_list_to_native_model(
+                            self.component.state_vars
+                        )
+                        + (validate_vars if validate_vars is not None else [])
+                    )
+                )
+            else:
+                raise ValueError(
+                    f"Unknown validate_class '{validate_class}'. "
+                    "Currently only 'state' is supported."
+                )
+        super().add_output_file(
+            filename=filename,
+            validate_vars=validate_vars,
+            check_properties=check_properties,
+        )

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from polaris.tasks.ocean import Ocean
 
 
-class OceanIOStep(Step, OceanModelFilesMixin):
+class OceanIOStep(OceanModelFilesMixin, Step):
     """
     A step that writes input and/or output files for Omega or MPAS-Ocean
     """
@@ -277,57 +277,4 @@ class OceanIOStep(Step, OceanModelFilesMixin):
         """
         return self.component.open_model_dataset(
             filename, config=config, **kwargs
-        )
-
-    def add_output_file(
-        self,
-        filename,
-        validate_vars=None,
-        check_properties=None,
-        validate_class=None,
-    ):
-        """
-        Add an output file, optionally resolving ``validate_class`` to a
-        pre-defined list of variables from the Ocean component.
-
-        Parameters
-        ----------
-        filename : str
-            The output filename to register.
-
-        validate_vars : list of str, optional
-            Explicit list of variable names to validate against a baseline.
-            Mutually exclusive with ``validate_class``.
-
-        validate_class : str, optional
-            A named class of variables to validate.  Currently only
-            ``'state'`` is supported, which resolves to
-            ``self.component.state_vars`` mapped to the native model's
-            variable names.
-
-        **kwargs
-            Forwarded to :py:meth:`polaris.Step.add_output_file`.
-        """
-        if validate_class is not None:
-            if validate_class == 'state':
-                if self.component.state_vars is None:
-                    self.component._read_variables_yaml()
-                assert self.component.state_vars is not None
-                validate_vars = list(
-                    dict.fromkeys(
-                        self.component.map_var_list_to_native_model(
-                            self.component.state_vars
-                        )
-                        + (validate_vars if validate_vars is not None else [])
-                    )
-                )
-            else:
-                raise ValueError(
-                    f"Unknown validate_class '{validate_class}'. "
-                    "Currently only 'state' is supported."
-                )
-        super().add_output_file(
-            filename=filename,
-            validate_vars=validate_vars,
-            check_properties=check_properties,
         )

--- a/polaris/ocean/model/ocean_model_files_mixin.py
+++ b/polaris/ocean/model/ocean_model_files_mixin.py
@@ -136,33 +136,52 @@ class OceanModelFilesMixin:
             Forwarded to :py:meth:`polaris.Step.add_output_file`.
 
         validate_class : str, optional
-            A named class of variables to validate.  Currently only
-            ``'state'`` is supported, which resolves to
-            ``self.component.state_vars`` mapped to the native model's
-            variable names.  The resulting list is unioned with any
-            explicitly supplied ``validate_vars``.
+            A named class of variables to validate. 'state' or 'vert_coord'
+            are supported. The resulting list is unioned with any explicitly
+            supplied ``validate_vars``.
         """
+        validate_vars_native = None
         if validate_class is not None:
-            if validate_class == 'state':
+            if validate_class == 'vert_coord':
+                if self.component.vert_coord_vars is None:
+                    self.component._read_variables_yaml()
+                assert self.component.vert_coord_vars is not None
+                validate_vars_native = (
+                    self.component.map_var_list_to_native_model(
+                        self.component.vert_coord_vars
+                    )
+                )
+            elif validate_class == 'state':
                 if self.component.state_vars is None:
                     self.component._read_variables_yaml()
                 assert self.component.state_vars is not None
-                validate_vars = list(
-                    dict.fromkeys(
-                        self.component.map_var_list_to_native_model(
-                            self.component.state_vars
-                        )
-                        + (validate_vars if validate_vars is not None else [])
+                # build validate_vars in the MPAS-Ocean namespace used by
+                # open_model_dataset during validation
+                validate_vars_native = (
+                    self.component.map_var_list_to_native_model(
+                        self.component.state_vars
                     )
                 )
             else:
                 raise ValueError(
                     f"Unknown validate_class '{validate_class}'. "
-                    "Currently only 'state' is supported."
+                    "Currently only 'vert_coord' and 'state' are supported."
                 )
+        validate_vars = list(
+            dict.fromkeys(
+                (
+                    self.component.map_var_list_from_native_model(
+                        validate_vars_native
+                    )
+                    if validate_vars_native is not None
+                    else []
+                )
+                + (validate_vars if validate_vars is not None else [])
+            )
+        )
         super().add_output_file(  # type: ignore[misc]
             filename=filename,
-            validate_vars=validate_vars,
+            validate_vars=validate_vars if validate_vars else None,
             check_properties=check_properties,
         )
 

--- a/polaris/ocean/model/ocean_model_files_mixin.py
+++ b/polaris/ocean/model/ocean_model_files_mixin.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from polaris.config import PolarisConfigParser
@@ -29,20 +29,7 @@ class OceanModelFilesMixin:
     # These attributes and methods are provided by the Step base class:
     config: 'PolarisConfigParser'
     input_data: list[dict[str, Any]]
-
-    def add_input_file(
-        self,
-        filename=None,
-        target=None,
-        database=None,
-        database_component=None,
-        url=None,
-        work_dir_target=None,
-        package=None,
-        copy=False,
-    ) -> None:
-        """Provided by :py:class:`polaris.Step`."""
-        raise NotImplementedError
+    add_input_file: Callable[..., None]
 
     # --- filename getters ---
 
@@ -125,6 +112,59 @@ class OceanModelFilesMixin:
             :py:meth:`polaris.Step.add_input_file`.
         """
         self.add_input_file(filename='<<<init>>>', **kwargs)
+
+    def add_output_file(
+        self,
+        filename,
+        validate_vars=None,
+        check_properties=None,
+        validate_class=None,
+    ):
+        """
+        Add an output file, optionally resolving ``validate_class`` to a
+        pre-defined list of variables from the Ocean component.
+
+        Parameters
+        ----------
+        filename : str
+            The output filename to register.
+
+        validate_vars : list of str, optional
+            Explicit list of variable names to validate against a baseline.
+
+        check_properties : dict, optional
+            Forwarded to :py:meth:`polaris.Step.add_output_file`.
+
+        validate_class : str, optional
+            A named class of variables to validate.  Currently only
+            ``'state'`` is supported, which resolves to
+            ``self.component.state_vars`` mapped to the native model's
+            variable names.  The resulting list is unioned with any
+            explicitly supplied ``validate_vars``.
+        """
+        if validate_class is not None:
+            if validate_class == 'state':
+                if self.component.state_vars is None:
+                    self.component._read_variables_yaml()
+                assert self.component.state_vars is not None
+                validate_vars = list(
+                    dict.fromkeys(
+                        self.component.map_var_list_to_native_model(
+                            self.component.state_vars
+                        )
+                        + (validate_vars if validate_vars is not None else [])
+                    )
+                )
+            else:
+                raise ValueError(
+                    f"Unknown validate_class '{validate_class}'. "
+                    "Currently only 'state' is supported."
+                )
+        super().add_output_file(  # type: ignore[misc]
+            filename=filename,
+            validate_vars=validate_vars,
+            check_properties=check_properties,
+        )
 
     # --- shared placeholder resolution ---
 

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -34,7 +34,7 @@ ConfigsType = Dict[
 ]
 
 
-class OceanModelStep(ModelStep, OceanModelFilesMixin):
+class OceanModelStep(OceanModelFilesMixin, ModelStep):
     """
     An Omega or MPAS-Ocean step
 

--- a/polaris/ocean/model/variables.yaml
+++ b/polaris/ocean/model/variables.yaml
@@ -48,6 +48,7 @@ ocean:
     - temperature
     - salinity
     - normalVelocity
+    - surfacePressure
 
 mpas-ocean:
   vert_coord_variables:
@@ -57,8 +58,8 @@ mpas-ocean:
 
 Omega:
   vert_coord_variables:
+    # [MinLayerCell, MaxLayerCell, BottomGeomDepth,
+    # VertCoordMovementWeights, RefPseudoThickness]
     - RefPseudoThickness
-    - SurfacePressure
   state_variables:
-    - SurfacePressure
     - PseudoThickness

--- a/polaris/ocean/model/variables.yaml
+++ b/polaris/ocean/model/variables.yaml
@@ -44,11 +44,21 @@ ocean:
     - maxLevelCell
     - bottomDepth
     - vertCoordMovementWeights
+  state_variables:
+    - temperature
+    - salinity
+    - normalVelocity
 
 mpas-ocean:
   vert_coord_variables:
     - restingThickness
+  state_variables:
+    - layerThickness
 
 Omega:
   vert_coord_variables:
     - RefPseudoThickness
+    - SurfacePressure
+  state_variables:
+    - SurfacePressure
+    - PseudoThickness

--- a/polaris/ocean/model/variables.yaml
+++ b/polaris/ocean/model/variables.yaml
@@ -48,7 +48,6 @@ ocean:
     - temperature
     - salinity
     - normalVelocity
-    - surfacePressure
 
 mpas-ocean:
   vert_coord_variables:
@@ -63,3 +62,4 @@ Omega:
     - RefPseudoThickness
   state_variables:
     - PseudoThickness
+    - SurfacePressure

--- a/polaris/ocean/model/variables.yaml
+++ b/polaris/ocean/model/variables.yaml
@@ -60,6 +60,6 @@ Omega:
     # [MinLayerCell, MaxLayerCell, BottomGeomDepth,
     # VertCoordMovementWeights, RefPseudoThickness]
     - RefPseudoThickness
+    - SurfacePressure
   state_variables:
     - PseudoThickness
-    - SurfacePressure

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -57,7 +57,7 @@ def pseudothickness_from_ds(
     ----------
     ds : xarray.Dataset
         An ocean dataset containing 'temperature', 'salinity',
-        src_var_name, and 'ssh'
+        src_var_name, and 'SurfacePressure'
 
     config : polaris.config.PolarisConfigParser
         Configuration options for the test case, including
@@ -93,7 +93,16 @@ def pseudothickness_from_ds(
     if iter_count is None:
         iter_count = get_iter_count_for_eos(config)
 
-    surface_pressure = config.getfloat('vertical_grid', 'surface_pressure')
+    if 'SurfacePressure' not in ds.keys():
+        surface_pressure = config.getfloat('vertical_grid', 'surface_pressure')
+        print(
+            'SurfacePressure not found in dataset. Setting SurfacePressure '
+            f'to {surface_pressure} from config file'
+        )
+        ds['SurfacePressure'] = xr.DataArray(
+            surface_pressure * np.ones((1, ds.sizes['nCells']), dtype=float),
+            dims=('Time', 'nCells'),
+        )
     src_var = ds[src_var_name]
     src_has_time = 'Time' in src_var.dims
     if not src_has_time:
@@ -103,7 +112,7 @@ def pseudothickness_from_ds(
         src_var,
         ds.temperature,
         ds.salinity,
-        surface_pressure * xr.ones_like(ds.ssh),
+        ds.SurfacePressure,
         iter_count=iter_count,
     )
 

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -177,7 +177,7 @@ class Ocean(Component):
             ]
         return renamed_vars
 
-    def write_model_dataset(self, ds, filename, config):
+    def write_model_dataset(self, ds, filename, config, contains_state=False):
         """
         Write out the given dataset, mapping dimension and variable names from
         MPAS-Ocean to Omega names if appropriate
@@ -194,6 +194,10 @@ class Ocean(Component):
             Configuration for the task; used when the model is Omega to
             convert geometric layer thickness to pseudo-thickness before
             writing.
+
+        contains_state : bool, optional
+            If True, perform additional validation that all configured state
+            variables are present in the dataset after mapping.
         """
         if self.model == 'omega':
             # fields to be converted from geometric to pseudo thickness
@@ -234,10 +238,20 @@ class Ocean(Component):
                             )
                             ds[omega_var] = ds[mpas_var] / (spec_vol * RhoSw)
 
-        # After map_to_native_model_vars, the dataset contains
-        # LayerThickness and PseudoThickness which are both
-        # pseudo-thickness
         ds = self.map_to_native_model_vars(ds)
+
+        if contains_state:
+            # After map_to_native_model_vars, the dataset contains
+            # LayerThickness and PseudoThickness which are both
+            # pseudo-thickness
+            if self.state_vars is None:
+                self._read_variables_yaml()
+            if self.model == 'omega' and self.mpaso_to_omega_var_map is None:
+                self._read_var_map()
+            assert self.state_vars is not None
+
+            native_vars = self.map_var_list_to_native_model(self.state_vars)
+            self._check_vars_present(ds, native_vars, 'write_model_dataset')
 
         write_netcdf(ds=ds, fileName=filename)
 
@@ -319,7 +333,6 @@ class Ocean(Component):
         assert self.vert_coord_vars is not None
 
         native_vars = self.map_var_list_to_native_model(self.vert_coord_vars)
-
         if self.model != 'omega':
             self._check_vars_present(
                 ds, native_vars, 'write_vert_coord_dataset'
@@ -338,10 +351,24 @@ class Ocean(Component):
                 if 'Time' in pseudothickness.dims:
                     pseudothickness = pseudothickness.isel(Time=0)
                 ds_vc['RefPseudoThickness'] = pseudothickness
+        if 'vertCoordMovementWeights' not in ds_vc:
+            print(
+                'vertCoordMovementWeights not found in vert_coord dataset; '
+                'defaulting to ones'
+            )
+            ds_vc['vertCoordMovementWeights'] = xr.DataArray(
+                data=np.ones(
+                    (1, ds_vc.sizes['nVertLevels'], ds_vc.sizes['nCells']),
+                    dtype=float,
+                ),
+                dims=['Time', 'nVertLevels', 'nCells'],
+                attrs={
+                    'units': '',
+                    'long_name': 'Vertical coordinate movement weights',
+                },
+            )
 
         ds_vc = self.map_to_native_model_vars(ds_vc)
-        # native_vars for Omega: [MinLayerCell, MaxLayerCell,
-        #   BottomGeomDepth, VertCoordMovementWeights, RefPseudoThickness]
         self._check_vars_present(
             ds_vc, native_vars, 'write_vert_coord_dataset'
         )
@@ -392,29 +419,24 @@ class Ocean(Component):
             Configuration for the task; forwarded to
             :py:meth:`write_model_dataset`.
         """
+        if self.model is None:
+            self.model = config.get('ocean', 'model')
         ds = self.remove_horiz_mesh_vars(ds)
         if self.model == 'omega':
             ds = self.remove_vert_coord_vars(ds)
 
-        if self.state_vars is None:
-            self._read_variables_yaml()
-        if self.model == 'omega' and self.mpaso_to_omega_var_map is None:
-            self._read_var_map()
-        assert self.state_vars is not None
-
-        native_vars = self.map_var_list_to_native_model(self.state_vars)
-
         # make sure surfacePressure is present for Omega
         if 'surfacePressure' not in ds and 'SurfacePressure' not in ds:
+            print(
+                'surfacePressure not found in initial_state dataset; '
+                'defaulting to zeros'
+            )
             ds['surfacePressure'] = xr.DataArray(
                 data=np.zeros((1, ds.sizes['nCells']), dtype=float),
                 dims=['Time', 'nCells'],
                 attrs={'units': 'Pa', 'long_name': 'Surface Pressure'},
             )
-        self._check_vars_present(
-            ds, native_vars, 'write_initial_state_dataset'
-        )
-        self.write_model_dataset(ds, filename, config)
+        self.write_model_dataset(ds, filename, config, contains_state=True)
 
     def map_from_native_model_vars(self, ds):
         """
@@ -647,6 +669,7 @@ class Ocean(Component):
         if (
             self.horiz_mesh_vars is not None
             and self.vert_coord_vars is not None
+            and self.state_vars is not None
         ):
             return
         package = 'polaris.ocean.model'
@@ -658,6 +681,7 @@ class Ocean(Component):
         self.vert_coord_vars = list(
             nested_dict['ocean']['vert_coord_variables']
         )
+        self.state_vars = list(nested_dict['ocean']['state_variables'])
         model_section_map = {'mpas-ocean': 'mpas-ocean', 'omega': 'Omega'}
         model_key = model_section_map.get(self.model or '')
         if model_key:
@@ -665,6 +689,8 @@ class Ocean(Component):
                 'vert_coord_variables', []
             )
             self.vert_coord_vars.extend(extra)
+            extra = nested_dict.get(model_key, {}).get('state_variables', [])
+            self.state_vars.extend(extra)
 
     def _read_var_map(self):
         """

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -341,6 +341,22 @@ class Ocean(Component):
 
         ds_vc = ds.copy()
 
+        # make sure SurfacePressure is present for Omega
+        if 'SurfacePressure' not in ds.keys():
+            if 'surfacePressure' in ds.keys():
+                # Because 'SurfacePressure' is required for Omega only,
+                # we must use Omega naming
+                ds['SurfacePressure'] = ds.surfacePressure
+            else:
+                print(
+                    'surfacePressure not found in initial_state dataset; '
+                    'defaulting to zeros'
+                )
+                ds['SurfacePressure'] = xr.DataArray(
+                    data=np.zeros((1, ds.sizes['nCells']), dtype=float),
+                    dims=['Time', 'nCells'],
+                    attrs={'units': 'Pa', 'long_name': 'Surface Pressure'},
+                )
         # Convert restingThickness (geometric) to RefPseudoThickness (pseudo)
         if 'restingThickness' in ds_vc and 'RefPseudoThickness' not in ds_vc:
             pseudothickness, _ = pseudothickness_from_ds(
@@ -425,22 +441,6 @@ class Ocean(Component):
         if self.model == 'omega':
             ds = self.remove_vert_coord_vars(ds)
 
-        # make sure SurfacePressure is present for Omega
-        if 'SurfacePressure' not in ds:
-            if 'surfacePressure' in ds:
-                # Because 'SurfacePressure' is required for Omega only,
-                # we must use Omega naming
-                ds['SurfacePressure'] = ds.surfacePressure
-            else:
-                print(
-                    'surfacePressure not found in initial_state dataset; '
-                    'defaulting to zeros'
-                )
-                ds['SurfacePressure'] = xr.DataArray(
-                    data=np.zeros((1, ds.sizes['nCells']), dtype=float),
-                    dims=['Time', 'nCells'],
-                    attrs={'units': 'Pa', 'long_name': 'Surface Pressure'},
-                )
         self.write_model_dataset(ds, filename, config, contains_state=True)
 
     def map_from_native_model_vars(self, ds):

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -666,12 +666,6 @@ class Ocean(Component):
         """
         Read horiz_mesh_vars and vert_coord_vars from variables.yaml
         """
-        if (
-            self.horiz_mesh_vars is not None
-            and self.vert_coord_vars is not None
-            and self.state_vars is not None
-        ):
-            return
         package = 'polaris.ocean.model'
         filename = 'variables.yaml'
         text = imp_res.files(package).joinpath(filename).read_text()

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -425,17 +425,22 @@ class Ocean(Component):
         if self.model == 'omega':
             ds = self.remove_vert_coord_vars(ds)
 
-        # make sure surfacePressure is present for Omega
-        if 'surfacePressure' not in ds and 'SurfacePressure' not in ds:
-            print(
-                'surfacePressure not found in initial_state dataset; '
-                'defaulting to zeros'
-            )
-            ds['surfacePressure'] = xr.DataArray(
-                data=np.zeros((1, ds.sizes['nCells']), dtype=float),
-                dims=['Time', 'nCells'],
-                attrs={'units': 'Pa', 'long_name': 'Surface Pressure'},
-            )
+        # make sure SurfacePressure is present for Omega
+        if 'SurfacePressure' not in ds:
+            if 'surfacePressure' in ds:
+                # Because 'SurfacePressure' is required for Omega only,
+                # we must use Omega naming
+                ds['SurfacePressure'] = ds.surfacePressure
+            else:
+                print(
+                    'surfacePressure not found in initial_state dataset; '
+                    'defaulting to zeros'
+                )
+                ds['SurfacePressure'] = xr.DataArray(
+                    data=np.zeros((1, ds.sizes['nCells']), dtype=float),
+                    dims=['Time', 'nCells'],
+                    attrs={'units': 'Pa', 'long_name': 'Surface Pressure'},
+                )
         self.write_model_dataset(ds, filename, config, contains_state=True)
 
     def map_from_native_model_vars(self, ds):

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -58,6 +58,7 @@ class Ocean(Component):
         self.mpaso_to_omega_var_map: Union[None, Dict[str, str]] = None
         self.horiz_mesh_vars: Union[None, list[str]] = None
         self.vert_coord_vars: Union[None, list[str]] = None
+        self.state_vars: Union[None, list[str]] = None
 
     def configure(self, config, tasks):
         """
@@ -395,13 +396,24 @@ class Ocean(Component):
         if self.model == 'omega':
             ds = self.remove_vert_coord_vars(ds)
 
-            # make sure surfacePressure is present for Omega
-            if 'surfacePressure' not in ds and 'SurfacePressure' not in ds:
-                ds['surfacePressure'] = xr.DataArray(
-                    data=np.zeros((1, ds.sizes['nCells']), dtype=float),
-                    dims=['Time', 'nCells'],
-                    attrs={'units': 'Pa', 'long_name': 'Surface Pressure'},
-                )
+        if self.state_vars is None:
+            self._read_variables_yaml()
+        if self.model == 'omega' and self.mpaso_to_omega_var_map is None:
+            self._read_var_map()
+        assert self.state_vars is not None
+
+        native_vars = self.map_var_list_to_native_model(self.state_vars)
+
+        # make sure surfacePressure is present for Omega
+        if 'surfacePressure' not in ds and 'SurfacePressure' not in ds:
+            ds['surfacePressure'] = xr.DataArray(
+                data=np.zeros((1, ds.sizes['nCells']), dtype=float),
+                dims=['Time', 'nCells'],
+                attrs={'units': 'Pa', 'long_name': 'Surface Pressure'},
+            )
+        self._check_vars_present(
+            ds, native_vars, 'write_initial_state_dataset'
+        )
         self.write_model_dataset(ds, filename, config)
 
     def map_from_native_model_vars(self, ds):

--- a/polaris/tasks/ocean/baroclinic_channel/forward.py
+++ b/polaris/tasks/ocean/baroclinic_channel/forward.py
@@ -130,12 +130,7 @@ class Forward(OceanModelStep):
 
         self.add_output_file(
             filename='output.nc',
-            validate_vars=[
-                'temperature',
-                'salinity',
-                'layerThickness',
-                'normalVelocity',
-            ],
+            validate_class='state',
         )
 
         self.dt = None

--- a/polaris/tasks/ocean/geostrophic/init.py
+++ b/polaris/tasks/ocean/geostrophic/init.py
@@ -46,17 +46,11 @@ class Init(OceanIOStep):
 
     def setup(self):
         super().setup()
-        self.add_output_file(filename='culled_mesh.nc')
-        validate_vars = [
-            'temperature',
-            'salinity',
-            'layerThickness',
-            'normalVelocity',
-        ]
-        self.add_output_file(filename='init.nc', validate_vars=validate_vars)
-        model = self.config.get('ocean', 'model')
-        if model == 'omega':
-            self.add_output_file(filename='vert_coord.nc')
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            vert_coord_filename='vert_coord.nc',
+            init_filename='init.nc',
+        )
 
     def run(self):
         """

--- a/polaris/tasks/ocean/ice_shelf_2d/init.py
+++ b/polaris/tasks/ocean/ice_shelf_2d/init.py
@@ -41,15 +41,13 @@ class Init(OceanIOStep):
 
     def setup(self):
         super().setup()
-        for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info']:
-            self.add_output_file(file)
-        self.add_output_file(
-            'init.nc',
-            validate_vars=['temperature', 'salinity', 'layerThickness'],
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            vert_coord_filename='vert_coord.nc',
+            init_filename='init.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
         )
-        model = self.config.get('ocean', 'model')
-        if model == 'omega':
-            self.add_output_file('vert_coord.nc')
 
     def run(self):
         """

--- a/polaris/tasks/ocean/inertial_gravity_wave/init.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/init.py
@@ -111,4 +111,4 @@ class Init(OceanIOStep):
         normal_velocity = normal_velocity.expand_dims(dim='Time', axis=0)
         ds['normalVelocity'] = normal_velocity
 
-        self.write_initial_state_dataset(ds, 'init.nc', config)
+        self.write_model_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/inertial_gravity_wave/init.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/init.py
@@ -52,6 +52,7 @@ class Init(OceanIOStep):
             horiz_mesh_filename='culled_mesh.nc',
             base_mesh_filename='base_mesh.nc',
             graph_filename='culled_graph.info',
+            skip_validation=True,  # since not all state variables are included
         )
 
     def run(self):

--- a/polaris/tasks/ocean/internal_wave/init.py
+++ b/polaris/tasks/ocean/internal_wave/init.py
@@ -36,7 +36,7 @@ class Init(OceanIOStep):
             self.add_output_file(file)
         self.add_output_file(
             'init.nc',
-            validate_vars=['temperature', 'salinity', 'layerThickness'],
+            validate_class='state',
         )
         model = self.config.get('ocean', 'model')
         if model == 'omega':

--- a/polaris/tasks/ocean/internal_wave/init.py
+++ b/polaris/tasks/ocean/internal_wave/init.py
@@ -32,15 +32,13 @@ class Init(OceanIOStep):
 
     def setup(self):
         super().setup()
-        for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info']:
-            self.add_output_file(file)
-        self.add_output_file(
-            'init.nc',
-            validate_class='state',
+        self.add_output_files_for_ocean_model_input(
+            horiz_mesh_filename='culled_mesh.nc',
+            vert_coord_filename='vert_coord.nc',
+            init_filename='init.nc',
+            base_mesh_filename='base_mesh.nc',
+            graph_filename='culled_graph.info',
         )
-        model = self.config.get('ocean', 'model')
-        if model == 'omega':
-            self.add_output_file('vert_coord.nc')
 
     def run(self):
         """

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -51,6 +51,7 @@ Omega:
       Contents:
       - NormalVelocity
       - PseudoThickness
+      - SurfacePressure
     History:
       Filename: output.nc
       Freq: {{ output_freq }}

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -51,7 +51,6 @@ Omega:
       Contents:
       - NormalVelocity
       - PseudoThickness
-      - SurfacePressure
     History:
       Filename: output.nc
       Freq: {{ output_freq }}

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -104,11 +104,7 @@ class Forward(OceanModelStep):
 
         self.add_output_file(
             filename='output.nc',
-            validate_vars=[
-                'layerThickness',
-                'normalVelocity',
-                'temperature',
-            ],
+            validate_class='state',
         )
 
     def dynamic_model_config(self, at_setup):

--- a/tests/ocean/test_mesh_init_split.py
+++ b/tests/ocean/test_mesh_init_split.py
@@ -42,8 +42,12 @@ def test_write_initial_state_dataset_omega_drops_horiz_mesh_vars(tmp_path):
         data_vars=dict(
             xCell=('nCells', [0.0, 1.0]),
             fCell=('nCells', [1.0, 2.0]),
+            normalVelocity=(('nEdges', 'nVertLevels'), [[0.0], [0.0]]),
+            layerThickness=(('nCells', 'nVertLevels'), [[1.0], [1.0]]),
             temperature=(('nCells', 'nVertLevels'), [[3.0], [4.0]]),
             salinity=(('nCells', 'nVertLevels'), [[35.0], [35.0]]),
+            SurfacePressure=('nCells', [0.0, 0.0]),
+            PseudoThickness=(('nCells', 'nVertLevels'), [[1.0], [1.0]]),
         )
     )
 
@@ -66,6 +70,9 @@ def test_write_initial_state_dataset_omega_drops_vert_coord_vars(tmp_path):
 
     ds = xr.Dataset(
         data_vars=dict(
+            normalVelocity=(('nEdges', 'nVertLevels'), [[0.0], [0.0]]),
+            RefPseudoThickness=(('nCells', 'nVertLevels'), [[1.0], [1.0]]),
+            PseudoThickness=(('nCells', 'nVertLevels'), [[1.0], [1.0]]),
             temperature=(('nCells', 'nVertLevels'), [[3.0], [4.0]]),
             salinity=(('nCells', 'nVertLevels'), [[35.0], [35.0]]),
             minLevelCell=('nCells', [0, 0]),
@@ -97,6 +104,8 @@ def test_write_initial_state_dataset_mpas_ocean_keeps_vert_coord_vars(
 
     ds = xr.Dataset(
         data_vars=dict(
+            normalVelocity=(('nEdges', 'nVertLevels'), [[0.0], [0.0]]),
+            layerThickness=(('nCells', 'nVertLevels'), [[1.0], [1.0]]),
             temperature=(('nCells', 'nVertLevels'), [[3.0], [4.0]]),
             salinity=(('nCells', 'nVertLevels'), [[35.0], [35.0]]),
             minLevelCell=('nCells', [0, 0]),
@@ -129,7 +138,10 @@ def test_write_vert_coord_dataset_noop_for_mpas_ocean(tmp_path):
             minLevelCell=('nCells', [0, 0]),
             maxLevelCell=('nCells', [0, 0]),
             bottomDepth=('nCells', [100.0, 200.0]),
-            restingThickness=(('nCells', 'nVertLevels'), [[50.0], [100.0]]),
+            restingThickness=(
+                ('nCells', 'nVertLevels'),
+                [[50.0], [100.0]],
+            ),
             vertCoordMovementWeights=('nVertLevels', [1.0]),
         )
     )
@@ -161,6 +173,7 @@ def test_write_vert_coord_dataset_raises_on_missing_vars(
         data_vars=dict(
             minLevelCell=('nCells', [0, 0]),
             maxLevelCell=('nCells', [0, 0]),
+            vertCoordMovementWeights=('nVertLevels', [1.0]),
             bottomDepth=('nCells', [100.0, 200.0]),
         )
     )


### PR DESCRIPTION
**Includes submodule update to https://github.com/E3SM-Project/Omega/pull/433**

Currently, `write_vert_coord_dataset` requires the `vert_coord` variables. Similarly, here `write_initial_state_dataset` requires the `state` variables. This ensures that all model-specific required inputs are present. 

Thus, this PR adds `surfacePressure` to the initial state dataset, requiring that Omega have the capability to read it in, provided by https://github.com/E3SM-Project/Omega/pull/433.

The implications of this PR are that any tests _not_ using all of the state variables (e.g., those not including tracers) must use `write_model_dataset` or `add_outputs_for_model_inputs(..., skip_validation=True)`, which does not require state variables by default.

Checklist
* [X] `Testing` comment in the PR documents testing used to verify the changes

Fixes https://github.com/E3SM-Project/polaris/issues/594