### PR TITLE
Adds cronjob support for Aurora system

### DIFF
--- a/cron-scripts/machines/config_aurora.sh
+++ b/cron-scripts/machines/config_aurora.sh
@@ -2,6 +2,12 @@
 
 set -eo pipefail
 
+source /usr/share/lmod/8.7.59/init/bash
+
+export MODULEPATH="/opt/aurora/26.26.0/spack/unified/1.1.1/install/modulefiles/mpich/5.0.0.aurora_test.3c70a61-hlkigtk/Core:/opt/aurora/26.26.0/spack/unified/1.1.1/install/modulefiles/mpich/5.0.0.aurora_test.3c70a61-hlkigtk/intel-oneapi-compilers/2025.3.1:/opt/aurora/26.26.0/spack/unified/1.1.1/install/modulefiles/Core:/opt/aurora/26.26.0/spack/unified/1.1.1/install/modulefiles/intel-oneapi-compilers/2025.3.1:/usr/share/lmod/modulefiles/Linux:/usr/share/lmod/modulefiles/Core:/usr/share/lmod/lmod/modulefiles/Core:/opt/cray/pals/lmod/modulefiles/core:/opt/cray/modulefiles:/opt/aurora/26.26.0/modulefiles:/opt/aurora/25.190.0/modulefiles"
+
+export PATH=/opt/pbs/bin:$PATH
+
 module load cmake
 
 export CRONJOB_BASEDIR="${POLARIS_CRON_ROOT:?POLARIS_CRON_ROOT must be set}"
@@ -12,5 +18,6 @@ declare -A COMPILER_MAP
 COMPILER_MAP["oneapi-ifxgpu"]="SYCL"
 
 export COMPILER_MAP_DEF=$(declare -p COMPILER_MAP)
+export JOB_SCHEDULER=PBS
 
 mkdir -p "$CRONJOB_BASEDIR"

--- a/cron-scripts/machines/config_chrysalis.sh
+++ b/cron-scripts/machines/config_chrysalis.sh
@@ -14,5 +14,6 @@ COMPILER_MAP["gnu"]="SERIAL"
 COMPILER_MAP["intel"]="SERIAL"
 
 export COMPILER_MAP_DEF=$(declare -p COMPILER_MAP)
+export JOB_SCHEDULER=SLURM
 
 mkdir -p "$CRONJOB_BASEDIR"

--- a/cron-scripts/machines/config_frontier.sh
+++ b/cron-scripts/machines/config_frontier.sh
@@ -17,5 +17,6 @@ COMPILER_MAP["craycray"]="SERIAL"
 COMPILER_MAP["crayamd"]="SERIAL"
 
 export COMPILER_MAP_DEF=$(declare -p COMPILER_MAP)
+export JOB_SCHEDULER=SLURM
 
 mkdir -p "$CRONJOB_BASEDIR"

--- a/cron-scripts/machines/config_pm-cpu.sh
+++ b/cron-scripts/machines/config_pm-cpu.sh
@@ -13,5 +13,6 @@ declare -A COMPILER_MAP
 COMPILER_MAP["gnu"]="SERIAL"
 
 export COMPILER_MAP_DEF=$(declare -p COMPILER_MAP)
+export JOB_SCHEDULER=SLURM
 
 mkdir -p "$CRONJOB_BASEDIR"

--- a/cron-scripts/machines/config_pm-gpu.sh
+++ b/cron-scripts/machines/config_pm-gpu.sh
@@ -12,6 +12,6 @@ declare -A COMPILER_MAP
 COMPILER_MAP["gnugpu"]="CUDA"
 
 export COMPILER_MAP_DEF=$(declare -p COMPILER_MAP)
-
+export JOB_SCHEDULER=SLURM
 
 mkdir -p "$CRONJOB_BASEDIR"

--- a/cron-scripts/tasks/omega_cdash/job_aurora_omega_cdash.pbs
+++ b/cron-scripts/tasks/omega_cdash/job_aurora_omega_cdash.pbs
@@ -1,0 +1,24 @@
+#!/bin/bash -l
+#PBS -N OmegaCdash
+#PBS -A E3SM_Dec
+#PBS -l select=1
+#PBS -l walltime=01:00:00
+#PBS -l place=scatter
+#PBS -q debug
+#PBS -l filesystems=home:flare
+
+if [ -f /etc/bash.bashrc ]; then
+    source /etc/bash.bashrc
+fi
+
+TARGET_SCRIPT="$RUNSCRIPT_DIR/run_omega_cdash.sh"
+
+if [ -f "$TARGET_SCRIPT" ]; then
+    echo "Running script from: $TARGET_SCRIPT"
+    exec bash "$TARGET_SCRIPT"
+else
+    echo "Error: $TARGET_SCRIPT not found."
+    echo "Current directory: $(pwd)"
+    echo "RUNSCRIPT_DIR: $RUNSCRIPT_DIR"
+    exit 1
+fi

--- a/cron-scripts/tasks/omega_cdash/launch_omega_cdash.sh
+++ b/cron-scripts/tasks/omega_cdash/launch_omega_cdash.sh
@@ -57,10 +57,27 @@ export CRONJOB_DATE
 export TESTROOT
 export OMEGA_ROOT
 
-sbatch \
-  --job-name=OmegaCdash \
-  --output="$CRONJOB_LOGDIR/omega_cdash_%j.out" \
-  --error="$CRONJOB_LOGDIR/omega_cdash_%j.err" \
-  "${HERE}/job_${CRONJOB_MACHINE}_omega_cdash.sbatch"
+case "${JOB_SCHEDULER}" in
+  SLURM)
+    sbatch \
+      --job-name=OmegaCdash \
+      --output="${CRONJOB_LOGDIR}/omega_cdash_%j.out" \
+      --error="${CRONJOB_LOGDIR}/omega_cdash_%j.err" \
+      "${HERE}/job_${CRONJOB_MACHINE}_omega_cdash.sbatch"
+    ;;
+
+  PBS)
+    qsub \
+      -N OmegaCdash \
+      -o "${CRONJOB_LOGDIR}/omega_cdash_${PBS_JOBID}.out" \
+      -e "${CRONJOB_LOGDIR}/omega_cdash_${PBS_JOBID}.err" \
+      "${HERE}/job_${CRONJOB_MACHINE}_omega_cdash.pbs"
+    ;;
+
+  *)
+    echo "Error: Unsupported job scheduler '${JOB_SCHEDULER}'." >&2
+    exit 1
+    ;;
+esac
 
 echo "[$(date)] Finished $SCRIPT_NAME"

--- a/cron-scripts/tasks/omega_cdash/launch_omega_cdash.sh
+++ b/cron-scripts/tasks/omega_cdash/launch_omega_cdash.sh
@@ -69,8 +69,9 @@ case "${JOB_SCHEDULER}" in
   PBS)
     qsub \
       -N OmegaCdash \
-      -o "${CRONJOB_LOGDIR}/omega_cdash_${PBS_JOBID}.out" \
-      -e "${CRONJOB_LOGDIR}/omega_cdash_${PBS_JOBID}.err" \
+      -V \
+      -o "${CRONJOB_LOGDIR}/" \
+      -e "${CRONJOB_LOGDIR}/" \
       "${HERE}/job_${CRONJOB_MACHINE}_omega_cdash.pbs"
     ;;
 

--- a/cron-scripts/tasks/omega_cdash/run_omega_cdash.sh
+++ b/cron-scripts/tasks/omega_cdash/run_omega_cdash.sh
@@ -20,6 +20,10 @@ elif [[ "${CRONJOB_MACHINE:-unknown}" == "pm-cpu" ]]; then
     module load cray-python cmake
     PARMETIS_TPL="/global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_10_0_COMPILER_mpich/var/spack/environments/dev_polaris_0_10_0_COMPILER_mpich/.spack-env/view"
 
+elif [[ "${CRONJOB_MACHINE:-unknown}" == "aurora" ]]; then
+    module load python cmake
+    PARMETIS_TPL="/lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view"
+
 elif [[ "${CRONJOB_MACHINE:-unknown}" == "unknown" ]]; then
     echo "CRONJOB_MACHINE is not set."
     exit 1

--- a/cron-scripts/tasks/omega_cdash/run_omega_cdash.sh
+++ b/cron-scripts/tasks/omega_cdash/run_omega_cdash.sh
@@ -78,6 +78,6 @@ for COMPILER in "${!COMPILER_MAP[@]}"; do
       -DCTEST_BUILD_COMMAND="${WORKDIR}/omega_build.sh" \
       -DCTEST_BUILD_CONFIGURATION="Release" \
       -DCTEST_DROP_SITE_CDASH=TRUE \
-      -DCTEST_SUBMIT_URL="https://my.cdash.org/submit.php?project=E3SM";
+      -DCTEST_SUBMIT_URL="https://my.cdash.org/submit.php?project=omega";
 
 done

--- a/cron-scripts/tasks/polaris_cdash/launch_polaris_ctest.sh
+++ b/cron-scripts/tasks/polaris_cdash/launch_polaris_ctest.sh
@@ -28,7 +28,11 @@ elif [[ "$CRONJOB_MACHINE" == "pm-cpu" ]]; then
     module load cray-python cmake
     PARMETIS_TPL="/global/cfs/cdirs/e3sm/software/polaris/pm-cpu/spack/dev_polaris_0_10_0_COMPILER_mpich/var/spack/environments/dev_polaris_0_10_0_COMPILER_mpich/.spack-env/view"
 
-elif [[ "$CRONJOB_MACHINE" == "unknown" ]]; then
+elif [[ "$CRONJOB_MACHINE" == "aurora" ]]; then
+    module load python cmake
+    PARMETIS_TPL="/lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack/dev_polaris_1.0.0/var/spack/environments/spack_env_oneapi-ifx_mpich/.spack-env/view"
+
+elif [[ "${CRONJOB_MACHINE:-unknown}" == "unknown" ]]; then
   echo "CRONJOB_MACHINE is not set."
   exit 1
 
@@ -126,7 +130,21 @@ run_baseline_suite() {
         cd "$polaris_build"
         echo "Submitting baseline job in $(pwd)..."
         # Fire and forget / continue on error
-        sbatch --wait job_script.omega_nightly.sh || true
+	case "${JOB_SCHEDULER}" in
+	  SLURM)
+	    sbatch --wait job_script.omega_nightly.sh || true
+	    ;;
+
+	  PBS)
+	    qsub -W block=true job_script.omega_nightly.sh || true
+	    ;;
+
+	  *)
+	    echo "Error: Unsupported JOB_SCHEDULER='${JOB_SCHEDULER}'." >&2
+	    exit 1
+	    ;;
+	esac
+
     else
         echo "Error: Baseline directory $polaris_build was not created."
     fi


### PR DESCRIPTION
This PR adds cron job support for the ALCF Aurora system.

Notes:

* Adds support for the PBS job scheduler on Aurora.
* Adds the MODULEPATH and PATH environment variables to the Aurora configuration to enable the module and qsub commands to work correctly. This may be updated if a better solution is identified.
* related issue: https://github.com/E3SM-Project/polaris/issues/631