### PR TITLE
Add `surface_pressure_gradient test` to `horiz_press_grad`

### DIFF
--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -745,7 +745,10 @@ class MyInit(PStarInitStep, OceanIOStep):
 
 At convergence, the returned dataset contains all p-star coordinate variables
 plus ``temperature``, ``salinity``, ``SpecVol``, ``pressure``, ``GeomZMid``,
-``GeomZInterface``, ``bottomDepth``, and ``ssh``.
+``GeomZInterface``, ``bottomDepth``, and ``ssh``.  Here ``bottomDepth`` is the
+geometric seafloor depth below $z = 0$ (the negation of the converged bottom
+interface height), which Omega reads as ``BottomGeomDepth``; it equals the
+geometric water-column thickness only when ``ssh`` is zero.
 
 The iteration is controlled by two ``vertical_grid`` config options:
 

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -6,11 +6,12 @@ The {py:class}`polaris.tasks.ocean.horiz_press_grad.task.HorizPressGradTask`
 provides two-column Omega tests for pressure-gradient-acceleration (`HPGA`)
 accuracy and convergence across horizontal and vertical resolutions.
 
-The task family includes three variants:
+The task family includes four variants:
 
 - `salinity_gradient`
 - `temperature_gradient`
 - `ztilde_gradient`
+- `surface_pressure_gradient`
 
 ## framework
 

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -28,6 +28,7 @@ The tasks currently provided are:
 ocean/column/horiz_press_grad/salinity_gradient
 ocean/column/horiz_press_grad/temperature_gradient
 ocean/column/horiz_press_grad/ztilde_gradient
+ocean/column/horiz_press_grad/surface_pressure_gradient
 ```
 
 ```{image} images/horiz_press_grad_salin_grad.png
@@ -69,7 +70,10 @@ the `salinity_gradient` and `temperature_gradient` tests, the z-tilde
 interfaces are level, so pressure surfaces are also horizontally level except
 where they intersect the bathymetry.  In the `ztilde_gradient` test, the
 prescribed z-tilde gradient tilts the layers, so the pressure surfaces are
-sloped and the along-layer direction follows those sloping layers.
+sloped and the along-layer direction follows those sloping layers.  In the
+`surface_pressure_gradient` test, a horizontally varying surface pressure
+depresses and tilts the surface pseudo-height (and compresses the column), so
+the layers are sloped even though the z-tilde profile itself is level.
 
 ## reference solution
 
@@ -105,10 +109,13 @@ where:
   $\alpha_{\Theta} = \partial \alpha / \partial \Theta$ are TEOS-10 first derivatives
   of specific volume.
 
-The surface boundary term is kept fully general, so a nonzero sea-surface
-height or surface pressure (nonzero `geom_ssh_grad` and/or surface
-`z_tilde_grad` node) is supported without further changes.  The three task
-variants currently provided all use zero surface slope.
+The surface boundary term is kept fully general, so a nonzero surface pressure
+or sea-surface height is supported.  The `surface_pressure_gradient` variant
+exercises this: a nonzero `surface_pressure_grad` sets the surface
+pseudo-height $\tilde z_s = -p_s / (\rho_0 g)$ and, by default, a matching
+sea-surface-height slope $\eta' = -\partial_x p_s / (\rho_0 g)$ (overridable
+with the optional `geom_ssh_grad`).  The other three variants use zero surface
+slope.
 
 The gradients $\partial_x S_A$ and $\partial_x \Theta$ at fixed $\tilde z$ are
 obtained by centred finite-differencing PCHIP interpolants evaluated at
@@ -185,9 +192,14 @@ horiz_resolutions = [4.0, 3.0, 2.0, 1.5, 1.0, 0.75, 0.5]
 # vertical resolution in m for each two-column setup
 vert_resolutions = [4.0, 3.0, 2.0, 1.5, 1.0, 0.75, 0.5]
 
