### PR TITLE
Fix spurious sea-surface height from p-star partial-cell snapping

### DIFF
--- a/docs/design_docs/pstar_init.md
+++ b/docs/design_docs/pstar_init.md
@@ -155,7 +155,9 @@ Contributors: Xylar Asay-Davis, Claude
 The core algorithm is a fixed-point iteration in pseudo-height space. Let:
 
 - $\eta_0$ = prescribed sea-surface height (m); defaults to $-P_\text{surf}/(\rho_0 g)$,
-  the resting surface-pressure depression for a reference-density fluid
+  the sea-surface depression that balances the surface pressure for a
+  reference-density fluid (being at rest does not imply $\eta_0 = 0$; surface
+  loading depresses the sea surface even at rest)
 - $H_\text{geo}^\star$ = target geometric water-column thickness $= \eta_0 - z_\text{bot}$
 - $P_\text{surf}$ = prescribed sea-surface pressure (Pa; due to atmosphere,
   sea ice, ice shelves, etc.)

--- a/polaris/ocean/vertical/pstar.py
+++ b/polaris/ocean/vertical/pstar.py
@@ -98,12 +98,12 @@ def init_pstar_vertical_coord(config, ds):
         config, pseudo_bottom_depth, ref_pseudo_depth_bot, max_level_cell
     )
 
-    # Update BottomPressure after partial-cell snap.  The resting depth
+    # Update BottomPressure after partial-cell snap.  The reference depth
     # (SurfacePressure = 0) determines the snap; SurfacePressure then scales
     # the layers uniformly, analogous to ssh in z-star.
     ds['BottomPressure'] = pseudo_bottom_depth * (RhoSw * Gravity)
 
-    # Resting pseudo-thicknesses (as if SurfacePressure = 0), then scale by
+    # Reference pseudo-thicknesses (as if SurfacePressure = 0), then scale by
     # (BottomPressure - SurfacePressure) / BottomPressure to account for the
     # surface pressure squashing the column — the p-star analogue of z-star's
     # layerThickness = restingThickness * (ssh + bottomDepth) / bottomDepth.
@@ -268,7 +268,7 @@ def _compute_ref_pseudo_thickness(
     max_level_cell,
 ):
     """
-    Compute resting p-star pseudo-thicknesses (as if SurfacePressure = 0)
+    Compute reference p-star pseudo-thicknesses (as if SurfacePressure = 0)
     by clipping reference layers at ``pseudo_bottom_depth``.
     """
     n_vert_levels = ref_pseudo_depth_bot.sizes['nVertLevels']

--- a/polaris/ocean/vertical/pstar_init.py
+++ b/polaris/ocean/vertical/pstar_init.py
@@ -124,9 +124,12 @@ class PStarInitStep(Step, ABC):
 
         At convergence the returned dataset contains all p-star coordinate
         variables, converged tracer fields, specific volume, pressure,
-        geometric height at layer midpoints and interfaces, ``bottomDepth``
-        set to the actual converged geometric water-column thickness, and
-        ``ssh`` computed as the diagnostic geometric sea-surface height.
+        geometric height at layer midpoints and interfaces, ``ssh`` set to the
+        prescribed ``sea_surface_height``, and ``bottomDepth`` diagnosed as the
+        geometric depth of the (surface-anchored) column.  The two agree with
+        the target bathymetry where the iteration converges; where partial-cell
+        snapping prevents an exact match, the residual adjusts ``bottomDepth``
+        (the representable bathymetry) rather than ``ssh``.
 
         Parameters
         ----------
@@ -336,6 +339,23 @@ class PStarInitStep(Step, ABC):
         ds.pressure.attrs['long_name'] = 'pressure at layer midpoints'
         ds.pressure.attrs['units'] = 'Pa'
 
