### PR TITLE
Add del4 variant of overflow test case

### DIFF
--- a/docs/developers_guide/ocean/tasks/overflow.md
+++ b/docs/developers_guide/ocean/tasks/overflow.md
@@ -2,10 +2,10 @@
 
 # overflow
 
-The overflow task group is currently comprised of three `smoke_test` tasks
-for quick testing (one for each horizontal advection order: 2, 3, and 4),
+The overflow task group is currently comprised of four `smoke_test` tasks
+for quick testing (one for each horizontal advection order, 2, 3, and 4, and one with horizontal advection order 2 but del4 viscosity enabled),
 and one `rpe` test which shows how the resting potential energy changes across
-forward runs with different viscosities.
+forward runs with different del2 viscosities.
 
 ## framework
 
@@ -61,7 +61,9 @@ task runs the `init` step, a short `forward` step, and (optionally, not run
 by default) the `viz` step. Three instances are created, one for each
 horizontal advection order (2, 3, and 4), producing tasks named
 `smoke_test_horiz_adv_order_2`, `smoke_test_horiz_adv_order_3`, and
-`smoke_test_horiz_adv_order_4`.
+`smoke_test_horiz_adv_order_4`. An additional tests is provided to test del4
+viscosity alonside the overflow topography,
+`smoke_test_horiz_adv_order_2_del4`.
 
 ## rpe
 

--- a/docs/users_guide/ocean/tasks/overflow.md
+++ b/docs/users_guide/ocean/tasks/overflow.md
@@ -3,7 +3,13 @@
 # overflow
 
 The ``ocean/overflow`` test group induces a density current flowing down a
-continental slope and includes four test cases.
+continental slope and includes the following test cases:
+
+1. ``smoke_test_horiz_adv_order_2`` — short (12 min) smoke test using horizontal advection order = 2 for rapid CI checks.
+2. ``smoke_test_horiz_adv_order_2_del4`` — same as (1) but with del4 viscosity enabled with the default viscosity value.
+3. ``smoke_test_horiz_adv_order_3`` — short (12 min) smoke test using horizontal advection order = 3 for rapid CI checks.
+4. ``smoke_test_horiz_adv_order_4`` — short (12 min) smoke test using horizontal advection order = 4 for rapid CI checks.
+5. ``rpe`` — long run (40 days) exploring Resting Potential Energy (RPE) evolution for a set of Laplacian viscosities.
 
 ## supported models
 

--- a/polaris/suites/ocean/omega_pr.txt
+++ b/polaris/suites/ocean/omega_pr.txt
@@ -5,7 +5,7 @@ ocean/planar/manufactured_solution/convergence_both/default
 ocean/planar/manufactured_solution/convergence_both/del2
 ocean/planar/manufactured_solution/convergence_both/del4
 ocean/planar/merry_go_round/default
-ocean/planar/overflow/smoke_test_horiz_adv_order_2
+ocean/planar/overflow/smoke_test_horiz_adv_order_2_del4
 ocean/planar/overflow/smoke_test_horiz_adv_order_3
 ocean/planar/overflow/smoke_test_horiz_adv_order_4
 ocean/spherical/icos/cosine_bell/decomp

--- a/polaris/tasks/ocean/overflow/__init__.py
+++ b/polaris/tasks/ocean/overflow/__init__.py
@@ -38,7 +38,7 @@ def add_overflow_tasks(component):
         component=component,
         indir=taskdir,
         init=init_step,
-        horiz_adv_order=2,
+        horiz_adv_order=4,
         use_mom_del4=True,
     )
     smoke_test.set_shared_config(config, link=config_filename)

--- a/polaris/tasks/ocean/overflow/__init__.py
+++ b/polaris/tasks/ocean/overflow/__init__.py
@@ -34,6 +34,15 @@ def add_overflow_tasks(component):
         )
         smoke_test.set_shared_config(config, link=config_filename)
         component.add_task(smoke_test)
+    smoke_test = SmokeTest(
+        component=component,
+        indir=taskdir,
+        init=init_step,
+        horiz_adv_order=2,
+        use_mom_del4=True,
+    )
+    smoke_test.set_shared_config(config, link=config_filename)
+    component.add_task(smoke_test)
 
     component.add_task(
         Rpe(

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -33,6 +33,7 @@ class Forward(OceanModelStep):
         openmp_threads=1,
         horiz_adv_order=None,
         nu=None,
+        use_mom_del4=False,
     ):
         """
         Create a new test case
@@ -90,6 +91,7 @@ class Forward(OceanModelStep):
         self.config_section = config_section
         self.horiz_adv_order = horiz_adv_order
         self.nu = nu
+        self.use_mom_del4 = use_mom_del4
 
         # make sure output is double precision
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')
@@ -162,6 +164,7 @@ class Forward(OceanModelStep):
             run_duration=run_duration_str,
             run_duration_units=run_duration_units,
             output_interval=output_interval_str,
+            use_mom_del4=self.use_mom_del4,
             nu=self.nu,
             output_freq=f'{output_freq}',
             output_freq_units=output_units,

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -174,7 +174,6 @@ class Forward(OceanModelStep):
             run_duration=run_duration_str,
             run_duration_units=run_duration_units,
             output_interval=output_interval_str,
-            use_mom_del2=not self.use_mom_del4,
             use_mom_del4=self.use_mom_del4,
             nu=self.nu,
             nu4=self.nu4,

--- a/polaris/tasks/ocean/overflow/forward.py
+++ b/polaris/tasks/ocean/overflow/forward.py
@@ -33,6 +33,7 @@ class Forward(OceanModelStep):
         openmp_threads=1,
         horiz_adv_order=None,
         nu=None,
+        nu4=None,
         use_mom_del4=False,
     ):
         """
@@ -73,7 +74,12 @@ class Forward(OceanModelStep):
             from the default for the test group)
 
         nu : float, optional
