### PR TITLE
Disable vertical mixing tendencies for selected `omega_pr` tests

### DIFF
--- a/polaris/ocean/config/single_layer.yaml
+++ b/polaris/ocean/config/single_layer.yaml
@@ -1,3 +1,10 @@
+ocean:
+  debug:
+    config_disable_thick_vadv: true
+    config_disable_vel_vadv: true
+    config_disable_vel_vmix: true
+    config_disable_tr_vmix: true
+
 mpas-ocean:
   cvmix:
     config_use_cvmix: false
@@ -6,8 +13,5 @@ mpas-ocean:
     config_ALE_thickness_proportionality: weights_only
   debug:
     config_compute_active_tracer_budgets: false
-    config_disable_thick_vadv: true
-    config_disable_vel_vadv: true
-    config_disable_vel_vmix: true
   pressure_gradient:
     config_pressure_gradient_type: ssh_gradient

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -188,6 +188,12 @@ config:
     config_explicit_bottom_drag_coeff: BottomDragCoeff
 
 - section:
+    debug: Tendencies
+  options:
+    config_disable_vel_vmix: not VelVertMixTendencyEnable
+    config_disable_tr_vmix: not TracerVertMixTendencyEnable
+
+- section:
     manufactured_solution: ManufacturedSolution
   options:
     config_manufactured_solution_wavelength_x: WavelengthX

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -14,6 +14,8 @@ ocean:
     config_use_bulk_wind_stress: true
   debug:
     config_disable_vel_explicit_bottom_drag: true
+    config_disable_vel_vmix: true
+    config_disable_tr_vmix: true
 
 mpas-ocean:
   run_modes:
@@ -57,9 +59,18 @@ mpas-ocean:
 
 Omega:
   Tendencies:
+    ThicknessVertAdvTendencyEnable: false
+    PVTendencyEnable: false
+    KETendencyEnable: false
     TracerHorzAdvTendencyEnable : false
+    TracerVertAdvTendencyEnable: false
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
+  VertMix:
+    Convective:
+      Enable: false
+    Shear:
+      Enable: false
   Advection:
     FluxThicknessType: Center
   IOStreams:

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -59,11 +59,7 @@ mpas-ocean:
 
 Omega:
   Tendencies:
-    ThicknessVertAdvTendencyEnable: false
-    PVTendencyEnable: false
-    KETendencyEnable: false
     TracerHorzAdvTendencyEnable : false
-    TracerVertAdvTendencyEnable: false
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
   Advection:

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -66,11 +66,6 @@ Omega:
     TracerVertAdvTendencyEnable: false
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
-  VertMix:
-    Convective:
-      Enable: false
-    Shear:
-      Enable: false
   Advection:
     FluxThicknessType: Center
   IOStreams:

--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -76,11 +76,6 @@ Omega:
     TracerHorzAdvTendencyEnable : true
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
-  VertMix:
-    Convective:
-      Enable: false
-    Shear:
-      Enable: false
   Tracers:
     Debug: [Debug1, Debug2, Debug3]
   IOStreams:

--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -7,6 +7,8 @@ ocean:
     config_time_integrator: {{ time_integrator }}
   debug:
     config_disable_vel_pgrad: true
+    config_disable_vel_vmix: true
+    config_disable_tr_vmix: true
 
 mpas-ocean:
   run_modes:
@@ -23,10 +25,8 @@ mpas-ocean:
     config_disable_vel_hmix: true
     config_disable_vel_surface_stress: true
     config_disable_vel_explicit_bottom_drag: true
-    config_disable_vel_vmix: true
     config_disable_vel_vadv: true
     config_disable_tr_hmix: true
-    config_disable_tr_vmix: true
     config_disable_tr_sflux: true
     config_disable_tr_nonlocalflux: true
     config_check_ssh_consistency: false
@@ -76,6 +76,11 @@ Omega:
     TracerHorzAdvTendencyEnable : true
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
+  VertMix:
+    Convective:
+      Enable: false
+    Shear:
+      Enable: false
   Tracers:
     Debug: [Debug1, Debug2, Debug3]
   IOStreams:

--- a/polaris/tasks/ocean/horiz_press_grad/forward.yaml
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.yaml
@@ -18,6 +18,13 @@ Omega:
     UseCustomTendency: false
     ManufacturedSolutionTendency: false
     PressureGradTendencyEnable: true
+    VelVertMixTendencyEnable: false
+    TracerVertMixTendencyEnable: false
+  VertMix:
+    Convective:
+      Enable: false
+    Shear:
+      Enable: false
   IOStreams:
     History:
       Filename: output.nc

--- a/polaris/tasks/ocean/horiz_press_grad/forward.yaml
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.yaml
@@ -20,11 +20,6 @@ Omega:
     PressureGradTendencyEnable: true
     VelVertMixTendencyEnable: false
     TracerVertMixTendencyEnable: false
