### PR TITLE
Add additional pseudo-* variables to omega/mpas-o conversion

### DIFF
--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -199,6 +199,7 @@ class Ocean(Component):
             mpas_to_omega_vars = {
                 'layerThickness': 'PseudoThickness',
                 'restingThickness': 'RefPseudoThickness',
+                'vertAleTransportTop': 'TotalVerticalPseudoVelocity',
                 'vertVelocityTop': 'VerticalPseudoVelocity',
             }
             for mpas_var, omega_var in mpas_to_omega_vars.items():
@@ -217,7 +218,10 @@ class Ocean(Component):
                                 and mpas_var == 'layerThickness'
                             ):
                                 ds['SpecVol'] = spec_vol
-                    elif mpas_var == 'vertVelocityTop':
+                    elif (
+                        mpas_var == 'vertVelocityTop'
+                        or mpas_var == 'vertAleTransportTop'
+                    ):
                         if (
                             'SpecVol' not in ds.keys()
                             and 'layerThickness' in ds.keys()

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -9,10 +9,18 @@ from mpas_tools.vector.reconstruct import reconstruct_variable
 from ruamel.yaml import YAML
 
 from polaris import Component
+from polaris.constants import get_constant
 from polaris.ocean.vertical.diagnostics import (
     geom_thickness_from_ds,
     pseudothickness_from_ds,
 )
+from polaris.ocean.vertical.ztilde import (
+    geom_height_from_pseudo_height,
+    get_iter_count_for_eos,
+    pressure_and_spec_vol_from_state_at_geom_height,
+)
+
+RhoSw = get_constant('seawater_density_reference')
 
 
 class Ocean(Component):
@@ -191,16 +199,35 @@ class Ocean(Component):
             mpas_to_omega_vars = {
                 'layerThickness': 'PseudoThickness',
                 'restingThickness': 'RefPseudoThickness',
+                'vertVelocityTop': 'VerticalPseudoVelocity',
             }
             for mpas_var, omega_var in mpas_to_omega_vars.items():
                 if mpas_var in ds.keys() and omega_var not in ds.keys():
-                    pseudothickness, spec_vol = pseudothickness_from_ds(
-                        ds, config=config, src_var_name=mpas_var
-                    )
-                    if pseudothickness is not None and spec_vol is not None:
-                        ds[omega_var] = pseudothickness
-                        if mpas_var == 'layerThickness':
-                            ds['SpecVol'] = spec_vol
+                    if 'Thickness' in mpas_var:
+                        pseudothickness, spec_vol = pseudothickness_from_ds(
+                            ds, config=config, src_var_name=mpas_var
+                        )
+                        if (
+                            pseudothickness is not None
+                            and spec_vol is not None
+                        ):
+                            ds[omega_var] = pseudothickness
+                            if (
+                                'SpecVol' not in ds.keys()
+                                and mpas_var == 'layerThickness'
+                            ):
+                                ds['SpecVol'] = spec_vol
+                    elif mpas_var == 'vertVelocityTop':
+                        if (
+                            'SpecVol' not in ds.keys()
+                            and 'layerThickness' in ds.keys()
+                        ):
+                            _, spec_vol = pseudothickness_from_ds(
+                                ds,
+                                config=config,
+                                src_var_name='layerThickness',
+                            )
+                            ds[omega_var] = ds[mpas_var] / (spec_vol * RhoSw)
 
         # After map_to_native_model_vars, the dataset contains
         # LayerThickness and PseudoThickness which are both
@@ -441,6 +468,7 @@ class Ocean(Component):
         filename,
         config,
         mesh_filename=None,
+        vert_filename=None,
         reconstruct_variables=None,
         coeffs_filename=None,
         **kwargs,
@@ -483,6 +511,65 @@ class Ocean(Component):
             and 'SpecVol' in ds.keys()
         ):
             ds['layerThickness'] = geom_thickness_from_ds(ds, config=config)
+        if (
+            self.model == 'omega'
+            and 'SpecVol' not in ds.keys()
+            and 'Temperature' in ds.keys()
+            and 'Salinity' in ds.keys()
+            and 'SurfacePressure' in ds.keys()
+        ):
+            iter_count = get_iter_count_for_eos(config)
+            _, _, spec_vol = pressure_and_spec_vol_from_state_at_geom_height(
+                config,
+                ds.layerThickness,
+                ds.Temperature,
+                ds.Salinity,
+                ds.SurfacePressure,
+                iter_count=iter_count,
+            )
+            ds.SpecVol = spec_vol
+        if (
+            self.model == 'omega'
+            and 'vertVelocityTop' not in ds.keys()
+            and 'PseudoThickness' in ds.keys()
+            and 'SpecVol' in ds.keys()
+            and 'VerticalPseudoVelocity' in ds.keys()
+            and mesh_filename is not None
+        ):
+            ds_vert = self.open_model_dataset(vert_filename, config)
+            geom_z_inter, geom_z_mid = geom_height_from_pseudo_height(
+                geom_z_bot=ds_vert.bottomDepth,
+                h_tilde=ds.PseudoThickness.rename(
+                    {'NVertLayers': 'nVertLevels', 'NCells': 'nCells'}
+                ),
+                spec_vol=ds.SpecVol.rename(
+                    {'NVertLayers': 'nVertLevels', 'NCells': 'nCells'}
+                ),
+                min_level_cell=ds_vert.minLevelCell,
+                max_level_cell=ds_vert.maxLevelCell,
+            )
+            n_time = geom_z_inter.sizes['time']
+            n_vert_levels_p1 = geom_z_inter.sizes['nVertLevelsP1']
+            n_cells = geom_z_inter.sizes['nCells']
+            spec_vol_inter_vals = np.zeros((n_time, n_vert_levels_p1, n_cells))
+            for i_time in range(ds.sizes['time']):
+                for i_cell in range(n_cells):
+                    x_vals = geom_z_inter.isel(nCells=i_cell, time=i_time)
+                    xp_vals = geom_z_mid.isel(nCells=i_cell, time=i_time)
+                    fp_vals = ds.SpecVol.isel(NCells=i_cell, time=i_time)
+                    interp_vals = np.interp(
+                        x_vals.values,
+                        xp_vals.values,
+                        fp_vals.values,
+                    )
+                    spec_vol_inter_vals[i_time, :, i_cell] = interp_vals
+            spec_vol_inter = xr.DataArray(
+                spec_vol_inter_vals,
+                dims=['time', 'NVertLayersP1', 'NCells'],
+            )
+            ds['vertVelocityTop'] = (
+                ds.VerticalPseudoVelocity * spec_vol_inter * RhoSw
+            )
         ds = self.map_from_native_model_vars(ds)
         if reconstruct_variables is not None:
             if mesh_filename is None:

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -204,7 +204,7 @@ class Ocean(Component):
             }
             for mpas_var, omega_var in mpas_to_omega_vars.items():
                 if mpas_var in ds.keys() and omega_var not in ds.keys():
