### PR TITLE
Use sphinx-jinja to provide supported machines in yaml format

### DIFF
--- a/deploy/pixi.toml.j2
+++ b/deploy/pixi.toml.j2
@@ -92,6 +92,7 @@ udunits2 = "*"
 sphinx = ">=7.0.0"
 sphinx_rtd_theme = "*"
 myst-parser = "*"
+sphinx-jinja = "*"
 
 # Visualization
 ncview = "*"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,3 +136,6 @@ with open(_machines_yaml_path, 'r') as f:
 jinja_contexts = {
     'supported_machines': _machines_data,
 }
+
+# Trim block whitespace so the generated pipe table has no blank rows
+jinja_env_kwargs = {'trim_blocks': True, 'lstrip_blocks': True}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,8 @@
 import os
 from datetime import date
 
+import yaml
+
 from polaris.version import __version__
 
 # -- Project information -----------------------------------------------------
@@ -44,6 +46,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
+    "sphinx_jinja",
 ]
 
 autosummary_generate = ['developers_guide/api.md',
@@ -116,4 +119,20 @@ html_static_path = ["_static"]
 
 html_context = {
     "current_version": os.getenv("DOCS_VERSION", "main"),
+}
+
+# -- Jinja context for sphinx-jinja ------------------------------------------
+
+# Load supported machines data from YAML
+_machines_yaml_path = os.path.join(
+    os.path.dirname(__file__),
+    'developers_guide',
+    'supported_machines.yaml'
+)
+
+with open(_machines_yaml_path, 'r') as f:
+    _machines_data = yaml.safe_load(f)
+
+jinja_contexts = {
+    'supported_machines': _machines_data,
 }

--- a/docs/developers_guide/machines/index.md
+++ b/docs/developers_guide/machines/index.md
@@ -49,22 +49,11 @@ combinations. The MPAS make target is only applicable for MPAS-Ocean and
 MPAS-Seaice builds.
 
 ```{jinja} supported_machines
-.. list-table::
-   :header-rows: 1
-   :widths: 15 10 20 10 20
-
-   * - Machine
-     - Model
-     - Compiler
-     - MPI
-     - MPAS Make Target
+| Machine | Model | Compiler | MPI | MPAS Make Target |
+| --- | --- | --- | --- | --- |
 {% for machine in machines %}
 {% for model in machine.models %}
-   * - {{ machine.name }}
-     - {{ model.model }}
-     - {{ model.compiler }}
-     - {{ model.mpi }}
-     - {{ model.mpas_target if model.mpas_target else "N/A" }}
+| {{ machine.name }} | {{ model.model }} | {{ model.compiler }} | {{ model.mpi }} | {{ model.mpas_target if model.mpas_target else "N/A" }} |
 {% endfor %}
 {% endfor %}
 ```

--- a/docs/developers_guide/machines/index.md
+++ b/docs/developers_guide/machines/index.md
@@ -42,73 +42,36 @@ frontier
 perlmutter
 ```
 
-(dev-mpas-supported-machines)=
+### Supported Machine Configurations
 
-### MPAS-Ocean and -Seaice Supported Machines
+The following table lists all supported machine, model, and compiler
+combinations. The MPAS make target is only applicable for MPAS-Ocean and
+MPAS-Seaice builds.
 
-These are the machines supported by MPAS-Ocean and -Seaice, including the
-"make target" used to build the MPAS component.
+```{jinja} supported_machines
+.. list-table::
+   :header-rows: 1
+   :widths: 15 10 20 10 20
 
-```{eval-rst}
-+--------------+------------+-----------+-------------------+
-| Machine      | Compiler   | MPI lib.  |  MPAS make target |
-+==============+============+===========+===================+
-| chrysalis    | intel      | openmpi   | ifort             |
-|              +------------+-----------+-------------------+
-|              | gnu        | openmpi   | gfortran          |
-+--------------+------------+-----------+-------------------+
-| frontier     | craygnu    | mpich     | gnu-cray          |
-|              +------------+-----------+-------------------+
-|              | craycray   | mpich     | cray-cray         |
-+--------------+------------+-----------+-------------------+
-| pm-cpu       | gnu        | mpich     | gnu-cray          |
-|              +------------+-----------+-------------------+
-|              | intel      | mpich     | intel-cray        |
-+--------------+------------+-----------+-------------------+
+   * - Machine
+     - Model
+     - Compiler
+     - MPI
+     - MPAS Make Target
+{% for machine in machines %}
+{% for model in machine.models %}
+   * - {{ machine.name }}
+     - {{ model.model }}
+     - {{ model.compiler }}
+     - {{ model.mpi }}
+     - {{ model.mpas_target if model.mpas_target else "N/A" }}
+{% endfor %}
+{% endfor %}
 ```
 
 :::{note}
 MPAS components currently do not support Aurora in standalone builds.
 :::
-
-(dev-omega-supported-machines)=
-
-### Omega Supported Machines
-
-These are the machines supported by Omega.  The MPI library is always the
-E3SM default for the given machine an compiler.
-
-```{eval-rst}
-+--------------+------------------+-----------+
-| Machine      | Compiler         | MPI lib.  |
-+==============+==================+===========+
-| aurora       | oneapi-ifx       | mpich     |
-+--------------+------------------+-----------+
-| chrysalis    | oneapi-ifx       | openmpi   |
-|              +------------------+-----------+
-|              | gnu              | openmpi   |
-|              +------------------+-----------+
-|              | intel            | openmpi   |
-+--------------+------------------+-----------+
-| frontier     | craygnu          | mpich     |
-|              +------------------+-----------+
-|              | craygnu-mphipcc  | mpich     |
-|              +------------------+-----------+
-|              | crayamd          | mpich     |
-|              +------------------+-----------+
-|              | crayamd-mphipcc  | mpich     |
-|              +------------------+-----------+
-|              | craycray         | mpich     |
-|              +------------------+-----------+
-|              | craycray-mphipcc | mpich     |
-+--------------+------------------+-----------+
-| pm-cpu       | gnu              | mpich     |
-|              +------------------+-----------+
-|              | intel            | mpich     |
-+--------------+------------------+-----------+
-| pm-gpu       | gnugpu           | mpich     |
-+--------------+------------------+-----------+
-```
 
 (dev-other-machines)=
 

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -409,7 +409,7 @@ to force rebuilding.
 #### Manual build (advanced/optional)
 
 For MPAS-Ocean and -Seaice both, see the last column of the table in
-{ref}`dev-mpas-supported-machines` for the right `<mpas_make_target>` command for
+{ref}`dev-supported-machines` for the right `<mpas_make_target>` command for
 each machine and compiler.
 
 To build MPAS-Ocean manually, you would typically run:
@@ -431,7 +431,7 @@ provided, MPAS-Ocean is usually detected automatically; otherwise, provide
 
 ### Omega
 
-See the table in {ref}`dev-omega-supported-machines` for a list of supported
+See the table in {ref}`dev-supported-machines` for a list of supported
 machines.
 
 If you simply wish to run the CTests from Omega, you likely want to use the

--- a/docs/developers_guide/supported_machines.yaml
+++ b/docs/developers_guide/supported_machines.yaml
@@ -1,0 +1,92 @@
+# Supported machines for MPAS-Ocean, MPAS-Seaice, and Omega
+machines:
+  - name: aurora
+    models:
+      - model: Omega
+        compiler: oneapi-ifx
+        mpi: mpich
+        mpas_target: null
+
+  - name: chrysalis
+    models:
+      - model: MPAS
+        compiler: intel
+        mpi: openmpi
+        mpas_target: ifort
+      - model: MPAS
+        compiler: gnu
+        mpi: openmpi
+        mpas_target: gfortran
+      - model: Omega
+        compiler: oneapi-ifx
+        mpi: openmpi
+        mpas_target: null
+      - model: Omega
+        compiler: gnu
+        mpi: openmpi
+        mpas_target: null
+      - model: Omega
+        compiler: intel
+        mpi: openmpi
+        mpas_target: null
+
+  - name: frontier
+    models:
+      - model: MPAS
+        compiler: craygnu
+        mpi: mpich
+        mpas_target: gnu-cray
+      - model: MPAS
+        compiler: craycray
+        mpi: mpich
+        mpas_target: cray-cray
+      - model: Omega
+        compiler: craygnu
+        mpi: mpich
+        mpas_target: null
+      - model: Omega
+        compiler: craygnu-mphipcc
+        mpi: mpich
+        mpas_target: null
+      - model: Omega
+        compiler: crayamd
+        mpi: mpich
+        mpas_target: null
+      - model: Omega
+        compiler: crayamd-mphipcc
+        mpi: mpich
+        mpas_target: null
+      - model: Omega
+        compiler: craycray
+        mpi: mpich
+        mpas_target: null
+      - model: Omega
+        compiler: craycray-mphipcc
+        mpi: mpich
+        mpas_target: null
+
+  - name: pm-cpu
+    models:
+      - model: MPAS
+        compiler: gnu
+        mpi: mpich
+        mpas_target: gnu-cray
+      - model: MPAS
+        compiler: intel
+        mpi: mpich
+        mpas_target: intel-cray
+      - model: Omega
+        compiler: gnu
+        mpi: mpich
+        mpas_target: null
+      - model: Omega
+        compiler: intel
+        mpi: mpich
+        mpas_target: null
+
+  - name: pm-gpu
+    models:
+      - model: Omega
+        compiler: gnugpu
+        mpi: mpich
+        mpas_target: null

--- a/docs/developers_guide/updating_spack/testing/running_test_suites.md
+++ b/docs/developers_guide/updating_spack/testing/running_test_suites.md
@@ -23,7 +23,7 @@ with Intel and OpenMPI):
    ```
 
    *(Replace `chrysalis`, `intel`, and `openmpi` with your machine, compiler,
-   and MPI as appropriate. See {ref}`dev-mpas-supported-machines`.)*
+   and MPI as appropriate. See {ref}`dev-supported-machines`.)*
 
 3. **Set Up (and Auto-Build) the Suite**
 
@@ -142,5 +142,5 @@ with `oneapi-ifx` and OpenMPI):
 **Tip:**
 If you are testing on a different machine or with a different compiler/MPI,
 simply substitute the appropriate names in the examples above. For a full list
-of supported combinations and the correct make targets, see the tables in
-{ref}`dev-mpas-supported-machines` and {ref}`dev-omega-supported-machines`.
+of supported combinations and the correct make targets, see the table in
+{ref}`dev-supported-machines`.


### PR DESCRIPTION
See https://github.com/E3SM-Project/polaris/discussions/652

Checklist
* [X] Developer's Guide has been updated
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected **Caveat: used pip install sphinx-jinja**