-# geometric sea-surface and sea-floor midpoint values and x-gradients
-geom_ssh_mid = 0.0
-geom_ssh_grad = 0.0
+# sea-surface gauge pressure midpoint and x-gradient (Pa and Pa/km).  The
+# sea-surface height defaults to the resting depression
+# -surface_pressure / (rho0 * g); add the optional geom_ssh_mid / geom_ssh_grad
+# to override that default.
+surface_pressure_mid = 0.0
+surface_pressure_grad = 0.0
+
+# geometric sea-floor midpoint value and x-gradient
 geom_z_bot_mid = -500.0
 geom_z_bot_grad = 0.0
 
@@ -225,11 +237,13 @@ error at the highest resolution, the allowed power-law convergence slope, and
 the finest horizontal resolution included in the convergence fit (all
 resolutions are still shown in the plots).
 
-The three task variants specialize one horizontal gradient field:
+The four task variants each specialize one horizontal gradient field:
 
 - `salinity_gradient`: nonzero `salinity_grad`
 - `temperature_gradient`: nonzero `temperature_grad`
 - `ztilde_gradient`: nonzero `z_tilde_bot_grad`
+- `surface_pressure_gradient`: nonzero `surface_pressure_grad` (with the
+  sea-surface height following the default surface-pressure depression)
 
 ## time step and run duration
 

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -41,6 +41,55 @@ same discrete answer as the Python initialization, but also to measure how the
 two-column discretization converges toward a more accurate non-local
 approximation of the continuous hydrostatic pressure-gradient force.
 
+Each variant isolates a different way a horizontal pressure gradient can arise:
+
+- `salinity_gradient` and `temperature_gradient` keep the layers level and
+  impose a horizontal density gradient, so the HPGA comes entirely from the
+  baroclinic term.
+- `ztilde_gradient` keeps the water properties horizontally uniform and tilts
+  the z-tilde interfaces, so the HPGA comes entirely from the geometric
+  (layer-slope) term.  This is the classic pressure-gradient-error
+  configuration for a terrain-following coordinate.
+- `surface_pressure_gradient` imposes a horizontally varying surface pressure,
+  as under a floating ice shelf, which tilts the layers through the surface
+  boundary condition rather than through the prescribed z-tilde profile.
+
+### why the `surface_pressure_gradient` variant
+
+Under an ice shelf the ocean surface is not a free surface at zero gauge
+pressure: it carries the weight of the ice above it, and the sea surface is
+depressed by roughly $-p_s / (\rho_0 g)$.  Wherever the ice thickness varies,
+both the surface pressure $p_s$ and the sea-surface height $\eta$ therefore
+vary horizontally, and in the p-star coordinate that depression also compresses
+the column so that *every* layer below is tilted, even though the prescribed
+z-tilde profile is level.
+
+This is precisely the regime in which pressure-gradient errors have
+historically been worst in terrain-following ocean models.  Two things happen at
+once: the layers acquire a steep slope, and the surface boundary term becomes
+large.  In the reference expression below, the two pieces of that boundary term,
+$-g\,\eta'$ and $+g\,\rho_0\,\alpha(\tilde z_s)\,\tilde z_s'$, nearly cancel
+because $\rho_0 \alpha \approx 1$, so the surviving HPGA is a small residual
+between two large numbers.  Any inconsistency in how Omega, the Python
+initialization, or the reference solution treat the surface would show up
+immediately as a large error that fails to converge.
+
+The variant is therefore meant to demonstrate that
+
+- Omega robustly supports a nonzero surface pressure and the corresponding
+  depressed, sloping sea surface;
+- Omega, the Python two-column diagnostic, and the analytic reference all
+  treat the surface boundary term consistently; and
+- Omega still converges to the reference at the same rate, and to comparable
+  accuracy, as in the variants with a flat, unloaded surface.
+
+Together these give confidence that the HPGA will remain consistent beneath real
+ice shelves, where layers can be steeply sloped.  The default configuration is
+sized for that application: `surface_pressure_mid = 8.99e5` Pa is the weight of
+about 100 m of Antarctic ice, and `surface_pressure_grad = 8.99e3` Pa/km
+corresponds to an ice-thickness slope of about 1 m/km (and hence a sea-surface
+slope of about &minus;0.9 m/km).
+
 ## supported models
 
 These tasks currently support Omega only.
@@ -242,8 +291,9 @@ The four task variants each specialize one horizontal gradient field:
 - `salinity_gradient`: nonzero `salinity_grad`
 - `temperature_gradient`: nonzero `temperature_grad`
 - `ztilde_gradient`: nonzero `z_tilde_bot_grad`
-- `surface_pressure_gradient`: nonzero `surface_pressure_grad` (with the
-  sea-surface height following the default surface-pressure depression)
+- `surface_pressure_gradient`: nonzero `surface_pressure_mid` and
+  `surface_pressure_grad` (with the sea-surface height following the default
+  surface-pressure depression), representing an overlying ice shelf
 
 ## time step and run duration
 

--- a/polaris/ocean/vertical/pstar_init.py
+++ b/polaris/ocean/vertical/pstar_init.py
@@ -346,10 +346,13 @@ class PStarInitStep(Step, ABC):
         )
         ds.GeomZInterface.attrs['units'] = 'm'
 
-        # Use the actual converged water-column thickness (not the target)
-        # for thermodynamic self-consistency, even when bottom-cell snapping
-        # prevents an exact match to the target bathymetry.
-        ds['bottomDepth'] = geom_water_column_thickness
+        # Geometric depth of the seafloor below z=0, i.e. the negation of the
+        # actual converged bottom interface height (not the water-column
+        # thickness, which only matches when the sea-surface height is zero).
+        # Omega reads this as BottomGeomDepth and anchors its column there, so
+        # it must be the true bathymetric depth for the diagnosed sea-surface
+        # height (and the resulting geopotential gradient) to be correct.
+        ds['bottomDepth'] = -geom_z_max
         ds.bottomDepth.attrs['long_name'] = 'seafloor geometric depth'
         ds.bottomDepth.attrs['units'] = 'm'
 

--- a/polaris/suites/ocean/omega_nightly.txt
+++ b/polaris/suites/ocean/omega_nightly.txt
@@ -1,4 +1,5 @@
 ocean/column/horiz_press_grad/salinity_gradient
+ocean/column/horiz_press_grad/surface_pressure_gradient
 ocean/column/horiz_press_grad/temperature_gradient
 ocean/column/horiz_press_grad/ztilde_gradient
 ocean/planar/baroclinic_channel/10km/decomp

--- a/polaris/tasks/ocean/horiz_press_grad/__init__.py
+++ b/polaris/tasks/ocean/horiz_press_grad/__init__.py
@@ -13,6 +13,7 @@ def add_horiz_press_grad_tasks(component):
     """
     for name in [
         'salinity_gradient',
+        'surface_pressure_gradient',
         'temperature_gradient',
         'ztilde_gradient',
     ]:

--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -40,11 +40,13 @@ horiz_resolutions = [4.0, 3.0, 2.0, 1.5, 1.0, 0.75, 0.5]
 # vertical resolution in m
 vert_resolutions = [4.0, 3.0, 2.0, 1.5, 1.0, 0.75, 0.5]
 
-# geometric sea surface height at the midpoint between the two columns
-# and its gradient
-geom_ssh_mid = 0.0
-# m / km
-geom_ssh_grad = 0.0
+# sea surface gauge pressure at the midpoint between the two columns and its
+# gradient. The sea-surface height defaults to the resting depression
+# -surface_pressure / (rho0 * g); set geom_ssh_mid / geom_ssh_grad (not
+# defined here) to override that default.
+surface_pressure_mid = 0.0
+# Pa / km
+surface_pressure_grad = 0.0
 
 # geometric sea floor height at the midpoint between the two columns
 # and its gradient

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -136,14 +136,21 @@ class Init(PStarInitStep, OceanIOStep):
         x = horiz_res * np.array([-0.5, 0.5], dtype=float)
         # Store x so init_tracers and _build_pstar_coord_ds can access it
         self.x = x
-        geom_ssh, geom_z_bot = self._get_geom_ssh_z_bot(x)
+        geom_z_bot = self._get_geom_z_bot(x)
+        surface_pressure = self._get_surface_pressure(x)
+        # geom_ssh is an optional override; when it is not configured the
+        # base class defaults the sea-surface height to the resting
+        # surface-pressure depression -surface_pressure / (RhoSw * Gravity).
+        geom_ssh = self._get_geom_ssh(x)
 
         # Delegate the p-star iterative initialization to the base class.
-        # surface_pressure defaults to zero; sea_surface_height drives the
-        # target water-column thickness.
+        # surface_pressure drives the surface gauge pressure;
+        # sea_surface_height (when given) drives the target water-column
+        # thickness.
         ds = self.run_pstar_init(
             ds_mesh=ds_mesh,
             geom_z_bot=geom_z_bot,
+            surface_pressure=surface_pressure,
             sea_surface_height=geom_ssh,
         )
 
@@ -379,33 +386,67 @@ class Init(PStarInitStep, OceanIOStep):
             'units': 'g kg-1 m-1',
         }
 
-    def _get_geom_ssh_z_bot(
-        self, x: np.ndarray
-    ) -> tuple[xr.DataArray, xr.DataArray]:
+    def _get_geom_z_bot(self, x: np.ndarray) -> xr.DataArray:
         """