-                    if 'Thickness' in mpas_var:
+                    if mpas_var in ['layerThickness', 'restingThickness']:
                         pseudothickness, spec_vol = pseudothickness_from_ds(
                             ds, config=config, src_var_name=mpas_var
                         )
@@ -218,10 +218,10 @@ class Ocean(Component):
                                 and mpas_var == 'layerThickness'
                             ):
                                 ds['SpecVol'] = spec_vol
-                    elif (
-                        mpas_var == 'vertVelocityTop'
-                        or mpas_var == 'vertAleTransportTop'
-                    ):
+                    elif mpas_var in [
+                        'vertVelocityTop',
+                        'vertAleTransportTop',
+                    ]:
                         if (
                             'SpecVol' not in ds.keys()
                             and 'layerThickness' in ds.keys()

--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -137,5 +137,6 @@ Omega:
       - State
       - Eos
       - SshCell
+      - VerticalPseudoVelocity
       FileFreq: 9999
       FileFreqUnits: years

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -73,12 +73,9 @@ class Viz(OceanIOStep):
         model = self.config.get('ocean', 'model')
         # TODO: remove as soon as Omega no longer needs this file
         if model == 'omega':
-            res = forward.name.split('_')[1]
             self.add_input_file(
                 filename='coeffs.nc',
-                target=f'{res}_coeffs.nc',
-                database_component='ocean',
-                database='merry_go_round',
+                work_dir_target=f'{forward.path}/coeffs.nc',
             )
 
     def run(self):

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -70,6 +70,16 @@ class Viz(OceanIOStep):
             filename='output.nc',
             work_dir_target=f'{forward.path}/output.nc',
         )
+        model = self.config.get('ocean', 'model')
+        # TODO: remove as soon as Omega no longer needs this file
+        if model == 'omega':
+            res = forward.name.split('_')[1]
+            self.add_input_file(
+                filename='coeffs.nc',
+                target=f'{res}_coeffs.nc',
+                database_component='ocean',
+                database='merry_go_round',
+            )
 
     def run(self):
         """
@@ -99,8 +109,15 @@ class Viz(OceanIOStep):
         ds_mesh = self.open_model_dataset('mesh.nc', config)
         ds_init = self.open_model_dataset('init.nc', config)
         ds_vert_coord = self.open_vert_coord_dataset(ds_init)
-        ds = self.open_model_dataset('output.nc', config, decode_times=False)
-
+        ds = self.open_model_dataset(
+            'output.nc',
+            config,
+            mesh_filename='mesh.nc',
+            vert_filename='vert_coord.nc',
+            coeffs_filename='coeffs.nc',
+            decode_times=False,
+            reconstruct_variables=['normalVelocity'],
+        )
         x_min = ds_mesh.xVertex.min().values
         x_max = ds_mesh.xVertex.max().values
         y_mid = ds_mesh.yCell.median().values
@@ -127,7 +144,6 @@ class Viz(OceanIOStep):
         )
 
         vert_velocity = ds.vertVelocityTop.isel(Time=tidx)
-
         tracer_exact = ds_init.tracer1.isel(Time=0)
         tracer_model = ds.tracer1.isel(Time=tidx)
         tracer_error = tracer_model - tracer_exact

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -146,6 +146,7 @@ Omega:
       Contents:
         - Tracers
         - State
+        - SpecVol
         - VerticalPseudoVelocity
         - TotalVerticalPseudoVelocity
     Highfreq:

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -108,3 +108,4 @@ Omega:
         - SpecVol
         - BottomGeomDepth
         - SshCell
+        - VerticalPseudoVelocity


### PR DESCRIPTION
This PR adds `vertVelocityTop`/`VerticalPseudoVelocity` and `vertAleTransportTop`/`TotalVerticalPseudoVelocity` conversions to the `open_model_dataset` and `write_model_dataset methods`. Without the former, the `merry_go_round` viz step fails.

Checklist
* [X] `Testing` comment in the PR documents testing used to verify the changes

Fixes https://github.com/E3SM-Project/polaris/issues/608