-            the viscosity (if different from the default for the test group)
+            the Laplacian (del2) viscosity (if different from the default for
+            the test group)
+
+        nu4 : float, optional
+            the biharmonic (del4) viscosity (if different from the default for
+            the test group)
         """
         if min_tasks is None:
             min_tasks = ntasks
@@ -91,6 +97,7 @@ class Forward(OceanModelStep):
         self.config_section = config_section
         self.horiz_adv_order = horiz_adv_order
         self.nu = nu
+        self.nu4 = nu4
         self.use_mom_del4 = use_mom_del4
 
         # make sure output is double precision
@@ -126,6 +133,9 @@ class Forward(OceanModelStep):
         )
         if self.nu is None:
             self.nu = config.getfloat('overflow', 'default_viscosity')
+
+        if self.nu4 is None:
+            self.nu4 = config.getfloat('overflow', 'default_del4_viscosity')
 
         if self.horiz_adv_order is None:
             self.horiz_adv_order = config.getint(
@@ -164,8 +174,10 @@ class Forward(OceanModelStep):
             run_duration=run_duration_str,
             run_duration_units=run_duration_units,
             output_interval=output_interval_str,
+            use_mom_del2=not self.use_mom_del4,
             use_mom_del4=self.use_mom_del4,
             nu=self.nu,
+            nu4=self.nu4,
             output_freq=f'{output_freq}',
             output_freq_units=output_units,
             horiz_adv_order=self.horiz_adv_order,

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -6,7 +6,7 @@ ocean:
     config_dt: {{ dt }}
     config_time_integrator: {{ time_integrator }}
   hmix_del2:
-    config_use_mom_del2: {{ use_mom_del2 }}
+    config_use_mom_del2: true
     config_mom_del2: {{ nu }}
     config_use_tracer_del2: false
   hmix_del4:

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -6,11 +6,12 @@ ocean:
     config_dt: {{ dt }}
     config_time_integrator: {{ time_integrator }}
   hmix_del2:
-    config_use_mom_del2: true
+    config_use_mom_del2: {{ use_mom_del2 }}
     config_mom_del2: {{ nu }}
     config_use_tracer_del2: false
   hmix_del4:
     config_use_mom_del4: {{ use_mom_del4 }}
+    config_mom_del4: {{ nu4 }}
     config_use_tracer_del4: false
   cvmix:
     config_use_cvmix_convection: false

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -10,7 +10,7 @@ ocean:
     config_mom_del2: {{ nu }}
     config_use_tracer_del2: false
   hmix_del4:
-    config_use_mom_del4: false
+    config_use_mom_del4: {{ use_mom_del4 }}
     config_use_tracer_del4: false
   cvmix:
     config_use_cvmix_convection: false

--- a/polaris/tasks/ocean/overflow/overflow.cfg
+++ b/polaris/tasks/ocean/overflow/overflow.cfg
@@ -75,6 +75,9 @@ higher_temperature = 20.0
 # Default viscosity (m^2/s)
 default_viscosity = 1000.0
 
+# Default biharmonic (del4) viscosity (m^4/s), scaled ~ dx^3 for 2 km resolution
+default_del4_viscosity = 5.0e7
+
 # Default horizontal advection order
 default_horiz_adv_order = 2
 

--- a/polaris/tasks/ocean/overflow/smoke_test.py
+++ b/polaris/tasks/ocean/overflow/smoke_test.py
@@ -12,7 +12,9 @@ class SmokeTest(Task):
     initial condition, then performs a short forward run on 4 cores.
     """
 
-    def __init__(self, component, indir, init, horiz_adv_order):
+    def __init__(
+        self, component, indir, init, horiz_adv_order, use_mom_del4=False
+    ):
         """
         Create the test case
 
@@ -31,6 +33,8 @@ class SmokeTest(Task):
             The horizontal advection order for the test case
         """
         task_name = f'smoke_test_horiz_adv_order_{horiz_adv_order}'
+        if use_mom_del4:
+            task_name += '_del4'
         super().__init__(component=component, name=task_name, indir=indir)
 
         self.add_step(init, symlink='init')
@@ -42,6 +46,7 @@ class SmokeTest(Task):
             name='forward',
             indir=self.subdir,
             horiz_adv_order=horiz_adv_order,
+            use_mom_del4=use_mom_del4,
         )
         self.add_step(forward_step)
 


### PR DESCRIPTION
Fixes https://github.com/E3SM-Project/polaris/issues/639 by adding a del4 viscosity variant of the overflow test case.

Submodule already includes https://github.com/E3SM-Project/Omega/pull/456

Checklist
* [X] User's Guide has been updated
* [X] Developer's Guide has been updated
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes
* [X] New tests have been added to a test suite