+        # Anchor the geometric column at the prescribed free surface: ``ssh``
+        # is prescribed (``sea_surface_height``) and ``bottomDepth`` is the
+        # diagnosed geometric depth of the column.
+        # ``geom_height_from_pseudo_height`` builds the column anchored at the
+        # seafloor (its bottom interface equals the raw target ``geom_z_bot``),
+        # so we shift the whole column vertically so its top interface lands on
+        # ``sea_surface_height`` instead.  For cells the iteration can
+        # represent this shift is zero; for partial-cell-snapped cells (whose
+        # geometric column thickness cannot exactly match the target
+        # bathymetry) the snap residual then correctly adjusts ``bottomDepth``
+        # rather than ``ssh`` — the same tradeoff z-star partial cells make.
+        # ``ssh`` therefore matches its prescribed value (0 here, because
+        # ``SurfacePressure = 0``) to machine precision.
+        shift = sea_surface_height - geom_z_min
+        geom_z_mid = geom_z_mid + shift
+        geom_z_inter = geom_z_inter + shift
+
         ds['GeomZMid'] = geom_z_mid
         ds.GeomZMid.attrs['long_name'] = 'geometric height at layer midpoints'
         ds.GeomZMid.attrs['units'] = 'm'
@@ -347,16 +367,17 @@ class PStarInitStep(Step, ABC):
         ds.GeomZInterface.attrs['units'] = 'm'
 
         # Geometric depth of the seafloor below z=0, i.e. the negation of the
-        # actual converged bottom interface height (not the water-column
-        # thickness, which only matches when the sea-surface height is zero).
-        # Omega reads this as BottomGeomDepth and anchors its column there, so
-        # it must be the true bathymetric depth for the diagnosed sea-surface
-        # height (and the resulting geopotential gradient) to be correct.
-        ds['bottomDepth'] = -geom_z_max
+        # (shifted) bottom interface height.  With the surface-anchored column
+        # this is the representable bathymetry consistent with the pseudo
+        # column: it equals the raw target where the iteration converges, and
+        # the partial-cell-snapped depth otherwise.  Omega reads this as
+        # BottomGeomDepth and anchors its column there, so that (together with
+        # BottomPressure) it recovers the same prescribed ``ssh``.
+        ds['bottomDepth'] = -(geom_z_max + shift)
         ds.bottomDepth.attrs['long_name'] = 'seafloor geometric depth'
         ds.bottomDepth.attrs['units'] = 'm'
 
-        ds['ssh'] = geom_z_min
+        ds['ssh'] = sea_surface_height
         ds.ssh.attrs['long_name'] = 'sea surface geometric height'
         ds.ssh.attrs['units'] = 'm'
 

--- a/polaris/ocean/vertical/pstar_init.py
+++ b/polaris/ocean/vertical/pstar_init.py
@@ -300,23 +300,21 @@ class PStarInitStep(Step, ABC):
             # The column is anchored at the prescribed sea surface below, so
             # the residual moves bottomDepth (the representable bathymetry)
             # and leaves ssh exact.
+            #
+            # This only fires when *every* column is frozen; on a mesh where
+            # some columns are still converging, the loop simply runs out of
+            # iterations.  Either way, the post-loop report below describes
+            # how far the sea floor had to move.
             if (
                 prev_adjusted_bottom_pressure is not None
                 and (
                     adjusted_bottom_pressure == prev_adjusted_bottom_pressure
                 ).all()
             ):
-                shortfall = (
-                    goal_geom_water_column_thickness
-                    - geom_water_column_thickness
-                )
                 logger.info(
                     f'Iteration {iteration}: cell snapping is holding '
-                    'BottomPressure constant, so the requested bathymetry is '
-                    'not exactly representable — stopping early. bottomDepth '
-                    'will be the nearest representable depth, moved by up to '
-                    f'{np.abs(shortfall).max().item():.3f} m from the target; '
-                    'ssh is unaffected.'
+                    'BottomPressure constant in every column — stopping '
+                    'early.'
                 )
                 break
 
