### PR TITLE
Update to mpas_tools 2.0.0

### DIFF
--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -4,7 +4,7 @@ bootstrap_python = 3.14
 python = 3.14
 geometric_features = 1.6.3
 mache = 3.7.1
-mpas_tools = 1.6.0
+mpas_tools = 2.0.0
 otps = 2021.10
 parallelio = 2.6.9
 

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -22,5 +22,5 @@ esmf = 8.9.1
 metis = 5.1.0
 moab = 5.6.0
 netcdf_c = 4.10.0
-netcdf_fortran = 4.6.2
+netcdf_fortran = 4.6.3
 pnetcdf = 1.14.1

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -2,9 +2,8 @@ import importlib.resources as imp_res
 import json
 import os
 
-import xarray as xr
 from mache.parallel import ParallelSystem, get_parallel_system
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 from mpas_tools.logging import check_call
 
 from polaris.config import PolarisConfigParser
@@ -288,7 +287,7 @@ class Component:
         ds : xarray.Dataset
             The dataset with variables named as expected in MPAS-Ocean
         """
-        ds = xr.open_dataset(filename, **kwargs)
+        ds = open_dataset(filename, **kwargs)
         return ds
 
     def write_model_dataset(self, ds, filename, config):

--- a/polaris/mesh/spherical/__init__.py
+++ b/polaris/mesh/spherical/__init__.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from jigsawpy.savejig import savejig
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 from mpas_tools.logging import check_call
 from mpas_tools.mesh.creation.jigsaw_to_netcdf import jigsaw_to_netcdf
 from mpas_tools.ocean.inject_meshDensity import inject_spherical_meshDensity
@@ -126,7 +126,7 @@ class SphericalBaseStep(Step):
         check_call(args=args, logger=logger)
 
         # open the mesh and rewrite it in the desired NetCDF format
-        ds_mesh = xr.open_dataset(tmp_mesh_filename)
+        ds_mesh = open_dataset(tmp_mesh_filename)
 
         angle_edge = recompute_angle_edge(ds_mesh)
         ds_mesh.angleEdge.values = angle_edge.values

--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -4,8 +4,8 @@ from collections import OrderedDict
 from typing import Dict, List, Union
 
 import numpy as np
-import xarray as xr
 from lxml import etree
+from mpas_tools.io import open_dataset
 from mpas_tools.logging import check_call
 
 import polaris.namelist
@@ -1044,7 +1044,7 @@ def make_graph_file(
         weights
     """
 
-    with xr.open_dataset(mesh_filename) as ds:
+    with open_dataset(mesh_filename) as ds:
         nCells = ds.sizes['nCells']
 
         nEdgesOnCell = ds.nEdgesOnCell.values

--- a/polaris/ocean/ice_shelf/ssh_adjustment.py
+++ b/polaris/ocean/ice_shelf/ssh_adjustment.py
@@ -1,6 +1,5 @@
 import numpy as np
-import xarray as xr
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 
 from polaris import Step
 from polaris.constants import get_constant
@@ -67,9 +66,9 @@ class SshAdjustment(Step):
         init_filename = 'init.nc'
         final_filename = 'final.nc'
         out_filename = 'output.nc'
-        ds_mesh = xr.open_dataset(mesh_filename)
-        ds_init = xr.open_dataset(init_filename)
-        ds_final = xr.open_dataset(final_filename)
+        ds_mesh = open_dataset(mesh_filename)
+        ds_init = open_dataset(init_filename)
+        ds_final = open_dataset(final_filename)
         ds_out = ds_init.copy()
 
         if adjust_variable not in ['ssh', 'landIcePressure']:

--- a/polaris/tasks/e3sm/init/topo/cull/cull.py
+++ b/polaris/tasks/e3sm/init/topo/cull/cull.py
@@ -1,7 +1,7 @@
 import os
 
 import xarray as xr
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 from mpas_tools.logging import check_call
 from mpas_tools.mesh.conversion import cull
 from mpas_tools.mesh.creation.sort_mesh import sort_mesh
@@ -138,14 +138,14 @@ class CullMeshStep(Step):
             'land': 'landCullMask',
         }
 
