### PR TITLE
Default omega_pr and mpaso_pr suites to the debug queue

### DIFF
--- a/docs/users_guide/suites.md
+++ b/docs/users_guide/suites.md
@@ -53,3 +53,30 @@ run with cached meshes and initial conditions.
 
 Including the `-v` verbose argument to `polaris list --suites` will
 print the tasks belonging to each given suite.
+
+(debug-suites)=
+
+## Suites that default to the debug queue
+
+Pull-request review is time-sensitive, so a few suites default to the machine's
+**debug** queue, partition, or QOS (whichever the machine provides) to get
+faster turnaround.  By default these are the `omega_pr` and `mpaso_pr` suites,
+controlled by the `debug_suites` option in the `[job]` config section:
+
+```cfg
+[job]
+
+# a comma-separated list of suites that default to the machine's debug
+# queue/partition/qos (if it has one) for fast PR-review turnaround; jobs too
+# large for the debug node limit fall back to the machine's normal default
+debug_suites = omega_pr, mpaso_pr
+```
+
+When you set up one of these suites on a machine that has a debug
+queue/partition/qos, the suite's job script (`job_script.<suite>.sh`) is written
+to use it, and its wall time is capped to the debug limit.  If the suite needs
+more nodes than the debug queue allows, it automatically falls back to the
+machine's normal default queue.  Machines without a debug queue are unaffected.
+
+You can add your own suites to this list (or remove the defaults) by overriding
+`debug_suites` in a user config file passed to `polaris suite`.

--- a/polaris/default.cfg
+++ b/polaris/default.cfg
@@ -52,6 +52,11 @@ job_name = <<<default>>>
 # wall-clock time
 wall_time = 1:00:00
 
+# a comma-separated list of suites that default to the machine's debug
+# queue/partition/qos (if it has one) for fast PR-review turnaround; jobs too
+# large for the debug node limit fall back to the machine's normal default
+debug_suites = omega_pr, mpaso_pr
+
 # The job partition to use, by default, taken from the first partition (if any)
 # provided for the machine by mache
 partition = <<<default>>>

--- a/polaris/job/__init__.py
+++ b/polaris/job/__init__.py
@@ -1,3 +1,4 @@
+import copy as copy
 import importlib.resources as imp_res
 import os as os
 
@@ -132,6 +133,13 @@ def write_job_script(
 
     desired_wall_time = config.get('job', 'wall_time')
 
+    # some suites (e.g. omega_pr, mpaso_pr) should prefer the machine's debug
+    # queue/partition/qos for fast PR-review turnaround
+    use_debug = bool(suite) and suite in config.getlist('job', 'debug_suites')
+    combined = config.combined
+    if use_debug:
+        combined = _prefer_debug_targets(combined)
+
     if system == 'slurm':
         (
             partition,
@@ -141,7 +149,7 @@ def write_job_script(
             max_wallclock,
             nodes,
         ) = SlurmSystem.get_slurm_options(
-            config=config.combined,
+            config=combined,
             nodes=nodes,
             min_nodes_allowed=min_nodes_allowed,
         )
@@ -163,7 +171,7 @@ def write_job_script(
             filesystems,
             nodes,
         ) = PbsSystem.get_pbs_options(
-            config=config.combined,
+            config=combined,
             nodes=nodes,
             min_nodes_allowed=min_nodes_allowed,
         )
@@ -212,6 +220,27 @@ def write_job_script(
         script_filename = os.path.join(work_dir, script_filename)
     with open(script_filename, 'w') as handle:
         handle.write(text)
+
+
+def _prefer_debug_targets(combined):
+    """Return a copy of the combined config with any 'debug' entry moved to the
+    front of the parallel partitions/qos/queues lists, so mache selects a debug
+    target for jobs small enough to fit its node limit."""
+    combined = copy.deepcopy(combined)
+    for option in ('partitions', 'qos', 'queues'):
+        if not combined.has_option('parallel', option):
+            continue
+        values = [
+            value.strip()
+            for value in combined.get('parallel', option).split(',')
+            if value.strip() != ''
+        ]
+        debug = [value for value in values if 'debug' in value.lower()]
+        if len(debug) == 0:
+            continue
+        others = [value for value in values if 'debug' not in value.lower()]
+        combined.set('parallel', option, ', '.join(debug + others))
+    return combined
 
 
 def _get_min_nodes_allowed(


### PR DESCRIPTION
Adds a [job] debug_suites config option and, for those suites, reorders the machine's debug partition/qos/queue to the front so small PR jobs prefer the debug queue for faster review turnaround. Reuses mache's node-count fitting so jobs that exceed the debug node limit fall back to the machine's normal default queue. Machines without a debug target are unaffected.

Fixes #654

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