-        Get the geometric sea surface height and sea floor height for each
-        column from the configuration.
+        Get the geometric sea floor height for each column from the
+        configuration.
+        """
+        geom_z_bot = get_array_from_mid_grad(self.config, 'geom_z_bot', x)
+        return xr.DataArray(
+            data=geom_z_bot,
+            dims=['nCells'],
+            attrs={
+                'long_name': 'seafloor geometric height',
+                'units': 'm',
+            },
+        )
+
+    def _get_geom_ssh(self, x: np.ndarray) -> xr.DataArray | None:
+        """
+        Get the optional geometric sea surface height override for each column
+        from the configuration. Returns ``None`` when ``geom_ssh_mid`` /
+        ``geom_ssh_grad`` are not set, in which case the base class defaults
+        the sea-surface height to the resting surface-pressure depression.
         """
         config = self.config
+        if not (
+            config.has_option('horiz_press_grad', 'geom_ssh_mid')
+            and config.has_option('horiz_press_grad', 'geom_ssh_grad')
+        ):
+            return None
         geom_ssh = get_array_from_mid_grad(config, 'geom_ssh', x)
-        geom_z_bot = get_array_from_mid_grad(config, 'geom_z_bot', x)
-        return (
-            xr.DataArray(
-                data=geom_ssh,
-                dims=['nCells'],
-                attrs={
-                    'long_name': 'sea surface geometric height',
-                    'units': 'm',
-                },
-            ),
-            xr.DataArray(
-                data=geom_z_bot,
-                dims=['nCells'],
-                attrs={
-                    'long_name': 'seafloor geometric height',
-                    'units': 'm',
-                },
-            ),
+        return xr.DataArray(
+            data=geom_ssh,
+            dims=['nCells'],
+            attrs={
+                'long_name': 'sea surface geometric height',
+                'units': 'm',
+            },
+        )
+
+    def _get_surface_pressure(self, x: np.ndarray) -> xr.DataArray:
+        """
+        Get the sea-surface gauge pressure for each column from the
+        configuration. Defaults to zero when ``surface_pressure_mid`` /
+        ``surface_pressure_grad`` are not set.
+        """
+        config = self.config
+        if not (
+            config.has_option('horiz_press_grad', 'surface_pressure_mid')
+            and config.has_option('horiz_press_grad', 'surface_pressure_grad')
+        ):
+            surface_pressure = np.zeros_like(x)
+        else:
+            surface_pressure = get_array_from_mid_grad(
+                config, 'surface_pressure', x
+            )
+        return xr.DataArray(
+            data=surface_pressure,
+            dims=['nCells'],
+            attrs={
+                'long_name': 'sea surface gauge pressure',
+                'units': 'Pa',
+            },
         )
 
     def _get_z_tilde_t_s_nodes(

--- a/polaris/tasks/ocean/horiz_press_grad/reference.py
+++ b/polaris/tasks/ocean/horiz_press_grad/reference.py
@@ -77,19 +77,32 @@ class ReferenceColumn:
 
         # Surface anchor. The model honours the surface boundary (sea-surface
         # height and surface pressure), so the reference integral is anchored
-        # there rather than at the seafloor. These are kept fully general so a
-        # follow-up surface-pressure test (nonzero geom_ssh_grad and/or a
-        # nonzero top z_tilde node) is supported without further changes.
-        geom_ssh_grad = section.getfloat('geom_ssh_grad')
+        # there rather than at the seafloor. A nonzero surface gauge pressure
+        # depresses the surface pseudo-height by -p_surf / (RhoSw * Gravity);
+        # its gradient drives the surface-pressure HPGA. A nonzero top z_tilde
+        # node is also supported and adds to the surface pseudo-height.
         z_tilde_mid = section.getnumpy('z_tilde_mid')
         z_tilde_grad = section.getnumpy('z_tilde_grad')
         # the surface is the shallowest (largest) pseudo-height node
         surf_node = int(np.argmax(z_tilde_mid))
 
-        self._z_tilde_surf = float(z_tilde_mid[surf_node])
+        p_surf_mid, p_surf_grad = _get_surface_pressure_mid_grad(config)
+        p_surf_depression = p_surf_mid / (RhoSw * Gravity)
+        p_surf_depression_grad = p_surf_grad / (RhoSw * Gravity)
+
+        self._z_tilde_surf = float(z_tilde_mid[surf_node] - p_surf_depression)
         # Convert config gradients from m/km to m/m; project onto edge normal
+        zt_surf_grad = z_tilde_grad[surf_node] - p_surf_depression_grad
+        self._zt_surf_prime = (zt_surf_grad / 1000.0) * x_sign
+
+        # Sea-surface-height gradient eta'. When geom_ssh is not configured it
+        # defaults to the resting surface-pressure depression gradient,
+        # mirroring the init step's run_pstar_init default.
+        if config.has_option('horiz_press_grad', 'geom_ssh_grad'):
+            geom_ssh_grad = section.getfloat('geom_ssh_grad')
+        else:
+            geom_ssh_grad = -p_surf_depression_grad
         self._eta_prime = (geom_ssh_grad / 1000.0) * x_sign
-        self._zt_surf_prime = (z_tilde_grad[surf_node] / 1000.0) * x_sign
 
         # Evaluate node arrays at x = 0, +eps, -eps in km (config x direction)
         x_eval = np.array([0.0, eps_km, -eps_km])
@@ -238,6 +251,25 @@ class ReferenceColumn:
             if layer_dz[k] > 0.0:
                 result[k] = np.dot(wts_arr[s0:s1], a_arr[s0:s1]) / layer_dz[k]
         return result
+
+
+def _get_surface_pressure_mid_grad(
+    config: PolarisConfigParser,
+) -> tuple[float, float]:
+    """
+    Read the surface gauge pressure midpoint value and gradient (Pa and
+    Pa/km) from the ``horiz_press_grad`` section, defaulting to zero when the
+    options are not configured.
+    """
+    section = config['horiz_press_grad']
+    if config.has_option(
+        'horiz_press_grad', 'surface_pressure_mid'
+    ) and config.has_option('horiz_press_grad', 'surface_pressure_grad'):
+        return (
+            section.getfloat('surface_pressure_mid'),
+            section.getfloat('surface_pressure_grad'),
+        )
+    return 0.0, 0.0
 
 
 class _ClampedInterp:

--- a/polaris/tasks/ocean/horiz_press_grad/surface_pressure_gradient.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/surface_pressure_gradient.cfg
@@ -1,0 +1,12 @@
+# config options for two column testcases
+[horiz_press_grad]
+
+# sea surface pressure at the midpoint between the two columns
+# and its gradient.
+# mid value corresponds to ~100 m of Antarctic ice (rho_ice ~ 917 kg/m^3):
+#   917 * 9.80665 * 100 ~= 8.99e5 Pa
+surface_pressure_mid = 8.99e5
+# gradient corresponding to ~1 m/km ice-thickness slope:
+#   917 * 9.80665 * 1 ~= 8.99e3 Pa/km
+# Pa / km
+surface_pressure_grad = 8.99e3

--- a/tests/ocean/vertical/test_pstar_init.py
+++ b/tests/ocean/vertical/test_pstar_init.py
@@ -212,11 +212,12 @@ def test_nonzero_surface_pressure_shifts_pressures():
     SSH = -SP/(RhoSw * Gravity).
 
     For constant density equal to RhoSw the coordinate converges in two
-    iterations. The target SSH is -ssp/(RhoSw*Gravity), so bottomDepth equals
-    target_depth - ssp/(RhoSw*Gravity) (the actual water-column thickness
-    between the depressed surface and the seafloor).  The reference grid needs
-    to reach pseudo_bottom_depth = target_depth (not target_depth +
-    ssp/(RhoSw*Gravity)) because the SP terms cancel in the initial BP.
+    iterations. The target SSH is -ssp/(RhoSw*Gravity). bottomDepth is the
+    geometric seafloor depth below z=0 (Omega's BottomGeomDepth), i.e.
+    -geom_z_bot = target_depth, independent of the surface pressure.  The
+    reference grid needs to reach pseudo_bottom_depth = target_depth (not
+    target_depth + ssp/(RhoSw*Gravity)) because the SP terms cancel in the
+    initial BP.
     """
     target_depth = 500.0
     # ~1 m of water-column pressure (well below the 500 m column)
@@ -247,8 +248,9 @@ def test_nonzero_surface_pressure_shifts_pressures():
     ssh = float(ds.ssh.values.flat[0])
     np.testing.assert_allclose(ssh, expected_ssh, rtol=1e-10)
 
-    # bottomDepth is the actual water column: SSH − geom_z_bot.
-    expected_bottom_depth = expected_ssh - float(geom_z_bot.values.flat[0])
+    # bottomDepth is the geometric seafloor depth below z=0 (Omega's
+    # BottomGeomDepth), i.e. −geom_z_bot, independent of the surface pressure.
+    expected_bottom_depth = -float(geom_z_bot.values.flat[0])
     bottom_depth = float(ds.bottomDepth.values.flat[0])
     np.testing.assert_allclose(bottom_depth, expected_bottom_depth, rtol=1e-10)
 
@@ -321,7 +323,8 @@ def test_surface_pressure_total_pseudo_thickness():
 
 def test_two_cell_surface_pressure_gradient():
     """Two cells with different surface pressures each converge to
-    ssh[i] = −SP[i]/(ρ₀g) and bottomDepth[i] = ssh[i] − geom_z_bot.
+    ssh[i] = −SP[i]/(ρ₀g) and bottomDepth[i] = −geom_z_bot (the geometric
+    seafloor depth below z=0, independent of the surface pressure).
     Each cell's ZTildeInterface top equals ssh[i].
 
     This directly mimics the surface_pressure_gradient geometry and
@@ -348,9 +351,7 @@ def test_two_cell_surface_pressure_gradient():
 
     for i in range(ncells):
         expected_ssh = -ssp[i] / (RhoSw * Gravity)
-        expected_bottom_depth = expected_ssh - float(
-            geom_z_bot.isel(nCells=i).values
-        )
+        expected_bottom_depth = -float(geom_z_bot.isel(nCells=i).values)
 
         ssh = float(ds.ssh.isel(nCells=i).values)
         np.testing.assert_allclose(


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
We add support for a non-zero sea-surface pressure and test it with this new configuration.

This PR also fixes a bug in `BottomGeomDepth` from p-star coordinate that only emerges with non-zero initial SSH: the bottom depth is `-geom_z_max`, not the total column thickness.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