@@ -338,6 +336,18 @@ class PStarInitStep(Step, ABC):
 
             prev_adjusted_bottom_pressure = adjusted_bottom_pressure
             prev_geom_water_column_thickness = geom_water_column_thickness
+
+        # Report the columns the iteration could not place on the requested
+        # bathymetry, however the loop ended (stagnation, or simply running
+        # out of iterations while other columns were still converging).
+        _report_snapped_bathymetry(
+            logger=logger,
+            goal_geom_water_column_thickness=(
+                goal_geom_water_column_thickness
+            ),
+            geom_water_column_thickness=geom_water_column_thickness,
+            frac_change_threshold=water_col_adjust_frac_change_threshold,
+        )
 
         # Assemble the output dataset from the converged state
         ds['temperature'] = ct
@@ -410,3 +420,33 @@ class PStarInitStep(Step, ABC):
         ds.PseudoThickness.attrs['units'] = 'm'
 
         return ds
+
+
+def _report_snapped_bathymetry(
+    logger,
+    goal_geom_water_column_thickness,
+    geom_water_column_thickness,
+    frac_change_threshold,
+):
+    """
+    Log how far the sea floor had to move in columns where cell snapping
+    kept the iteration from reaching the requested bathymetry.  ``ssh`` is
+    prescribed, so the residual shows up in ``bottomDepth``.
+    """
+    residual = goal_geom_water_column_thickness - geom_water_column_thickness
+    frac_residual = np.abs(residual) / goal_geom_water_column_thickness
+    snapped = frac_residual > frac_change_threshold
+    count = int(snapped.sum().item())
+    if count == 0:
+        return
+
+    total = int(snapped.count().item())
+    max_move = np.abs(residual).where(snapped).max().item()
+    mean_move = np.abs(residual).where(snapped).mean().item()
+    logger.info(
+        f'{count} of {total} columns ({100.0 * count / total:.2f}%) have a '
+        'requested bathymetry that cell snapping cannot represent. '
+        'bottomDepth is the nearest representable depth, moved from the '
+        f'target by up to {max_move:.3f} m (mean {mean_move:.3f} m); ssh is '
+        'unaffected.'
+    )

--- a/polaris/ocean/vertical/pstar_init.py
+++ b/polaris/ocean/vertical/pstar_init.py
@@ -288,20 +288,35 @@ class PStarInitStep(Step, ABC):
                     )
                     break
 
-            # full-cell stagnation check — convergence check above takes
+            # Snap stagnation check — the convergence check above takes
             # priority so that a perfect initial guess (scaling = 1) exits
-            # cleanly rather than triggering this warning.
+            # cleanly rather than reporting a snap that did not happen.
+            #
+            # Partial- and full-cell snapping quantize the achievable
+            # pseudo-bottom depth, so a requested bathymetry between two
+            # representable depths cannot be reached: the snap keeps pushing
+            # BottomPressure back and the iteration cannot converge.  This is
+            # expected, not a failure — it is what min_pc_fraction asks for.
+            # The column is anchored at the prescribed sea surface below, so
+            # the residual moves bottomDepth (the representable bathymetry)
+            # and leaves ssh exact.
             if (
                 prev_adjusted_bottom_pressure is not None
                 and (
                     adjusted_bottom_pressure == prev_adjusted_bottom_pressure
                 ).all()
             ):