-  VertMix:
-    Convective:
-      Enable: false
-    Shear:
-      Enable: false
   IOStreams:
     History:
       Filename: output.nc

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -44,11 +44,6 @@ Omega:
     VelHyperDiffTendencyEnable: false
     UseCustomTendency: true
     ManufacturedSolutionTendency: true
-  VertMix:
-    Convective:
-      Enable: false
-    Shear:
-      Enable: false
   IOStreams:
     InitialState:
       UsePointerFile: false

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -9,6 +9,9 @@ ocean:
     config_mom_del2: 1.5e6
   hmix_del4:
     config_mom_del4: 5.e13
+  debug:
+    config_disable_vel_vmix: true
+    config_disable_tr_vmix: true
 
 mpas-ocean:
   bottom_drag:
@@ -19,7 +22,6 @@ mpas-ocean:
      config_use_manufactured_solution: true
   debug:
     config_compute_active_tracer_budgets: false
-    config_disable_vel_vmix: true
     config_disable_tr_all_tend: true
   streams:
     restart: {}
@@ -42,6 +44,11 @@ Omega:
     VelHyperDiffTendencyEnable: false
     UseCustomTendency: true
     ManufacturedSolutionTendency: true
+  VertMix:
+    Convective:
+      Enable: false
+    Shear:
+      Enable: false
   IOStreams:
     InitialState:
       UsePointerFile: false

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -11,6 +11,8 @@ ocean:
     config_disable_thick_vadv: true
     config_disable_thick_hadv: true
     config_disable_vel_pgrad: true
+    config_disable_vel_vmix: true
+    config_disable_tr_vmix: true
   hmix_del2:
     config_use_mom_del2: false
     config_use_tracer_del2: false
@@ -36,8 +38,8 @@ mpas-ocean:
   debug:
     config_disable_thick_all_tend: true
     config_disable_vel_all_tend: true
+    config_disable_vel_hmix: true
     config_disable_tr_hmix: true
-    config_disable_vel_vmix: true
     config_disable_tr_sflux: true
     config_disable_tr_nonlocalflux: true
     config_check_ssh_consistency: false
@@ -78,12 +80,10 @@ Omega:
     VerticalTracerFluxLimiterEnable: false
   Tendencies:
     TracerHorzAdvTendencyEnable: true
+    TracerVertAdvTendencyEnable: true
     PVTendencyEnable: false
     KETendencyEnable: false
     SSHTendencyEnable: false
-    ThicknessVertAdvTendencyEnable: false
-    VelocityVertAdvTendencyEnable: false
-    TracerVertAdvTendencyEnable: true
   Tracers:
     Debug: [Debug1, Debug2, Debug3]
   IOStreams:

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -71,7 +71,6 @@ Omega:
     ThicknessFluxTendencyEnable : true
     PVTendencyEnable : false
     KETendencyEnable : false
-    VelocityVertAdvTendencyEnable: false
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false
     TracerHorzAdvTendencyEnable : true

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -79,11 +79,6 @@ Omega:
     TracerHyperDiffTendencyEnable : false
   Advection:
     VerticalTracerFluxLimiterEnable: false
-  VertMix:
-    Convective:
-      Enable: false
-    Shear:
-      Enable: false
   Tracers:
     Debug: [Debug1, Debug2, Debug3]
   IOStreams:

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -9,6 +9,8 @@ ocean:
     config_horiz_tracer_adv_order: 3
   debug:
     config_disable_vel_pgrad: true
+    config_disable_vel_vmix: true
+    config_disable_tr_vmix: true
 
 mpas-ocean:
   run_modes:
@@ -69,12 +71,19 @@ Omega:
     ThicknessFluxTendencyEnable : true
     PVTendencyEnable : false
     KETendencyEnable : false
-    SSHTendencyEnable : false
+    VelocityVertAdvTendencyEnable: false
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false
     TracerHorzAdvTendencyEnable : true
     TracerDiffTendencyEnable : false
     TracerHyperDiffTendencyEnable : false
+  Advection:
+    VerticalTracerFluxLimiterEnable: false
+  VertMix:
+    Convective:
+      Enable: false
+    Shear:
+      Enable: false
   Tracers:
     Debug: [Debug1, Debug2, Debug3]
   IOStreams:

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -11,6 +11,7 @@ ocean:
     config_disable_vel_pgrad: true
     config_disable_vel_vmix: true
     config_disable_tr_vmix: true
+    config_disable_vel_vadv: true
 
 mpas-ocean:
   run_modes:


### PR DESCRIPTION
This PR updates `forward.yaml` for selected `omega_pr` tests to explicitly disable vertical mixing tendencies where they are not needed.

Since vertical mixing tendencies are now enabled by default, some `omega_pr` tests need to disable them explicitly. This PR applies that update to tests that do not require vertical mixing tendencies.

- Disabled vertical mixing tendencies for the following `omega_pr` tests:
  - cosine_bell
  - horiz_press_grad
  - manufactured_solution
  - barotropic_gyre
  - sphere_transport

- Added config mappings in `mpaso_to_omega.yaml` for velocity and tracer vertical mixing tendencies.


Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes
