### PR TITLE
Load vert_coord_vars lazily in open_vert_coord_dataset

### DIFF
--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -126,10 +126,12 @@ class OceanIOStep(Step, OceanModelFilesMixin):
         elif model == 'mpas-ocean':
             ds_vert_coord = xr.Dataset()
             if self.component.vert_coord_vars is None:
-                raise ValueError(
-                    'Vertical coordinate variables not defined in the Ocean '
-                    'component'
-                )
+                # Populate the variable list lazily.  In a full task run it is
+                # set as a side effect of writing the initial state, but a
+                # step run on its own (e.g. re-running only the viz step) must
+                # load it here.
+                self.component._read_variables_yaml()
+            assert self.component.vert_coord_vars is not None
             for var in self.component.vert_coord_vars:
                 if var not in ds_init:
                     raise ValueError(

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -128,7 +128,7 @@ class OceanIOStep(Step, OceanModelFilesMixin):
             if self.component.vert_coord_vars is None:
                 # Populate the variable list lazily.  In a full task run it is
                 # set as a side effect of writing the initial state, but a
-                # step run on its own (e.g. re-running only the viz step) must
+                # step run on its own (e.g. re-running only a viz step) must
                 # load it here.
                 self.component._read_variables_yaml()
             assert self.component.vert_coord_vars is not None


### PR DESCRIPTION
For MPAS-Ocean, open_vert_coord_dataset extracts the vertical-coordinate variables from the initial-condition dataset using the component's vert_coord_vars list.  That list is populated as a side effect of writing the initial state, so in a full task run it is set before any analysis step reads it.  When a step is run on its own (e.g. re-running only a viz step via `polaris serial`), nothing has written the initial state in that process, so vert_coord_vars was still None and the method raised "Vertical coordinate variables not defined in the Ocean component".

Populate the list lazily via _read_variables_yaml() instead of raising, matching how the component's write methods load it.  Omega was unaffected because its branch reads vert_coord.nc directly.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
