### PR TITLE
Fix u.oi30.lr10 culling

### DIFF
--- a/docs/design_docs/index.md
+++ b/docs/design_docs/index.md
@@ -14,6 +14,7 @@ unified_mesh_prepare_coastline
 unified_mesh_prepare_river_network
 unified_mesh_build_sizing_field
 unified_mesh_create_base_mesh
+unified_mesh_cull_leak
 vector_reconstruction
 template
 ```

--- a/docs/design_docs/unified_mesh_cull_leak.md
+++ b/docs/design_docs/unified_mesh_cull_leak.md
@@ -1,0 +1,284 @@
+# Unified Mesh: Fixing Resolution Leakage into the Ocean/Sea-Ice Domain
+
+date: 2026/07/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+## Summary
+
+Unified meshes prescribe finer resolution for the land/river domain than for
+parts of the ocean/sea-ice domain (e.g. 10 km land vs 30 km ocean in
+`u.oi30.lr10`). The ocean and sea ice are CFL limited, so land/river
+resolution "leaking" into the culled ocean/sea-ice meshes causes forward-run
+instability: `u.oi30.lr10` was found to contain edges with `dcEdge` down to
+9.16 km against a 30 km nominal ocean background, and the MPAS-Ocean `short`
+forward run produced NaNs precisely at the finest cells.
+
+This design adds two capabilities:
+
+1. A **ratio-based `dcEdge` diagnostic** in the `e3sm/init` `topo/cull` mask
+   step that fails loudly if the culled ocean/sea-ice domain contains edges
+   whose `dcEdge` deviates too far from the local ocean background cell width,
+   before any forward run is attempted.
+2. An **effective ocean mask** for the unified sizing field that anticipates
+   what the MPAS cull will keep, by emulating the cull on the lat/lon sizing
+   grid at mesh scale, so the sizing field never prescribes land/river
+   resolution in regions that end up in the ocean/sea-ice domain.
+
+Success means (a) all four unified meshes rebuild with no ocean/sea-ice edge
+below the diagnostic threshold, and (b) any future regression of this kind is
+caught at the cull-mask step rather than by a forward-run crash.
+
+The offline analysis and validation prototype behind this design live in
+`utils/unified_mesh/cull_leak/`. This document is the canonical explanation
+of the design; user- and developer-guide pages describe only configuration and
+behavior and link here.
+
+## Diagnosis
+
+Analysis of the `test_20260721` results on Chrysalis (all four unified
+meshes: `u.oi30.lr10`, `u.oi240.lr240`, `u.oi6to18.lr6to10`,
+`u.oi.so12to30.lr10`) established two mechanisms. Defining the *ratio* of an
+edge as `dcEdge` divided by the ocean background cell width at the edge
+location, clean jigsaw noise spans about [0.76, 1.39]; every mesh except the
+uniform-resolution `u.oi240.lr240` had edges with ratios of 0.29–0.34.
+
+### Mechanism A (dominant): flood-fill connectivity is resolution dependent
+
+Coastal lagoons and shallow banks (Banc d'Arguin, Chukotka lagoons, Exmouth
+Gulf, the Vistula/Curonian Lagoons, Gulf of Sidra, ...) are below sea level
+but sit behind thin barriers (spits, tidal flats). At the 1/32-degree
+resolution of the shared coastline products, the barrier is *resolved*: the
+coastline flood fill classifies the whole lagoon as land, so the sizing field
+places it in the land-side coastline blend (10 -> 30 km for `u.oi30.lr10`).
+On the MPAS mesh, however, the same cells have `ocean_frac` of 0.5–1.0 (the
+conservative remap of the same source ocean mask is correct — most of their
+*area* is below sea level), the barrier occupies too little area of any
+mesh-scale cell to pull `ocean_frac` below 0.5, and a connected path of
+candidate-ocean cells reaches the lagoon, so the MPAS flood fill keeps it.
+
+No land cell is promoted to ocean anywhere in this mechanism: the two grids
+simply see different topology at different resolutions. The lagoon is culled
+on the fine lat/lon grid but retained on the coarse MPAS mesh because
+averaging erases the narrow land barrier.
+
+### Mechanism B (secondary): critical passages preserved wider on MPAS
+
+Critical ocean passages (Fury & Hecla Strait, the Northwest Passage, Nares
+Strait, Akimiski Strait, Ilulissat, Carroll Inlet) are preserved on the MPAS
+mesh via transect cell masks plus `widen_transect_edge_masks` — a swath 1–3
+cells wide — while the lat/lon rasterization of the same transects is a
+single grid cell (~0.125 degree) wide. Cells with `ocean_frac` as low as
+0.10 are kept inside a region the sizing field classifies as land-side blend.
+
+## Requirements
+
+### Requirement: dcEdge ratio diagnostic in the cull-mask step
+
+Date last modified: 2026/07/23
+
+Contributors: Xylar Asay-Davis, Claude
+
+For unified meshes, the `topo/cull` mask step of the `e3sm/init` component
+must fail with an informative error if the ocean/sea-ice domain implied by
+the ocean cull mask contains base-mesh edges whose `dcEdge` is below
+`min_dc_edge_ratio` times, or above `max_dc_edge_ratio` times, the local
+ocean background cell width. The thresholds must be config options so each
+unified mesh can override them. The check must be ratio based (not absolute)
+so it applies to variable-resolution meshes. The error must localize the
+violations (worst clusters in lat/lon) and a diagnostics file must be
+written to aid debugging.
+
+### Requirement: sizing field consistent with the MPAS-mesh view of topography
+
+Date last modified: 2026/07/23
+
+Contributors: Xylar Asay-Davis, Claude
+
+The unified sizing field must prescribe (approximately) the full ocean
+background cell width everywhere the MPAS cull will keep as ocean/sea-ice,
+while preserving land/river refinement elsewhere. Constraints agreed during
+design:
+
+- The cull masks themselves stay on the MPAS mesh; culling from a remapped
+  lat/lon coastline is not an option because much of the cull logic is mesh
+  dependent.
+- The shared coastline products (`prepare_coastline`) stay mesh independent
+  and unchanged; all mesh-dependent adjustments happen per mesh in the
+  sizing-field step.
+- Widening of critical passages for sizing must be proportional to the local
+  ocean background resolution.
+- Exact prediction of the cull is impossible (the outcome near the
+  `ocean_frac` = 0.5 threshold depends on the exact MPAS cell tiling), so
+  the prediction must be deliberately generous toward ocean, with the
+  diagnostic from the first requirement as the backstop.
+
+## Algorithm Design
+
+### Algorithm Design: dcEdge ratio diagnostic in the cull-mask step
+
+Date last modified: 2026/07/23
+
+Contributors: Xylar Asay-Davis, Claude
+
+After the ocean cull mask is created, select base-mesh edges whose two
+adjacent cells are both kept (the interior edges of the future culled ocean
+mesh). Sample the ocean background cell width from the mesh's sizing-field
+product (nearest neighbor on the lat/lon sizing grid) at each edge location
+and form `ratio = dcEdge / background`. Fail if
+`min(ratio) < min_dc_edge_ratio` or `max(ratio) > max_dc_edge_ratio`.
+
+Threshold justification (from `test_20260721`): clean jigsaw noise spans
+[0.76, 1.39] x background; the contaminated meshes reached 0.29. Defaults
+`min_dc_edge_ratio = 0.65` and `max_dc_edge_ratio = 1.5` leave margin on
+both sides while failing the contaminated meshes decisively.
+
+### Algorithm Design: effective ocean mask via mesh-scale cull emulation
+
+Date last modified: 2026/07/23
+
+Contributors: Xylar Asay-Davis, Claude
+
+Build a per-mesh *effective ocean mask* on the lat/lon sizing grid:
+
+1. **Candidate fraction**: start from the combined-topography `ocean_mask`
+   fraction (the same source field that becomes `ocean_frac` on the MPAS
+   mesh) block-averaged from the finest (1/32-degree) grid to the mesh's
+   sizing grid.
+2. **Mesh-scale averaging**: box-average the fraction over the local ocean
+   background cell width L(x) — emulating `ocean_frac` on mesh-scale cells —
+   and threshold at 0.5. The local window is quantized into geometric bins;
+   the longitude window grows as 1/cos(latitude).
+3. **Critical transects**: remove rasterized land blockages; add ocean
+   passages dilated to a swath of `passage_widen_factor` x L (a larger
+   factor poleward of the sea-ice latitude threshold, mimicking
+   `widen_transect_edge_masks`).
+4. **Flood fill** from the standard ocean seed points (as the MPAS cull
+   does), with periodic longitude connectivity.
+5. **Hysteresis growth**: extend the flood-filled mask into connected
+   regions whose fraction is at least `grow_threshold` (< 0.5). This covers
+   cells whose fate at the strict threshold depends on the exact MPAS cell
+   tiling, without promoting isolated inland regions.
+6. **Union** with the shared flood-filled coastline `ocean_mask`. The union
+   never demotes shared-mask ocean, so true coastlines are unaffected.
+
+Recompute the signed distance from the effective coastline (reusing the
+existing KD-tree machinery) and apply the existing land-side blend to the
+effective signed distance.
+
+The trade-off is asymmetric by construction: over-prediction (effective
+ocean that the actual cull removes) only coarsens land/river sizing toward
+the ocean background — no CFL hazard — while under-prediction is caught by
+the diagnostic. Prototype validation on all four meshes (see below) showed
+over-prediction of 2.4–3.7% of the ocean cell count with essentially no
+overlap with river channels.
+
+### Prototype validation (2026/07/23)
+
+The algorithm was prototyped offline (`utils/unified_mesh/cull_leak/
+emulate_cull.py`) with `grow_threshold = 0.35` and passage widening of
+1.5x / 3.0x L equatorward/poleward of 43 degrees, and validated against the
+actual cull masks of the `test_20260721` runs:
+
+| mesh | kept cells | under-pred (base -> emul) | over-pred (on river) | current min ratio | predicted min ratio |
+| --- | --- | --- | --- | --- | --- |
+| u.oi30.lr10 | 462,924 | 1,328 -> 335 | 16,943 (0) | 0.31 | 0.76 |
+| u.oi240.lr240 | 7,313 | 125 -> 1 | 185 (0) | 0.80 (clean) | 1.00 |
+| u.oi6to18.lr6to10 | 4,015,940 | 5,930 -> 1,168 | 30,287 (19) | 0.34 | 0.86 |
+| u.oi.so12to30.lr10 | 794,665 | 1,179 -> 181 | 18,927 (0) | 0.29 | 0.82 |
+
+"Predicted min ratio" is the minimum, over the current culled-mesh edges, of
+the sizing the effective coastline would prescribe relative to the ocean
+background; it exceeds the 0.65 diagnostic threshold on every mesh (no
+edge below threshold), with residual under-predicted cells all lying close
+enough to the effective coastline that the blend keeps them near the ocean
+background.
+
+## Implementation
+
+### Implementation: dcEdge ratio diagnostic in the cull-mask step
+
+Date last modified: 2026/07/23
+
+Contributors: Xylar Asay-Davis, Claude
+
+- The ratio check is a testable public function in
+  `polaris/tasks/e3sm/init/topo/cull/dc_edge_diagnostics.py`; it writes
+  `ocean_dc_edge_diagnostics.nc` (per-edge ratio and violation masks), logs
+  a summary with the worst violation clusters, and raises `ValueError` on
+  failure.
+- `CullMaskStep` gains an optional `sizing_field_step`; when set (unified
+  meshes), `sizing_field.nc` is linked as an input and the check runs at
+  the end of `run()`, after all masks are written, using `oceanCullMask`
+  (the ocean/sea-ice domain including cavities).
+- `get_cull_topo_steps()` passes the sizing-field build step (already
+  constructed upstream for unified meshes) to `CullMaskStep`; for simple
+  meshes the diagnostic is skipped.
+- `_get_cull_topo_config()` additionally merges the unified-mesh configs
+  (`unified_mesh.cfg` and `{mesh_name}.cfg`) so per-mesh threshold
+  overrides are honored; defaults live in
+  `polaris/tasks/e3sm/init/topo/cull/cull.cfg` (`[cull_mesh]`
+  `min_dc_edge_ratio`, `max_dc_edge_ratio`).
+
+### Implementation: effective ocean mask via mesh-scale cull emulation
+
+Date last modified: 2026/07/23
+
+Contributors: Xylar Asay-Davis, Claude
+
+- Reusable helpers in a dependency-light leaf module
+  `polaris/mesh/spherical/unified/effective_ocean.py`: mesh-scale variable
+  box averaging, passage widening, seeded flood fill, hysteresis growth,
+  and effective-mask assembly.
+- `BuildSizingFieldStep` links the finest-resolution combined topography
+  (for the candidate fraction) as an additional input, builds the effective
+  ocean mask and effective signed distance, and passes them (instead of the
+  shared coastline fields) to `sizing_field_dataset()`. New diagnostic
+  variables are added to `sizing_field.nc`: the effective and emulated
+  ocean masks, the widened passages and the effective signed distance.
+- New config options in `[sizing_field]`: `enable_cull_emulation` (default
+  `true`), `cull_emulation_grow_threshold` (0.35), `passage_widen_factor`
+  (1.5), `passage_widen_factor_high_lat` (3.0) and
+  `passage_widen_latitude_threshold` (43 degrees).
+- The base meshes change as a result; downstream cached products (sizing
+  field, base mesh and `e3sm/init` topography products) are regenerated,
+  while shared coastline caches are unaffected.
+
+Development takes place on the `fix-uoi30lr10-cull` branch; see
+`PLAN_fix_unified_mesh_cull_leak.md` there for the commit series.
+
+## Testing
+
+### Testing and Validation: dcEdge ratio diagnostic in the cull-mask step
+
+Date last modified: 2026/07/23
+
+Contributors: Xylar Asay-Davis, Claude
+
+Unit tests in `tests/e3sm/init/topo/test_cull_mask.py` exercise the pure
+ratio-check function with small synthetic meshes and sizing fields: a
+passing case, a min-ratio failure, a max-ratio failure, correct edge
+selection (only edges with both cells kept), and the contents of the
+diagnostics file. Integration-wise, re-running only the mask step against
+the existing `test_20260721` work directories must fail on the current
+contaminated masks and pass after the meshes are regenerated with the fix.
+
+### Testing and Validation: effective ocean mask via mesh-scale cull emulation
+
+Date last modified: 2026/07/23
+
+Contributors: Xylar Asay-Davis, Claude
+
+Unit tests for `effective_ocean.py` construct synthetic topographies where
+the expected behavior is known: a thin-barrier lagoon that must be included
+at a coarse mesh scale and excluded at a fine one; hysteresis growth that
+adds threshold-ambiguous fringes connected to the ocean but not isolated
+inland depressions; passage widening whose swath width scales with the
+local background. `test_sizing_field.py` is extended to verify the
+integration (effective fields present in the output, ocean-background
+sizing on emulated-ocean cells). Final validation is the regeneration of
+all four unified meshes with the Part 1 diagnostic active, which must pass,
+plus spot checks of the former hotspots.

--- a/docs/design_docs/unified_mesh_cull_leak.md
+++ b/docs/design_docs/unified_mesh_cull_leak.md
@@ -32,11 +32,6 @@ Success means (a) all four unified meshes rebuild with no ocean/sea-ice edge
 below the diagnostic threshold, and (b) any future regression of this kind is
 caught at the cull-mask step rather than by a forward-run crash.
 
-The offline analysis and validation prototype behind this design live in
-`utils/unified_mesh/cull_leak/`. This document is the canonical explanation
-of the design; user- and developer-guide pages describe only configuration and
-behavior and link here.
-
 ## Diagnosis
 
 Analysis of the `test_20260721` results on Chrysalis (all four unified
@@ -132,9 +127,19 @@ and form `ratio = dcEdge / background`. Fail if
 `min(ratio) < min_dc_edge_ratio` or `max(ratio) > max_dc_edge_ratio`.
 
 Threshold justification (from `test_20260721`): clean jigsaw noise spans
-[0.76, 1.39] x background; the contaminated meshes reached 0.29. Defaults
-`min_dc_edge_ratio = 0.65` and `max_dc_edge_ratio = 1.5` leave margin on
-both sides while failing the contaminated meshes decisively.
+[0.76, 1.39] x background; the contaminated meshes reached 0.29. The
+lower bound is the meaningful guard, since fine cells leaking into the
+ocean are a CFL hazard; `min_dc_edge_ratio = 0.65` leaves margin above the
+clean noise floor while failing the contaminated meshes decisively.
+
+The upper bound only flags anomalously coarse edges, which are a mild
+mesh-quality issue rather than a stability hazard. It must tolerate
+isolated jigsaw outliers whose magnitude grows with the number of edges:
+across the four regenerated meshes the maximum ratio rose monotonically
+with edge count (1.32 at 21k edges, 1.42 at 1.4M, 1.50 at 2.4M, 1.51 at
+12M), so a tight ceiling is fragile. `max_dc_edge_ratio = 2.0` still
+catches an edge that is genuinely double the intended resolution while
+tolerating lone coarse jigsaw blips on large meshes.
 
 ### Algorithm Design: effective ocean mask via mesh-scale cull emulation
 
@@ -178,10 +183,9 @@ overlap with river channels.
 
 ### Prototype validation (2026/07/23)
 
-The algorithm was prototyped offline (`utils/unified_mesh/cull_leak/
-emulate_cull.py`) with `grow_threshold = 0.35` and passage widening of
-1.5x / 3.0x L equatorward/poleward of 43 degrees, and validated against the
-actual cull masks of the `test_20260721` runs:
+The algorithm was prototyped offline with `grow_threshold = 0.35`
+and passage widening of 1.5x / 3.0x L equatorward/poleward of 43 degrees, and
+validated against the actual cull masks of the `test_20260721` runs:
 
 | mesh | kept cells | under-pred (base -> emul) | over-pred (on river) | current min ratio | predicted min ratio |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/developers_guide/e3sm/init/api.md
+++ b/docs/developers_guide/e3sm/init/api.md
@@ -121,5 +121,7 @@
 
    get_cull_topo_steps
    add_cull_topo_tasks
+
+   dc_edge_diagnostics.check_ocean_dc_edge
 ```
 

--- a/docs/developers_guide/e3sm/init/tasks/topo/cull.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/cull.md
@@ -48,8 +48,27 @@ The culling steps are configured through the `[cull_mesh]` section in the config
   considered to belong to land ice.
 - `land_ice_min_fraction`: Minimum land-ice fraction for flood-filling the
   land-ice mask.
+- `min_dc_edge_ratio` and `max_dc_edge_ratio`: The allowed range of `dcEdge`
+  relative to the local ocean background cell width in the culled
+  ocean/sea-ice domain (unified meshes only).
 
 See `cull.cfg` for the full set of options.
+
+## dcEdge Diagnostic for Unified Meshes
+
+For unified meshes, land/river regions are typically meshed at finer
+resolution than the CFL-limited ocean/sea-ice regions, so resolution
+"leaking" across the coastline into the culled ocean mesh can destabilize
+forward runs. After all masks are written, `CullMaskStep` calls
+{py:func}`polaris.tasks.e3sm.init.topo.cull.dc_edge_diagnostics.check_ocean_dc_edge`,
+which compares `dcEdge` on base-mesh edges interior to the ocean cull mask
+against the ocean background cell width sampled from the mesh's sizing
+field, writes `ocean_dc_edge_diagnostics.nc`, and raises an error listing
+the worst violation clusters if any ratio falls outside
+`[min_dc_edge_ratio, max_dc_edge_ratio]`. For simple base meshes there is
+no sizing field and the check is skipped. The motivation, mechanisms and
+threshold justification are documented in the `unified_mesh_cull_leak`
+design doc (see {ref}`design-docs`).
 
 The Antarctic land-ice ownership mask also includes southern cells that have
 already been removed from the open-ocean cull mask, so the cull workflow

--- a/docs/developers_guide/mesh/tasks/unified/sizing_field.md
+++ b/docs/developers_guide/mesh/tasks/unified/sizing_field.md
@@ -41,8 +41,10 @@ plus:
 ### `build.py`
 
 `BuildSizingFieldStep.setup()` links the coastline convention file from
-the upstream coastline step and `river_network.nc` from the upstream
-lat-lon rasterize step.  It also calls the mesh-family hook
+the upstream coastline step, `river_network.nc` from the upstream
+lat-lon rasterize step, and `topography_finest.nc` from the
+finest-resolution combined-topography step (used for cull emulation).
+It also calls the mesh-family hook
 `setup_sizing_field_step()` so family-specific inputs (e.g. the Southern
 Ocean high-resolution region GeoJSON for `so_region` meshes) can be
 registered.
@@ -53,6 +55,19 @@ delegates ocean-background construction to the mesh family via
 {py:func}`polaris.tasks.mesh.spherical.unified.sizing_field.sizing_field_dataset`
 to compose the full sizing field.  The resulting dataset is written to
 `sizing_field.nc`.
+
+When `enable_cull_emulation` is true (the default), the shared coastline
+`ocean_mask` and `signed_distance` are first replaced by *effective*
+fields built with the helpers in
+`polaris.mesh.spherical.unified.effective_ocean` (mesh-scale averaging of
+the candidate-ocean fraction, critical-transect handling with
+resolution-proportional passage widening, a seeded flood fill and
+hysteresis growth) and
+{py:func}`polaris.mesh.spherical.coastline.signed_distance_from_ocean_mask`.
+Diagnostic variables (`effective_ocean_mask`, `emulated_ocean_mask`,
+`mesh_scale_ocean_fraction`, `passages_widened`) are stored in
+`sizing_field.nc`.  The rationale and validation are in the
+`unified_mesh_cull_leak` design doc.
 
 The public helper `sizing_field_dataset()` combines:
 
@@ -95,6 +110,13 @@ All sizing-field steps use mesh-specific configs built through
 - `coastline_transition_land_km` — width of the land-side transition zone
 - `enable_river_channel_refinement` — toggle river-channel refinement
 - `river_channel_km` — target cell width along river channels
+- `enable_cull_emulation` — toggle the effective ocean mask built by
+  emulating the MPAS cull at mesh scale
+- `cull_emulation_grow_threshold` — hysteresis lower bound on the
+  mesh-scale candidate fraction
+- `passage_widen_factor`, `passage_widen_factor_high_lat` and
+  `passage_widen_latitude_threshold` — width of the passage swath that
+  receives ocean-background sizing, relative to the local background
 
 `VizSizingFieldStep` consumes the `[sizing_field_viz]` section:
 

--- a/docs/users_guide/e3sm/init/tasks/topo.md
+++ b/docs/users_guide/e3sm/init/tasks/topo.md
@@ -125,3 +125,9 @@ Common user-tunable options are:
 	critical land transects as land ice.
 - `land_ice_min_fraction`: Minimum land-ice fraction used in south-pole flood
 	filling for the land-ice mask.
+- `min_dc_edge_ratio` and `max_dc_edge_ratio`: For unified meshes, the allowed
+	range of `dcEdge` relative to the local ocean background cell width in the
+	culled ocean/sea-ice domain.  The mask step fails if resolution intended for
+	the land/river domain has leaked into the CFL-limited ocean/sea-ice domain
+	(see the {ref}`design doc <design-docs>` `unified_mesh_cull_leak` for the
+	motivation and choice of defaults).

--- a/docs/users_guide/mesh/tasks/unified/sizing_field.md
+++ b/docs/users_guide/mesh/tasks/unified/sizing_field.md
@@ -58,6 +58,20 @@ Reduces the target cell width to `river_channel_km` on rasterized river
 channels. This aligns mesh edges with river centerlines in the final JIGSAW
 mesh.
 
+## Cull emulation
+
+By default (`enable_cull_emulation`), the coastline used for the land-side
+blend is not the shared coastline product directly but an *effective*
+coastline that anticipates which cells the MPAS cull in `e3sm/init` will
+keep as ocean/sea-ice: the below-sea-level fraction is averaged at the local
+ocean-background scale, critical ocean passages are widened in proportion to
+the local resolution, and the result is flood filled and unioned with the
+shared coastline mask. This prevents land/river refinement from leaking
+into the CFL-limited ocean/sea-ice domain (e.g. in coastal lagoons whose
+thin barriers are not resolved at mesh scale). The design and validation
+are documented in the `unified_mesh_cull_leak` design doc (see
+{ref}`design-docs`).
+
 ## Configuration
 
 The sizing-field task shares the mesh's `sizing_field.cfg` file. The
@@ -81,6 +95,15 @@ relevant options are in the `[sizing_field]` section:
 - `enable_river_channel_refinement`: whether to refine cells on the
   river-channel mask.
 - `river_channel_km`: target cell width in km along river channels.
+- `enable_cull_emulation`: whether to build the effective ocean mask by
+  emulating the MPAS cull at mesh scale (see above).
+- `cull_emulation_grow_threshold`: hysteresis lower bound on the mesh-scale
+  candidate-ocean fraction for growing the emulated ocean into
+  threshold-ambiguous fringes.
+- `passage_widen_factor` and `passage_widen_factor_high_lat`: width of the
+  swath around critical ocean passages that receives ocean-background
+  sizing, in units of the local ocean background cell width, equatorward
+  and poleward of `passage_widen_latitude_threshold` respectively.
 
 Visualization options are in `[sizing_field_viz]`:
 

--- a/polaris/mesh/spherical/coastline.py
+++ b/polaris/mesh/spherical/coastline.py
@@ -138,6 +138,81 @@ def build_coastline_dataset(
     return ds_coastlines[convention]
 
 
+def signed_distance_from_ocean_mask(
+    ocean_mask,
+    lon,
+    lat,
+    distance_chunk_size=64,
+    workers=1,
+):
+    """
+    Compute the signed distance to the coastline of an ocean mask.
+
+    Parameters
+    ----------
+    ocean_mask : numpy.ndarray
+        A boolean ocean mask with dimensions ``(lat, lon)``
+
+    lon : numpy.ndarray
+        The longitude coordinate in degrees
+
+    lat : numpy.ndarray
+        The latitude coordinate in degrees
+
+    distance_chunk_size : int, optional
+        Number of latitude rows per signed-distance query chunk
+
+    workers : int, optional
+        Number of workers to use in KD-tree queries
+
+    Returns
+    -------
+    signed_distance : numpy.ndarray
+        The signed distance in meters to the nearest coastline sample
+        (positive over ocean, negative over land)
+    """
+    edge_east, edge_north = _coastline_edges(ocean_mask)
+    return _signed_distance_from_mask(
+        ocean_mask=ocean_mask,
+        edge_east=edge_east,
+        edge_north=edge_north,
+        lon=lon,
+        lat=lat,
+        chunk_size=distance_chunk_size,
+        workers=workers,
+    )
+
+
+def rasterize_critical_transects(critical_transects, lon, lat):
+    """
+    Rasterize critical land blockages and passages onto a lat-lon grid.
+
+    Parameters
+    ----------
+    critical_transects : CriticalTransects or None
+        Critical land blockages and passages (a
+        :py:class:`polaris.mesh.spherical.critical_transects.CriticalTransects`
+        object) to rasterize
+
+    lon : numpy.ndarray
+        The longitude coordinate in degrees
+
+    lat : numpy.ndarray
+        The latitude coordinate in degrees
+
+    Returns
+    -------
+    land_blockages : numpy.ndarray
+        A boolean mask of rasterized land blockages
+
+    passages : numpy.ndarray
+        A boolean mask of rasterized ocean passages
+    """
+    return _rasterize_critical_transects(
+        critical_transects=critical_transects, lon=lon, lat=lat
+    )
+
+
 def _build_single_coastline_dataset(
     convention,
     ds_topo,

--- a/polaris/mesh/spherical/unified/effective_ocean.py
+++ b/polaris/mesh/spherical/unified/effective_ocean.py
@@ -1,0 +1,465 @@
+"""
+Build a per-mesh "effective ocean mask" on a lat/lon sizing grid that
+anticipates what the MPAS cull will keep as ocean/sea-ice.
+
+The MPAS cull decides ocean ownership from the conservative
+below-sea-level area fraction (``ocean_frac``) on mesh-scale cells plus
+a flood fill, so its coastline topology differs from the fine-scale
+lat/lon coastline products: thin land barriers that disconnect coastal
+lagoons at fine resolution are diluted away at mesh scale.  The
+functions here emulate the cull on the sizing grid — mesh-scale
+averaging of the candidate-ocean fraction, critical-transect handling
+with resolution-proportional passage widening, a seeded flood fill and
+hysteresis growth — so the sizing field can prescribe the full ocean
+background cell width everywhere the cull is likely to keep.
+
+See the ``unified_mesh_cull_leak`` design doc for the motivation,
+algorithm details and validation.
+"""
+
+import numpy as np
+from scipy import ndimage
+from scipy.spatial import cKDTree
+
+from polaris.constants import get_constant
+
+EARTH_RADIUS = get_constant('mean_radius')
+KM_PER_DEG = np.pi / 180.0 * EARTH_RADIUS / 1e3
+
+
+def build_effective_ocean_mask(
+    candidate_fraction,
+    shared_ocean_mask,
+    ocean_background,
+    lat,
+    lon,
+    resolution,
+    land_blockages=None,
+    passages=None,
+    seed_points=None,
+    grow_threshold=0.35,
+    passage_widen_factor=1.5,
+    passage_widen_factor_high_lat=3.0,
+    passage_widen_latitude_threshold=43.0,
+):
+    """
+    Build the effective ocean mask by emulating the MPAS cull.
+
+    Parameters
+    ----------
+    candidate_fraction : numpy.ndarray
+        The candidate-ocean area fraction on the sizing grid (the
+        conservative average of the source ocean mask, the same
+        quantity that becomes ``ocean_frac`` on the MPAS mesh), with
+        dimensions ``(lat, lon)``
+
+    shared_ocean_mask : numpy.ndarray
+        The flood-filled ocean mask from the shared coastline products
+        on the same grid
+
+    ocean_background : numpy.ndarray
+        The ocean background cell width in km on the same grid
+
+    lat : numpy.ndarray
+        The latitude coordinate in degrees
+
+    lon : numpy.ndarray
+        The longitude coordinate in degrees
+
+    resolution : float
+        The grid resolution in degrees
+
+    land_blockages : numpy.ndarray, optional
+        A boolean mask of rasterized critical land blockages (removed
+        from the emulated ocean)
+
+    passages : numpy.ndarray, optional
+        A boolean mask of rasterized critical ocean passages (widened
+        and added to the emulated ocean)
+
+    seed_points : list of tuple, optional
+        ``(lon, lat)`` seed points in degrees for the flood fill; if
+        ``None``, no flood fill is performed and all mesh-scale ocean
+        is retained
+
+    grow_threshold : float, optional
+        The hysteresis lower bound on the candidate fraction (< 0.5);
+        connected regions above this threshold that touch the strict
+        flood-filled ocean are added, covering cells whose fate at the
+        strict 0.5 threshold depends on the exact MPAS cell tiling
+
+    passage_widen_factor : float, optional
+        The passage swath width in units of the local ocean background
+        cell width
+
+    passage_widen_factor_high_lat : float, optional
+        The passage swath width factor poleward of
+        ``passage_widen_latitude_threshold`` (mimicking
+        ``widen_transect_edge_masks`` in the MPAS cull)
+
+    passage_widen_latitude_threshold : float, optional
+        The latitude in degrees poleward of which
+        ``passage_widen_factor_high_lat`` applies
+
+    Returns
+    -------
+    fields : dict of str to numpy.ndarray
+        ``'effective_ocean_mask'``: the union of the shared and
+        emulated ocean masks; ``'emulated_ocean_mask'``: the
+        flood-filled, hysteresis-grown mesh-scale ocean mask;
+        ``'mesh_scale_fraction'``: the mesh-scale candidate fraction;
+        ``'passages_widened'``: the widened passage mask
+    """
+    mesh_scale_fraction = variable_box_average(
+        frac=candidate_fraction,
+        lat=lat,
+        resolution=resolution,
+        width_km=ocean_background,
+    )
+    emulated = mesh_scale_fraction >= 0.5
+
+    if passages is not None:
+        passages_widened = widen_passages(
+            passages=passages,
+            lat=lat,
+            lon=lon,
+            resolution=resolution,
+            width_km=ocean_background,
+            factor=passage_widen_factor,
+            high_lat_factor=passage_widen_factor_high_lat,
+            latitude_threshold=passage_widen_latitude_threshold,
+        )
+    else:
+        passages_widened = np.zeros(emulated.shape, dtype=bool)
+
+    if land_blockages is not None:
+        emulated = np.logical_and(emulated, np.logical_not(land_blockages))
+    emulated = np.logical_or(emulated, passages_widened)
+
+    if seed_points is not None:
+        emulated = flood_fill_from_seeds(
+            mask=emulated, lat=lat, lon=lon, seed_points=seed_points
+        )
+
+    if grow_threshold is not None and grow_threshold < 0.5:
+        grow_fraction = mesh_scale_fraction
+        if land_blockages is not None:
+            grow_fraction = np.where(
+                np.logical_not(land_blockages), grow_fraction, 0.0
+            )
+        grow_fraction = np.where(passages_widened, 1.0, grow_fraction)
+        emulated = hysteresis_grow(
+            filled=emulated,
+            frac=grow_fraction,
+            grow_threshold=grow_threshold,
+        )
+
+    effective = np.logical_or(shared_ocean_mask, emulated)
+
+    return dict(
+        effective_ocean_mask=effective,
+        emulated_ocean_mask=emulated,
+        mesh_scale_fraction=mesh_scale_fraction,
+        passages_widened=passages_widened,
+    )
+
+
+def block_average(field, factor):
+    """
+    Block-average a 2D field by an integer factor in both dimensions.
+
+    Parameters
+    ----------
+    field : numpy.ndarray
+        The field to average, with dimensions ``(lat, lon)`` divisible
+        by ``factor``
+
+    factor : int
+        The block size
+
+    Returns
+    -------
+    averaged : numpy.ndarray
+        The block-averaged field
+    """
+    if factor == 1:
+        return field
+    nlat, nlon = field.shape
+    if nlat % factor != 0 or nlon % factor != 0:
+        raise ValueError(
+            f'Field shape {field.shape} is not divisible by {factor}.'
+        )
+    return field.reshape(nlat // factor, factor, nlon // factor, factor).mean(
+        axis=(1, 3)
+    )
+
+
+def variable_box_average(frac, lat, resolution, width_km, max_window=720):
+    """
+    Box-average a fraction over a local window of ``width_km``,
+    emulating the conservative area fraction on mesh-scale cells.
+
+    The width field is quantized into geometric bins; each bin gets a
+    separable box filter (nearest at the latitude boundaries, periodic
+    in longitude) whose longitude window grows as 1/cos(latitude).
+
+    Parameters
+    ----------
+    frac : numpy.ndarray
+        The fraction to average, with dimensions ``(lat, lon)``
+
+    lat : numpy.ndarray
+        The latitude coordinate in degrees
+
+    resolution : float
+        The grid resolution in degrees
+
+    width_km : numpy.ndarray
+        The local averaging width in km on the same grid
+
+    max_window : int, optional
+        The maximum longitude window in grid cells (limits cost near
+        the poles)
+
+    Returns
+    -------
+    averaged : numpy.ndarray
+        The locally averaged fraction
+    """
+    dlat_km = resolution * KM_PER_DEG
+    width_km = np.maximum(width_km, dlat_km)
+    log_width = np.log(width_km)
+    log_range = log_width.max() - log_width.min()
+    nbins = max(1, int(np.ceil(log_range / np.log(1.3))))
+    edges = np.linspace(log_width.min(), log_width.max(), nbins + 1)
+    centers = np.exp(0.5 * (edges[:-1] + edges[1:]))
+    bin_index = np.clip(np.digitize(log_width, edges) - 1, 0, nbins - 1)
+
+    cos_lat = np.maximum(np.cos(np.radians(lat)), 1e-3)
+    out = np.empty_like(frac)
+    for bin, width in enumerate(centers):
+        rows = np.nonzero(np.any(bin_index == bin, axis=1))[0]
+        if rows.size == 0:
+            continue
+        lat_window = max(1, int(round(width / dlat_km)))
+        filtered = ndimage.uniform_filter1d(
+            frac, size=lat_window, axis=0, mode='nearest'
+        )
+        for row in rows:
+            lon_window = max(1, int(round(width / (dlat_km * cos_lat[row]))))
+            lon_window = min(lon_window, max_window)
+            values = ndimage.uniform_filter1d(
+                filtered[row], size=lon_window, mode='wrap'
+            )
+            mask = bin_index[row] == bin
+            out[row, mask] = values[mask]
+    return out
+
+
+def widen_passages(
+    passages,
+    lat,
+    lon,
+    resolution,
+    width_km,
+    factor,
+    high_lat_factor=None,
+    latitude_threshold=43.0,
+):
+    """
+    Dilate rasterized passage lines to a swath proportional to the
+    local ocean background cell width.
+
+    Parameters
+    ----------
+    passages : numpy.ndarray
+        A boolean mask of rasterized passage lines, with dimensions
+        ``(lat, lon)``
+
+    lat : numpy.ndarray
+        The latitude coordinate in degrees
+
+    lon : numpy.ndarray
+        The longitude coordinate in degrees
+
+    resolution : float
+        The grid resolution in degrees
+
+    width_km : numpy.ndarray
+        The local ocean background cell width in km on the same grid
+
+    factor : float
+        The swath width in units of the local background cell width
+        (the dilation radius is half the swath width)
+
+    high_lat_factor : float, optional
+        The swath width factor poleward of ``latitude_threshold``
+
+    latitude_threshold : float, optional
+        The latitude in degrees poleward of which ``high_lat_factor``
+        applies
+
+    Returns
+    -------
+    widened : numpy.ndarray
+        The widened passage mask
+    """
+    if factor <= 0.0 or not passages.any():
+        return passages.copy()
+
+    rows, cols = np.nonzero(passages)
+    tree = cKDTree(_lon_lat_to_xyz(lon[cols], lat[rows]))
+
+    factor_2d = np.full((lat.size, lon.size), factor, dtype=float)
+    if high_lat_factor is not None:
+        factor_2d[np.abs(lat) > latitude_threshold, :] = high_lat_factor
+    radius_km = 0.5 * factor_2d * width_km
+    max_radius_km = float(np.max(radius_km))
+    pad = int(np.ceil(max_radius_km / (resolution * KM_PER_DEG))) + 1
+
+    # only query grid cells near the passages
+    region = ndimage.binary_dilation(
+        passages, structure=np.ones((3, 3), dtype=bool), iterations=pad
+    )
+    r_rows, r_cols = np.nonzero(region)
+    chord, _ = tree.query(_lon_lat_to_xyz(lon[r_cols], lat[r_rows]))
+    chord = np.clip(chord, 0.0, 2.0)
+    distance_km = 2.0 * np.arcsin(0.5 * chord) * EARTH_RADIUS / 1e3
+    keep = distance_km <= radius_km[r_rows, r_cols]
+    widened = passages.copy()
+    widened[r_rows[keep], r_cols[keep]] = True
+    return widened
+
+
+def flood_fill_from_seeds(mask, lat, lon, seed_points):
+    """
+    Keep the connected components of a mask that contain seed points.
+
+    Connectivity is 4-connected with periodic wrap in longitude.
+
+    Parameters
+    ----------
+    mask : numpy.ndarray
+        A boolean mask with dimensions ``(lat, lon)``
+
+    lat : numpy.ndarray
+        The latitude coordinate in degrees
+
+    lon : numpy.ndarray
+        The longitude coordinate in degrees
+
+    seed_points : list of tuple
+        ``(lon, lat)`` seed points in degrees
+
+    Returns
+    -------
+    filled : numpy.ndarray
+        The mask restricted to components containing seed points
+    """
+    labels, count, find = _label_with_wrap(mask)
+    if count == 0:
+        return np.zeros_like(mask)
+
+    seed_roots = set()
+    for point_lon, point_lat in seed_points:
+        row = int(np.argmin(np.abs(lat - point_lat)))
+        delta = np.mod(lon - point_lon + 180.0, 360.0) - 180.0
+        col = int(np.argmin(np.abs(delta)))
+        if mask[row, col]:
+            seed_roots.add(find(labels[row, col]))
+
+    return _keep_components(labels, count, find, seed_roots, mask)
+
+
+def hysteresis_grow(filled, frac, grow_threshold):
+    """
+    Grow a flood-filled ocean mask into connected regions whose
+    fraction is at least ``grow_threshold``.
+
+    Only components of the lower-threshold mask that touch the strict
+    flood-filled ocean are added, so isolated inland regions are not
+    promoted.
+
+    Parameters
+    ----------
+    filled : numpy.ndarray
+        The strict flood-filled ocean mask, with dimensions
+        ``(lat, lon)``
+
+    frac : numpy.ndarray
+        The mesh-scale candidate fraction on the same grid
+
+    grow_threshold : float
+        The lower bound on the fraction for growth
+
+    Returns
+    -------
+    grown : numpy.ndarray
+        The grown mask
+    """
+    grow_mask = np.logical_or(filled, frac >= grow_threshold)
+    labels, count, find = _label_with_wrap(grow_mask)
+    if count == 0:
+        return filled
+
+    seed_labels = np.unique(labels[filled])
+    seed_roots = {find(label) for label in seed_labels if label != 0}
+    if not seed_roots:
+        return filled
+
+    return _keep_components(labels, count, find, seed_roots, grow_mask)
+
+
+def _label_with_wrap(mask):
+    """
+    Label 4-connected components with longitude wrap via union-find.
+
+    Returns the label array, the label count and a ``find`` function
+    that resolves a label to its wrap-merged root.
+    """
+    structure = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=np.int8)
+    labels, count = ndimage.label(mask, structure=structure)
+    parent = np.arange(count + 1, dtype=np.int64)
+
+    def find(label):
+        while parent[label] != label:
+            parent[label] = parent[parent[label]]
+            label = parent[label]
+        return label
+
+    wrap_rows = np.nonzero(mask[:, 0] & mask[:, -1])[0]
+    for row in wrap_rows:
+        left = find(labels[row, 0])
+        right = find(labels[row, -1])
+        if left != right:
+            parent[right] = left
+
+    return labels, count, find
+
+
+def _keep_components(labels, count, find, seed_roots, mask):
+    """
+    Build a mask of the components whose roots are in ``seed_roots``.
+    """
+    if not seed_roots:
+        return np.zeros_like(mask)
+    keep = np.zeros(count + 1, dtype=bool)
+    for label in range(1, count + 1):
+        keep[label] = find(label) in seed_roots
+    return keep[labels]
+
+
+def _lon_lat_to_xyz(lon, lat):
+    """
+    Convert lon/lat in degrees to Cartesian points on the unit sphere.
+    """
+    lon_rad = np.radians(lon)
+    lat_rad = np.radians(lat)
+    cos_lat = np.cos(lat_rad)
+    return np.column_stack(
+        [
+            cos_lat * np.cos(lon_rad),
+            cos_lat * np.sin(lon_rad),
+            np.sin(lat_rad),
+        ]
+    )

--- a/polaris/mesh/spherical/unified/sizing_field/sizing_field.cfg
+++ b/polaris/mesh/spherical/unified/sizing_field/sizing_field.cfg
@@ -29,6 +29,32 @@ coastline_transition_land_km = 0.0
 # Target cell width (km) along rasterized river channels
 river_channel_km = 240.0
 
+# Whether to emulate the MPAS cull at mesh scale when building the
+# effective ocean mask used for coastline blending, so the sizing field
+# prescribes the ocean background everywhere the cull is likely to keep
+# (see the unified_mesh_cull_leak design doc)
+enable_cull_emulation = true
+
+# Hysteresis lower bound on the mesh-scale candidate-ocean fraction:
+# connected regions above this threshold that touch the flood-filled
+# emulated ocean are included, covering cells whose fate at the strict
+# 0.5 threshold depends on the exact MPAS cell tiling
+cull_emulation_grow_threshold = 0.35
+
+# Width of the swath around critical ocean passages that receives ocean
+# background sizing, in units of the local ocean background cell width
+passage_widen_factor = 1.5
+
+# The passage swath width factor poleward of the latitude threshold,
+# mimicking the extra widening of transects in the MPAS cull that
+# prevents land-locked sea-ice cells
+passage_widen_factor_high_lat = 3.0
+
+# The latitude (degrees) poleward of which the high-latitude passage
+# widening factor applies (matching sea_ice_latitude_threshold in the
+# cull_mesh section)
+passage_widen_latitude_threshold = 43.0
+
 
 [sizing_field_viz]
 # output resolution for diagnostic plots

--- a/polaris/tasks/e3sm/init/topo/cull/cull.cfg
+++ b/polaris/tasks/e3sm/init/topo/cull/cull.cfg
@@ -28,3 +28,11 @@ land_ice_max_latitude = -60.0
 #       and also regions of non-zero land-ice fraction that are not within
 #       the land-ice mask
 land_ice_min_fraction = 0.01
+
+# the allowed range of dcEdge relative to the local ocean background cell
+# width for edges in the culled ocean/sea-ice domain (unified meshes only);
+# violations indicate that land/river resolution has leaked into the
+# CFL-limited ocean/sea-ice domain (see the unified_mesh_cull_leak design
+# doc).  Clean jigsaw noise spans roughly [0.76, 1.39] times the background.
+min_dc_edge_ratio = 0.65
+max_dc_edge_ratio = 1.5

--- a/polaris/tasks/e3sm/init/topo/cull/cull.cfg
+++ b/polaris/tasks/e3sm/init/topo/cull/cull.cfg
@@ -34,5 +34,10 @@ land_ice_min_fraction = 0.01
 # violations indicate that land/river resolution has leaked into the
 # CFL-limited ocean/sea-ice domain (see the unified_mesh_cull_leak design
 # doc).  Clean jigsaw noise spans roughly [0.76, 1.39] times the background.
+# The lower bound is the meaningful guard: fine cells leaking into the
+# ocean are a CFL hazard.  The upper bound only catches anomalously coarse
+# edges, which are a mild mesh-quality issue rather than a stability
+# hazard, so it is set loose enough to tolerate isolated jigsaw outliers
+# (whose magnitude grows with the number of edges) on large meshes.
 min_dc_edge_ratio = 0.65
-max_dc_edge_ratio = 1.5
+max_dc_edge_ratio = 2.0

--- a/polaris/tasks/e3sm/init/topo/cull/dc_edge_diagnostics.py
+++ b/polaris/tasks/e3sm/init/topo/cull/dc_edge_diagnostics.py
@@ -1,0 +1,207 @@
+import numpy as np
+import xarray as xr
+from mpas_tools.io import write_netcdf
+
+
+def check_ocean_dc_edge(
+    ds_base_mesh,
+    ocean_cull_mask,
+    ds_sizing,
+    min_ratio,
+    max_ratio,
+    logger,
+    out_filename='ocean_dc_edge_diagnostics.nc',
+    max_clusters=10,
+):
+    """
+    Check that ``dcEdge`` in the ocean/sea-ice domain stays within
+    bounds relative to the local ocean background cell width.
+
+    Edges whose two adjacent cells are both kept by the ocean cull mask
+    (the interior edges of the future culled ocean mesh) are compared
+    against the ocean background cell width sampled from the unified
+    sizing field at the edge location.  A diagnostics file with the
+    per-edge ratio and violation masks is written, and a ``ValueError``
+    is raised if any ratio falls below ``min_ratio`` or above
+    ``max_ratio``.
+
+    See the design document ``unified_mesh_cull_leak`` in the
+    documentation for the motivation and the choice of thresholds.
+
+    Parameters
+    ----------
+    ds_base_mesh : xarray.Dataset
+        The base MPAS mesh, with ``dcEdge``, ``latEdge``, ``lonEdge``
+        and ``cellsOnEdge``
+
+    ocean_cull_mask : xarray.DataArray or numpy.ndarray
+        The ocean cull mask on base-mesh cells (1 where cells are
+        culled, 0 where they are kept as ocean/sea-ice)
+
+    ds_sizing : xarray.Dataset
+        The unified sizing field, with ``ocean_background_cell_width``
+        (km) on ``lat``/``lon`` coordinates (degrees)
+
+    min_ratio : float
+        The minimum allowed ratio of ``dcEdge`` to the local ocean
+        background cell width
+
+    max_ratio : float
+        The maximum allowed ratio of ``dcEdge`` to the local ocean
+        background cell width
+
+    logger : logging.Logger
+        The logger for summary output
+
+    out_filename : str, optional
+        The name of the diagnostics file to write
+
+    max_clusters : int, optional
+        The maximum number of violation clusters to report
+
+    Raises
+    ------
+    ValueError
+        If any ocean-interior edge violates the ratio bounds
+    """
+    dc_edge = ds_base_mesh.dcEdge.values / 1e3
+    lat_edge = np.degrees(ds_base_mesh.latEdge.values)
+    lon_edge = np.degrees(ds_base_mesh.lonEdge.values)
+    cells_on_edge = ds_base_mesh.cellsOnEdge.values
+
+    kept = np.asarray(ocean_cull_mask) == 0
+
+    # ocean-interior edges: both adjacent cells exist and are kept
+    valid = np.all(cells_on_edge > 0, axis=1)
+    cell0 = np.maximum(cells_on_edge[:, 0] - 1, 0)
+    cell1 = np.maximum(cells_on_edge[:, 1] - 1, 0)
+    ocean_edge = valid & kept[cell0] & kept[cell1]
+
+    background = _sample_nearest(
+        ds_sizing.ocean_background_cell_width.values,
+        ds_sizing.lat.values,
+        ds_sizing.lon.values,
+        lat_edge,
+        lon_edge,
+    )
+
+    ratio = np.full(dc_edge.shape, np.nan)
+    ratio[ocean_edge] = dc_edge[ocean_edge] / background[ocean_edge]
+
+    too_small = ocean_edge & (ratio < min_ratio)
+    too_large = ocean_edge & (ratio > max_ratio)
+
+    ds_out = xr.Dataset()
+    ds_out['oceanEdgeMask'] = (
+        ('nEdges',),
+        ocean_edge.astype(np.int32),
+    )
+    ds_out['dcEdgeRatio'] = (('nEdges',), ratio)
+    ds_out['dcEdgeTooSmallMask'] = (
+        ('nEdges',),
+        too_small.astype(np.int32),
+    )
+    ds_out['dcEdgeTooLargeMask'] = (
+        ('nEdges',),
+        too_large.astype(np.int32),
+    )
+    ds_out.attrs['min_dc_edge_ratio'] = min_ratio
+    ds_out.attrs['max_dc_edge_ratio'] = max_ratio
+    write_netcdf(ds_out, out_filename)
+
+    n_ocean = int(ocean_edge.sum())
+    if n_ocean == 0:
+        logger.info('dcEdge diagnostic: no ocean-interior edges found.')
+        return
+
+    ratio_ocean = ratio[ocean_edge]
+    logger.info(
+        f'dcEdge diagnostic: {n_ocean} ocean-interior edges, '
+        f'ratio range [{ratio_ocean.min():.3f}, {ratio_ocean.max():.3f}], '
+        f'allowed [{min_ratio}, {max_ratio}].'
+    )
+
+    n_small = int(too_small.sum())
+    n_large = int(too_large.sum())
+    if n_small == 0 and n_large == 0:
+        logger.info('dcEdge diagnostic passed.')
+        return
+
+    lines = []
+    for label, mask in [
+        ('below min_dc_edge_ratio', too_small),
+        ('above max_dc_edge_ratio', too_large),
+    ]:
+        count = int(mask.sum())
+        if count == 0:
+            continue
+        lines.append(f'{count} ocean-interior edges {label}:')
+        clusters = _cluster_violations(
+            lat_edge[mask], lon_edge[mask], ratio[mask]
+        )
+        for lon, lat, n_members, worst in clusters[:max_clusters]:
+            lines.append(
+                f'  lon={lon:8.2f} lat={lat:7.2f} n={n_members:5d} '
+                f'worst ratio={worst:.3f}'
+            )
+
+    message = (
+        'The culled ocean/sea-ice domain contains edges whose dcEdge '
+        'is out of bounds relative to the local ocean background cell '
+        'width, indicating that resolution intended for the land/river '
+        f'domain has leaked into the ocean (see {out_filename} and the '
+        'unified_mesh_cull_leak design doc):\n' + '\n'.join(lines)
+    )
+    logger.error(message)
+    raise ValueError(message)
+
+
+def _sample_nearest(field, lat, lon, lat_points, lon_points):
+    """
+    Sample a lat/lon field at scattered points via nearest neighbor.
+    """
+    dlat = lat[1] - lat[0]
+    dlon = lon[1] - lon[0]
+    lon_points = np.mod(lon_points - lon[0], 360.0) + lon[0]
+    lat_index = np.clip(
+        np.round((lat_points - lat[0]) / dlat).astype(int),
+        0,
+        lat.size - 1,
+    )
+    lon_index = np.clip(
+        np.round((lon_points - lon[0]) / dlon).astype(int),
+        0,
+        lon.size - 1,
+    )
+    return field[lat_index, lon_index]
+
+
+def _cluster_violations(lat, lon, ratio, radius_deg=2.0):
+    """
+    Greedily cluster violating edges by proximity for reporting.
+
+    Returns a list of ``(lon, lat, count, worst_ratio)`` tuples sorted
+    by how far the worst member deviates from 1.
+    """
+    lon = np.mod(lon + 180.0, 360.0) - 180.0
+    deviation = np.abs(np.log(np.maximum(ratio, 1e-10)))
+    order = np.argsort(-deviation)
+    assigned = np.zeros(lat.size, dtype=bool)
+    clusters = []
+    for index in order:
+        if assigned[index]:
+            continue
+        dlon = np.abs(lon - lon[index])
+        dlon = np.minimum(dlon, 360.0 - dlon)
+        dlat = np.abs(lat - lat[index])
+        members = (dlon < radius_deg) & (dlat < radius_deg) & ~assigned
+        assigned[members] = True
+        clusters.append(
+            (
+                float(lon[index]),
+                float(lat[index]),
+                int(members.sum()),
+                float(ratio[index]),
+            )
+        )
+    return clusters

--- a/polaris/tasks/e3sm/init/topo/cull/mask.py
+++ b/polaris/tasks/e3sm/init/topo/cull/mask.py
@@ -19,6 +19,9 @@ from polaris import Step
 from polaris.mesh.spherical.critical_transects import (
     load_default_critical_transects,
 )
+from polaris.tasks.e3sm.init.topo.cull.dc_edge_diagnostics import (
+    check_ocean_dc_edge,
+)
 
 
 class CullMaskStep(Step):
@@ -36,6 +39,11 @@ class CullMaskStep(Step):
     unsmoothed_topo_step : polaris.tasks.e3sm.init.topo.RemapTopoStep
         The step for remapping the topography to the MPAS base mesh without
         smoothing
+
+    sizing_field_step : polaris.Step or None
+        For unified meshes, the sizing-field build step whose
+        ``sizing_field.nc`` provides the ocean background cell width used
+        by the ``dcEdge`` diagnostic
     """
 
     def __init__(
@@ -45,6 +53,7 @@ class CullMaskStep(Step):
         unsmoothed_topo_step,
         name,
         subdir,
+        sizing_field_step=None,
     ):
         """
         Create a new step
@@ -66,6 +75,11 @@ class CullMaskStep(Step):
 
         subdir : str
             the subdirectory for the step
+
+        sizing_field_step : polaris.Step, optional
+            For unified meshes, the sizing-field build step whose
+            ``sizing_field.nc`` provides the ocean background cell width
+            used by the ``dcEdge`` diagnostic
         """
         super().__init__(
             component,
@@ -76,6 +90,7 @@ class CullMaskStep(Step):
         )
         self.base_mesh_step = base_mesh_step
         self.unsmoothed_topo_step = unsmoothed_topo_step
+        self.sizing_field_step = sizing_field_step
 
         self.add_input_file(
             filename='south_pole.geojson',
@@ -110,6 +125,15 @@ class CullMaskStep(Step):
                 self.unsmoothed_topo_step.path, topo_filename
             ),
         )
+
+        if self.sizing_field_step is not None:
+            self.add_input_file(
+                filename='sizing_field.nc',
+                work_dir_target=os.path.join(
+                    self.sizing_field_step.path,
+                    self.sizing_field_step.sizing_field_filename,
+                ),
+            )
 
         self.cpus_per_task = section.getint('cpus_per_task')
         self.min_cpus_per_task = section.getint('min_cpus_per_task')
@@ -368,6 +392,7 @@ class CullMaskStep(Step):
         self._create_ocean_no_cavities_cull_mask()
         self._create_land_cull_mask()
         self._combine_masks()
+        self._check_ocean_dc_edge()
         logger.info('Completed CullMaskStep run sequence.')
 
     def _create_critical_transects(self):
@@ -683,6 +708,37 @@ class CullMaskStep(Step):
 
         write_netcdf(ds_masks, 'cull_masks.nc')
         logger.info('Wrote cull_masks.nc.')
+
+    def _check_ocean_dc_edge(self):
+        """
+        Check that dcEdge in the ocean/sea-ice domain stays within
+        bounds relative to the local ocean background cell width (only
+        available for unified meshes with a sizing-field step).
+        """
+        logger = self.logger
+        if self.sizing_field_step is None:
+            logger.info(
+                'No sizing-field step, skipping the dcEdge diagnostic.'
+            )
+            return
+
+        config = self.config
+        section = config['cull_mesh']
+        min_ratio = section.getfloat('min_dc_edge_ratio')
+        max_ratio = section.getfloat('max_dc_edge_ratio')
+
+        ds_base_mesh = open_dataset('base_mesh.nc')
+        ds_masks = open_dataset('cull_masks.nc')
+        ds_sizing = open_dataset('sizing_field.nc')
+
+        check_ocean_dc_edge(
+            ds_base_mesh=ds_base_mesh,
+            ocean_cull_mask=ds_masks.oceanCullMask.values,
+            ds_sizing=ds_sizing,
+            min_ratio=min_ratio,
+            max_ratio=max_ratio,
+            logger=logger,
+        )
 
     @staticmethod
     def _antarctic_land_ice_ownership(

--- a/polaris/tasks/e3sm/init/topo/cull/steps.py
+++ b/polaris/tasks/e3sm/init/topo/cull/steps.py
@@ -1,6 +1,7 @@
 import os
 
 from polaris.config import PolarisConfigParser
+from polaris.mesh.spherical.unified import UNIFIED_MESH_NAMES
 from polaris.step import Step
 from polaris.tasks.e3sm.init import e3sm_init
 from polaris.tasks.e3sm.init.topo.cull.cull import CullMeshStep
@@ -41,6 +42,9 @@ def get_cull_topo_steps(mesh_name, include_viz=False):
     )
     base_mesh_step = remap_steps['base_mesh']
     unsmoothed_topo_step = remap_steps['remap_unsmoothed_topo']
+    # only unified meshes have a sizing-field step, used by the dcEdge
+    # diagnostic in the cull-mask step
+    sizing_field_step = remap_steps.get('sizing_field', None)
 
     config_filename = 'cull_topo.cfg'
     filepath = os.path.join(
@@ -49,6 +53,7 @@ def get_cull_topo_steps(mesh_name, include_viz=False):
     config = _get_cull_topo_config(
         filepath=filepath,
         base_mesh_step=base_mesh_step,
+        mesh_name=mesh_name,
     )
 
     steps: dict[str, Step] = dict(remap_steps)
@@ -63,6 +68,7 @@ def get_cull_topo_steps(mesh_name, include_viz=False):
         base_mesh_step=base_mesh_step,
         unsmoothed_topo_step=unsmoothed_topo_step,
         name=step_name,
+        sizing_field_step=sizing_field_step,
     )
     steps['cull_mask'] = cull_mask_step
 
@@ -82,7 +88,7 @@ def get_cull_topo_steps(mesh_name, include_viz=False):
     return steps, config
 
 
-def _get_cull_topo_config(filepath, base_mesh_step):
+def _get_cull_topo_config(filepath, base_mesh_step, mesh_name):
     component = e3sm_init
     if filepath in component.configs:
         return component.configs[filepath]
@@ -90,6 +96,16 @@ def _get_cull_topo_config(filepath, base_mesh_step):
     config = PolarisConfigParser(filepath=filepath)
     config.add_from_package('polaris.tasks.e3sm.init.topo.cull', 'cull.cfg')
     config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+
+    if mesh_name in UNIFIED_MESH_NAMES:
+        # unified-mesh config options (e.g. per-mesh overrides of the
+        # dcEdge diagnostic thresholds)
+        config.add_from_package(
+            'polaris.mesh.spherical.unified', 'unified_mesh.cfg'
+        )
+        config.add_from_package(
+            'polaris.mesh.spherical.unified', f'{mesh_name}.cfg'
+        )
 
     convention = base_mesh_step.config.get(
         'spherical_mesh', 'antarctic_boundary_convention'

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
@@ -2,8 +2,21 @@ import os
 
 import numpy as np
 import xarray as xr
+from geometric_features import GeometricFeatures
 
+from polaris.mesh.spherical.coastline import (
+    rasterize_critical_transects,
+    signed_distance_from_ocean_mask,
+)
+from polaris.mesh.spherical.critical_transects import (
+    load_default_critical_transects,
+)
 from polaris.mesh.spherical.unified import get_unified_mesh_family
+from polaris.mesh.spherical.unified.effective_ocean import (
+    block_average,
+    build_effective_ocean_mask,
+)
+from polaris.mesh.spherical.unified.resolutions import FINEST_RESOLUTION
 from polaris.step import Step
 
 
@@ -15,6 +28,12 @@ class BuildSizingFieldStep(Step):
     mesh, delegates ocean-background construction to the mesh family, and
     writes a multi-variable sizing-field dataset to ``sizing_field.nc``.
 
+    When cull emulation is enabled (the default), the shared coastline
+    ocean mask and signed distance are replaced by *effective* fields
+    that anticipate what the MPAS cull will keep as ocean/sea-ice (see
+    the ``unified_mesh_cull_leak`` design doc), so that land/river
+    refinement never leaks into the CFL-limited ocean/sea-ice domain.
+
     Attributes
     ----------
     coastline_step : polaris.Step
@@ -23,11 +42,17 @@ class BuildSizingFieldStep(Step):
     river_step : polaris.Step
         The shared lat-lon river-network step whose masks are consumed
 
+    fine_topo_step : polaris.tasks.e3sm.init.topo.combine.CombineStep
+        The step with combined topography at the finest lat-lon
+        resolution, used for the cull-emulation candidate fraction
+
     sizing_field_filename : str
         Name of the output sizing-field NetCDF file
     """
 
-    def __init__(self, component, coastline_step, river_step, subdir):
+    def __init__(
+        self, component, coastline_step, river_step, fine_topo_step, subdir
+    ):
         """
         Create a new step.
 
@@ -42,6 +67,10 @@ class BuildSizingFieldStep(Step):
         river_step : polaris.Step
             The shared lat-lon river-network step
 
+        fine_topo_step : polaris.tasks.e3sm.init.topo.combine.CombineStep
+            The step with combined topography at the finest lat-lon
+            resolution, used for the cull-emulation candidate fraction
+
         subdir : str
             The subdirectory within the component work directory where the
             step runs
@@ -55,6 +84,7 @@ class BuildSizingFieldStep(Step):
         )
         self.coastline_step = coastline_step
         self.river_step = river_step
+        self.fine_topo_step = fine_topo_step
         self.sizing_field_filename = 'sizing_field.nc'
 
     def setup(self):
@@ -83,6 +113,13 @@ class BuildSizingFieldStep(Step):
                 self.river_step.path, self.river_step.masks_filename
             ),
         )
+        self.add_input_file(
+            filename='topography_finest.nc',
+            work_dir_target=os.path.join(
+                self.fine_topo_step.path,
+                self.fine_topo_step.combined_filename,
+            ),
+        )
         self._get_mesh_family().setup_sizing_field_step(self)
         self.add_output_file(filename=self.sizing_field_filename)
 
@@ -98,11 +135,23 @@ class BuildSizingFieldStep(Step):
         section = self.config['sizing_field']
         unified_section = self.config['unified_mesh']
 
+        enable_cull_emulation = section.getboolean('enable_cull_emulation')
+
         with xr.open_dataset('coastline.nc') as ds_coastline:
             with xr.open_dataset('river_network.nc') as ds_river:
                 ocean_background = self._get_ocean_background(
                     ds_coastline=ds_coastline, section=section
                 )
+                emulation_fields = None
+                if enable_cull_emulation:
+                    ds_coastline, emulation_fields = (
+                        self._apply_cull_emulation(
+                            ds_coastline=ds_coastline,
+                            ocean_background=ocean_background,
+                            section=section,
+                            unified_section=unified_section,
+                        )
+                    )
                 ds_sizing = sizing_field_dataset(
                     ds_coastline=ds_coastline,
                     ds_river=ds_river,
@@ -122,9 +171,105 @@ class BuildSizingFieldStep(Step):
                     river_channel_km=section.getfloat('river_channel_km'),
                 )
 
+        if emulation_fields is not None:
+            dims = ('lat', 'lon')
+            for var_name, values in emulation_fields.items():
+                ds_sizing[var_name] = xr.DataArray(values, dims=dims)
+            ds_sizing.emulated_ocean_mask.attrs['long_name'] = (
+                'Mesh-scale emulation of the MPAS ocean cull'
+            )
+            ds_sizing.effective_ocean_mask.attrs['long_name'] = (
+                'Union of the shared coastline and emulated ocean masks'
+            )
+        ds_sizing.attrs['cull_emulation'] = str(enable_cull_emulation)
+
         ds_sizing.attrs['source_coastline_step'] = self.coastline_step.subdir
         ds_sizing.attrs['source_river_step'] = self.river_step.subdir
         ds_sizing.to_netcdf(self.sizing_field_filename)
+
+    def _apply_cull_emulation(
+        self, ds_coastline, ocean_background, section, unified_section
+    ):
+        """
+        Replace the shared coastline ocean mask and signed distance
+        with effective fields that anticipate the MPAS cull.
+        """
+        logger = self.logger
+        lat = ds_coastline.lat.values
+        lon = ds_coastline.lon.values
+        resolution = unified_section.getfloat('resolution_latlon')
+
+        logger.info('Cull emulation: computing candidate fraction.')
+        factor = int(round(resolution / FINEST_RESOLUTION))
+        with xr.open_dataset('topography_finest.nc') as ds_topo:
+            fraction = ds_topo.ocean_mask.transpose(
+                'lat', 'lon'
+            ).values.astype(np.float64)
+        fraction = np.where(np.isfinite(fraction), fraction, 0.0)
+        candidate_fraction = block_average(fraction, factor)
+
+        logger.info('Cull emulation: rasterizing critical transects.')
+        critical_transects = load_default_critical_transects()
+        land_blockages, passages = rasterize_critical_transects(
+            critical_transects=critical_transects, lon=lon, lat=lat
+        )
+
+        gf = GeometricFeatures()
+        fc_seed = gf.read(
+            componentName='ocean', objectType='point', tags=['seed_point']
+        )
+        seed_points = [
+            feature['geometry']['coordinates'][:2]
+            for feature in fc_seed.features
+        ]
+
+        logger.info('Cull emulation: building effective ocean mask.')
+        fields = build_effective_ocean_mask(
+            candidate_fraction=candidate_fraction,
+            shared_ocean_mask=ds_coastline.ocean_mask.values > 0,
+            ocean_background=np.asarray(ocean_background, dtype=float),
+            lat=lat,
+            lon=lon,
+            resolution=resolution,
+            land_blockages=land_blockages,
+            passages=passages,
+            seed_points=seed_points,
+            grow_threshold=section.getfloat('cull_emulation_grow_threshold'),
+            passage_widen_factor=section.getfloat('passage_widen_factor'),
+            passage_widen_factor_high_lat=section.getfloat(
+                'passage_widen_factor_high_lat'
+            ),
+            passage_widen_latitude_threshold=section.getfloat(
+                'passage_widen_latitude_threshold'
+            ),
+        )
+
+        logger.info('Cull emulation: computing effective signed distance.')
+        effective = fields['effective_ocean_mask']
+        signed_distance = signed_distance_from_ocean_mask(
+            ocean_mask=effective,
+            lon=lon,
+            lat=lat,
+            workers=self.cpus_per_task,
+        )
+
+        ds_effective = ds_coastline.copy()
+        ds_effective['ocean_mask'] = xr.DataArray(
+            effective.astype(np.int8), dims=('lat', 'lon')
+        )
+        ds_effective['signed_distance'] = xr.DataArray(
+            signed_distance.astype(np.float32), dims=('lat', 'lon')
+        )
+
+        emulation_fields = dict(
+            effective_ocean_mask=effective.astype(np.int8),
+            emulated_ocean_mask=fields['emulated_ocean_mask'].astype(np.int8),
+            mesh_scale_ocean_fraction=fields['mesh_scale_fraction'].astype(
+                np.float32
+            ),
+            passages_widened=fields['passages_widened'].astype(np.int8),
+        )
+        return ds_effective, emulation_fields
 
     def _get_ocean_background(self, ds_coastline, section):
         """

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/steps.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/steps.py
@@ -1,5 +1,7 @@
 import os
 
+from polaris.e3sm.init.topo import format_lat_lon_resolution_name
+from polaris.mesh.spherical.unified.resolutions import FINEST_RESOLUTION
 from polaris.step import Step
 from polaris.tasks.mesh.spherical.unified.river.steps import (
     get_unified_mesh_river_steps,
@@ -64,6 +66,12 @@ def get_unified_mesh_sizing_field_steps(
 
     coastline_step = river_steps['coastline_final']
     river_step = river_steps['river_rasterize']
+    # the finest-resolution combined-topography step (an ancestor of the
+    # coastline steps) provides the candidate fraction for cull emulation
+    fine_resolution_name = format_lat_lon_resolution_name(FINEST_RESOLUTION)
+    fine_topo_step = river_steps[
+        f'combine_topo_lat_lon_{fine_resolution_name}'
+    ]
 
     subdir = os.path.join(
         'spherical',
@@ -80,6 +88,7 @@ def get_unified_mesh_sizing_field_steps(
         config_filename=config_filename,
         coastline_step=coastline_step,
         river_step=river_step,
+        fine_topo_step=fine_topo_step,
     )
 
     steps: dict[str, Step] = dict(river_steps)

--- a/tests/e3sm/init/topo/test_antarctic_boundary.py
+++ b/tests/e3sm/init/topo/test_antarctic_boundary.py
@@ -60,6 +60,7 @@ def test_topo_configs_inherit_base_mesh_convention():
     cull_config = _get_cull_topo_config(
         filepath='test/QU240/topo/cull/cull_topo.cfg',
         base_mesh_step=base_mesh_step,
+        mesh_name='QU240',
     )
 
     for config in [remap_config, cull_config]:

--- a/tests/e3sm/init/topo/test_dc_edge_diagnostics.py
+++ b/tests/e3sm/init/topo/test_dc_edge_diagnostics.py
@@ -1,0 +1,159 @@
+import logging
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.tasks.e3sm.init.topo.cull.dc_edge_diagnostics import (
+    check_ocean_dc_edge,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_check_ocean_dc_edge_passes(tmp_path):
+    ds_base_mesh = _base_mesh(dc_edge_km=[30.0, 29.0, 31.0, 28.0])
+    ds_sizing = _sizing(background_km=30.0)
+    # all cells kept
+    ocean_cull_mask = np.zeros(4, dtype=int)
+
+    check_ocean_dc_edge(
+        ds_base_mesh=ds_base_mesh,
+        ocean_cull_mask=ocean_cull_mask,
+        ds_sizing=ds_sizing,
+        min_ratio=0.65,
+        max_ratio=1.5,
+        logger=LOGGER,
+        out_filename=str(tmp_path / 'diags.nc'),
+    )
+
+    with xr.open_dataset(tmp_path / 'diags.nc') as ds:
+        assert int(ds.oceanEdgeMask.sum()) == 3
+        assert int(ds.dcEdgeTooSmallMask.sum()) == 0
+        assert int(ds.dcEdgeTooLargeMask.sum()) == 0
+
+
+def test_check_ocean_dc_edge_too_small(tmp_path):
+    # one edge is much finer than the 30 km background
+    ds_base_mesh = _base_mesh(dc_edge_km=[30.0, 10.0, 31.0, 28.0])
+    ds_sizing = _sizing(background_km=30.0)
+    ocean_cull_mask = np.zeros(4, dtype=int)
+
+    with pytest.raises(ValueError, match='below min_dc_edge_ratio'):
+        check_ocean_dc_edge(
+            ds_base_mesh=ds_base_mesh,
+            ocean_cull_mask=ocean_cull_mask,
+            ds_sizing=ds_sizing,
+            min_ratio=0.65,
+            max_ratio=1.5,
+            logger=LOGGER,
+            out_filename=str(tmp_path / 'diags.nc'),
+        )
+
+    with xr.open_dataset(tmp_path / 'diags.nc') as ds:
+        assert int(ds.dcEdgeTooSmallMask.sum()) == 1
+        assert int(ds.dcEdgeTooLargeMask.sum()) == 0
+
+
+def test_check_ocean_dc_edge_too_large(tmp_path):
+    ds_base_mesh = _base_mesh(dc_edge_km=[30.0, 50.0, 31.0, 28.0])
+    ds_sizing = _sizing(background_km=30.0)
+    ocean_cull_mask = np.zeros(4, dtype=int)
+
+    with pytest.raises(ValueError, match='above max_dc_edge_ratio'):
+        check_ocean_dc_edge(
+            ds_base_mesh=ds_base_mesh,
+            ocean_cull_mask=ocean_cull_mask,
+            ds_sizing=ds_sizing,
+            min_ratio=0.65,
+            max_ratio=1.5,
+            logger=LOGGER,
+            out_filename=str(tmp_path / 'diags.nc'),
+        )
+
+
+def test_check_ocean_dc_edge_ignores_culled_and_boundary(tmp_path):
+    # the fine edge is adjacent to a culled cell, so it is not an
+    # ocean-interior edge and must not trigger a failure; the edge with
+    # a missing neighbor (cellsOnEdge == 0) must also be skipped
+    ds_base_mesh = _base_mesh(dc_edge_km=[30.0, 10.0, 31.0, 9.0])
+    ds_sizing = _sizing(background_km=30.0)
+    # cull the cell adjacent to the 10 km edge
+    ocean_cull_mask = np.array([0, 0, 1, 0])
+
+    check_ocean_dc_edge(
+        ds_base_mesh=ds_base_mesh,
+        ocean_cull_mask=ocean_cull_mask,
+        ds_sizing=ds_sizing,
+        min_ratio=0.65,
+        max_ratio=1.5,
+        logger=LOGGER,
+        out_filename=str(tmp_path / 'diags.nc'),
+    )
+
+    with xr.open_dataset(tmp_path / 'diags.nc') as ds:
+        # only the first edge is ocean-interior
+        np.testing.assert_array_equal(ds.oceanEdgeMask.values, [1, 0, 0, 0])
+
+
+def test_check_ocean_dc_edge_local_background(tmp_path):
+    # a 10 km edge is fine where the local background is 12 km but a
+    # failure where it is 30 km
+    ds_sizing = _sizing(background_km=None)
+    ds_base_mesh = _base_mesh(
+        dc_edge_km=[10.0, 10.0, 30.0, 30.0],
+        lat_edge=[-70.0, -70.0, 40.0, 40.0],
+    )
+    ocean_cull_mask = np.zeros(4, dtype=int)
+
+    check_ocean_dc_edge(
+        ds_base_mesh=ds_base_mesh,
+        ocean_cull_mask=ocean_cull_mask,
+        ds_sizing=ds_sizing,
+        min_ratio=0.65,
+        max_ratio=1.5,
+        logger=LOGGER,
+        out_filename=str(tmp_path / 'diags.nc'),
+    )
+
+
+def _base_mesh(dc_edge_km, lat_edge=None):
+    """
+    A tiny synthetic mesh: 4 cells in a ring, 4 edges.  Edge i connects
+    cells i and i+1 (1-based, periodic), except the last edge, which has
+    a missing second neighbor (0) to exercise boundary handling.
+    """
+    n_edges = len(dc_edge_km)
+    cells_on_edge = np.array([[1, 2], [2, 3], [3, 4], [4, 0]], dtype=np.int32)
+    if lat_edge is None:
+        lat_edge = np.zeros(n_edges)
+    lon_edge = np.linspace(10.0, 40.0, n_edges)
+    return xr.Dataset(
+        data_vars=dict(
+            dcEdge=('nEdges', 1e3 * np.asarray(dc_edge_km, dtype=float)),
+            latEdge=('nEdges', np.radians(lat_edge)),
+            lonEdge=('nEdges', np.radians(lon_edge)),
+            cellsOnEdge=(('nEdges', 'TWO'), cells_on_edge),
+        )
+    )
+
+
+def _sizing(background_km):
+    """
+    A coarse global lat/lon sizing dataset.  If ``background_km`` is
+    None, the background is 12 km south of 45 S and 30 km elsewhere
+    (mimicking a Southern Ocean regional refinement).
+    """
+    lat = np.linspace(-89.0, 89.0, 90)
+    lon = np.linspace(-179.0, 179.0, 180)
+    if background_km is None:
+        background = np.where(lat < -45.0, 12.0, 30.0)[:, np.newaxis]
+        background = background * np.ones((lat.size, lon.size))
+    else:
+        background = np.full((lat.size, lon.size), background_km)
+    return xr.Dataset(
+        coords=dict(lat=('lat', lat), lon=('lon', lon)),
+        data_vars=dict(
+            ocean_background_cell_width=(('lat', 'lon'), background)
+        ),
+    )

--- a/tests/mesh/spherical/unified/test_effective_ocean.py
+++ b/tests/mesh/spherical/unified/test_effective_ocean.py
@@ -1,0 +1,223 @@
+import numpy as np
+import pytest
+
+from polaris.mesh.spherical.unified.effective_ocean import (
+    block_average,
+    build_effective_ocean_mask,
+    flood_fill_from_seeds,
+    hysteresis_grow,
+    variable_box_average,
+    widen_passages,
+)
+
+# a coarse global grid (4-degree resolution) for fast tests
+RESOLUTION = 4.0
+LAT = np.arange(-88.0, 89.0, RESOLUTION)
+LON = np.arange(-180.0, 180.0, RESOLUTION)
+
+
+def _grid_indices(lon0, lat0):
+    return (
+        int(np.argmin(np.abs(LAT - lat0))),
+        int(np.argmin(np.abs(LON - lon0))),
+    )
+
+
+def _lagoon_candidate(barrier_fraction):
+    """
+    A mid-latitude ocean basin in the western half of the domain, a
+    coastal lagoon just east of the coastline separated by a one-cell
+    barrier column whose candidate fraction is ``barrier_fraction``,
+    and dry land everywhere else (including poleward of 40 degrees, so
+    nothing can connect around the poles where the longitude window
+    widens).
+    """
+    fraction = np.zeros((LAT.size, LON.size))
+    coast_col = LON.size // 2
+    mid_lat = np.abs(LAT) < 40.0
+    fraction[mid_lat, :coast_col] = 1.0
+    # barrier column
+    fraction[mid_lat, coast_col] = barrier_fraction
+    # lagoon column (below sea level)
+    fraction[mid_lat, coast_col + 1] = 1.0
+    return fraction, coast_col
+
+
+def test_block_average():
+    field = np.arange(16.0).reshape(4, 4)
+    averaged = block_average(field, 2)
+    assert averaged.shape == (2, 2)
+    np.testing.assert_allclose(averaged[0, 0], np.mean([0, 1, 4, 5]))
+
+    with pytest.raises(ValueError, match='not divisible'):
+        block_average(np.zeros((3, 4)), 2)
+
+
+def test_variable_box_average_dilutes_barrier():
+    # with a coarse (mesh-scale) averaging width, a thin barrier is
+    # diluted above 0.5; with a fine width, it is preserved
+    fraction, coast_col = _lagoon_candidate(barrier_fraction=0.0)
+
+    coarse_width = np.full(fraction.shape, 2000.0)
+    averaged = variable_box_average(
+        frac=fraction, lat=LAT, resolution=RESOLUTION, width_km=coarse_width
+    )
+    row = LAT.size // 2
+    assert averaged[row, coast_col] >= 0.5
+
+    fine_width = np.full(fraction.shape, 100.0)
+    averaged = variable_box_average(
+        frac=fraction, lat=LAT, resolution=RESOLUTION, width_km=fine_width
+    )
+    assert averaged[row, coast_col] < 0.5
+
+
+def test_flood_fill_from_seeds():
+    mask = np.zeros((LAT.size, LON.size), dtype=bool)
+    # two separate regions
+    mask[10:15, 5:10] = True
+    mask[20:25, 30:35] = True
+    seed = (float(LON[7]), float(LAT[12]))
+    filled = flood_fill_from_seeds(
+        mask=mask, lat=LAT, lon=LON, seed_points=[seed]
+    )
+    assert filled[12, 7]
+    assert not filled[22, 32]
+    assert filled.sum() == mask[10:15, 5:10].sum()
+
+
+def test_flood_fill_wraps_in_longitude():
+    mask = np.zeros((LAT.size, LON.size), dtype=bool)
+    # a band crossing the antimeridian
+    mask[10, :5] = True
+    mask[10, -5:] = True
+    seed = (float(LON[-2]), float(LAT[10]))
+    filled = flood_fill_from_seeds(
+        mask=mask, lat=LAT, lon=LON, seed_points=[seed]
+    )
+    assert filled[10, 2]
+
+
+def test_hysteresis_grow():
+    filled = np.zeros((LAT.size, LON.size), dtype=bool)
+    filled[10:15, 5:10] = True
+    fraction = np.zeros(filled.shape)
+    # a fringe connected to the filled region
+    fraction[10:15, 10:12] = 0.4
+    # an isolated inland depression with the same fraction
+    fraction[30:32, 40:42] = 0.4
+    grown = hysteresis_grow(filled=filled, frac=fraction, grow_threshold=0.35)
+    assert grown[12, 10]
+    assert not grown[30, 40]
+    # original mask preserved
+    assert grown[12, 7]
+
+
+def test_widen_passages_scales_with_background():
+    passages = np.zeros((LAT.size, LON.size), dtype=bool)
+    row, col = _grid_indices(0.0, 0.0)
+    passages[row, col] = True
+
+    narrow = widen_passages(
+        passages=passages,
+        lat=LAT,
+        lon=LON,
+        resolution=RESOLUTION,
+        width_km=np.full(passages.shape, 100.0),
+        factor=1.5,
+    )
+    wide = widen_passages(
+        passages=passages,
+        lat=LAT,
+        lon=LON,
+        resolution=RESOLUTION,
+        width_km=np.full(passages.shape, 2000.0),
+        factor=1.5,
+    )
+    assert narrow.sum() >= 1
+    assert wide.sum() > narrow.sum()
+
+
+def test_widen_passages_high_lat_factor():
+    passages = np.zeros((LAT.size, LON.size), dtype=bool)
+    row_low, col = _grid_indices(0.0, 0.0)
+    row_high, _ = _grid_indices(0.0, 60.0)
+    passages[row_low, col] = True
+    passages[row_high, col] = True
+
+    widened = widen_passages(
+        passages=passages,
+        lat=LAT,
+        lon=LON,
+        resolution=RESOLUTION,
+        width_km=np.full(passages.shape, 800.0),
+        factor=1.0,
+        high_lat_factor=3.0,
+        latitude_threshold=43.0,
+    )
+    # meridional extent of the swath around each passage cell
+    low_extent = int(np.sum(widened[:, col] & (np.abs(LAT) < 30.0)))
+    high_extent = int(np.sum(widened[:, col] & (np.abs(LAT - 60.0) < 25.0)))
+    assert high_extent > low_extent
+
+
+def test_build_effective_ocean_mask_includes_lagoon():
+    # the lagoon is separated by a dry barrier: at mesh scale the
+    # barrier is diluted, so the emulated ocean must include the lagoon
+    # even though the shared (fine-scale) coastline calls it land
+    fraction, coast_col = _lagoon_candidate(barrier_fraction=0.0)
+    shared = fraction >= 0.5
+    shared[:, coast_col:] = False  # fine-scale mask: lagoon is land
+
+    seed = (float(LON[2]), 0.0)
+    fields = build_effective_ocean_mask(
+        candidate_fraction=fraction,
+        shared_ocean_mask=shared,
+        ocean_background=np.full(fraction.shape, 2000.0),
+        lat=LAT,
+        lon=LON,
+        resolution=RESOLUTION,
+        seed_points=[seed],
+    )
+    row = LAT.size // 2
+    assert fields['effective_ocean_mask'][row, coast_col + 1]
+
+    # with a fine background, the barrier is resolved and the lagoon
+    # stays land (it is disconnected from the seed)
+    fields = build_effective_ocean_mask(
+        candidate_fraction=fraction,
+        shared_ocean_mask=shared,
+        ocean_background=np.full(fraction.shape, 100.0),
+        lat=LAT,
+        lon=LON,
+        resolution=RESOLUTION,
+        seed_points=[seed],
+        grow_threshold=None,
+    )
+    assert not fields['effective_ocean_mask'][row, coast_col + 1]
+
+
+def test_build_effective_ocean_mask_respects_blockages():
+    fraction = np.ones((LAT.size, LON.size))
+    shared = np.zeros(fraction.shape, dtype=bool)
+    blockages = np.zeros(fraction.shape, dtype=bool)
+    # a meridional blockage wall splitting the domain
+    wall_col = LON.size // 2
+    blockages[:, wall_col] = True
+
+    seed = (float(LON[2]), 0.0)
+    fields = build_effective_ocean_mask(
+        candidate_fraction=fraction,
+        shared_ocean_mask=shared,
+        ocean_background=np.full(fraction.shape, 100.0),
+        lat=LAT,
+        lon=LON,
+        resolution=RESOLUTION,
+        land_blockages=blockages,
+        seed_points=[seed],
+        grow_threshold=None,
+    )
+    emulated = fields['emulated_ocean_mask']
+    row = LAT.size // 2
+    assert not emulated[row, wall_col]
+    assert emulated[row, 2]

--- a/tests/mesh/spherical/unified/test_sizing_field.py
+++ b/tests/mesh/spherical/unified/test_sizing_field.py
@@ -416,6 +416,11 @@ def test_so_mesh_family_links_shared_region_and_builds_field(
         path='river',
         masks_filename='river_network.nc',
     )
+    fine_topo_step = SimpleNamespace(
+        subdir='topo/combine_bedmap3_gebco2023/lat_lon/0.03125_degree',
+        path='combine',
+        combined_filename='topography_finest.nc',
+    )
     config = get_sizing_field_config(
         mesh_name='u.oi.so12to30.lr10',
         filepath='mesh/spherical/unified/'
@@ -425,6 +430,7 @@ def test_so_mesh_family_links_shared_region_and_builds_field(
         component=component,
         coastline_step=coastline_step,
         river_step=river_step,
+        fine_topo_step=fine_topo_step,
         subdir='spherical/unified/u.oi.so12to30.lr10/sizing_field/build',
     )
     step.set_shared_config(config, link='sizing_field.cfg')

--- a/utils/unified_mesh/cull_leak/setup_regeneration.sh
+++ b/utils/unified_mesh/cull_leak/setup_regeneration.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Set up the regeneration runs that validate the cull-leak fix on all
+# four unified meshes (see PLAN_fix_unified_mesh_cull_leak.md and the
+# unified_mesh_cull_leak design doc).
+#
+# Prerequisites (developer actions):
+#   - ./deploy.py has been run on this branch so pixi-env/ exists
+#   - a compiled model build (Omega or MPAS-Ocean) to point -p at
+#
+# What re-runs vs what stays cached: only the shared coastline
+# compute/remap steps are cached by default, and they are unaffected by
+# the fix, so their caches remain valid.  The sizing-field, base-mesh
+# and all e3sm/init topography steps run fresh, which is exactly what
+# the fix changes.  The new dcEdge diagnostic runs in each mesh's
+# topo/cull mask step and will fail the run if resolution still leaks
+# into the ocean/sea-ice domain.
+#
+# Usage:
+#   ./setup_regeneration.sh <work_dir> <build_dir> [<model>]
+#
+# Review the generated job script in <work_dir> before submitting.
+
+set -e
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <work_dir> <build_dir> [<model>]"
+    exit 1
+fi
+
+work_dir=$1
+build_dir=$2
+model=${3:-omega}
+
+tasks=(
+    ocean/spherical/realistic_global/u.oi30.lr10/init/task
+    ocean/spherical/realistic_global/u.oi240.lr240/init/task
+    ocean/spherical/realistic_global/u.oi6to18.lr6to10/init/task
+    ocean/spherical/realistic_global/u.oi.so12to30.lr10/init/task
+    ocean/spherical/realistic_global/u.oi30.lr10/forward/task
+    ocean/spherical/realistic_global/u.oi240.lr240/forward/task
+    ocean/spherical/realistic_global/u.oi6to18.lr6to10/forward/task
+    ocean/spherical/realistic_global/u.oi.so12to30.lr10/forward/task
+)
+
+polaris setup \
+    -t "${tasks[@]}" \
+    --model "${model}" \
+    -w "${work_dir}" \
+    -p "${build_dir}"
+
+echo
+echo "Setup complete.  Review the job script in ${work_dir} before"
+echo "submitting.  After the run, check that the topo/cull mask steps"
+echo "passed the dcEdge diagnostic for all four meshes and spot-check"
+echo "the former hotspots (Banc d'Arguin, Chukotka lagoons, Foxe"
+echo "Basin) with utils/unified_mesh/cull_leak/diagnose_dc_edge.py."


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Unified meshes prescribe finer resolution for the land/river domain than for parts of the ocean/sea-ice domain (e.g. 10 km land vs 30 km ocean in `u.oi30.lr10`). The ocean and sea ice are CFL limited, so land/river resolution "leaking" into the culled ocean/sea-ice meshes causes forward-run instability: `u.oi30.lr10` was found to contain edges with `dcEdge` down to 9.16 km against a 30 km nominal ocean background (reported in #671), and the MPAS-Ocean `short` forward run produced NaNs precisely at the finest cells.

This PR adds two capabilities:

1. A **ratio-based `dcEdge` diagnostic** in the `e3sm/init` `topo/cull` mask step that fails loudly if the culled ocean/sea-ice domain contains edges whose `dcEdge` deviates too far from the local ocean background cell width, before any forward run is attempted.
2. An **effective ocean mask** for the unified sizing field that anticipates what the MPAS cull will keep, by emulating the cull on the lat/lon sizing grid at mesh scale, so the sizing field never prescribes land/river resolution in regions that end up in the ocean/sea-ice domain.

Testing mush show that all four unified meshes rebuild with no ocean/sea-ice edge below the diagnostic threshold.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

Fixes #671