-        ds_cull_masks = xr.open_dataset('cull_masks.nc')
+        ds_cull_masks = open_dataset('cull_masks.nc')
         cull_mask = ds_cull_masks[cull_vars[prefix]]
         ds_mask = xr.Dataset()
         ds_mask['regionCellMasks'] = cull_mask.expand_dims(
             dim='nRegions', axis=1
         )
 
-        ds_base_mesh = xr.open_dataset('base_mesh.nc')
+        ds_base_mesh = open_dataset('base_mesh.nc')
 
         ds_culled_mesh = cull(
             dsIn=ds_base_mesh,

--- a/polaris/tasks/e3sm/init/topo/cull/mask.py
+++ b/polaris/tasks/e3sm/init/topo/cull/mask.py
@@ -7,7 +7,7 @@ from geometric_features import (
     GeometricFeatures,
     read_feature_collection,
 )
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 from mpas_tools.logging import check_call
 from mpas_tools.mesh.mask import compute_mpas_flood_fill_mask
 from mpas_tools.ocean.coastline_alteration import (
@@ -247,7 +247,7 @@ class CullMaskStep(Step):
             logger.info(
                 'Applying critical land transect mask to ocean cull mask.'
             )
-            ds_crit = xr.open_dataset(crit_land_filename)
+            ds_crit = open_dataset(crit_land_filename)
             preserve_land = ds_crit.regionCellMasks.isel(nRegions=0) > 0
             cull_mask = np.logical_or(cull_mask, preserve_land)
 
@@ -257,7 +257,7 @@ class CullMaskStep(Step):
             logger.info(
                 'Applying critical ocean transect mask to ocean cull mask.'
             )
-            ds_crit = xr.open_dataset(crit_ocean_filename)
+            ds_crit = open_dataset(crit_ocean_filename)
             preserve_ocean = ds_crit.regionCellMasks.isel(nRegions=0) > 0
             cull_mask = np.logical_and(
                 cull_mask, np.logical_not(preserve_ocean)
@@ -335,11 +335,11 @@ class CullMaskStep(Step):
             logger.info(
                 'Applying critical ocean transect mask to land cull mask.'
             )
-            ds_crit = xr.open_dataset(crit_ocean_filename)
+            ds_crit = open_dataset(crit_ocean_filename)
             preserve_ocean = ds_crit.regionCellMasks.isel(nRegions=0) > 0
             cull_mask = np.logical_or(cull_mask, preserve_ocean)
 
-        ds_ocean_no_cavity_cull_mask = xr.open_dataset(
+        ds_ocean_no_cavity_cull_mask = open_dataset(
             'ocean_no_cavities_cull_mask.nc'
         )
 
@@ -386,7 +386,7 @@ class CullMaskStep(Step):
 
         gf = GeometricFeatures()
 
-        ds_base_mesh = xr.open_dataset('base_mesh.nc')
+        ds_base_mesh = open_dataset('base_mesh.nc')
 
         fc_crit_land_transects = self.define_critical_land_transects(gf)
 
@@ -416,7 +416,7 @@ class CullMaskStep(Step):
             ]
             check_call(args, logger=logger)
 
-            ds_all = xr.open_dataset(nc_filename)
+            ds_all = open_dataset(nc_filename)
 
             # combine into a single field
             preserve = xr.where(
@@ -460,7 +460,7 @@ class CullMaskStep(Step):
                 netcdf_engine,
             ]
             check_call(args, logger=logger)
-            ds_all = xr.open_dataset(nc_filename)
+            ds_all = open_dataset(nc_filename)
 
             ds_widened = widen_transect_edge_masks(
                 ds_all, ds_base_mesh, latitude_threshold=latitude_threshold
@@ -491,9 +491,9 @@ class CullMaskStep(Step):
         logger = self.logger
         logger.info('Creating ocean cull mask.')
 
-        ds_base_mesh = xr.open_dataset('base_mesh.nc')
+        ds_base_mesh = open_dataset('base_mesh.nc')
 
-        ds_topo = xr.open_dataset('topography_unsmoothed.nc')
+        ds_topo = open_dataset('topography_unsmoothed.nc')
         ocean_frac = ds_topo.ocean_frac
         cull_mask = ocean_frac < 0.5
 
@@ -520,12 +520,12 @@ class CullMaskStep(Step):
         land_ice_max_latitude = section.getfloat('land_ice_max_latitude')
         land_ice_min_fraction = section.getfloat('land_ice_min_fraction')
 
-        ds_base_mesh = xr.open_dataset('base_mesh.nc')
+        ds_base_mesh = open_dataset('base_mesh.nc')
 
-        ds_topo = xr.open_dataset('topography_unsmoothed.nc')
+        ds_topo = open_dataset('topography_unsmoothed.nc')
         land_ice_frac = ds_topo.ice_frac
 
-        ds_ocean_cull_mask = xr.open_dataset('ocean_cull_mask.nc')
+        ds_ocean_cull_mask = open_dataset('ocean_cull_mask.nc')
         ocean_cull_mask = ds_ocean_cull_mask.oceanCullMask > 0
 
         land_ice_present = self._antarctic_land_ice_ownership(
@@ -572,12 +572,12 @@ class CullMaskStep(Step):
         latitude_threshold = section.getfloat('sea_ice_latitude_threshold')
         iterations = section.getint('land_locked_cell_iterations')
 
-        ds_base_mesh = xr.open_dataset('base_mesh.nc')
+        ds_base_mesh = open_dataset('base_mesh.nc')
 
-        ds_ocean_cull_mask = xr.open_dataset('ocean_cull_mask.nc')
+        ds_ocean_cull_mask = open_dataset('ocean_cull_mask.nc')
         ocean_cull_mask = ds_ocean_cull_mask.oceanCullMask > 0
 
-        ds_land_ice_mask = xr.open_dataset('land_ice_mask_preliminary.nc')
+        ds_land_ice_mask = open_dataset('land_ice_mask_preliminary.nc')
         land_ice_mask = ds_land_ice_mask.landIceMask > 0
 
         # Exclude all land ice, not just the grounded ice
@@ -643,12 +643,12 @@ class CullMaskStep(Step):
         logger = self.logger
         logger.info('Creating land cull mask.')
 
-        ds_topo = xr.open_dataset('topography_unsmoothed.nc')
+        ds_topo = open_dataset('topography_unsmoothed.nc')
         land_frac = ds_topo.land_frac
         cull_mask = land_frac < 0.5
 
         cull_mask = self.refine_land_cull_mask(
-            ds_base_mesh=xr.open_dataset('base_mesh.nc'),
+            ds_base_mesh=open_dataset('base_mesh.nc'),
             ds_topo=ds_topo,
             cull_mask=cull_mask,
         )
@@ -666,12 +666,12 @@ class CullMaskStep(Step):
         logger = self.logger
         logger.info('Combining land and ocean cull masks.')
 
-        ds_ocean_cull_mask = xr.open_dataset('ocean_cull_mask.nc')
-        ds_ocean_no_cavities_cull_mask = xr.open_dataset(
+        ds_ocean_cull_mask = open_dataset('ocean_cull_mask.nc')
+        ds_ocean_no_cavities_cull_mask = open_dataset(
             'ocean_no_cavities_cull_mask.nc'
         )
-        ds_land_cull_mask = xr.open_dataset('land_cull_mask.nc')
-        ds_land_ice_mask = xr.open_dataset('land_ice_mask.nc')
+        ds_land_cull_mask = open_dataset('land_cull_mask.nc')
+        ds_land_ice_mask = open_dataset('land_ice_mask.nc')
 
         ds_masks = xr.Dataset()
         ds_masks['oceanCullMask'] = ds_ocean_cull_mask.oceanCullMask

--- a/polaris/tasks/e3sm/init/topo/remap/remap.py
+++ b/polaris/tasks/e3sm/init/topo/remap/remap.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 from mpas_tools.logging import check_call
 from pyremap import MpasCellMeshDescriptor
 
@@ -215,7 +215,7 @@ class RemapTopoStep(Step):
             target = os.path.join(unsmoothed_path, target_filename)
             symlink(target, unsmoothed_filename)
 
-            ds_unsmoothed = xr.open_dataset(unsmoothed_filename)
+            ds_unsmoothed = open_dataset(unsmoothed_filename)
             self.expand_distance, self.expand_factor = self.define_smoothing(
                 ds_unsmoothed
             )
@@ -329,7 +329,7 @@ class RemapTopoStep(Step):
         section = config['remap_topography']
         renorm_threshold = section.getfloat('renorm_threshold')
 
-        ds_in = xr.open_dataset('topography_ncremap.nc')
+        ds_in = open_dataset('topography_ncremap.nc')
         ds_in = ds_in.rename({'ncol': 'nCells'})
 
         drop_vars = [

--- a/polaris/tasks/e3sm/init/topo/remap/viz.py
+++ b/polaris/tasks/e3sm/init/topo/remap/viz.py
@@ -1,5 +1,5 @@
 import cmocean  # noqa: F401
-import xarray as xr
+from mpas_tools.io import open_dataset
 
 from polaris import Step
 from polaris.viz import plot_global_mpas_field
@@ -64,7 +64,7 @@ class VizRemappedTopoStep(Step):
         config = self.config
         mesh_name = self.mesh_name
 
-        ds = xr.open_dataset('topography.nc')
+        ds = open_dataset('topography.nc')
 
         descriptor = None
 

--- a/polaris/tasks/mesh/spherical/unified/base_mesh/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/base_mesh/viz.py
@@ -5,6 +5,7 @@ import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
+from mpas_tools.io import open_dataset
 from shapely.geometry import box
 
 from polaris.step import Step
@@ -116,7 +117,7 @@ class VizBaseMeshStep(Step):
         """
         Create durable mesh, sizing-field and river-alignment diagnostics.
         """
-        with xr.open_dataset('base_mesh.nc') as ds_mesh:
+        with open_dataset('base_mesh.nc') as ds_mesh:
             area_km2 = ds_mesh.areaCell * 1.0e-6
             resolution_km = _estimate_dc_edge_from_area_cell(area_km2.values)
             dc_edge_km = 1.0e-3 * ds_mesh.dcEdge

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -4,7 +4,7 @@ from typing import Dict, Tuple, Union
 
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 from mpas_tools.vector.reconstruct import reconstruct_variable
 from ruamel.yaml import YAML
 
@@ -475,7 +475,7 @@ class Ocean(Component):
         ds : xarray.Dataset
             The dataset with variables named as expected in MPAS-Ocean
         """
-        ds = xr.open_dataset(filename, **kwargs)
+        ds = open_dataset(filename, **kwargs)
         if (
             self.model == 'omega'
             and 'layerThickness' not in ds.keys()
@@ -691,7 +691,7 @@ def _add_reconstructed_variables_to_dataset(
         if f'{out_var_name}Zonal' in ds and f'{out_var_name}Meridional' in ds:
             continue
 
-        ds_coeff = xr.open_dataset(coeffs_filename)
+        ds_coeff = open_dataset(coeffs_filename)
         coeffs_reconstruct = ds_coeff.coeffs_reconstruct
 
         if ds_coeff.sizes['nCells'] != ds_mesh.sizes['nCells']:

--- a/polaris/tasks/ocean/barotropic_gyre/analysis.py
+++ b/polaris/tasks/ocean/barotropic_gyre/analysis.py
@@ -68,10 +68,9 @@ class Analysis(OceanIOStep):
         ds_mesh = self.open_model_dataset('mesh.nc', self.config)
         ds = self.open_model_dataset('output.nc', self.config)
         ds_vert = self.open_model_dataset('vert_coord.nc', self.config)
-        ds_mesh['maxLevelCell'] = ds_vert.maxLevelCell
 
         field_mpas = compute_barotropic_streamfunction(
-            ds_mesh, ds, prefix='', time_index=-1
+            ds_mesh, ds, ds_vert_coord=ds_vert, prefix='', time_index=-1
         )
         x_maxpsi = ds_mesh.xVertex.isel(nVertices=np.argmax(field_mpas.values))
         logger.info(f'Streamfunction reaches maximum at x = {x_maxpsi.values}')

--- a/polaris/tasks/ocean/cosine_bell/analysis.py
+++ b/polaris/tasks/ocean/cosine_bell/analysis.py
@@ -1,5 +1,6 @@
 import numpy as np
 import xarray as xr
+from mpas_tools.io import open_dataset
 from mpas_tools.transects import lon_lat_to_cartesian
 from mpas_tools.vector import Vector
 
@@ -80,7 +81,7 @@ class Analysis(ConvergenceAnalysis):
         psi0 = config.getfloat('cosine_bell', 'psi0')
         vel_pd = config.getfloat('cosine_bell', 'vel_pd')
 
-        ds_mesh = xr.open_dataset(f'mesh_r{refinement_factor:02g}.nc')
+        ds_mesh = open_dataset(f'mesh_r{refinement_factor:02g}.nc')
         sphere_radius = ds_mesh.sphere_radius
 
         ds_init = self.open_model_dataset(

--- a/polaris/tasks/ocean/cosine_bell/init.py
+++ b/polaris/tasks/ocean/cosine_bell/init.py
@@ -1,5 +1,6 @@
 import numpy as np
 import xarray as xr
+from mpas_tools.io import open_dataset
 from mpas_tools.transects import lon_lat_to_cartesian
 from mpas_tools.vector import Vector
 
@@ -62,7 +63,7 @@ class Init(OceanIOStep):
         section = config['vertical_grid']
         bottom_depth = section.getfloat('bottom_depth')
 
-        ds_mesh = xr.open_dataset('mesh.nc')
+        ds_mesh = open_dataset('mesh.nc')
         angleEdge = ds_mesh.angleEdge
         latCell = ds_mesh.latCell
         latEdge = ds_mesh.latEdge

--- a/polaris/tasks/ocean/external_gravity_wave/init.py
+++ b/polaris/tasks/ocean/external_gravity_wave/init.py
@@ -1,5 +1,6 @@
 import numpy as np
 import xarray as xr
+from mpas_tools.io import open_dataset
 
 from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
@@ -63,7 +64,7 @@ class Init(OceanIOStep):
         section = config['vertical_grid']
         bottom_depth = section.getfloat('bottom_depth')
 
-        ds_mesh = xr.open_dataset('mesh.nc')
+        ds_mesh = open_dataset('mesh.nc')
         latCell = ds_mesh.latCell
         latEdge = ds_mesh.latEdge
         lonCell = ds_mesh.lonCell

--- a/polaris/tasks/ocean/external_gravity_wave/lts_regions.py
+++ b/polaris/tasks/ocean/external_gravity_wave/lts_regions.py
@@ -2,8 +2,7 @@ import math
 
 import netCDF4 as nc
 import numpy as np
-import xarray as xr
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 from mpas_tools.viz.paraview_extractor import extract_vtk
 from shapely import distance
 from shapely.geometry import Point
@@ -117,7 +116,7 @@ def label_mesh(
     use_progress_bar,
 ):
     # read in mesh data
-    ds = xr.open_dataset(mesh)
+    ds = open_dataset(mesh)
     n_cells = ds['nCells'].size
     n_edges = ds['nEdges'].size
     area_cell = ds['areaCell'].values
@@ -151,7 +150,7 @@ def label_mesh(
 
     # copy the init file and add LTSRegion to it
 
-    ds_msh = xr.open_dataset(init)
+    ds_msh = open_dataset(init)
     ds_ltsmsh = ds_msh.copy(deep=True)
     ltsmsh_name = 'init.nc'
     write_netcdf(ds_ltsmsh, ltsmsh_name)

--- a/polaris/tasks/ocean/geostrophic/exact_solution.py
+++ b/polaris/tasks/ocean/geostrophic/exact_solution.py
@@ -1,5 +1,5 @@
 import numpy as np
-import xarray as xr
+from mpas_tools.io import open_dataset
 
 from polaris.constants import get_constant
 
@@ -16,7 +16,7 @@ def compute_exact_solution(alpha, vel_period, gh_0, mesh_filename):
     u_0 = 2 * np.pi * a / (vel_period * sec_per_day)
     h_0 = gh_0 / g
 
-    ds_mesh = xr.open_dataset(mesh_filename)
+    ds_mesh = open_dataset(mesh_filename)
     angleEdge = ds_mesh.angleEdge
     latCell = ds_mesh.latCell
     lonCell = ds_mesh.lonCell

--- a/polaris/tasks/ocean/geostrophic/init.py
+++ b/polaris/tasks/ocean/geostrophic/init.py
@@ -1,4 +1,5 @@
 import xarray as xr
+from mpas_tools.io import open_dataset
 
 from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
@@ -79,7 +80,7 @@ class Init(OceanIOStep):
         section = config['vertical_grid']
         bottom_depth = section.getfloat('bottom_depth')
 
-        ds_mesh = xr.open_dataset('mesh.nc')
+        ds_mesh = open_dataset('mesh.nc')
         latCell = ds_mesh.latCell
 
         config.set('coriolis', 'rotated_sphere_alpha', str(alpha))

--- a/polaris/tasks/ocean/inertial_gravity_wave/analysis.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/analysis.py
@@ -1,4 +1,4 @@
-import xarray as xr
+from mpas_tools.io import open_dataset
 
 from polaris.ocean.convergence.analysis import ConvergenceAnalysis
 from polaris.tasks.ocean.inertial_gravity_wave.exact_solution import (
@@ -74,7 +74,7 @@ class Analysis(ConvergenceAnalysis):
         solution : xarray.DataArray
             The exact solution as derived from the initial condition
         """
-        ds_mesh = xr.open_dataset(f'mesh_r{refinement_factor:02g}.nc')
+        ds_mesh = open_dataset(f'mesh_r{refinement_factor:02g}.nc')
         exact = ExactSolution(ds_mesh, self.config)
         if field_name != 'ssh':
             raise ValueError(f'{field_name} is not currently supported')

--- a/polaris/tasks/ocean/isomip_plus/mesh/cull.py
+++ b/polaris/tasks/ocean/isomip_plus/mesh/cull.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 from mpas_tools.logging import LoggingContext
 from mpas_tools.mesh.conversion import cull
 from mpas_tools.mesh.creation.sort_mesh import sort_mesh
@@ -77,8 +77,8 @@ class CullMesh(Step):
                 min_ocean_fraction=min_ocean_fraction,
             )
 
-            ds_base = xr.open_dataset('base_mesh.nc')
-            ds_land_mask = xr.open_dataset('land_mask.nc')
+            ds_base = open_dataset('base_mesh.nc')
+            ds_land_mask = open_dataset('land_mask.nc')
 
             # cull the mesh based on the land mask
             ds_culled = cull(
@@ -101,7 +101,7 @@ class CullMesh(Step):
 
 
 def _land_mask_from_topo(topo_filename, mask_filename, min_ocean_fraction):
-    ds_topo = xr.open_dataset(topo_filename)
+    ds_topo = open_dataset(topo_filename)
 
     ocean_frac = ds_topo.oceanFraction
 

--- a/polaris/tasks/ocean/isomip_plus/mesh/spherical.py
+++ b/polaris/tasks/ocean/isomip_plus/mesh/spherical.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pyproj
-import xarray as xr
 from geometric_features import FeatureCollection
+from mpas_tools.io import open_dataset
 from mpas_tools.mesh.creation.signed_distance import (
     signed_distance_from_geojson,
 )
@@ -84,7 +84,7 @@ class SphericalMesh(QuasiUniformSphericalMeshStep):
         """
         super().run()
 
-        ds = xr.open_dataset('base_mesh_without_xy.nc')
+        ds = open_dataset('base_mesh_without_xy.nc')
         add_isomip_plus_xy(ds)
         ds.to_netcdf('base_mesh.nc')
 

--- a/polaris/tasks/ocean/isomip_plus/topo/remap.py
+++ b/polaris/tasks/ocean/isomip_plus/topo/remap.py
@@ -1,6 +1,6 @@
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 
 from polaris import Step
 from polaris.constants import get_constant
@@ -120,7 +120,7 @@ class TopoRemap(Step):
 
     @staticmethod
     def _rename():
-        with xr.open_dataset('topography_ncremap.nc') as ds_out:
+        with open_dataset('topography_ncremap.nc') as ds_out:
             drop = ['x', 'y', 'area', 'lat_vertices', 'lon_vertices']
             if 't' in ds_out.dims:
                 # this confusing bit first drops the t coordinate, then renames
@@ -140,7 +140,7 @@ class TopoRemap(Step):
 
     @staticmethod
     def _renormalize():
-        with xr.open_dataset('topography_rename.nc') as ds_out:
+        with open_dataset('topography_rename.nc') as ds_out:
             if 'Time' in ds_out.dims:
                 ds_out = ds_out.chunk({'Time': 1})
             # renormalize all variables by ocean_frac

--- a/polaris/tasks/ocean/isomip_plus/topo/scale.py
+++ b/polaris/tasks/ocean/isomip_plus/topo/scale.py
@@ -2,7 +2,7 @@ import os
 from typing import List
 
 import xarray as xr
-from mpas_tools.io import write_netcdf
+from mpas_tools.io import open_dataset, write_netcdf
 
 from polaris import Step
 
@@ -68,7 +68,7 @@ class TopoScale(Step):
             'isomip_plus_scaling', f'{experiment}_scales', dtype=float
         )
 
-        ds_orig = xr.open_dataset('topography_unscaled.nc')
+        ds_orig = open_dataset('topography_unscaled.nc')
 
         ds_list: List[xr.Dataset] = list()
 

--- a/polaris/tasks/ocean/sphere_transport/init.py
+++ b/polaris/tasks/ocean/sphere_transport/init.py
@@ -1,5 +1,6 @@
 import numpy as np
 import xarray as xr
+from mpas_tools.io import open_dataset
 
 from polaris.constants import get_constant
 from polaris.ocean.coriolis import add_coriolis_to_dataset
@@ -83,7 +84,7 @@ class Init(OceanIOStep):
         section = config['vertical_grid']
         bottom_depth = section.getfloat('bottom_depth')
 
-        ds_mesh = xr.open_dataset('mesh.nc')
+        ds_mesh = open_dataset('mesh.nc')
         latCell = ds_mesh.latCell
         latEdge = ds_mesh.latEdge
         lonCell = ds_mesh.lonCell

--- a/polaris/tasks/seaice/single_column/standard_physics/viz.py
+++ b/polaris/tasks/seaice/single_column/standard_physics/viz.py
@@ -1,7 +1,7 @@
 import importlib.resources as imp_res
 
 import matplotlib.pyplot as plt
-import xarray as xr
+from mpas_tools.io import open_dataset
 
 from polaris import Step
 
@@ -36,7 +36,7 @@ class Viz(Step):
         """
         style_filename = str(imp_res.files('polaris.viz') / 'polaris.mplstyle')
         plt.style.use(style_filename)
-        ds = xr.open_dataset('output.2000.nc', decode_times=False)
+        ds = open_dataset('output.2000.nc', decode_times=False)
         daysSinceStartOfSim = ds.daysSinceStartOfSim.values
         snowVolumeCell = ds.snowVolumeCell.values
         iceVolumeCell = ds.iceVolumeCell.values

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.0-alpha.9'
+__version__ = '1.0.0-alpha.10'

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -6,8 +6,8 @@ import matplotlib.colors as cols
 import matplotlib.pyplot as plt
 import mosaic
 import numpy as np
-import xarray as xr
 from cartopy.geodesic import Geodesic
+from mpas_tools.io import open_dataset
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from pyremap.descriptor.utility import interp_extrap_corner
 
@@ -120,7 +120,7 @@ def plot_global_mpas_field(
                 'Either mesh_filename or descriptor must be given'
                 ' as parameters to Descriptor'
             )
-        mesh_ds = xr.open_dataset(mesh_filename)
+        mesh_ds = open_dataset(mesh_filename)
         mesh_ds.attrs['is_periodic'] = 'NO'
         if cell_indices is not None:
             mesh_ds = mesh_ds.isel(nCells=cell_indices)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This version of mpas_tools brings in https://github.com/MPAS-Dev/MPAS-Tools/pull/736, which supports Omega horizontal grid, vertical coordinate, and state splitting.  It also brings in https://github.com/MPAS-Dev/MPAS-Tools/pull/737, which sets the xarray engine for reading files to `mpas_tools.io.default_engine` rather than guessing.

To support the MPAS-Tools changes, Polaris has been updated to:
* properly use Omega's split files in the barotropic streamfunction calls in the barotropic gyre tests
* use MPAS-Tools' version of `open_dataset()` for all MPAS datasets (but not lon/lat or cubed sphere, for example).

We will need to find out if the latter present a problem.  It doesn't make too much sense to use an MPAS-Tools function to open non-MPAS meshes but if we see crashes, we may have to, or we may need to set `engine` explicitly.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #624 