### PR TITLE
update call to compute_barotropic_streamfunction

### DIFF
--- a/polaris/tasks/ocean/barotropic_gyre/analysis.py
+++ b/polaris/tasks/ocean/barotropic_gyre/analysis.py
@@ -57,17 +57,21 @@ class Analysis(OceanIOStep):
         self.add_input_file(
             filename='output.nc', target='../long_forward/output.nc'
         )
+        self.add_input_file(
+            filename='vert_coord.nc', target='../init/vert_coord.nc'
+        )
         self.boundary_condition = boundary_condition
         self.test_name = test_name
 
     def run(self):
         logger = self.logger
         ds_mesh = self.open_model_dataset('mesh.nc', self.config)
-        ds_init = self.open_model_dataset('init.nc', self.config)
         ds = self.open_model_dataset('output.nc', self.config)
+        ds_vert = self.open_model_dataset('vert_coord.nc', self.config)
+        ds_mesh['maxLevelCell'] = ds_vert.maxLevelCell
 
         field_mpas = compute_barotropic_streamfunction(
-            ds_init.isel(Time=0), ds, prefix='', time_index=-1
+            ds_mesh, ds, prefix='', time_index=-1
         )
         x_maxpsi = ds_mesh.xVertex.isel(nVertices=np.argmax(field_mpas.values))
         logger.info(f'Streamfunction reaches maximum at x = {x_maxpsi.values}')


### PR DESCRIPTION
fixes https://github.com/E3SM-Project/polaris/issues/625
Credit to @cbegeman for helping me navigate the bux and the fix. 

The call to compute_barotropic_streamfunction() has been updated to use `ds_mesh`. 
`ds_mesh` has been updated to contain `maxLevelCell`, which is required but has been moved to `vert_coord.nc`.


tested on pm-cpu (gnu) with submodule omega only.
