### PR TITLE
Add all horizontal advection orders with del4 to overflow

### DIFF
--- a/polaris/tasks/ocean/overflow/__init__.py
+++ b/polaris/tasks/ocean/overflow/__init__.py
@@ -34,15 +34,16 @@ def add_overflow_tasks(component):
         )
         smoke_test.set_shared_config(config, link=config_filename)
         component.add_task(smoke_test)
-    smoke_test = SmokeTest(
-        component=component,
-        indir=taskdir,
-        init=init_step,
-        horiz_adv_order=4,
-        use_mom_del4=True,
-    )
-    smoke_test.set_shared_config(config, link=config_filename)
-    component.add_task(smoke_test)
+
+        smoke_test = SmokeTest(
+            component=component,
+            indir=taskdir,
+            init=init_step,
+            horiz_adv_order=horiz_adv_order,
+            use_mom_del4=True,
+        )
+        smoke_test.set_shared_config(config, link=config_filename)
+        component.add_task(smoke_test)
 
     component.add_task(
         Rpe(


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
Currently, the `omega_pr` suite contains the `smoke_test_horiz_adv_order_2_del4` test, but the only del4 variant added by the overflow tasks is `smoke_test_horiz_adv_order_4_del4`. This PR adds a del4 variant for all orders.

Fixes #668 

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