-                logger.warning(
-                    f'Iteration {iteration}: full-cell snap is holding '
-                    'BottomPressure constant — stopping early to avoid '
-                    'non-convergence. bottomDepth will reflect the actual '
-                    'cell bottom rather than the target bathymetry.'
+                shortfall = (
+                    goal_geom_water_column_thickness
+                    - geom_water_column_thickness
+                )
+                logger.info(
+                    f'Iteration {iteration}: cell snapping is holding '
+                    'BottomPressure constant, so the requested bathymetry is '
+                    'not exactly representable — stopping early. bottomDepth '
+                    'will be the nearest representable depth, moved by up to '
+                    f'{np.abs(shortfall).max().item():.3f} m from the target; '
+                    'ssh is unaffected.'
                 )
                 break
 

--- a/polaris/ocean/vertical/pstar_init.py
+++ b/polaris/ocean/vertical/pstar_init.py
@@ -149,7 +149,9 @@ class PStarInitStep(Step, ABC):
             geom_z_bot``; the iteration adjusts ``BottomPressure`` until
             this target is met, so the converged ``ssh`` equals this value.
             Defaults to ``-surface_pressure / (RhoSw * Gravity)``, i.e. the
-            resting surface-pressure depression for a reference-density fluid.
+            sea-surface depression that balances the surface pressure for a
+            reference-density fluid.  (Being at rest does not imply
+            ``ssh = 0``; surface loading depresses ``ssh`` even at rest.)
 
         Returns
         -------

--- a/tests/ocean/vertical/test_pstar_init.py
+++ b/tests/ocean/vertical/test_pstar_init.py
@@ -9,6 +9,7 @@ import logging
 from configparser import ConfigParser
 
 import numpy as np
+import pytest
 import xarray as xr
 
 from polaris.ocean.vertical.pstar_init import PStarInitStep
@@ -71,6 +72,56 @@ def _make_step(cls, config, logger=None):
     step.config = config
     step.logger = logger or logging.getLogger('test_pstar_init')
     return step
+
+
+def _omega_geom_z_interface(ds):
+    """Rebuild the geometric column the way Omega does, from what Polaris
+    wrote.
+
+    This is a deliberate transcription of ``VertCoord::computeGeomZHeight``
+    (``components/omega/src/ocn/VertCoord.cpp``): anchor at
+    ``-BottomGeomDepth`` (Polaris' ``bottomDepth``), scan upward, and
+    accumulate ``RhoSw * SpecVol * PseudoThickness``.  It must *not* call
+    ``geom_height_from_pseudo_height``: re-anchoring the written column with
+    the helper that built it is an identity and would pass unconditionally.
+
+    ``minLevelCell`` / ``maxLevelCell`` are 1-based in the dataset (Omega
+    converts to its 0-based ``MinLayerCell`` / ``MaxLayerCell`` on read), so
+    they are converted here.  Interfaces outside the valid range are left as
+    NaN, matching what Polaris masks out.
+
+    Returns
+    -------
+    z_inter : numpy.ndarray
+        Interface heights with shape ``(nCells, nVertLevels + 1)``.
+    ssh : numpy.ndarray
+        The topmost valid interface of each column, which is what Omega
+        stores as ``ssh``.
+    """
+    ncells = ds.sizes['nCells']
+    nvertlevels = ds.sizes['nVertLevels']
+    bottom_depth = ds.bottomDepth.values
+    spec_vol = ds.SpecVol.isel(Time=0).values
+    # PseudoThickness is NaN outside the valid range; invalid layers must
+    # contribute nothing, as the helper's mid_mask enforces.
+    h_tilde = np.nan_to_num(ds.PseudoThickness.isel(Time=0).values)
+    min_level_cell = ds.minLevelCell.values - 1
+    max_level_cell = ds.maxLevelCell.values - 1
+
+    z_inter = np.full((ncells, nvertlevels + 1), np.nan)
+    ssh = np.full(ncells, np.nan)
+    for icell in range(ncells):
+        k_min = min_level_cell[icell]
+        k_max = max_level_cell[icell]
+        z_bot = -bottom_depth[icell]
+        accum = 0.0
+        z_inter[icell, k_max + 1] = z_bot
+        for k_lyr in range(k_max, k_min - 1, -1):
+            accum += RhoSw * spec_vol[icell, k_lyr] * h_tilde[icell, k_lyr]
+            z_inter[icell, k_lyr] = z_bot + accum
+        ssh[icell] = z_inter[icell, k_min]
+
+    return z_inter, ssh
 
 
 class _ConstantTracerPStarStep(PStarInitStep):
@@ -376,6 +427,99 @@ def test_two_cell_surface_pressure_gradient():
             rtol=1e-10,
             err_msg=f'cell {i} ZTildeInterface top',
         )
