### PR TITLE
Vector reconstruction at cells and vertices following Peixoto and Barros (2014)

### DIFF
--- a/docs/developers_guide/ocean/index.md
+++ b/docs/developers_guide/ocean/index.md
@@ -107,4 +107,5 @@ appropriate for whichever of the {ref}`machines` you are using.
 tasks/index
 framework
 models/index
+utils/index
 ```

--- a/docs/developers_guide/ocean/utils/add_reconstruction_weights.md
+++ b/docs/developers_guide/ocean/utils/add_reconstruction_weights.md
@@ -1,0 +1,53 @@
+(dev-ocean-add-reconstruction-weights)=
+
+# add_reconstruction_weights
+
+`utils/omega/add_reconstruction_weights.py` is a standalone script that
+computes edge vector reconstruction weights and appends them to an existing
+MPAS-Ocean or Omega mesh file.
+
+The weights are computed using the least-squares method described in
+[Peixoto and Barros (2014)](https://doi.org/10.1016/j.jcp.2014.04.043)
+using a two-ring edge stencil (see Figure 5 of that paper).
+
+The script auto-detects whether the input file uses MPAS-Ocean or Omega
+naming conventions and writes output in the same convention.  Only the
+small mesh/grid variables are loaded; large state/tracer fields are
+skipped, making it safe to run on production meshes.
+
+## Usage
+
+```bash
+./utils/omega/add_reconstruction_weights.py \
+    -i <input_mesh.nc> \
+    -o <output_mesh.nc> \
+    [-w <num_workers>] \
+    [-c <chunk_size>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-i` / `--input_file`  | Input mesh file (MPAS-Ocean or Omega format) |
+| `-o` / `--output_file` | Output file (copy of input with weights appended) |
+| `-w` / `--num_workers` | Number of dask worker processes (enables parallel mode) |
+| `-c` / `--chunk_size`  | Cells per dask chunk (default: 10 000) |
+
+Passing either `-w` or `-c` enables dask parallelism. If `-c` is given
+without `-w`, the worker count is inferred from mache (requires running
+on a recognised machine).
+
+## Parallel performance
+
+The script uses a local multiprocessing dask scheduler and can exploit
+all cores on a single node. Based on timing tests on Chrysalis with the
+EC30to60 mesh (~1.8 M cells, 32 workers):
+
+| `num_workers` | `chunk_size` | wall time |
+|:---:|---:|---:|
+| 32 | 7 000 | ~5m 57s |
+| 32 | 3 700 | ~4m 42s |
+| 32 | 1 850 | ~4m 16s |
+
+**Fewer workers with more, smaller chunks per worker tends to be faster
+than filling each worker with one large chunk.**  Start with a chunk size
+that gives several chunks per worker and tune from there.

--- a/docs/developers_guide/ocean/utils/add_reconstruction_weights.md
+++ b/docs/developers_guide/ocean/utils/add_reconstruction_weights.md
@@ -30,7 +30,7 @@ skipped, making it safe to run on production meshes.
 | `-i` / `--input_file`  | Input mesh file (MPAS-Ocean or Omega format) |
 | `-o` / `--output_file` | Output file (copy of input with weights appended) |
 | `-w` / `--num_workers` | Number of dask worker processes (enables parallel mode) |
-| `-c` / `--chunk_size`  | Cells per dask chunk (default: 10 000) |
+| `-c` / `--chunk_size`  | Cells per dask chunk (default: 1000) |
 
 Passing either `-w` or `-c` enables dask parallelism. If `-c` is given
 without `-w`, the worker count is inferred from mache (requires running
@@ -44,9 +44,9 @@ EC30to60 mesh (~1.8 M cells, 32 workers):
 
 | `num_workers` | `chunk_size` | wall time |
 |:---:|---:|---:|
-| 32 | 7 000 | ~5m 57s |
-| 32 | 3 700 | ~4m 42s |
-| 32 | 1 850 | ~4m 16s |
+| 32 | 7000 | ~5m 57s |
+| 32 | 3700 | ~4m 42s |
+| 32 | 1850 | ~4m 16s |
 
 **Fewer workers with more, smaller chunks per worker tends to be faster
 than filling each worker with one large chunk.**  Start with a chunk size

--- a/docs/developers_guide/ocean/utils/index.md
+++ b/docs/developers_guide/ocean/utils/index.md
@@ -1,0 +1,11 @@
+(dev-ocean-utils)=
+
+# Ocean utilities
+
+Developer utilities for the `ocean` component.
+
+```{toctree}
+:titlesonly: true
+
+add_reconstruction_weights
+```

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -1,5 +1,5 @@
 """
-NOTE: Intermidiate connecitity arrays are computed using the lightweight
+NOTE: Intermediate connectivity arrays are computed using the lightweight
 synchronous dask scheduler to avoid the overhead of spinning up a process
 pool for small integer topology data.
 """
@@ -39,7 +39,7 @@ def fix_out_of_bounds_indices(ds: xr.Dataset) -> xr.Dataset:
     Some meshes (e.g. QU240km) don't do masking of ragged indices with zeros,
     instead they use `nInidices+1` as the invalid value.
 
-    NOTE: Assumes connecitity array are 1-indexed
+    NOTE: Assumes connectivity array are 1-indexed
 
     Parameters
     ----------
@@ -219,7 +219,7 @@ def construct_rotation_matrix(
 ) -> xr.DataArray:
     """
     Construct a rotation matrix from Cartesian coordinates to local orthogonal
-    projection to a tangent plane at the recoconstruction point.
+    projection to a tangent plane at the reconstruction point.
 
     The projection is done in two steps: first a rotation about the x-axis and
     then a rotation about the y-axis.
@@ -383,7 +383,7 @@ def compute_lstsq_weights(
             raise ValueError(
                 'A stencil edge has been rotated into the lower '
                 'hemisphere of the local tangent plane. This is not '
-                'expexted for realistic MPAS mesh resolution; check for '
+                'expected for realistic MPAS mesh resolution; check for '
                 'degenerate or high distorted cells'
             )
 
@@ -549,12 +549,12 @@ def build_reconstruction_weights(
     weights = solve_psuedo_inverse(matrix)
     weights *= np.sqrt(w)
 
-    # Becuase we only support reconstruction at the reconstruction points
+    # Because we only support reconstruction at the reconstruction points
     # (i.e. cell or vertex centers) we only need to keep the first two rows
     # of the weights matrix. But that will produce a vector reconstructed on
     # the tangent plane. So, we keep an extra column of the weights matrix,
     # and assume the z component to be zero, in order to be able to apply the
-    # inverse of 3x3 rotation matrix resiluting in a catesian vector
+    # inverse of 3x3 rotation matrix resulting in a Cartesian vector
     weights = weights.isel(SIX=[0, 1, 2]).rename({'SIX': 'R3'})
     weights.loc[{'R3': 2}] = 0.0
 
@@ -698,7 +698,7 @@ def compute_reconstruction_weights(
     ds: xr.Dataset, location: ReconstructionType = 'cell'
 ) -> xr.Dataset:
     """
-    Compute the weights and stencil indices needed for recoconstruction
+    Compute the weights and stencil indices needed for reconstruction
     a edge normal vector field at cell or vertex centers
 
     Parameters
@@ -712,7 +712,7 @@ def compute_reconstruction_weights(
     -------
     ds: xr.Dataset
         A minimal dataset containing the reconstruction stencil, edge-count,
-        and coefficent fields for the requeste reconstruction point location.
+        and coefficient fields for the requested reconstruction point location.
     """
 
     names = _RECONSTRUCTION_FIELD_NAMES[location]

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -6,8 +6,10 @@ pool for small integer topology data.
 
 from typing import Literal
 
+import dask
 import numpy as np
 import xarray as xr
+from dask.diagnostics import ProgressBar
 from scipy import linalg
 
 from polaris.mesh.vector import compute_edge_normal_vec
@@ -664,6 +666,69 @@ def cartesian_to_local_geographic(
     return u_zonal, u_merid, u_radial
 
 
+def compute_reconstruction_weights(
+    ds: xr.Dataset, location: ReconstructionType = 'cell'
+) -> xr.Dataset:
+    """
+    Compute the weights and stencil indices needed for recoconstruction
+    a edge normal vector field at cell or vertex centers
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        MPAS mesh dataset
+    location: str ["cell", "vertex"]
+        Point location where the reconstruction occurs
+
+    Returns
+    -------
+    ds: xr.Dataset
+        A minimal dataset containing the reconstruction stencil, edge-count,
+        and coefficent fields for the requeste reconstruction point location.
+    """
+
+    names = _RECONSTRUCTION_FIELD_NAMES[location]
+
+    if names['coeffs'] in ds:
+        print(
+            f"Warning: overwriting existing '{names['coeffs']}' field "
+            'in the mesh dataset.'
+        )
+
+    # For stencil creation to work all indices in the connectivity arrays must
+    # [0, dim_size], where 0 is the invalid index sentinel
+    ds = fix_out_of_bounds_indices(ds)
+
+    stencil, weights = build_reconstruction_weights(ds, location)
+
+    stencil_dim = _stencil_dim(stencil)
+    n_edges = (stencil != 0).sum(dim=stencil_dim).astype(stencil.dtype)
+
+    stencil = _add_reconstruct_attrs(
+        stencil, 'edge stencil used to reconstruct a vector'
+    )
+    n_edges = _add_reconstruct_attrs(
+        n_edges, 'number of edges in the reconstruction stencil'
+    )
+    weights = _add_reconstruct_attrs(
+        weights,
+        'weights used to reconstruct a Cartesian vector from '
+        'edge-normal values on the reconstruction stencil',
+        units='unitless',
+    )
+
+    with ProgressBar():
+        stencil, n_edges, weights = dask.compute(stencil, n_edges, weights)
+
+    return xr.Dataset(
+        {
+            names['stencil']: stencil,
+            names['n_edges']: n_edges,
+            names['coeffs']: weights,
+        }
+    )
+
+
 def add_reconstruction_weights_to_dataset(
     ds_mesh: xr.Dataset,
     location: ReconstructionType = 'cell',
@@ -686,33 +751,10 @@ def add_reconstruction_weights_to_dataset(
         coefficient fields whose names depend on ``location`` (see
         ``_RECONSTRUCTION_FIELD_NAMES``)
     """
-    names = _RECONSTRUCTION_FIELD_NAMES[location]
 
-    if names['coeffs'] in ds_mesh:
-        print(
-            f"Warning: overwriting existing '{names['coeffs']}' field "
-            'in the mesh dataset.'
-        )
+    weights_ds = compute_reconstruction_weights(ds_mesh, location)
 
-    stencil, weights = build_reconstruction_weights(ds_mesh, location)
-
-    stencil_dim = _stencil_dim(stencil)
-    n_edges = (stencil != 0).sum(dim=stencil_dim).astype(stencil.dtype)
-
-    ds_mesh[names['stencil']] = _add_reconstruct_attrs(
-        stencil, 'edge stencil used to reconstruct a vector'
-    )
-    ds_mesh[names['n_edges']] = _add_reconstruct_attrs(
-        n_edges, 'number of edges in the reconstruction stencil'
-    )
-    ds_mesh[names['coeffs']] = _add_reconstruct_attrs(
-        weights,
-        'weights used to reconstruct a Cartesian vector from '
-        'edge-normal values on the reconstruction stencil',
-        units='unitless',
-    )
-
-    return ds_mesh
+    return ds_mesh.merge(weights_ds)
 
 
 def _add_reconstruct_attrs(

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -252,6 +252,14 @@ def construct_rotation_matrix(
     # directly from the coordinate arrays, rather than hard-coding it
     point_dim = x_hat.dims[0]
     n_points = x_hat.sizes[point_dim]
+    # preserve existing chunking along point_dim. If None; use a single chunk
+    point_chunks = ds.chunksizes.get(point_dim, -1)
+
+    # return identity matrix for planar meshes
+    if ds.attrs['on_a_sphere'] == 'NO':
+        return xr.DataArray(
+            np.ones((n_points, 3, 3)), dims=(point_dim, 'd1', 'd2')
+        ).chunk({point_dim: point_chunks, 'd1': -1, 'd2': -1})
 
     c_y = np.sqrt(y_hat**2 + z_hat**2)
     s_y = x_hat
@@ -273,9 +281,6 @@ def construct_rotation_matrix(
     U_y[:, 1, 1] = 1.0
     U_y[:, 2, 0] = s_y
     U_y[:, 2, 2] = c_y
-
-    # preserve existing chunking along point_dim. If None; use a single chunk
-    point_chunks = ds.chunksizes.get(point_dim, -1)
 
     return xr.DataArray(
         np.matmul(U_y, U_x), dims=(point_dim, 'd1', 'd2')
@@ -324,22 +329,22 @@ def project_edge_normal_to_tangent_plane(
 
 
 def compute_lstsq_weights(
+    ds: xr.Dataset,
     local_edge_coords: xr.DataArray,
     stencil: xr.DataArray,
-    sphere_radius: float,
 ) -> xr.DataArray:
     """
     Compute the least squares weights as described by Renka (1984) pg. 422.
 
     Parameters
     ----------
+    ds: xr.Dataset
+        MPAS mesh dataset
     local_edge_coords: xr.DataArray (nCells or nVertices, maxEdges2/NINE, R3)
         Edge coordinate vectors projected onto the local tangent plane at the
         the reconstruction point
     stencil: xr.DataArray (nCells or nVertices, maxEdges2 or NINE)
         A two level stencil of edges neighboring the reconstruction point
-    sphere_radius: float
-        Radius of the sphere for the mesh
 
     Returns
     -------
@@ -348,20 +353,43 @@ def compute_lstsq_weights(
     """
     stencil_dim = _stencil_dim(stencil)
     valid = stencil != 0
+    planar = ds.attrs['on_a_sphere'] == 'NO'
 
-    # normalize the rotated z coord onto the unit sphere to match Renka (1984)
-    # z_hat = 1 at reconstruction point and decreases with increasing angular
-    # distance from the reconstruction point.
-    z_hat = local_edge_coords.isel(R3=2) / sphere_radius
-
-    if bool((z_hat.where(valid) < 0).any()):
-        raise ValueError(
-            'A stencil edge has been rotated into the lower hemisphere of the'
-            'local tangent plane. This is not expexted for realistic MPAS mesh'
-            'resolution; check for degenerate or high distorted cells'
+    if planar:
+        # planar: use actual distance from reconstruction point as D
+        point_dim = local_edge_coords.dims[0]
+        if point_dim in ('nCells', 'NCells'):
+            ref_point = xr.concat([ds.xCell, ds.yCell], dim='R3').T
+        elif point_dim in ('nVertices', 'NVertices'):
+            ref_point = xr.concat([ds.xVertex, ds.yVertex], dim='R3').T
+        else:
+            raise ValueError(
+                'Could not infer the reconstruction point location from '
+                f"dimension '{point_dim}'. Expected 'nCells'/'NCells' or "
+                "'nVertices'/'NVertices'."
+            )
+        D = np.sqrt(
+            ((local_edge_coords.isel(R3=[0, 1]) - ref_point) ** 2).sum(
+                dim='R3'
+            )
         )
+    else:
+        # normalize the rotated z coord onto the unit sphere to match
+        # Renka (1984): z_hat = 1 at the reconstruction point and
+        # decreases with increasing angular distance from it.
+        z_hat = local_edge_coords.isel(R3=2) / ds.sphere_radius
 
-    D = xr.where(valid, 1.0 - z_hat, np.nan)
+        if bool((z_hat.where(valid) < 0).any()):
+            raise ValueError(
+                'A stencil edge has been rotated into the lower '
+                'hemisphere of the local tangent plane. This is not '
+                'expexted for realistic MPAS mesh resolution; check for '
+                'degenerate or high distorted cells'
+            )
+
+        D = 1.0 - z_hat
+
+    D = xr.where(valid, D, np.nan)
 
     # Unlike Renka (1984) we use a static stencil, so R_k is set to the
     # maximum distance of the stencil edges from the reconstruction
@@ -497,7 +525,7 @@ def build_reconstruction_weights(
     )
 
     # weight the LSTSQ matrix following Renka (1984) pg. 422
-    w = compute_lstsq_weights(local_edge_coords, stencil, ds.sphere_radius)
+    w = compute_lstsq_weights(ds, local_edge_coords, stencil)
 
     # Build Eqn. 20 from Piexoto and Barros (2014)
     matrix = xr.concat(
@@ -640,9 +668,9 @@ def cartesian_to_local_geographic(
     """
     # infer whether these are cell- or vertex-centered values from the
     # dimensions of u_x, rather than requiring a separate location arg
-    if 'nCells' in u_x.dims:
+    if 'nCells' in u_x.dims or 'NCells' in u_x.dims:
         lon, lat = ds.lonCell, ds.latCell
-    elif 'nVertices' in u_x.dims:
+    elif 'nVertices' in u_x.dims or 'NVertices' in u_x.dims:
         lon, lat = ds.lonVertex, ds.latVertex
     else:
         raise ValueError(

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -1,3 +1,9 @@
+"""
+NOTE: Intermidiate connecitity arrays are computed using the lightweight
+synchronous dask scheduler to avoid the overhead of spinning up a process
+pool for small integer topology data.
+"""
+
 from typing import Literal
 
 import numpy as np
@@ -80,6 +86,8 @@ def construct_edgesOnVerticesOnCell(ds: xr.Dataset) -> xr.DataArray:
 
     maxEdges2 = ds.sizes['maxEdges2']
 
+    ds['verticesOnCell'] = ds.verticesOnCell.compute(scheduler='sync')
+
     conn = ds.edgesOnVertex[ds.verticesOnCell - 1]
     conn = conn.where(ds.verticesOnCell != 0, 0)
 
@@ -95,7 +103,7 @@ def construct_edgesOnVerticesOnCell(ds: xr.Dataset) -> xr.DataArray:
         dask_gufunc_kwargs={
             'output_sizes': {'maxEdges2': maxEdges2},
         },
-    )
+    ).compute(scheduler='sync')
 
 
 def construct_edgesOnVerticesOnVertex(ds: xr.Dataset) -> xr.DataArray:
@@ -120,6 +128,8 @@ def construct_edgesOnVerticesOnVertex(ds: xr.Dataset) -> xr.DataArray:
     vertex_degree = ds.sizes['vertexDegree']
     max_neighbors = 2 * vertex_degree
     nine = 3 * vertex_degree
+
+    ds['edgesOnVertex'] = ds.edgesOnVertex.compute(scheduler='sync')
 
     # one-ring of neighboring vertices (including the vertex itself),
     conn = ds.verticesOnEdge[ds.edgesOnVertex - 1]
@@ -154,7 +164,7 @@ def construct_edgesOnVerticesOnVertex(ds: xr.Dataset) -> xr.DataArray:
         dask_gufunc_kwargs={
             'output_sizes': {'NINE': nine},
         },
-    )
+    ).compute(scheduler='sync')
 
 
 def construct_rotation_matrix(
@@ -217,7 +227,12 @@ def construct_rotation_matrix(
     U_y[:, 2, 0] = s_y
     U_y[:, 2, 2] = c_y
 
-    return xr.DataArray(np.matmul(U_y, U_x), dims=(point_dim, 'd1', 'd2'))
+    # preserve existing chunking along point_dim. If None; use a single chunk
+    point_chunks = ds.chunksizes.get(point_dim, -1)
+
+    return xr.DataArray(
+        np.matmul(U_y, U_x), dims=(point_dim, 'd1', 'd2')
+    ).chunk({point_dim: point_chunks, 'd1': -1, 'd2': -1})
 
 
 def project_edge_normal_to_tangent_plane(
@@ -420,10 +435,10 @@ def build_reconstruction_weights(
 
     # compute the normal vector for each edge in Cartesian coordinates
     cartesian_normal_vector = compute_edge_normal_vec(ds)
-    # build the edge coordinate vectors (nEdges, R3)
+    # build the edge coord vec (nEdges, R3), w/ single chunk along the R3 dim
     cartesian_edge_coords = xr.concat(
         [ds.xEdge, ds.yEdge, ds.zEdge], dim='R3'
-    ).T
+    ).T.chunk({'R3': -1})
 
     # project the normal vector onto the tangent plane at the cell center
     local_normal_vector = project_edge_normal_to_tangent_plane(
@@ -441,6 +456,11 @@ def build_reconstruction_weights(
     matrix = xr.concat(
         [local_normal_vector.isel(R3=[0, 1])] * 3, dim='R3'
     ).rename({'R3': 'SIX'})
+
+    # We just want to parallelize over the reconstruction point dimension
+    # so we set a single chunk along all other dimensions
+    stencil_dim = _stencil_dim(stencil)
+    matrix = matrix.chunk({'SIX': -1, stencil_dim: -1})
 
     matrix.loc[{'SIX': [2, 3]}] *= local_edge_coords.isel(R3=0)
     matrix.loc[{'SIX': [4, 5]}] *= local_edge_coords.isel(R3=1)

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -1,0 +1,660 @@
+from typing import Literal
+
+import numpy as np
+import xarray as xr
+from scipy import linalg
+
+from polaris.mesh.vector import compute_edge_normal_vec
+
+# TODO: when python 3.11 is dropped add type alias
+ReconstructionType = Literal['cell', 'vertex']
+
+_RECONSTRUCTION_FIELD_NAMES: dict[ReconstructionType, dict[str, str]] = {
+    'cell': {
+        'stencil': 'reconstructStencilCell',
+        'n_edges': 'nCellReconstructEdges',
+        'coeffs': 'reconstructCoefsCell',
+    },
+    'vertex': {
+        'stencil': 'reconstructStencilVertex',
+        'n_edges': 'nVertexReconstructEdges',
+        'coeffs': 'reconstructVertex',
+    },
+}
+
+
+def _stencil_dim(da: xr.DataArray) -> str:
+    """Infer the name of the edge-stencil dimension"""
+
+    if 'NINE' in da.dims and 'maxEdges2' in da.dims:
+        raise ValueError(
+            f'Ambiguous stencil dimension: {da.dims}. '
+            "Cannot have both 'NINE' and 'maxEdges2' in the same array."
+        )
+    elif 'NINE' not in da.dims and 'maxEdges2' not in da.dims:
+        raise ValueError(
+            f'Could not find stencil dimension in {da.dims}. '
+            "Expected either 'NINE' or 'maxEdges2'."
+        )
+    else:
+        return 'NINE' if 'NINE' in da.dims else 'maxEdges2'
+
+
+def _unique(a, size):
+    """Helper function to get the unique values and pad the rest with zeros."""
+
+    out = np.full(size, 0, dtype=a.dtype)
+
+    unique_values = np.unique(a.ravel())
+    unique_values = unique_values[unique_values > 0]
+
+    n = len(unique_values)
+
+    if n > size:
+        print(unique_values)
+        msg = f'Too many unique values: {n} > {size}'
+        raise ValueError(msg)
+
+    out[:n] = unique_values
+
+    return out
+
+
+def construct_edgesOnVerticesOnCell(ds: xr.Dataset) -> xr.DataArray:
+    """Build a stencil of the unique edges on the vertices of each cell.
+
+    This stencil is used for cell-centered reconstruction of edge-normal vector
+    field, as described by Piexoto and Barros (2014); see Figure 5(a).
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        MPAS mesh dataset containing the edgesOnVertex and verticesOnCell
+        connectivity arrays
+
+    Returns
+    -------
+    edgesOnVerticesOnCell: xr.DataArray (nCells, maxEdges2)
+        Stencil of the unique edges on the vertices of each cell
+    """
+
+    maxEdges2 = ds.sizes['maxEdges2']
+
+    conn = ds.edgesOnVertex[ds.verticesOnCell - 1]
+    conn = conn.where(ds.verticesOnCell != 0, 0)
+
+    return xr.apply_ufunc(
+        _unique,
+        conn,
+        kwargs={'size': maxEdges2},
+        input_core_dims=[['maxEdges', 'vertexDegree']],
+        output_core_dims=[['maxEdges2']],
+        vectorize=True,
+        dask='parallelized',
+        output_dtypes=[conn.dtype],
+        dask_gufunc_kwargs={
+            'output_sizes': {'maxEdges2': maxEdges2},
+        },
+    )
+
+
+def construct_edgesOnVerticesOnVertex(ds: xr.Dataset) -> xr.DataArray:
+    """Build a stencil of the unique edges on the vertices of each vertex.
+
+    This stencil is used for vertex-centered reconstruction of edge-normal
+    vector field, as described by Piexoto and Barros (2014); see Figure
+    5(b).
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        MPAS mesh dataset containing the edgesOnVertex and verticesOnEdge
+        connectivity arrays
+
+    Returns
+    -------
+    edgesOnVerticesOnVertex: xr.DataArray (nVertices, NINE)
+        Stencil of the unique edges on the vertices of each vertex
+    """
+
+    vertex_degree = ds.sizes['vertexDegree']
+    max_neighbors = 2 * vertex_degree
+    nine = 3 * vertex_degree
+
+    # one-ring of neighboring vertices (including the vertex itself),
+    conn = ds.verticesOnEdge[ds.edgesOnVertex - 1]
+    conn = conn.where(ds.edgesOnVertex != 0, 0)
+
+    neighbor_vertices = xr.apply_ufunc(
+        _unique,
+        conn,
+        kwargs={'size': max_neighbors},
+        input_core_dims=[['vertexDegree', 'TWO']],
+        output_core_dims=[['maxVertexNeighbors']],
+        vectorize=True,
+        dask='parallelized',
+        output_dtypes=[conn.dtype],
+        dask_gufunc_kwargs={
+            'output_sizes': {'maxVertexNeighbors': max_neighbors},
+        },
+    )
+
+    # union of edgesOnVertex over the two-ring edge stencil for target vertex
+    conn = conn.where(neighbor_vertices != 0, 0)
+
+    return xr.apply_ufunc(
+        _unique,
+        conn,
+        kwargs={'size': nine},
+        input_core_dims=[['maxVertexNeighbors', 'vertexDegree']],
+        output_core_dims=[['NINE']],
+        vectorize=True,
+        dask='parallelized',
+        output_dtypes=[conn.dtype],
+        dask_gufunc_kwargs={
+            'output_sizes': {'NINE': nine},
+        },
+    )
+
+
+def construct_rotation_matrix(
+    ds: xr.Dataset, location: ReconstructionType = 'cell'
+) -> xr.DataArray:
+    """
+    Construct a rotation matrix from Cartesian coordinates to local orthogonal
+    projection to a tangent plane at the recoconstruction point.
+
+    The projection is done in two steps: first a rotation about the x-axis and
+    then a rotation about the y-axis.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        MPAS mesh containing the reconstruction-point coordinates
+        (e.g. xCell/yCell/zCell or xVertex/yVertex/zVertex) and the
+        sphere radius (sphere_radius) for the mesh.
+    location: str ["cell", "vertex"]
+        Point location where the reconstruction occurs
+
+    Returns
+    -------
+    rotation_matrix: xr.DataArray (nCells or nVertices, 3, 3)
+        Rotation matrix for each reconstruction point to go from
+        Cartesian coordinates to local orthogonal projection, where the
+        reconstruction point is (0, 0, sphere_radius) in the local
+        coordinate system.
+    """
+
+    # e.g. "cell" -> "xCell", "vertex" -> "xVertex"
+    prefix = location.capitalize()
+    x_hat = ds[f'x{prefix}'] / ds.sphere_radius
+    y_hat = ds[f'y{prefix}'] / ds.sphere_radius
+    z_hat = ds[f'z{prefix}'] / ds.sphere_radius
+
+    # infer the reconstruction-point dimension ("nCells" or "nVertices")
+    # directly from the coordinate arrays, rather than hard-coding it
+    point_dim = x_hat.dims[0]
+    n_points = x_hat.sizes[point_dim]
+
+    c_y = np.sqrt(y_hat**2 + z_hat**2)
+    s_y = x_hat
+
+    c_x = xr.where(c_y != 0, z_hat / c_y, 1.0)
+    s_x = xr.where(c_y != 0.0, y_hat / c_y, 0.0)
+
+    U_x = np.zeros((n_points, 3, 3))
+    U_y = np.zeros((n_points, 3, 3))
+
+    U_x[:, 0, 0] = 1.0
+    U_x[:, 1, 1] = c_x
+    U_x[:, 1, 2] = s_x * -1.0
+    U_x[:, 2, 1] = s_x
+    U_x[:, 2, 2] = c_x
+
+    U_y[:, 0, 0] = c_y
+    U_y[:, 0, 2] = s_y * -1.0
+    U_y[:, 1, 1] = 1.0
+    U_y[:, 2, 0] = s_y
+    U_y[:, 2, 2] = c_y
+
+    return xr.DataArray(np.matmul(U_y, U_x), dims=(point_dim, 'd1', 'd2'))
+
+
+def project_edge_normal_to_tangent_plane(
+    normal_vector: xr.DataArray,
+    rotation_matrix: xr.DataArray,
+    stencil: xr.DataArray,
+) -> xr.DataArray:
+    """ "
+
+    Parameters
+    ----------
+    normal_vector : xr.DataArray (nEdges, 3)
+        Normal vector in Cartesian coordinates for each edge in the mesh
+    rotation_matrix: np.ndarray (nCells or nVertices, 3, 3)
+        Rotation matrix from Cartesian to local orthogonal projection to a
+        tangent plane at the reconstruction point
+    stencil: xr.DataArray (nCells or nVertices, maxEdges2 or NINE)
+        Indices of the unique edges on the vertices of each reconstruction
+        point. Produces a larger footprint stencil than just edges on cell
+        (or edges on vertex)
+    """
+
+    stencil_dim = _stencil_dim(stencil)
+    stencil_size = stencil.sizes[stencil_dim]
+
+    # get the edge normal vector for the edges in the stencil
+    edge_normal_vector = normal_vector.isel(nEdges=stencil - 1)
+
+    return xr.apply_ufunc(
+        lambda U, n: np.einsum('lg,eg->el', U, n),
+        rotation_matrix,
+        edge_normal_vector,
+        input_core_dims=[['d1', 'd2'], [stencil_dim, 'R3']],
+        output_core_dims=[[stencil_dim, 'R3']],
+        vectorize=True,
+        dask='parallelized',
+        output_dtypes=[edge_normal_vector.dtype],
+        dask_gufunc_kwargs={
+            'output_sizes': {stencil_dim: stencil_size, 'R3': 3},
+        },
+    )
+
+
+def compute_lstsq_weights(
+    local_edge_coords: xr.DataArray,
+    stencil: xr.DataArray,
+    sphere_radius: float,
+) -> xr.DataArray:
+    """
+    Compute the least squares weights as described by Renka (1984) pg. 422.
+
+    Parameters
+    ----------
+    local_edge_coords: xr.DataArray (nCells or nVertices, maxEdges2/NINE, R3)
+        Edge coordinate vectors projected onto the local tangent plane at the
+        the reconstruction point
+    stencil: xr.DataArray (nCells or nVertices, maxEdges2 or NINE)
+        A two level stencil of edges neighboring the reconstruction point
+    sphere_radius: float
+        Radius of the sphere for the mesh
+
+    Returns
+    -------
+    weights: xr.DataArray (nCells or nVertices, maxEdges2 or NINE)
+        Least squares weights for each edge in the stencil
+    """
+    stencil_dim = _stencil_dim(stencil)
+    valid = stencil != 0
+
+    # normalize the rotated z coord onto the unit sphere to match Renka (1984)
+    # z_hat = 1 at reconstruction point and decreases with increasing angular
+    # distance from the reconstruction point.
+    z_hat = local_edge_coords.isel(R3=2) / sphere_radius
+
+    if bool((z_hat.where(valid) < 0).any()):
+        raise ValueError(
+            'A stencil edge has been rotated into the lower hemisphere of the'
+            'local tangent plane. This is not expexted for realistic MPAS mesh'
+            'resolution; check for degenerate or high distorted cells'
+        )
+
+    D = xr.where(valid, 1.0 - z_hat, np.nan)
+
+    # Unlike Renka (1984) we use a static stencil, so R_k is set to the
+    # maximum distance of the stencil edges from the reconstruction
+    # point, plus a small epsilon to avoid divide by zero errors
+    R = D.max(dim=stencil_dim, skipna=True) * (1 + 1.0e-3)
+
+    w = 1.0 / D - 1.0 / R
+
+    return xr.where(valid, w, 0.0)
+
+
+def rotate_local_to_cartesian(
+    rotation_matrix: xr.DataArray,
+    weights: xr.DataArray,
+) -> xr.DataArray:
+    """
+    Rotate the reconstruction weights from the local tangent-plane frame
+    back to Cartesian coordinates, by applying the inverse (i.e. transpose)
+    of the rotation matrix.
+
+    Parameters
+    ----------
+    rotation_matrix: xr.DataArray (nCells or nVertices, d1, d2)
+        Rotation matrix from Cartesian to local orthogonal projection to a
+        tangent plane at the reconstruction point, as produced by
+        ``construct_rotation_matrix``
+    weights: xr.DataArray (nCells or nVertices, R3, maxEdges2 or NINE)
+        Reconstruction weights in the local tangent-plane frame
+
+    Returns
+    -------
+    weights: xr.DataArray (nCells or nVertices, R3, maxEdges2 or NINE)
+        Reconstruction weights rotated into Cartesian coordinates
+    """
+    stencil_dim = _stencil_dim(weights)
+
+    return xr.apply_ufunc(
+        lambda U, w: np.einsum('lg,le->ge', U, w),
+        rotation_matrix,
+        weights,
+        input_core_dims=[['d1', 'd2'], ['R3', stencil_dim]],
+        output_core_dims=[['R3', stencil_dim]],
+        vectorize=True,
+        dask='parallelized',
+        output_dtypes=[weights.dtype],
+        dask_gufunc_kwargs={
+            'output_sizes': {'R3': 3, stencil_dim: weights.sizes[stencil_dim]},
+        },
+    )
+
+
+def solve_psuedo_inverse(M: xr.DataArray) -> xr.DataArray:
+    """
+    Solve the batched pseudo-inverse of a matrix M using scipy.linalg.pinv
+
+    Will parallelize over the reconstruction-point dimension if M is a
+    dask array and chunked along said dimension.
+
+    Parameters
+    ----------
+    M : xr.DataArray (nCells or nVertices, maxEdges2 or NINE, SIX)
+        Matrix to be inverted
+
+    Returns
+    -------
+    M_inv : xr.DataArray (nCells or nVertices, SIX, maxEdges2 or NINE)
+        Pseudo-inverse of M
+    """
+    stencil_dim = _stencil_dim(M)
+
+    return xr.apply_ufunc(
+        linalg.pinv,
+        M,
+        input_core_dims=[[stencil_dim, 'SIX']],
+        output_core_dims=[['SIX', stencil_dim]],
+        vectorize=True,
+        dask='parallelized',
+        output_dtypes=[M.dtype],
+        dask_gufunc_kwargs={
+            'output_sizes': {'SIX': 6, stencil_dim: M.sizes[stencil_dim]},
+        },
+    )
+
+
+def build_reconstruction_weights(
+    ds: xr.Dataset,
+    location: ReconstructionType = 'cell',
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """
+    Build the reconstruction weights for each reconstruction point in the
+    mesh.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        MPAS mesh dataset
+    location: str ["cell", "vertex"]
+        Point location where the reconstruction occurs
+
+    Returns
+    -------
+    stencil: xr.DataArray (nCells or nVertices, maxEdges2 or NINE)
+        Edge stencil for each reconstruction point
+
+    weights: xr.DataArray (nCells or nVertices, R3, maxEdges2 or NINE)
+        Reconstruction weights for each reconstruction point
+    """
+    if location == 'cell':
+        stencil = construct_edgesOnVerticesOnCell(ds)
+    elif location == 'vertex':
+        stencil = construct_edgesOnVerticesOnVertex(ds)
+    else:
+        raise ValueError(
+            f"Invalid location: {location}. Must be 'cell' or 'vertex'."
+        )
+
+    rotation_matrix = construct_rotation_matrix(ds, location)
+
+    # compute the normal vector for each edge in Cartesian coordinates
+    cartesian_normal_vector = compute_edge_normal_vec(ds)
+    # build the edge coordinate vectors (nEdges, R3)
+    cartesian_edge_coords = xr.concat(
+        [ds.xEdge, ds.yEdge, ds.zEdge], dim='R3'
+    ).T
+
+    # project the normal vector onto the tangent plane at the cell center
+    local_normal_vector = project_edge_normal_to_tangent_plane(
+        cartesian_normal_vector, rotation_matrix, stencil
+    )
+    # project the edge coordinate vectors onto the local tangent plane
+    local_edge_coords = project_edge_normal_to_tangent_plane(
+        cartesian_edge_coords, rotation_matrix, stencil
+    )
+
+    # weight the LSTSQ matrix following Renka (1984) pg. 422
+    w = compute_lstsq_weights(local_edge_coords, stencil, ds.sphere_radius)
+
+    # Build Eqn. 20 from Piexoto and Barros (2014)
+    matrix = xr.concat(
+        [local_normal_vector.isel(R3=[0, 1])] * 3, dim='R3'
+    ).rename({'R3': 'SIX'})
+
+    matrix.loc[{'SIX': [2, 3]}] *= local_edge_coords.isel(R3=0)
+    matrix.loc[{'SIX': [4, 5]}] *= local_edge_coords.isel(R3=1)
+
+    # replace the out of bounds values with zeros
+    matrix = matrix.where(stencil != 0, 0.0)
+
+    # apply the weights to the matrix
+    matrix *= np.sqrt(w)
+    # solve pseudo-inverse of the matrix to get the reconstruction weights
+    weights = solve_psuedo_inverse(matrix)
+    weights *= np.sqrt(w)
+
+    # Becuase we only support reconstruction at the reconstruction points
+    # (i.e. cell or vertex centers) we only need to keep the first two rows
+    # of the weights matrix. But that will produce a vector reconstructed on
+    # the tangent plane. So, we keep an extra column of the weights matrix,
+    # and assume the z component to be zero, in order to be able to apply the
+    # inverse of 3x3 rotation matrix resiluting in a catesian vector
+    weights = weights.isel(SIX=[0, 1, 2]).rename({'SIX': 'R3'})
+    weights.loc[{'R3': 2}] = 0.0
+
+    weights = rotate_local_to_cartesian(rotation_matrix, weights)
+
+    return stencil, weights
+
+
+def tangential_reconstruction(
+    ds: xr.Dataset,
+    edge_normal_field: xr.DataArray,
+    stencil: xr.DataArray | None = None,
+    weights: xr.DataArray | None = None,
+    location: ReconstructionType | None = None,
+) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray]:
+    """
+    Reconstruct a tangential vector field from an edge-normal vector field.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        MPAS mesh dataset
+
+    edge_normal_field: xr.DataArray (nEdges, ...)
+        Scalar field defined normal to each edge (e.g. ``normalVelocity``).
+        May include additional dimensions besides ``nEdges`` (e.g.
+        ``nVertLevels``, ``Time``); these are carried through unchanged.
+
+    stencil: xr.DataArray (nCells or nVertices, maxEdges2 or NINE), optional
+        Precomputed edge stencil for each reconstruction point. If not
+        provided (along with ``weights``), it is built from ``ds`` using
+        ``location``.
+
+    weights: xr.DataArray (nCells or nVertices, R3, maxEdges2/NINE), optional
+        Precomputed reconstruction weights for each reconstruction point.
+        If not provided (along with ``stencil``), it is built from ``ds``
+        using ``location``.
+
+    location: str ["cell", "vertex"], optional
+        Point location where the reconstruction occurs. Required if
+        ``stencil`` and ``weights`` are not both provided.
+
+    Returns
+    -------
+    u_x: xr.DataArray (nCells or nVertices, ...)
+        Reconstructed x-component of the tangential vector field
+    u_y: xr.DataArray (nCells or nVertices, ...)
+        Reconstructed y-component of the tangential vector field
+    u_z: xr.DataArray (nCells or nVertices, ...)
+        Reconstructed z-component of the tangential vector field
+    """
+    if stencil is None or weights is None:
+        if location is None:
+            raise ValueError(
+                'If stencil and weights are not provided, location must be '
+                'provided to build the reconstruction weights.'
+            )
+        stencil, weights = build_reconstruction_weights(ds, location)
+
+    stencil_dim = _stencil_dim(stencil)
+    valid = stencil != 0
+
+    # gather the field values onto the stencil edges; padded entries
+    # (stencil == 0) are redirected to edge 0 to avoid wrapping around to
+    # the last edge via a "-1" index, then masked out immediately below
+    field_on_stencil = edge_normal_field.isel(
+        nEdges=stencil.where(valid, 1) - 1
+    )
+    field_on_stencil = field_on_stencil.where(valid, 0.0)
+
+    # weights and field_on_stencil share the stencil and reconstruction
+    # point dimensions by name, so `xr.dot` contracts over the stencil dim
+    # and broadcasts over R3 and any extra dims (e.g. nVertLevels, Time)
+    # regardless of whether the reconstruction point is a cell or vertex
+    reconstructed = xr.dot(weights, field_on_stencil, dims=stencil_dim)
+
+    return (
+        reconstructed.isel(R3=0),
+        reconstructed.isel(R3=1),
+        reconstructed.isel(R3=2),
+    )
+
+
+def cartesian_to_local_geographic(
+    ds: xr.Dataset, u_x: xr.DataArray, u_y: xr.DataArray, u_z: xr.DataArray
+) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray]:
+    """
+    Convert a vector field from Cartesian coordinates to local geographic
+    coordinates (zonal, meridional, radial) at the reconstruction point.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        mesh dataset containing geographic coordinates of reconstruction
+        points
+    u_x: xr.DataArray (nCells or nVertices)
+        x-component of the vector field in Cartesian coordinates
+    u_y: xr.DataArray (nCells or nVertices)
+        y-component of the vector field in Cartesian coordinates
+    u_z: xr.DataArray (nCells or nVertices)
+        z-component of the vector field in Cartesian coordinates
+
+    Returns
+    -------
+    u_zonal: xr.DataArray (nCells or nVertices)
+        Zonal component of the vec field in local geographic coordinates
+    u_merid: xr.DataArray (nCells or nVertices)
+        Meridional component of the vec field in local geographic coordinates
+    u_radial: xr.DataArray (nCells or nVertices)
+        Radial component of the vec field in local geographic coordinates
+    """
+    # infer whether these are cell- or vertex-centered values from the
+    # dimensions of u_x, rather than requiring a separate location arg
+    if 'nCells' in u_x.dims:
+        lon, lat = ds.lonCell, ds.latCell
+    elif 'nVertices' in u_x.dims:
+        lon, lat = ds.lonVertex, ds.latVertex
+    else:
+        raise ValueError(
+            'Could not infer the reconstruction point location from '
+            f"the dimensions of u_x: {u_x.dims}. Expected 'nCells' or "
+            "'nVertices'."
+        )
+
+    clon = np.cos(lon)
+    slon = np.sin(lon)
+    clat = np.cos(lat)
+    slat = np.sin(lat)
+
+    u_zonal = -u_x * slon + u_y * clon
+    # horizontal is the component of the vector in the equatorial plane,
+    # i.e. before it is split into meridional and radial parts
+    horizontal = u_x * clon + u_y * slon
+    u_merid = -horizontal * slat + u_z * clat
+    u_radial = horizontal * clat + u_z * slat
+
+    return u_zonal, u_merid, u_radial
+
+
+def add_reconstruction_weights_to_dataset(
+    ds_mesh: xr.Dataset,
+    location: ReconstructionType = 'cell',
+) -> xr.Dataset:
+    """
+    Add vector-reconstruction stencil and weight fields to a mesh dataset.
+
+    Parameters
+    ----------
+    ds_mesh: xr.Dataset
+        The mesh dataset to update
+
+    location: str ["cell", "vertex"]
+        Point location where the reconstruction occurs
+
+    Returns
+    -------
+    xr.Dataset
+        The updated dataset with reconstruction stencil, edge-count, and
+        coefficient fields whose names depend on ``location`` (see
+        ``_RECONSTRUCTION_FIELD_NAMES``)
+    """
+    names = _RECONSTRUCTION_FIELD_NAMES[location]
+
+    if names['coeffs'] in ds_mesh:
+        print(
+            f"Warning: overwriting existing '{names['coeffs']}' field "
+            'in the mesh dataset.'
+        )
+
+    stencil, weights = build_reconstruction_weights(ds_mesh, location)
+
+    stencil_dim = _stencil_dim(stencil)
+    n_edges = (stencil != 0).sum(dim=stencil_dim).astype(stencil.dtype)
+
+    ds_mesh[names['stencil']] = _add_reconstruct_attrs(
+        stencil, 'edge stencil used to reconstruct a vector'
+    )
+    ds_mesh[names['n_edges']] = _add_reconstruct_attrs(
+        n_edges, 'number of edges in the reconstruction stencil'
+    )
+    ds_mesh[names['coeffs']] = _add_reconstruct_attrs(
+        weights,
+        'weights used to reconstruct a Cartesian vector from '
+        'edge-normal values on the reconstruction stencil',
+        units='unitless',
+    )
+
+    return ds_mesh
+
+
+def _add_reconstruct_attrs(
+    data_array: xr.DataArray, long_name: str, units: str | None = None
+) -> xr.DataArray:
+    attrs = {'long_name': long_name}
+    if units is not None:
+        attrs['units'] = units
+    data_array.attrs.update(attrs)
+    return data_array

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -21,12 +21,12 @@ _RECONSTRUCTION_FIELD_NAMES: dict[ReconstructionType, dict[str, str]] = {
     'cell': {
         'stencil': 'reconstructStencilCell',
         'n_edges': 'nCellReconstructEdges',
-        'coeffs': 'reconstructCoefsCell',
+        'weights': 'reconstructWeightsCell',
     },
     'vertex': {
         'stencil': 'reconstructStencilVertex',
         'n_edges': 'nVertexReconstructEdges',
-        'coeffs': 'reconstructVertex',
+        'weights': 'reconstructWeightsVertex',
     },
 }
 
@@ -689,9 +689,9 @@ def compute_reconstruction_weights(
 
     names = _RECONSTRUCTION_FIELD_NAMES[location]
 
-    if names['coeffs'] in ds:
+    if names['weights'] in ds:
         print(
-            f"Warning: overwriting existing '{names['coeffs']}' field "
+            f"Warning: overwriting existing '{names['weights']}' field "
             'in the mesh dataset.'
         )
 
@@ -724,7 +724,7 @@ def compute_reconstruction_weights(
         {
             names['stencil']: stencil,
             names['n_edges']: n_edges,
-            names['coeffs']: weights,
+            names['weights']: weights,
         }
     )
 

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -29,6 +29,51 @@ _RECONSTRUCTION_FIELD_NAMES: dict[ReconstructionType, dict[str, str]] = {
 }
 
 
+def fix_out_of_bounds_indices(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Replace indices larger than the dimension size in connectivity arrays with
+    zeros.
+
+    Some meshes (e.g. QU240km) don't do masking of ragged indices with zeros,
+    instead they use `nInidices+1` as the invalid value.
+
+    NOTE: Assumes connecitity array are 1-indexed
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        MPAS mesh dataset containing connectivity arrays
+
+    Returns
+    -------
+    ds: xr.Dataset
+        MPAS mesh dataset with out-of-bounds indices in connectivity arrays
+        set to 0 (invalid)
+    """
+
+    def _is_connectivity_array(da: xr.DataArray) -> bool:
+        # uncapitalize the name
+        name = da.name[0].lower() + da.name[1:]
+        is_int = da.dtype.kind in ('i', 'u')
+
+        return 'On' in name and is_int and name.startswith(('c', 'e', 'v'))
+
+    for var in ds:
+        if _is_connectivity_array(ds[var]):
+            # supports both MPASO and Omega naming conventions
+            prefix = 'N' if var[0].isupper() else 'n'
+            # get the dimension name for the connectivity array
+            dim = prefix + var.split('On')[0].title()
+            # get the maximum valid size for the array to be indexed too
+            max_size = ds.sizes[dim]
+            # get mask of where index is out bounds
+            mask = ds[var] == max_size + 1
+            # where index is out of bounds, set to invalid (i.e. 0)
+            ds[var] = xr.where(mask, 0, ds[var])
+
+    return ds
+
+
 def _stencil_dim(da: xr.DataArray) -> str:
     """Infer the name of the edge-stencil dimension"""
 

--- a/polaris/mesh/vector.py
+++ b/polaris/mesh/vector.py
@@ -1,0 +1,39 @@
+import numpy as np
+import xarray as xr
+
+
+def compute_edge_normal_vec(ds: xr.Dataset) -> xr.DataArray:
+    """
+    Compute the normal vector for each edge in a mesh
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        MPAS mesh Dataset
+
+    Returns
+    -------
+    xr.DataArray (nEdges, R3)
+        Normal vector for each edge in the mesh
+    """
+
+    vec_cell = xr.concat([ds.xCell, ds.yCell, ds.zCell], dim='R3').T
+    vec_edge = xr.concat([ds.xEdge, ds.yEdge, ds.zEdge], dim='R3').T
+
+    cell_1 = ds.cellsOnEdge.isel(TWO=0) - 1
+    cell_2 = ds.cellsOnEdge.isel(TWO=1) - 1
+
+    # assume normal points from the cell1 to cell2 valid for non-boundary edges
+    normal = vec_cell.isel(nCells=cell_2) - vec_cell.isel(nCells=cell_1)
+
+    # boundary edge: normal points from the edge location to the cell location
+    normal = normal.where(
+        cell_1 != -1, vec_cell.isel(nCells=cell_2) - vec_edge
+    )
+
+    # boundary edge: normal points from the cell location to the edge location
+    normal = normal.where(
+        cell_2 != -1, vec_edge - vec_cell.isel(nCells=cell_1)
+    )
+
+    return normal / np.linalg.norm(normal, ord=2, axis=-1, keepdims=True)

--- a/polaris/mesh/vector.py
+++ b/polaris/mesh/vector.py
@@ -17,6 +17,14 @@ def compute_edge_normal_vec(ds: xr.Dataset) -> xr.DataArray:
         Normal vector for each edge in the mesh
     """
 
+    periodic = ds.attrs['is_periodic'].lower() == 'yes'
+    if periodic:
+        period = np.array([ds.attrs['x_period'], ds.attrs['y_period'], 0.0])
+    else:
+        # a zero period makes _fix_periodicity() a no-op, so the same
+        # formulas below are correct for non-periodic meshes as well
+        period = np.array([0.0, 0.0, 0.0])
+
     # concatenating along a new R3 dim leaves it chunked into one chunk
     # per input array; force it back to a single chunk so it can be used
     # as a core dimension in apply_ufunc(dask='parallelized', ...) calls
@@ -30,17 +38,39 @@ def compute_edge_normal_vec(ds: xr.Dataset) -> xr.DataArray:
     cell_1 = ds.cellsOnEdge.isel(TWO=0) - 1
     cell_2 = ds.cellsOnEdge.isel(TWO=1) - 1
 
-    # assume normal points from the cell1 to cell2 valid for non-boundary edges
-    normal = vec_cell.isel(nCells=cell_2) - vec_cell.isel(nCells=cell_1)
+    pos_cell_1 = vec_cell.isel(nCells=cell_1)
+    pos_cell_2 = vec_cell.isel(nCells=cell_2)
 
-    # boundary edge: normal points from the edge location to the cell location
+    # interior edge: normal points from cell 1 to cell 2, wrapping across
+    # a periodic boundary as needed
+    normal = _fix_periodicity(pos_cell_2, pos_cell_1, period) - pos_cell_1
+
+    # boundary edge (no cell 1): normal points from the edge location to
+    # the cell location
     normal = normal.where(
-        cell_1 != -1, vec_cell.isel(nCells=cell_2) - vec_edge
+        cell_1 != -1,
+        pos_cell_2 - _fix_periodicity(vec_edge, pos_cell_2, period),
     )
 
-    # boundary edge: normal points from the cell location to the edge location
+    # boundary edge (no cell 2): normal points from the cell location to
+    # the edge location
     normal = normal.where(
-        cell_2 != -1, vec_edge - vec_cell.isel(nCells=cell_1)
+        cell_2 != -1,
+        _fix_periodicity(vec_edge, pos_cell_1, period) - pos_cell_1,
     )
 
     return normal / np.linalg.norm(normal, ord=2, axis=-1, keepdims=True)
+
+
+def _fix_periodicity(point_1, point_2, period):
+    """
+    Recompute location of point 1 relative to point 2 with a given period
+
+    Implementation take from `mpas_fix_periodicity` subroutine in:
+        E3SM/components/mpas-framework/src/operators/mpas_vector_operations.F
+    """
+
+    dist = point_1 - point_2
+    wrapped = point_1 - np.sign(dist) * period
+
+    return xr.where(np.absolute(dist) > period * 0.5, wrapped, point_1)

--- a/polaris/mesh/vector.py
+++ b/polaris/mesh/vector.py
@@ -17,8 +17,15 @@ def compute_edge_normal_vec(ds: xr.Dataset) -> xr.DataArray:
         Normal vector for each edge in the mesh
     """
 
-    vec_cell = xr.concat([ds.xCell, ds.yCell, ds.zCell], dim='R3').T
-    vec_edge = xr.concat([ds.xEdge, ds.yEdge, ds.zEdge], dim='R3').T
+    # concatenating along a new R3 dim leaves it chunked into one chunk
+    # per input array; force it back to a single chunk so it can be used
+    # as a core dimension in apply_ufunc(dask='parallelized', ...) calls
+    vec_cell = xr.concat([ds.xCell, ds.yCell, ds.zCell], dim='R3').T.chunk(
+        {'R3': -1}
+    )
+    vec_edge = xr.concat([ds.xEdge, ds.yEdge, ds.zEdge], dim='R3').T.chunk(
+        {'R3': -1}
+    )
 
     cell_1 = ds.cellsOnEdge.isel(TWO=0) - 1
     cell_2 = ds.cellsOnEdge.isel(TWO=1) - 1

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -47,6 +47,14 @@ variables:
   kiteAreasOnVertex: KiteAreasOnVertex
   weightsOnEdge: WeightsOnEdge
 
+  # # variables used for LSTSQ vector reconstruction
+  reconstructStencilCell: ReconstructStencilCell
+  reconstructStencilVertex: ReconstructStencilVertex
+  nCellReconstructEdges: NCellReconstructEdges
+  nVertexReconstructEdges: NVertexReconstructEdges
+  reconstructWeightsCell: ReconstructWeightsCell
+  reconstructWeightsVertex: ReconstructWeightsVertex
+
   # Coriolis
   fCell: FCell
   fEdge: FEdge

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -1,6 +1,6 @@
 import importlib.resources as imp_res
 import os
-from typing import Dict, Tuple, Union
+from typing import Dict, Literal, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -10,6 +10,10 @@ from ruamel.yaml import YAML
 
 from polaris import Component
 from polaris.constants import get_constant
+from polaris.mesh.reconstruct import (
+    cartesian_to_local_geographic,
+    tangential_reconstruction,
+)
 from polaris.ocean.surface_pressure import surface_pressure_from_config
 from polaris.ocean.vertical.diagnostics import (
     geom_thickness_from_ds,
@@ -514,6 +518,7 @@ class Ocean(Component):
         vert_filename=None,
         reconstruct_variables=None,
         coeffs_filename=None,
+        reconstruct_method: Literal['RBF', 'LSTSQ'] = 'LSTSQ',
         **kwargs,
     ):
         """
@@ -530,13 +535,19 @@ class Ocean(Component):
             compute geometric layer thickness from pseudo-thickness.
 
         mesh_filename : str, optional
-            Path to the mesh NetCDF file.
+            Path to the mesh NetCDF file. Should contain the reconstruction
+            weights if using the LSTSQ reconstruction method.
 
         reconstruct_variables : list of str, optional
             List of variable names to reconstruct in the dataset.
 
         coeffs_filename : str, optional
             Path to the coefficients NetCDF file.
+
+        reonstruct_method : {'RBF', 'LSTSQ'}, optional
+            Method to use for reconstructing vector variables.
+            RBF: Radial Basis Function; approach used in MPAS-Ocean.
+            LSTSQ: Least-squares reconstruction; new approach in Omega
 
         kwargs
             keyword arguments passed to `xarray.open_dataset()`
@@ -620,17 +631,27 @@ class Ocean(Component):
                     'mesh_filename must be provided to open_model_dataset '
                     'for variable reconstruction'
                 )
-            if coeffs_filename is None:
+            if reconstruct_method == 'RBF' and coeffs_filename is None:
                 raise ValueError(
                     'coeffs_filename must be provided to open_model_dataset '
                     'for variable reconstruction'
                 )
             ds_mesh = self.open_model_dataset(mesh_filename, config)
+            if (
+                reconstruct_method == 'LSTSQ'
+                and not _reconstruction_weights_in_dataset(ds_mesh)
+            ):
+                raise ValueError(
+                    'Reconstruction weights are not present in the mesh '
+                    'dataset; cannot reconstruct variables using LSTSQ method'
+                )
+
             ds = _add_reconstructed_variables_to_dataset(
                 ds,
                 reconstruct_variables,
                 ds_mesh,
                 coeffs_filename,
+                reconstruct_method,
             )
         return ds
 
@@ -776,7 +797,11 @@ class Ocean(Component):
 
 
 def _add_reconstructed_variables_to_dataset(
-    ds, reconstruct_variables, ds_mesh, coeffs_filename
+    ds,
+    reconstruct_variables,
+    ds_mesh,
+    coeffs_filename,
+    reconstruct_method: Literal['RBF', 'LSTSQ'],
 ):
     """
     Add reconstructed vector variables to the dataset if requested.
@@ -789,11 +814,14 @@ def _add_reconstructed_variables_to_dataset(
     reconstruct_variables : list of str or None
         List of variable names to reconstruct.
 
-    mesh_filename : str
-        Path to the mesh NetCDF file.
+    ds_mesh : xarray.Dataset
+        Mesh dataset on which to perform the reconstruction.
 
     coeffs_filename : str
         Path to the coefficients NetCDF file.
+
+    reconstruct_method : {'RBF', 'LSTSQ'}
+        Method to use for reconstructing vector variables.
 
     Returns
     -------
@@ -802,6 +830,17 @@ def _add_reconstructed_variables_to_dataset(
     """
     if reconstruct_variables is None:
         return ds
+
+    if reconstruct_method == 'RBF':
+        ds_coeff = open_dataset(coeffs_filename)
+        coeffs_reconstruct = ds_coeff.coeffs_reconstruct
+
+        if ds_coeff.sizes['nCells'] != ds_mesh.sizes['nCells']:
+            print(
+                f'The sizes of coefficient dataset do not match mesh dataset;'
+                f' exiting without reconstructing {reconstruct_variables}'
+            )
+            return ds
 
     for variable in reconstruct_variables:
         if variable not in ds:
@@ -819,26 +858,61 @@ def _add_reconstructed_variables_to_dataset(
         if f'{out_var_name}Zonal' in ds and f'{out_var_name}Meridional' in ds:
             continue
 
-        ds_coeff = open_dataset(coeffs_filename)
-        coeffs_reconstruct = ds_coeff.coeffs_reconstruct
-
-        if ds_coeff.sizes['nCells'] != ds_mesh.sizes['nCells']:
-            print(
-                f'The sizes of coefficient dataset do not match mesh '
-                f'dataset; exiting without reconstructing {out_var_name}'
+        if reconstruct_method == 'RBF':
+            reconstruct_variable(
+                out_var_name,
+                ds[variable],
+                ds_mesh,
+                coeffs_reconstruct,
+                ds,
+                quiet=True,
             )
-            continue
 
-        reconstruct_variable(
-            out_var_name,
-            ds[variable],
-            ds_mesh,
-            coeffs_reconstruct,
-            ds,
-            quiet=True,
-        )
+        elif reconstruct_method == 'LSTSQ':
+            stencil = ds_mesh.reconstructStencilCell
+            weights = ds_mesh.reconstructWeightsCell
+
+            u_x, u_y, u_z = tangential_reconstruction(
+                ds_mesh, ds[variable], stencil=stencil, weights=weights
+            )
+            if ds_mesh.attrs['on_a_sphere'] == 'NO':
+                ds[f'{out_var_name}X'] = u_x
+                ds[f'{out_var_name}Y'] = u_y
+            else:
+                u_zonal, u_merid, _ = cartesian_to_local_geographic(
+                    ds_mesh, u_x, u_y, u_z
+                )
+
+                ds[f'{out_var_name}Zonal'] = u_zonal
+                ds[f'{out_var_name}Meridional'] = u_merid
 
     return ds
+
+
+def _reconstruction_weights_in_dataset(ds, vertices=False):
+    """
+    Check if the reconstruction weights are present in the dataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset to check for reconstruction weights.
+    vertices: bool, optional (default False)
+        Whether to check for vertex centered reconstruction weights
+
+    Returns
+    -------
+    present
+        True if reconstruction weights are present, False otherwise.
+    """
+    present = any(var.lower() == 'reconstructstencilcell' for var in ds)
+    present &= any(var.lower() == 'reconstructweightscell' for var in ds)
+
+    if vertices:
+        present &= any(var.lower() == 'reconstructstencilvertex' for var in ds)
+        present &= any(var.lower() == 'reconstructweightsvertex' for var in ds)
+
+    return present
 
 
 # create a single module-level instance available to other components

--- a/polaris/tasks/ocean/barotropic_channel/viz.py
+++ b/polaris/tasks/ocean/barotropic_channel/viz.py
@@ -56,6 +56,7 @@ class Viz(OceanIOStep):
             reconstruct_variables=['normalVelocity'],
             mesh_filename='mesh.nc',
             coeffs_filename='coeffs.nc',
+            reconstruct_method='RBF',
         )
 
         cell_mask = ds_vert_coord.maxLevelCell >= 1

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -114,6 +114,7 @@ class Viz(OceanIOStep):
             coeffs_filename='coeffs.nc',
             decode_times=False,
             reconstruct_variables=['normalVelocity'],
+            reconstruct_method='RBF',
         )
         x_min = ds_mesh.xVertex.min().values
         x_max = ds_mesh.xVertex.max().values

--- a/polaris/tasks/ocean/sphere_transport/forward.py
+++ b/polaris/tasks/ocean/sphere_transport/forward.py
@@ -1,4 +1,3 @@
-from polaris.mesh.base import parse_mesh_filepath
 from polaris.ocean.convergence.spherical import SphericalConvergenceForward
 
 
@@ -85,17 +84,3 @@ class Forward(SphericalConvergenceForward):
             refinement=refinement,
         )
         self.mesh_path = base_mesh.path
-
-    def setup(self):
-        super().setup()
-        model = self.config.get('ocean', 'model')
-        if model == 'omega':
-            component, database, mesh_name = parse_mesh_filepath(
-                self.mesh_path
-            )
-            self.add_input_file(
-                filename='coeffs.nc',
-                target=f'{mesh_name}_coeffs.nc',
-                database_component=component,
-                database=database,
-            )

--- a/polaris/tasks/ocean/sphere_transport/init.py
+++ b/polaris/tasks/ocean/sphere_transport/init.py
@@ -1,8 +1,9 @@
 import numpy as np
 import xarray as xr
-from mpas_tools.io import open_dataset
+from mpas_tools.io import open_dataset, write_netcdf
 
 from polaris.constants import get_constant
+from polaris.mesh.reconstruct import add_reconstruction_weights_to_dataset
 from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
@@ -91,6 +92,8 @@ class Init(OceanIOStep):
         lonEdge = ds_mesh.lonEdge
 
         ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
+        ds_mesh = add_reconstruction_weights_to_dataset(ds_mesh)
+        write_netcdf(ds_mesh, 'base_mesh_with_weights.nc')
         self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()

--- a/polaris/tasks/ocean/sphere_transport/viz.py
+++ b/polaris/tasks/ocean/sphere_transport/viz.py
@@ -48,7 +48,7 @@ class Viz(OceanIOStep):
         super().__init__(component=component, name=name, subdir=subdir)
         self.add_input_file(
             filename='mesh.nc',
-            work_dir_target=f'{base_mesh.path}/base_mesh.nc',
+            work_dir_target=f'{init.path}/base_mesh_with_weights.nc',
         )
         self.add_input_file(
             filename='initial_state.nc',
@@ -75,15 +75,6 @@ class Viz(OceanIOStep):
             self.add_output_file(f'{var}_final.png')
             self.add_output_file(f'{var}_diff.png')
 
-    def setup(self):
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer needs this file
-        if model == 'omega':
-            self.add_input_file(
-                filename='coeffs.nc',
-                work_dir_target=f'{self.forward.path}/coeffs.nc',
-            )
-
     def run(self):
         """
         Run this step of the test case
@@ -101,7 +92,6 @@ class Viz(OceanIOStep):
             decode_times=False,
             mesh_filename='mesh.nc',
             reconstruct_variables=['normalVelocity'],
-            coeffs_filename='coeffs.nc',
         )
         variables_in_init = [
             var for var in variables_to_plot.keys() if var in ds_init.variables
@@ -114,7 +104,6 @@ class Viz(OceanIOStep):
             decode_times=False,
             mesh_filename='mesh.nc',
             reconstruct_variables=['normalVelocity'],
-            coeffs_filename='coeffs.nc',
         )
         s_per_hour = 3600.0
 

--- a/utils/omega/add_reconstruction_weights.py
+++ b/utils/omega/add_reconstruction_weights.py
@@ -72,7 +72,7 @@ class MeshConverter:
 
         if is_omega and is_mpas:
             raise ValueError(
-                'Invlaid input: dataset contains both MPASO and Omega '
+                'Invalid input: dataset contains both MPASO and Omega '
                 'dimensions names.'
             )
 

--- a/utils/omega/add_reconstruction_weights.py
+++ b/utils/omega/add_reconstruction_weights.py
@@ -20,8 +20,7 @@ from ruamel.yaml import YAML
 
 from polaris.mesh.reconstruct import compute_reconstruction_weights
 
-# TODO: pick a more sensible default based on typical mesh sizes
-DEFAULT_CHUNK_SIZE = 10_000
+DEFAULT_CHUNK_SIZE = 1_000
 
 # Dimensions found only on large, multi-level/time-resolved/tracer
 # fields (e.g. layerThickness(nCells, nVertLevels)) that are never

--- a/utils/omega/add_reconstruction_weights.py
+++ b/utils/omega/add_reconstruction_weights.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+
+import argparse
+import contextlib
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from contextlib import contextmanager
+from importlib import resources
+from typing import Iterator, Literal
+
+import dask
+import xarray as xr
+from mache import MachineInfo
+from mache.discover import discover_machine
+from mache.parallel import get_parallel_system
+from ruamel.yaml import YAML
+
+from polaris.mesh.reconstruct import compute_reconstruction_weights
+
+# TODO: pick a more sensible default based on typical mesh sizes
+DEFAULT_CHUNK_SIZE = 10_000
+
+# Dimensions found only on large, multi-level/time-resolved/tracer
+# fields (e.g. layerThickness(nCells, nVertLevels)) that are never
+# needed to compute reconstruction weights. Filtering on these (rather
+# than enumerating every small mesh variable) keeps everything the
+# algorithm needs while skipping a production mesh's bulk. Names use
+# the MPAS-Ocean convention, since filtering always runs after
+# converting to that convention.
+_LARGE_STATE_DIMS = frozenset(
+    {'Time', 'nVertLevels', 'nVertLevelsP1', 'nTracers'}
+)
+
+
+class MeshConverter:
+    def __init__(self):
+        self.dim_map, self.var_map = self._load_mpaso_to_omega_map()
+
+    def _load_mpaso_to_omega_map(self):
+        text = (
+            resources.files('polaris.ocean.model')
+            .joinpath('mpaso_to_omega.yaml')
+            .read_text()
+        )
+        nested = YAML(typ='rt').load(text)
+
+        return nested['dimensions'], nested['variables']
+
+    def omega_to_mpas(self, ds: xr.Dataset) -> xr.Dataset:
+        # omega -> mpas
+        rename = {v: k for k, v in self.dim_map.items() if v in ds.dims}
+        rename.update({v: k for k, v in self.var_map.items() if v in ds})
+
+        return ds.rename(rename)
+
+    def mpas_to_omega(self, ds: xr.Dataset) -> xr.Dataset:
+        # mpas -> omega
+        rename = {k: v for k, v in self.dim_map.items() if k in ds.dims}
+        rename.update({k: v for k, v in self.var_map.items() if k in ds})
+
+        return ds.rename(rename)
+
+    def detect_format(self, ds: xr.Dataset) -> Literal['mpaso', 'omega']:
+
+        dims = ds.dims
+        items = self.dim_map.items()
+
+        is_omega = all(v in dims for k, v in items if k in dims or v in dims)
+        is_mpas = all(k in dims for k, v in items if k in dims or v in dims)
+
+        if is_omega and is_mpas:
+            raise ValueError(
+                'Invlaid input: dataset contains both MPASO and Omega '
+                'dimensions names.'
+            )
+
+        return 'omega' if is_omega else 'mpaso'
+
+
+def _select_grid_vars(ds: xr.Dataset) -> list[str]:
+    """Names of the mesh/grid variables, i.e. every variable except
+    those with a large state/time/tracer dimension (see
+    ``_LARGE_STATE_DIMS``). ``ds`` is expected to already be in
+    MPAS-Ocean naming convention.
+    """
+    return [
+        name
+        for name, da in ds.data_vars.items()
+        if not (set(da.dims) & _LARGE_STATE_DIMS)
+    ]
+
+
+def _default_num_workers() -> int:
+    """Default dask worker count from mache's parallel system info.
+
+    Using mache rather than reading SLURM environment variables
+    ourselves keeps this in sync with each machine's known core count
+    and correctly falls back to a login-node core count outside of a
+    job allocation.
+    """
+    machine = discover_machine(quiet=True)
+    if machine is None:
+        raise ValueError(
+            'Unable to discover the current machine from its host '
+            'name; mache does not support this machine. Pass '
+            '--num_workers explicitly instead.'
+        )
+    machine_info = MachineInfo(machine=machine, quiet=True)
+    system = get_parallel_system(machine_info.config)
+    return system.cores
+
+
+@contextmanager
+def _timed(step: str) -> Iterator[None]:
+    """Print how long the wrapped block of code took to run, labeled
+    with ``step``.
+    """
+    t0 = time.perf_counter()
+    yield
+    print(f'{step}: {time.perf_counter() - t0:.2f}s')
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Add edge vector reconstruction weights to a dataset.'
+    )
+    parser.add_argument(
+        '-i',
+        '--input_file',
+        required=True,
+        type=str,
+        help='Path to the input dataset file.',
+    )
+    parser.add_argument(
+        '-o',
+        '--output_file',
+        required=True,
+        type=str,
+        help='Path to the output dataset file.',
+    )
+    parser.add_argument(
+        '-w',
+        '--num_workers',
+        required=False,
+        type=int,
+        default=None,
+        help='Number of local dask worker processes to use. Providing '
+        'this (with or without --chunk_size) enables dask, attaching '
+        'to the resources available on the local node. If omitted, but '
+        '--chunk_size is provided, this is taken from mache instead '
+        '(requires running on a machine mache recognizes).',
+    )
+    parser.add_argument(
+        '-c',
+        '--chunk_size',
+        required=False,
+        type=int,
+        default=None,
+        help='Number of cells per dask chunk. Providing this (with or '
+        f'without --num_workers) enables dask. Defaults to '
+        f'{DEFAULT_CHUNK_SIZE} if dask is enabled via --num_workers '
+        'but --chunk_size is not given.',
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    use_dask = args.num_workers is not None or args.chunk_size is not None
+
+    converter = MeshConverter()
+
+    ds = xr.open_dataset(args.input_file)
+    input_format = converter.detect_format(ds)
+
+    ds_mpas = ds if input_format == 'mpaso' else converter.omega_to_mpas(ds)
+
+    # Only the small grid variables feed the reconstruction calculation.
+    # Restricting to those *before* loading/chunking anything means a
+    # production mesh's large state/tracer fields are never read.
+    mesh_ds = ds_mpas[_select_grid_vars(ds_mpas)]
+
+    # Done reading -- close the input file before copying it below.
+    ds.close()
+
+    # The output should contain the full input mesh plus the new
+    # weight fields, not just the weights. For a production mesh (40+
+    # GB) re-writing everything through xarray/netCDF would be far
+    # slower than necessary, so instead we copy the input file
+    # byte-for-byte and merge in the (small) computed weight fields
+    # via NCO below, once they're ready.
+    with _timed('copy input -> output'):
+        shutil.copyfile(args.input_file, args.output_file)
+
+    if use_dask:
+        chunk_size = args.chunk_size or DEFAULT_CHUNK_SIZE
+        num_workers = args.num_workers or _default_num_workers()
+        dask_config: dict[str, str | int] = {
+            'scheduler': 'processes',
+            'multiprocessing.context': 'spawn',
+        }
+        if num_workers is not None:
+            dask_config['num_workers'] = num_workers
+
+        print(
+            f'dask config: scheduler={dask_config["scheduler"]!r}, '
+            f'num_workers={dask_config.get("num_workers", "(dask default)")}, '
+            f'multiprocessing.context='
+            f'{dask_config["multiprocessing.context"]!r}, '
+            f'chunk_size={chunk_size}'
+        )
+
+        dask_ctx = dask.config.set(**dask_config)
+
+        with _timed('dask setup + load/chunk'):
+            # Read meshg variable subset into memory before chunking.
+            mesh_ds = mesh_ds.load()
+            mesh_ds = mesh_ds.chunk({'nCells': chunk_size})
+    else:
+        dask_ctx = contextlib.nullcontext()
+
+    with _timed('compute_reconstruction_weights total'):
+        with dask_ctx:
+            weights_ds = compute_reconstruction_weights(mesh_ds)
+
+    # Match the naming convention of the input file.
+    if input_format == 'omega':
+        weights_ds = converter.mpas_to_omega(weights_ds)
+
+    # Write weight to tmp file, then use `ncks` to merge into input mesh
+    with tempfile.NamedTemporaryFile(
+        suffix='.nc', prefix='weights_', dir=os.getcwd()
+    ) as tmp:
+        with _timed('write weights (temporary file)'):
+            weights_ds.to_netcdf(tmp.name, mode='w')
+
+        with _timed('merge weights into output (ncks -A)'):
+            subprocess.run(
+                ['ncks', '-A', tmp.name, args.output_file], check=True
+            )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds the ability to per-generate least squares weights for edge vector field reconstruction at cells or vertices. The method uses a two ring stencil of edges [see Figure 5 from [Peixoto and Barros (2014)](https://www.sciencedirect.com/science/article/pii/S002199911400312X?via%3Dihub)]. 

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes


<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
