### PR TITLE
Fix half-globe clipping in plot_global_mpas_field

### DIFF
--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -185,7 +185,10 @@ def plot_global_mpas_field(
         cbar.set_ticks(ticks)
         cbar.set_ticklabels([f'{tick}' for tick in ticks])
 
-    fig.savefig(out_filename, bbox_inches='tight', pad_inches=0.1)
+    # Let constrained_layout manage the margins; combining it with
+    # bbox_inches='tight' on a fixed-aspect GeoAxes with an attached colorbar
+    # can collapse the map axes so only part of the globe is drawn.
+    fig.savefig(out_filename)
 
 
 def plot_global_lat_lon_field(


### PR DESCRIPTION
The final savefig combined bbox_inches='tight' with the axes' constrained_layout on a fixed-aspect cartopy GeoAxes that also has an attached colorbar.  That combination is unstable: the tight bounding-box pass shrinks the map axes so only part of the globe is drawn (e.g. half the globe, or in extreme cases the map collapses entirely, leaving just the colorbar).

Drop bbox_inches='tight'/pad_inches and let constrained_layout manage the margins, which reliably renders the full field.  This affects all callers of plot_global_mpas_field.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