+
+
+@pytest.mark.parametrize(
+    'partial_cell_type, target_depths, ssp_metres, snapped',
+    [
+        # The 4-level, 600 m reference grid puts layer interfaces at 0, 150,
+        # 300, 450 and 600 m.  With min_pc_fraction = 0.1 a target of 455 m is
+        # too shallow to keep as a partial cell and snaps up to 450 m, while
+        # 460 m snaps down to the 465 m minimum partial-cell depth.  Either
+        # way the written bottomDepth differs from the target and the
+        # surface-anchoring shift is nonzero.
+        ('partial', [455.0], 0.0, True),
+        ('partial', [455.0], 1.0, True),
+        ('partial', [455.0, 460.0], 0.0, True),
+        (None, [455.0], 0.0, False),
+    ],
+    ids=[
+        'snapped_zero_surface_pressure',
+        'snapped_nonzero_surface_pressure',
+        'snapped_two_cells',
+        'converged_control',
+    ],
+)
+def test_geom_height_round_trips_from_written_bottom_depth(
+    partial_cell_type, target_depths, ssp_metres, snapped
+):
+    """Omega must recover Polaris' column from the fields Polaris writes.
+
+    Polaris builds the geometric column anchored at the prescribed sea
+    surface and writes back the *shifted* seafloor as ``bottomDepth``; Omega
+    reads that as ``BottomGeomDepth``, anchors its column there and
+    accumulates upward to recover ``ssh``.  This test closes that loop by
+    reimplementing Omega's accumulation (see ``_omega_geom_z_interface``) and
+    checking it reproduces ``GeomZInterface`` and ``ssh``.
+
+    The check only has content where the surface-anchoring shift is nonzero,
+    i.e. where partial-cell snapping keeps the iteration from reaching the
+    requested bathymetry; writing the raw pre-shift target instead of the
+    shifted one is invisible everywhere else.  The unsnapped case is included
+    as a control precisely to mark that boundary.
+    """
+    config = _make_config(
+        rhoref=RhoSw,
+        partial_cell_type=partial_cell_type,
+        bottom_depth=600.0,
+    )
+    step = _make_step(_ConstantTracerPStarStep, config)
+
+    ncells = len(target_depths)
+    ds_mesh = _make_ds_mesh(ncells)
+    geom_z_bot = xr.DataArray(-np.array(target_depths), dims=['nCells'])
+    surface_pressure = xr.DataArray(
+        np.full(ncells, RhoSw * Gravity * ssp_metres), dims=['nCells']
+    )
+
+    ds = step.run_pstar_init(
+        ds_mesh, geom_z_bot, surface_pressure=surface_pressure
+    )
+
+    # Does the configuration have teeth?  Where the written bottomDepth
+    # equals the target bathymetry the shift is zero and the round trip is
+    # insensitive to which of the two was written.
+    bottom_depth = ds.bottomDepth.values
+    depth_move = np.abs(bottom_depth - np.array(target_depths))
+    if snapped:
+        assert depth_move.min() > 1.0, (
+            'this case is meant to snap, but the written bottomDepth '
+            f'{bottom_depth} is within {depth_move.max():.3e} m of the '
+            f'target {target_depths}; with a zero shift the test cannot '
+            'distinguish the shifted bathymetry from the raw one and is '
+            'not testing anything'
+        )
+    else:
+        assert depth_move.max() < 1e-10, (
+            'the control case is meant to converge without snapping'
+        )
+
+    z_inter, ssh = _omega_geom_z_interface(ds)
+
+    # atol is a few epsilon of the ~500 m column: the reconstruction is the
+    # same floating-point operations in the same order as Polaris'.
+    np.testing.assert_allclose(
+        z_inter,
+        ds.GeomZInterface.isel(Time=0).values,
+        atol=1e-10,
+        err_msg='Omega-style reconstruction differs from GeomZInterface',
+    )
+    np.testing.assert_allclose(
+        ssh,
+        ds.ssh.values,
+        atol=1e-10,
+        err_msg='topmost reconstructed interface differs from ssh',
+    )
 
 
 def test_snap_stagnation_message_and_early_exit(caplog):

