### PR TITLE
Fix `barotropic_channel` omega support

### DIFF
--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -484,9 +484,24 @@ class Ocean(Component):
         ):
             ds['layerThickness'] = geom_thickness_from_ds(ds, config=config)
         ds = self.map_from_native_model_vars(ds)
-        ds = _add_reconstructed_variables_to_dataset(
-            ds, reconstruct_variables, mesh_filename, coeffs_filename
-        )
+        if reconstruct_variables is not None:
+            if mesh_filename is None:
+                raise ValueError(
+                    'mesh_filename must be provided to open_model_dataset '
+                    'for variable reconstruction'
+                )
+            if coeffs_filename is None:
+                raise ValueError(
+                    'coeffs_filename must be provided to open_model_dataset '
+                    'for variable reconstruction'
+                )
+            ds_mesh = self.open_model_dataset(mesh_filename, config)
+            ds = _add_reconstructed_variables_to_dataset(
+                ds,
+                reconstruct_variables,
+                ds_mesh,
+                coeffs_filename,
+            )
         return ds
 
     def _check_vars_present(self, ds, native_vars, context):
@@ -633,7 +648,7 @@ class Ocean(Component):
 
 
 def _add_reconstructed_variables_to_dataset(
-    ds, reconstruct_variables, mesh_filename, coeffs_filename
+    ds, reconstruct_variables, ds_mesh, coeffs_filename
 ):
     """
     Add reconstructed vector variables to the dataset if requested.
@@ -660,17 +675,6 @@ def _add_reconstructed_variables_to_dataset(
     if reconstruct_variables is None:
         return ds
 
-    if mesh_filename is None:
-        raise ValueError(
-            'mesh_filename must be provided to open_model_dataset for '
-            'variable reconstruction'
-        )
-    if coeffs_filename is None:
-        raise ValueError(
-            'coeffs_filename must be provided to open_model_dataset for '
-            'variable reconstruction'
-        )
-
     for variable in reconstruct_variables:
         if variable not in ds:
             raise ValueError(
@@ -687,7 +691,6 @@ def _add_reconstructed_variables_to_dataset(
         if f'{out_var_name}Zonal' in ds and f'{out_var_name}Meridional' in ds:
             continue
 
-        ds_mesh = xr.open_dataset(mesh_filename)
         ds_coeff = xr.open_dataset(coeffs_filename)
         coeffs_reconstruct = ds_coeff.coeffs_reconstruct
 

--- a/polaris/tasks/ocean/barotropic_channel/forward.py
+++ b/polaris/tasks/ocean/barotropic_channel/forward.py
@@ -91,6 +91,17 @@ class Forward(OceanModelStep):
             ],
         )
 
+    def setup(self):
+        super().setup()
+        model = self.config.get('ocean', 'model')
+        if model == 'omega':
+            self.add_input_file(
+                filename='coeffs.nc',
+                target='coeffs.nc',
+                database_component='ocean',
+                database='barotropic_channel',
+            )
+
     def dynamic_model_config(self, at_setup):
         super().dynamic_model_config(at_setup=at_setup)
 

--- a/polaris/tasks/ocean/barotropic_channel/forward.py
+++ b/polaris/tasks/ocean/barotropic_channel/forward.py
@@ -82,11 +82,6 @@ class Forward(OceanModelStep):
         self.add_vert_coord_input_file(target='../init/vert_coord.nc')
         self.add_init_input_file(target='../init/init.nc')
 
-        self.add_input_file(
-            filename='forcing.nc',
-            target='../init/forcing.nc',
-        )
-
         self.add_output_file(
             filename='output.nc',
             validate_vars=[

--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -43,7 +43,7 @@ mpas-ocean:
     restart:
       output_interval: 0000_01:00:00
     forcing:
-      filename_template: forcing.nc
+      filename_template: init.nc
       input_interval: initial_only
       type: input
       contents:

--- a/polaris/tasks/ocean/barotropic_channel/init.py
+++ b/polaris/tasks/ocean/barotropic_channel/init.py
@@ -39,7 +39,6 @@ class Init(OceanIOStep):
             base_mesh_filename='base_mesh.nc',
             graph_filename='culled_graph.info',
         )
-        self.add_output_file(filename='forcing.nc')
 
     def run(self):
         """
@@ -100,16 +99,14 @@ class Init(OceanIOStep):
         normal_velocity, _ = xr.broadcast(normal_velocity, ds.refBottomDepth)
         normal_velocity = normal_velocity.transpose('nEdges', 'nVertLevels')
         ds['normalVelocity'] = normal_velocity.expand_dims(dim='Time', axis=0)
-        self.write_initial_state_dataset(ds, 'init.nc', config)
 
         # set the wind stress forcing
-        ds_forcing = xr.Dataset()
         wind_stress_zonal = u_wind * xr.ones_like(ds.xCell)
         wind_stress_meridional = v_wind * xr.ones_like(ds.xCell)
-        ds_forcing['windStressZonal'] = wind_stress_zonal.expand_dims(
+        ds['windStressZonal'] = wind_stress_zonal.expand_dims(
             dim='Time', axis=0
         )
-        ds_forcing['windStressMeridional'] = (
-            wind_stress_meridional.expand_dims(dim='Time', axis=0)
+        ds['windStressMeridional'] = wind_stress_meridional.expand_dims(
+            dim='Time', axis=0
         )
-        self.write_model_dataset(ds_forcing, 'forcing.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/barotropic_channel/viz.py
+++ b/polaris/tasks/ocean/barotropic_channel/viz.py
@@ -54,6 +54,7 @@ class Viz(OceanIOStep):
             'output.nc',
             self.config,
             reconstruct_variables=['normalVelocity'],
+            mesh_filename='mesh.nc',
             coeffs_filename='coeffs.nc',
         )
 
@@ -71,7 +72,7 @@ class Viz(OceanIOStep):
                 ds = ds_out.isel(Time=t_index, nVertLevels=z_index)
                 if (
                     'velocityZonal' in ds.keys()
-                    and 'velocityZonal' in ds.keys()
+                    and 'velocityMeridional' in ds.keys()
                 ):
                     vmax = np.max(np.abs(ds.velocityZonal.values))
                     plot_horiz_field(

--- a/polaris/tasks/ocean/barotropic_channel/viz.py
+++ b/polaris/tasks/ocean/barotropic_channel/viz.py
@@ -34,6 +34,15 @@ class Viz(OceanIOStep):
             filename='output.nc', target='../forward/output.nc'
         )
 
+    def setup(self):
+        model = self.config.get('ocean', 'model')
+        # TODO: remove as soon as Omega no longer needs this file
+        if model == 'omega':
+            self.add_input_file(
+                filename='coeffs.nc',
+                target='../forward/coeffs.nc',
+            )
+
     def run(self):
         """
         Run this step of the task
@@ -41,7 +50,12 @@ class Viz(OceanIOStep):
         ds_mesh = self.open_model_dataset('mesh.nc', self.config)
         ds_init = self.open_model_dataset('init.nc', self.config)
         ds_vert_coord = self.open_vert_coord_dataset(ds_init)
-        ds_out = self.open_model_dataset('output.nc', self.config)
+        ds_out = self.open_model_dataset(
+            'output.nc',
+            self.config,
+            reconstruct_variables=['normalVelocity'],
+            coeffs_filename='coeffs.nc',
+        )
 
         cell_mask = ds_vert_coord.maxLevelCell >= 1
         vertex_mask = ds_mesh.boundaryVertex == 0


### PR DESCRIPTION
**Given unexpected behavior from Omega, removing from `omega_pr` suite**

This PR:

- Moves forcing variables to the initial state file until Omega supports a forcing file
- Uses MPAS-O coefficients to reconstruct the velocity field until Omega supports native reconstruction

Checklist
* [X] `Testing` comment in the PR documents testing used to verify the changes
* [N\A] New tests have been added to a test suite

Fixes https://github.com/E3SM-Project/polaris/issues/459