### PR TITLE
Update bottom drag options for `omega_pr`

### DIFF
--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -164,9 +164,17 @@ config:
     config_use_bulk_wind_stress: SfcStressForcingTendencyEnable
 
 - section:
-    debug: Tendencies
+    debug: [Tendencies, BottomDragTendency]
   options:
-    config_disable_vel_explicit_bottom_drag: not BottomDragTendencyEnable
+    config_disable_vel_explicit_bottom_drag: not Enable
+
+- section:
+    bottom_drag: [Tendencies, BottomDragTendency]
+  options:
+    config_bottom_drag_mode: Mode
+    config_implicit_bottom_drag_type: Type
+    config_explicit_bottom_drag_coeff: BottomDragCoeff
+    config_implicit_constant_bottom_drag_coeff: BottomDragCoeff
 
 - section:
     debug: Tendencies
@@ -192,11 +200,6 @@ config:
     debug: Tendencies
   options:
     config_disable_vel_pgrad: not PressureGradTendencyEnable
-
-- section:
-    bottom_drag: Tendencies
-  options:
-    config_explicit_bottom_drag_coeff: BottomDragCoeff
 
 - section:
     debug: Tendencies

--- a/polaris/tasks/ocean/baroclinic_channel/forward.yaml
+++ b/polaris/tasks/ocean/baroclinic_channel/forward.yaml
@@ -10,8 +10,8 @@ ocean:
     config_use_mom_del4: false
     config_use_tracer_del4: false
   cvmix:
-    config_use_cvmix_convection: false
-    config_use_cvmix_shear: false
+    config_use_cvmix_convection: true
+    config_use_cvmix_shear: true
     config_cvmix_background_diffusion: 1.0e-5
     config_cvmix_background_viscosity: 1.0e-4
   advection:
@@ -21,9 +21,6 @@ ocean:
 mpas-ocean:
   io:
     config_write_output_on_startup: false
-  bottom_drag:
-    config_bottom_drag_mode: explicit
-    config_explicit_bottom_drag_coeff: 0.0
   cvmix:
     config_use_cvmix: false
   advection:
@@ -35,9 +32,6 @@ mpas-ocean:
     config_disable_thick_sflux: true
     config_disable_vel_surface_stress: true
     config_disable_vel_topographic_wave_drag: true
-    config_disable_vel_explicit_bottom_drag: true
-    config_disable_vel_vmix: true
-    config_disable_tr_vmix: true
     config_disable_tr_sflux: true
     config_disable_tr_nonlocalflux: true
   streams:
@@ -63,8 +57,6 @@ Omega:
     VerticalTracerFluxLimiterEnable: false
   Eos:
     EosType: linear
-  Tendencies:
-    SSHTendencyEnable: false
   Tracers:
     Base: [Temperature, Salinity]
   IOStreams:

--- a/polaris/tasks/ocean/cosine_bell/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/forward.yaml
@@ -9,6 +9,7 @@ ocean:
     config_disable_vel_pgrad: true
     config_disable_vel_vmix: true
     config_disable_tr_vmix: true
+    config_disable_vel_explicit_bottom_drag: true
 
 mpas-ocean:
   run_modes:
@@ -24,7 +25,6 @@ mpas-ocean:
     config_disable_vel_coriolis: true
     config_disable_vel_hmix: true
     config_disable_vel_surface_stress: true
-    config_disable_vel_explicit_bottom_drag: true
     config_disable_vel_vadv: true
     config_disable_tr_hmix: true
     config_disable_tr_sflux: true

--- a/polaris/tasks/ocean/horiz_press_grad/forward.yaml
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.yaml
@@ -11,7 +11,8 @@ Omega:
     VelDiffTendencyEnable: false
     VelHyperDiffTendencyEnable: false
     SfcStressForcingTendencyEnable: false
-    BottomDragTendencyEnable: false
+    BottomDragTendency:
+      Enable: false
     TracerHorzAdvTendencyEnable: false
     TracerDiffTendencyEnable: false
     TracerHyperDiffTendencyEnable: false

--- a/polaris/tasks/ocean/manufactured_solution/forward.yaml
+++ b/polaris/tasks/ocean/manufactured_solution/forward.yaml
@@ -12,6 +12,7 @@ ocean:
   debug:
     config_disable_vel_vmix: true
     config_disable_tr_vmix: true
+    config_disable_vel_explicit_bottom_drag: true
 
 mpas-ocean:
   bottom_drag:

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -36,7 +36,7 @@ mpas-ocean:
   io:
     config_write_output_on_startup: false
   bottom_drag:
-    config_bottom_drag_mode: explicit
+    config_bottom_drag_mode: implicit
   # MPAS-Ocean-only cvmix options with no Omega equivalent (Omega's
   # convective mixing uses a single coefficient for both diffusivity
   # and viscosity)

--- a/polaris/tasks/ocean/sphere_transport/forward.yaml
+++ b/polaris/tasks/ocean/sphere_transport/forward.yaml
@@ -12,6 +12,7 @@ ocean:
     config_disable_vel_vmix: true
     config_disable_tr_vmix: true
     config_disable_vel_vadv: true
+    config_disable_vel_explicit_bottom_drag: true
 
 mpas-ocean:
   run_modes:
@@ -29,7 +30,6 @@ mpas-ocean:
     config_disable_vel_coriolis: true
     config_disable_vel_hmix: true
     config_disable_vel_surface_stress: true
-    config_disable_vel_explicit_bottom_drag: true
     config_disable_vel_vmix: true
     config_disable_vel_vadv: true
     config_disable_tr_hmix: true


### PR DESCRIPTION
This PR updates the bottom drag options in `forward.yaml` for the `omega_pr` suite to support the implicit bottom drag capability in Omega.

The implicit bottom drag capability will be introduced in Omega through E3SM-Project/Omega#469. Since implicit bottom drag is enabled by default, the `omega_pr` test suite requires corresponding updates to `forward.yaml`.


- Enable implicit bottom drag for:
  - baroclinic_channel
  - overflow
- Disable implicit bottom drag for:
  - cosine_bell
  - horiz_press_grad
  - manufactured_solution
  - sphere_transport

The Omega submodule is updated to bb4f572da963ffd61e417d35c9af6d4dc9276180 which includes the implicit bottom drag to bring in https://github.com/E3SM-Project/Omega/pull/469.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes


<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