--- a/tests/ocean/vertical/test_pstar_init.py
+++ b/tests/ocean/vertical/test_pstar_init.py
@@ -378,10 +378,10 @@ def test_two_cell_surface_pressure_gradient():
         )
 
 
-def test_full_cell_stagnation_warning_and_early_exit(caplog):
+def test_snap_stagnation_message_and_early_exit(caplog):
     """When _build_pstar_coord_ds always returns the same BottomPressure
-    (simulating full-cell snapping) the stagnation check should fire and the
-    loop should stop with a warning, without raising an exception.
+    (simulating cell snapping) the stagnation check should fire and the loop
+    should stop with an informational message, without raising an exception.
     """
 
     class _StagnantStep(_ConstantTracerPStarStep):
@@ -406,6 +406,10 @@ def test_full_cell_stagnation_warning_and_early_exit(caplog):
             ds['BottomPressure'] = fixed_pressure
             return ds
 
+    # The stagnation message and the snapped-bathymetry report are both
+    # logged at INFO: an unreachable bathymetry is the intended outcome of
+    # snapping, not a failure.
+
     config = _make_config(iter_count=10)
     step = _make_step(_StagnantStep, config)
 
@@ -413,9 +417,11 @@ def test_full_cell_stagnation_warning_and_early_exit(caplog):
     ds_mesh = _make_ds_mesh(ncells)
     geom_z_bot = xr.DataArray(np.full(ncells, -500.0), dims=['nCells'])
 
-    with caplog.at_level(logging.WARNING, logger='test_pstar_init'):
+    with caplog.at_level(logging.INFO, logger='test_pstar_init'):
         ds = step.run_pstar_init(ds_mesh, geom_z_bot)
 
-    assert 'full-cell snap' in caplog.text
+    assert 'cell snapping is holding BottomPressure constant' in caplog.text
+    # The post-loop report describes how far the sea floor had to move
+    assert 'cell snapping cannot represent' in caplog.text
     # Must still return a usable dataset
     assert 'bottomDepth' in ds


### PR DESCRIPTION
With `coord_type = p-star` and `partial_cell_type = partial`, a resting, unforced column with zero surface pressure could be initialized with a non-zero sea-surface height, which is a spurious barotropic pressure gradient.

**Cause:** partial-cell snapping quantizes the achievable pseudo bottom depth (`min_pc_fraction` forbids thin bottom cells by design), so some target bathymetries are unreachable and the `run_pstar_init` iteration stagnates on them. `geom_height_from_pseudo_height` anchored the column at the *requested* seafloor, so `bottomDepth` came out exactly on target and the whole quantization residual surfaced as `ssh`.

**Fix:** flip the invariant to match z-star partial cells — `ssh` is prescribed, `bottomDepth` is diagnosed. The converged column is shifted so its top interface lands on `sea_surface_height`, and `bottomDepth` follows from the shifted bottom interface. Where the iteration converges the shift is zero and `bottomDepth` still equals the target to machine precision; where it cannot, the residual moves the seafloor (the representable bathymetry, which is what `partial_cell_type` is documented to alter) instead of the sea surface.

The first two commits here are cherry-picked from #643, where this was independently hit and fixed on realistic global setups; 8427a6357 drops that branch's `polaris/tasks/ocean/realistic_global/` hunks.

Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes