### PR TITLE
Add resting-state pressure-gradient tests to `horiz_press_grad`

### DIFF
--- a/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
+++ b/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
@@ -69,17 +69,17 @@ resting-state property shall be a consequence of the configuration
 as functions of pseudo-height, with no surface-pressure gradient), not an
 approximation.
 
-### Requirement: The resting-state premise is verified, not assumed
+### Requirement: The geometry under test is verified, not assumed
 
 Date last modified: 2026/07/28
 
 Contributors: Xylar Asay-Davis, Claude
 
-The analysis shall confirm at run time that each configuration really is a
-resting state, and shall fail loudly if it is not. It shall not report a large
-HPGA as a discretization error when that HPGA is in fact a real, physical
-pressure gradient created by the vertical-grid construction failing to honour
-the requested bathymetry.
+The analysis shall confirm at run time that the geometry actually built is the
+geometry the configuration asked for, and shall fail loudly if it is not. A
+sweep whose swept parameter has been silently altered by the vertical-grid
+construction reports an error level for a configuration that was never tested,
+in either direction — too large or too small.
 
 ### Requirement: The test reaches the severity at which the centered scheme fails
 
@@ -301,39 +301,56 @@ difference quotient is unchanged. The horizontal sweep is therefore reduced to
 two resolutions — enough to confirm the same independence holds in Omega, which
 has not been checked — rather than the seven the existing variants use.
 
-### Algorithm Design: The resting-state guard
+### Algorithm Design: The bathymetry guard
 
 Date last modified: 2026/07/28
 
 Contributors: Xylar Asay-Davis, Claude
 
-A resting state has a flat sea surface. If the two columns' diagnosed
-sea-surface heights differ, the configuration carries a genuine barotropic
-pressure gradient and the measured HPGA is physics, not error. The analysis
+The swept tilt has to be the geometry actually under test. The analysis
 therefore checks
 
 $$
-\lvert \eta_1 - \eta_0 \rvert \;<\; \texttt{resting\_state\_max\_ssh\_diff}
+\max_i \lvert \texttt{bottomDepth}_i - \texttt{bottomDepthRequested}_i \rvert
+   \;<\; \texttt{resting\_state\_max\_bathy\_error}
 $$
 
-at every point in the sweep and fails otherwise.
+at every point in the sweep and fails otherwise, with `Init` writing the
+requested bathymetry alongside the achieved one.
 
-This is not hypothetical. With `partial_cell_type = partial`, the partial-cell
-snap in `_snap_partial_cells` moves the column bottom to enforce
-`min_pc_fraction`, while the p-star iteration in `run_pstar_init` moves
-`BottomPressure` to enforce the requested bathymetry. For sea-floor steps that
-land near a snapping threshold the two fight, the iteration stalls, and the
-columns converge to sea-surface heights differing by **12 m** — producing an
-apparent "error" of $3\times10^{-2}$ m s$^{-2}$ that is entirely real physics
-from a tilted sea surface. Without the guard this would be read as a
-catastrophic pressure-gradient error.
+The thing this guards against is partial-cell snapping. `min_pc_fraction`
+forbids bottom cells thinner than a set fraction of a layer, so the achievable
+pseudo-bottom depths are quantized and a requested bathymetry can fall in a gap
+between them; `_snap_partial_cells` then moves the sea floor to the nearest
+representable depth.
 
-Both new variants therefore set `partial_cell_type = None`, which leaves the
-requested bathymetry untouched. This does **not** cost partial-cell coverage:
-in a p-star column the reference grid is clipped at the pseudo-bottom depth
-regardless, so the deepest layer is a partial cell either way. The option
-controls only whether the topography is snapped. The guard remains in place so
-that anyone who later enables snapping finds out immediately.
+That does **not** break the resting state. Since `run_pstar_init` anchors the
+geometric column at the prescribed sea surface, `ssh` is exact by construction,
+the sea surface stays level, and the state remains exactly at rest. What breaks
+is the *meaning of the sweep*. This matters most for `bathymetry_step`, where
+the swept parameter is the sea floor itself: offline replication shows that at
+a nominal gradient of 100 m km$^{-1}$ over 4 km, snapping moves both columns to
+the same representable depth, so a nominal 400 m step becomes no step, and the
+measured RMS HPGA falls to $4\times10^{-16}$ m s$^{-2}$ — which would read as a
+spectacular pass rather than a test that had stopped testing anything.
+
+A guard on `ssh` would be useless here, and was: an earlier version of this
+design checked $\lvert \eta_1 - \eta_0 \rvert$, which is identically zero once
+the column is surface-anchored and therefore can never fire.
+
+Both new variants set `partial_cell_type = None`, which leaves the requested
+bathymetry untouched. This does **not** cost partial-cell coverage: in a p-star
+column the reference grid is clipped at the pseudo-bottom depth regardless, so
+the deepest layer is a partial cell either way. The option controls only
+whether the topography is snapped. The guard remains in place so that anyone
+who later enables snapping finds out immediately.
+
+> **Historical note.** Before `run_pstar_init` anchored the column at the
+> prescribed sea surface, the same snapping surfaced as a spurious *sea-surface*
+> tilt — up to 12 m between adjacent columns in this configuration, producing an
+> apparent "error" of $3\times10^{-2}$ m s$^{-2}$ that was entirely real
+> barotropic physics. That is fixed in the framework (see the p-star
+> partial-cell work), and this branch is rebased onto that fix.
 
 ## Implementation
 
@@ -416,7 +433,8 @@ existing step is untouched. Per sweep point it:
 5. RMS-differences the two and applies `omega_vs_polaris_rms_threshold`, which
    is retained: it confirms Omega implements the discretization Polaris thinks
    it does, independently of the resting-state property;
-6. applies the resting-state guard to `ssh` from `init.nc`.
+6. applies the bathymetry guard, comparing `bottomDepth` from
+   `vert_coord.nc` against `bottomDepthRequested` from `init.nc`.
 
 It then groups the sweep by resolution pair, fits `power_law_fit` over the
 points with tilt $\le$ `tilt_fit_max` when `tilt_fit` is true, writes
@@ -493,7 +511,7 @@ tilt_fit = False
 ```
 
 Both set `partial_cell_type = None` in `[vertical_grid]`, for the reason given
-under the resting-state guard above.
+under the bathymetry guard above.
 
 `forward.yaml` is unchanged for phase 1: the new variants run the existing
 `Centered` scheme. It gains a `PressureGrad` block in phase 2, once the Omega
@@ -545,11 +563,11 @@ Date last modified: 2026/07/28
 
 Contributors: Xylar Asay-Davis, Claude
 
-- **Resting-state guard.** Confirm it passes for both variants as configured,
-  and confirm it *fires* for a deliberately broken configuration — set
+- **Bathymetry guard.** Confirm it passes for both variants as configured, and
+  confirm it *fires* for a deliberately broken configuration — set
   `partial_cell_type = partial` on `bathymetry_step` with a sea-floor gradient
-  of 32 m km$^{-1}$, which offline replication shows drives the two columns'
-  sea-surface heights 12 m apart.
+  of 32 m km$^{-1}$, which offline replication shows moves the sea floor
+  12.33 m from the request.
 - **Zero-tilt sanity.** With the swept parameter set to zero the RMS HPGA must
   be exactly zero (offline replication gives 0.0, not merely round-off), since
   the two columns become identical.

--- a/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
+++ b/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
@@ -114,11 +114,20 @@ Date last modified: 2026/07/28
 
 Contributors: Xylar Asay-Davis, Claude
 
-The error metric for the resting-state variants shall include the deepest layer
-that is valid in both columns bounding the edge. That layer is the bottom
-partial cell, and it is where the global bottom-layer error is concentrated;
-excluding it, as the reference-based analysis does, removes the signal the test
-exists to measure.
+The error metric shall include the deepest layer that is valid in both columns
+bounding the edge. That layer is the bottom partial cell, and it is where the
+pressure-gradient error concentrates; excluding it removes the signal these
+tests exist to measure.
+
+This applies to the **reference-based `Analysis` step as well as** to the new
+resting-state analysis. `Analysis` currently drops that layer, which is a
+leftover from the previous five-column finite-difference reference whose
+stencil could not be formed where a neighbouring column's collocation point
+fell below its own bathymetry. The reference is now a single analytic column at
+the edge, documented as valid to the seafloor, so the exclusion no longer has a
+basis. Fixing it is in scope here because it is the same decision, and because
+leaving the two analysis steps disagreeing about which layers count would be
+incoherent.
 
 ### Requirement: The existing variants and their pass criteria are untouched
 
@@ -343,6 +352,51 @@ step modules, move them to a new dependency-light leaf module
 `format_value_list`, `format_value_error_pairs`) and have `analysis.py` import
 them. This commit is a pure refactor with no behaviour change.
 
+### Implementation: including the bottom layer in the reference-based analysis
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+In `analysis.py`, take one more interface and one more layer:
+
+```python
+# was: [: max_level_index + 1]  and  hpga_forward[:max_level_index]
+z_tilde_inter_for_ref = z_tilde_inter_edge[: max_level_index + 2]
+hpga_ref_diff = hpga_forward[: max_level_index + 1] - ref_layer_mean
+```
+
+This is safe with respect to interface masking: `ZTildeInterface` is valid for
+indices `0 .. maxLevelCell` in each column and `max_level_index` is
+`min(maxLevelCell) - 1`, so interfaces `0 .. max_level_index + 1` are finite in
+both columns by construction. The `omega_vs_python` comparison in the same
+function already used `[: max_level_index + 1]`, so after this change the two
+comparisons agree about which layers count.
+
+**Measured effect.** Running the real `Init` arithmetic and the real
+`ReferenceColumn` against a synthetic two-cell mesh (only mesh generation
+bypassed), with the Polaris HPGA standing in for Omega's tendency:
+
+| variant | fitted slope | RMS at 0.5 km |
+| --- | --- | --- |
+| `salinity_gradient` | 1.787 → 1.799 | 2.600e-07 → 2.601e-07 |
+| `surface_pressure_gradient` | 2.014 → 2.012 | 1.137e-11 → 1.136e-11 |
+| `temperature_gradient` | 1.625 → 1.625 | 2.770e-07 → 2.770e-07 |
+| `ztilde_gradient` | 2.003 → 1.119 | 6.779e-12 → 4.954e-11 |
+
+The first three are unaffected. `ztilde_gradient` is the only variant with a
+tilted coordinate, so its two columns clip the bottom layer at different
+thicknesses; that cell carries `-1.55e-09` m s$^{-2}$ at 0.5 km against an
+interior RMS of `6.8e-12`, converges at roughly first order, and pulls the
+fitted slope down. That is a real first-order error in the bottom partial cell
+which the exclusion was hiding — the same behaviour `hydrostatic_consistency`
+measures directly, and what the higher-order scheme exists to fix.
+
+`ztilde_gradient.cfg` therefore takes its own convergence band, provisionally
+`[0.9, 1.4]`, marked in the file as requiring re-tuning from the first real
+Omega run. The shared `omega_vs_reference_high_res_rms_threshold` of 1e-6 needs
+no change.
+
 ### Implementation: the reference-free analysis step
 
 Date last modified: 2026/07/28
@@ -503,8 +557,11 @@ Contributors: Xylar Asay-Davis, Claude
   must pass at every sweep point. Its present value of $10^{-10}$ was tuned for
   errors of order $10^{-7}$; it may need re-tuning for a signal of order
   $10^{-5}$ and should be set from the observed differences.
-- **Regression.** Run the four existing variants and confirm their results,
-  step names, and work directories are unchanged.
+- **Regression.** Run the four existing variants and confirm their step names
+  and work directories are unchanged. Their *results* change, because the
+  bottom layer is now included: three are unaffected in practice, while
+  `ztilde_gradient`'s convergence slope drops from ~2.0 to ~1.1 and its
+  provisional band must be re-tuned from the observed value.
 
 ### Testing and Validation: phase 2 (deferred)
 

--- a/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
+++ b/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
@@ -43,6 +43,36 @@ driven to an RMS HPGA of at least $10^{-6}$ m s$^{-2}$ somewhere in the sweep
 interpretable, and if the resulting diagnostic is ready to be pointed at the
 `FiniteVolume` scheme when it exists.
 
+### Two stages, and a note on the word "phase"
+
+This design was written and first implemented before Omega's `FiniteVolume`
+scheme existed, and extended once it did. The two Polaris stages are named
+rather than numbered, because `PGradHighOrder.md` uses **Phase 1** and **Phase
+2** for the scheme's *order* — Phase 1 being `HorzOrder: 2` with a linear
+vertical reconstruction, Phase 2 order 4 with PPM — and two independent pairs of
+ordinals in one document is a reliable source of confusion.
+
+| stage | what it delivered |
+| --- | --- |
+| **the calibration stage** | the two resting-state variants, the reference-free analysis, and the `Centered` baseline measured in Omega: tilt exponent $q = 1.000$, sensitivity gate passing by 21–23× |
+| **the rollout stage** | scheme selection and the §5.1 gates set from a `Centered`-versus-`FiniteVolume` comparison |
+
+Everything here concerns Omega Phase 1. "Phase" below always means the Omega
+sense.
+
+The calibration stage's output is what makes the rollout readable: with the
+centered exponent measured at 1.000 to five digits, a `FiniteVolume`
+measurement is read against a known-good value rather than against an
+expectation.
+
+### What the rollout stage adds
+
+- **A scheme axis.** Each variant runs both `Centered` and `FiniteVolume` over
+  one shared initial condition, so the two are compared at an identical state.
+- **A second Python kernel to compare against.** `init.py` writes
+  `HPGAFiniteVolume` alongside `HPGA`, and each analysis step compares Omega
+  against whichever matches the scheme that produced its output.
+
 The two variants deliberately isolate two different mechanisms, which the
 sizing work below showed are **not** the same mechanism:
 
@@ -131,7 +161,7 @@ incoherent.
 
 ### Requirement: The existing variants and their pass criteria are untouched
 
-Date last modified: 2026/07/28
+Date last modified: 2026/08/02
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -140,6 +170,53 @@ The four existing variants (`salinity_gradient`, `surface_pressure_gradient`,
 the convergence-rate and reference thresholds in `horiz_press_grad.cfg` shall
 behave exactly as they do today. The new capability shall not change their step
 names, work directories, or results.
+
+**Amended for the rollout stage.** This requirement held for the calibration
+stage and is deliberately relaxed by the rollout, in two respects:
+
+- the scheme axis puts a scheme label in every forward step's directory, so the
+  step names *do* change and the recorded centered baselines have to be
+  regenerated. This is the cost of running both schemes over one shared `Init`
+  rather than duplicating the initial condition per scheme;
+- the convergence bands become per-variant and per-scheme. A single band cannot
+  serve four variants whose measured centered rates are 1.6, 1.8, 2.0 and 1.1.
+
+What the rollout does **not** change is the four variants' *results* under
+`Centered`, or the meaning of `HPGA`. Any change there is a regression.
+
+### Requirement: The cross-implementation check compares the same algorithm
+
+Date last modified: 2026/08/02
+
+Contributors: Xylar Asay-Davis, Claude
+
+`omega_vs_polaris_rms_threshold` is the only check in the family that compares
+Omega's arithmetic against an independent implementation of the same scheme, and
+it is worth exactly as much as the claim that the two sides *are* the same
+algorithm. Where the Python kernel makes a discretization choice that Omega
+makes differently — the quadrature rule and its order, which end of the column
+the scan is anchored at, how the reconstruction is closed at the ends of a
+column, how the edge-shared expansion point is formed — the check stops
+measuring implementation disagreement and starts measuring the gap between two
+different algorithms, which is not distinguishable from a bug in either.
+
+Every such choice shall therefore be reconciled against `PGradHighOrder.md`
+before the check is run in anger, and each resolution recorded with its
+provenance. Two constraints on how:
+
+1. **The design is the source, not the C++.** The Python kernel was written from
+   `PGradHighOrder.md` precisely so that this comparison has content. Reading
+   the Omega implementation to settle a question of *intent* the design leaves
+   open is legitimate; transcribing it is not, because a Python kernel derived
+   from the C++ would compare an implementation against itself.
+2. **Reconcile up front rather than by bisection.** The check produces one
+   scalar per resolution. It can report that the two sides disagree; it cannot
+   report which of several choices disagrees, and several of them first bite in
+   the same configurations.
+
+Where a reconciliation finds that the *Python* follows the design and Omega does
+not, it stops being a Polaris change and is handed back rather than papered over
+by adjusting the Python to match.
 
 ## Algorithm Design
 
@@ -445,7 +522,7 @@ pair), logs the exponents, and applies the gates:
   `resting_state_sensitivity_min_rms`; this is a hard prerequisite, and failing
   it means the sweep must be redesigned before anything is concluded from it;
 - **consistency gate** — RMS below `resting_state_max_rms`, deliberately
-  disabled (`none`) until phase 2 measures a value to set it from;
+  disabled (`none`) until the rollout stage measures a value to set it from;
 - **Omega-vs-Polaris** and **resting-state** checks as above.
 
 ### Implementation: the tilt axis and the resting-state task
@@ -513,9 +590,51 @@ tilt_fit = False
 Both set `partial_cell_type = None` in `[vertical_grid]`, for the reason given
 under the bathymetry guard above.
 
-`forward.yaml` is unchanged for phase 1: the new variants run the existing
-`Centered` scheme. It gains a `PressureGrad` block in phase 2, once the Omega
-`FiniteVolume` option exists.
+`forward.yaml` was unchanged for the calibration stage: every variant ran the
+existing `Centered` scheme. The rollout gives it a `PressureGrad` block, filled
+in per step — see below.
+
+### Implementation: the scheme axis
+
+Date last modified: 2026/08/02
+
+Contributors: Xylar Asay-Davis, Claude
+
+`Forward` gains a `scheme` argument, and `forward.yaml` a `PressureGrad` block
+filled in through `add_yaml_file`'s `template_replacements`:
+
+```yaml
+PressureGrad:
+   PressureGradType: {{ pressure_grad_type }}
+   QuadraturePoints: {{ quadrature_points }}
+```
+
+`HorzOrder` and `VerticalReconstruction` are left at their Omega defaults of 2
+and `linear`, which are the only Phase 1 values; the Phase 2 values exist as
+keys but are rejected with an error, so a configuration written for Phase 2
+cannot quietly run as Phase 1. An unrecognized `PressureGradType` is likewise
+fatal rather than falling back to `Centered`, so a typo aborts the run instead
+of producing centered answers that read as a pass.
+
+Both task classes key their step dictionaries by `(resolution, scheme)` — or
+`(horiz_res, vert_res, tilt, scheme)` for the resting-state sweep — and build
+one `Forward` per scheme over **one shared `Init`**. `Init` is
+scheme-independent: it writes both `HPGA` and `HPGAFiniteVolume` from the same
+state, so duplicating it per scheme would cost run time and, worse, would leave
+the two schemes' comparison open to the objection that they were run on
+different initial conditions.
+
+This is the departure from the calibration stage's structure noted under the
+amended requirement above: it changes the existing variants' step directories.
+The alternative — a task per `(variant, scheme)` pair — preserves them, but runs
+`Init` twice per state and leaves no analysis step that sees both schemes, which
+is the comparison the rollout exists to make.
+
+`quadrature_points` is a single config option that drives both this template and
+the Python kernel's Gauss order. It is deliberately not two options: the two
+sides using different quadrature would make them different algorithms, which is
+what the cross-implementation requirement above forbids. Sweeping it for
+accuracy remains available and moves both sides together.
 
 ## Testing
 
@@ -539,7 +658,7 @@ retained `omega_vs_polaris_rms_threshold` check.
 
 If the gate fails, the sweep is not exercising the failure mode and must be
 redesigned before the variants are used to judge any scheme. This is the single
-most consequential check in phase 1.
+most consequential check in the calibration stage.
 
 ### Testing and Validation: the tilt exponent
 
@@ -581,19 +700,63 @@ Contributors: Xylar Asay-Davis, Claude
   `ztilde_gradient`'s convergence slope drops from ~2.0 to ~1.1 and its
   provisional band must be re-tuned from the observed value.
 
-### Testing and Validation: phase 2 (deferred)
+### Testing and Validation: the rollout stage
 
-Date last modified: 2026/07/28
+Date last modified: 2026/08/02
 
 Contributors: Xylar Asay-Davis, Claude
 
-Once Omega's `FiniteVolume` option exists in at least its reduced configuration
-(`ReconstructionOrder: 2`, `VerticalReconstruction: constant`,
-`QuadraturePoints: 2`), add the scheme selection to `forward.yaml`, add a Python
-counterpart of the reduced finite-volume kernel to `init.py` so the
-Omega-vs-Polaris check continues to apply, re-run both variants, and record the
-measured exponent and absolute levels. `resting_state_max_rms` is then set from
-what is measured. The result — whichever way it falls — should be written back
-into `PGradHighOrder.md` §2.3, §3.3, §3.7 and §5.2 as a measured property with
-its configuration and tilt range attached, replacing an assertion that currently
-rests on an unchecked analytic argument.
+Two corrections to how this section read before Omega's `FiniteVolume` landed,
+both from `omega_finite_volume_handoff.md`. The keys are `HorzOrder: 2` and
+`VerticalReconstruction: linear`, **not** `ReconstructionOrder` and `constant` —
+`constant` truncates the equation-of-state expansion to $\alpha_0$ and would run
+the centered scheme under a new name. And there is **no "reduced configuration"
+or centered limit** of the new scheme: the two are separate implementations and
+no setting reduces one to the other. Phase 1 offers exactly two configurations,
+`Centered` and `FiniteVolume` with its defaults.
+
+The Python counterpart also already exists — it was written during the
+calibration stage, from the design rather than from the C++ — so what this stage
+tests is not whether it can be built but whether it and Omega agree.
+
+**Reconciliation, before anything is run.** Work through every discretization
+choice named in the cross-implementation requirement above, record its
+resolution and provenance, and give each confirmed mismatch its own fix and its
+own test. Two are already confirmed: the Python kernel defaults to a 4-point
+Gauss rule where Omega defaults to 2, and it anchors its column scan at the sea
+surface where Omega anchors at the sea floor. Neither shows up on the exact set,
+where the integrand is zero at every quadrature point; both bite off it, which
+is where the §5.1 gates live.
+
+**Gates, set from measurement and not before.** Three points, of which the
+first two would otherwise have been got wrong:
+
+- bands are **per variant**, not per scheme alone. The measured `Centered` rates
+  are 1.6, 1.8, 2.0 and 1.1 across the four gradient variants, so a single
+  "≈ 2 for centered" band fails three of them;
+- the accuracy gate is a **ratio at the coarse end**, set from the measured
+  advantage — 6.5× at 256 m layers, 2.4× at 64 m, ~400× on stepped bathymetry;
+- **do not gate on relative convergence order.** The two schemes converge at
+  similar rates on smooth profiles; the advantage is a constant factor that
+  *narrows* under refinement, so a gate requiring the new scheme's slope to beat
+  the centered one would fail where nothing is wrong.
+
+`resting_state_max_rms` is set from the measured `FiniteVolume` level at a
+stated tilt, as an explicit multiple. The **improvement gate** — `FiniteVolume`
+RMS below `Centered` RMS at every sweep point — needs no prior measurement and
+ships with the analysis change.
+
+**Report absolutes.** $\max\lvert\mathcal{S}\rvert$ behaved unexpectedly under
+vertical refinement on the linear variant during the calibration stage, so
+absolute residuals and tendencies in m s$^{-2}$ are reported alongside any
+ratio, not in place of them.
+
+**The variant to expect surprises from is `bathymetry_step`.** Every Omega-side
+measurement of the new scheme so far used equal layer counts in both columns, so
+this is where the rule for evaluating a column's reconstruction below its own
+floor is first genuinely exercised.
+
+Finally, the result — whichever way it falls — is written back into
+`PGradHighOrder.md` as a measured property with its configuration and tilt range
+attached. That is an Omega-side commit in a separate repository and is not
+folded into the Polaris work.

--- a/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
+++ b/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
@@ -1,0 +1,518 @@
+# Discrete Hydrostatic Consistency in `horiz_press_grad`
+
+Creation date: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+## Summary
+
+The Omega design document for the higher-order horizontal pressure gradient
+(`components/omega/doc/design/PGradHighOrder.md`, §2.3 and §3.7) requires
+**discrete hydrostatic consistency**: for horizontally uniform conservative
+temperature and absolute salinity, with coordinate surfaces tilted arbitrarily
+between adjacent columns, the scheme must return exactly zero horizontal
+pressure-gradient acceleration (HPGA), to machine precision, with no background
+reference state. Its §5.2 makes that a gating test and names the Polaris
+two-column task as one of the places it should be exercised.
+
+This design adds two variants to the `ocean/horiz_press_grad` task family that
+measure that property, together with the reference-free analysis they need. The
+new capability is:
+
+- Two **exact resting states** in which the true HPGA is identically zero, so
+  the model's HPGA *is* the error and no reference solution is required:
+  `hydrostatic_consistency` (tilted coordinate, flat sea floor) and
+  `bathymetry_step` (flat coordinate, stepped sea floor).
+- A **tilt scan**: at fixed resolution, the tilt is swept over roughly three
+  decades and the exponent $q$ in $\lVert\text{HPGA}\rVert \sim
+  (\text{tilt})^{q}$ is measured. The exponent, not a single pass/fail, is the
+  discriminating output.
+- A **reference-free analysis step**, `RestingAnalysis`, which compares against
+  zero rather than against `ReferenceColumn`, retains the Omega-vs-Polaris
+  consistency check, and guards the resting-state premise itself.
+
+The primary challenge is not the numerics but the **severity of the
+configuration**. The existing `ztilde_gradient` variant is already structurally
+a resting state with a tilted coordinate, and the centered scheme passes it with
+an RMS HPGA of $\sim 7\times10^{-12}$ m s$^{-2}$ — six orders of magnitude below
+the $\sim 3\times10^{-6}$ m s$^{-2}$ bottom-layer error seen in realistic global
+Omega runs. A new variant that inherits that configuration would pass trivially
+and measure nothing. The design is **successful** if the centered scheme is
+driven to an RMS HPGA of at least $10^{-6}$ m s$^{-2}$ somewhere in the sweep
+(the *sensitivity gate*), if the measured tilt exponent is stable and
+interpretable, and if the resulting diagnostic is ready to be pointed at the
+`FiniteVolume` scheme when it exists.
+
+The two variants deliberately isolate two different mechanisms, which the
+sizing work below showed are **not** the same mechanism:
+
+| | `hydrostatic_consistency` | `bathymetry_step` |
+| --- | --- | --- |
+| what tilts | the p-star reference grid, via `z_tilde_bot_grad` | nothing; only the sea floor moves |
+| where the error lives | every layer, growing with depth | the deepest layer valid in both columns, only |
+| behaviour vs. the swept parameter | a clean power law | a staircase, set by where `maxLevelCell` changes |
+| what it represents | thin, steeply sloped layers in a general ALE coordinate | the bottom partial cell at a bathymetry step |
+
+## Requirements
+
+### Requirement: The test configuration is an exact resting state
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+Each new variant shall be a configuration whose true, continuous HPGA is
+identically zero at every point in the water column, so that the model's
+computed HPGA is entirely error and no reference solution is needed. The
+resting-state property shall be a consequence of the configuration
+(horizontally uniform conservative temperature and absolute salinity specified
+as functions of pseudo-height, with no surface-pressure gradient), not an
+approximation.
+
+### Requirement: The resting-state premise is verified, not assumed
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+The analysis shall confirm at run time that each configuration really is a
+resting state, and shall fail loudly if it is not. It shall not report a large
+HPGA as a discretization error when that HPGA is in fact a real, physical
+pressure gradient created by the vertical-grid construction failing to honour
+the requested bathymetry.
+
+### Requirement: The test reaches the severity at which the centered scheme fails
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+At its most severe configuration, the sweep shall drive the existing centered
+scheme to an RMS HPGA of at least $10^{-6}$ m s$^{-2}$ — the order of the
+bottom-layer HPGA error observed in realistic global Omega runs with a uniform
+temperature and salinity state. A sweep that does not reach this level is not
+exercising the failure mode the higher-order scheme is meant to fix, and any
+conclusion drawn from it about the new scheme would be unsupported.
+
+### Requirement: The measurement discriminates between mechanisms, not just pass and fail
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+The analysis shall report the exponent $q$ in $\lVert\text{HPGA}\rVert \sim
+(\text{tilt})^{q}$, restricted to the portion of the sweep where the result is
+well above the round-off floor, in addition to absolute error levels. A single
+pass/fail number cannot distinguish "the scheme represents specific volume as
+piecewise constant in pressure" from "the scheme has a higher-order residual"
+from "the scheme is exact", and those are the outcomes the test exists to
+separate.
+
+### Requirement: The deepest layer valid in both columns is measured, not discarded
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+The error metric for the resting-state variants shall include the deepest layer
+that is valid in both columns bounding the edge. That layer is the bottom
+partial cell, and it is where the global bottom-layer error is concentrated;
+excluding it, as the reference-based analysis does, removes the signal the test
+exists to measure.
+
+### Requirement: The existing variants and their pass criteria are untouched
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+The four existing variants (`salinity_gradient`, `surface_pressure_gradient`,
+`temperature_gradient`, `ztilde_gradient`), the `ReferenceColumn` evaluator, and
+the convergence-rate and reference thresholds in `horiz_press_grad.cfg` shall
+behave exactly as they do today. The new capability shall not change their step
+names, work directories, or results.
+
+## Algorithm Design
+
+### Algorithm Design: Why these configurations are exact resting states
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+Omega's vertical coordinate is pseudo-height $\tilde z = -p/(\rho_0 g)$, so
+pressure is an exactly linear function of $\tilde z$ and a surface of constant
+$\tilde z$ is a surface of constant $p$. `Init` interpolates conservative
+temperature $\Theta$ and absolute salinity $S_A$ against $\tilde z$ from
+piecewise profiles whose node values and node pseudo-heights are set by
+`*_mid` and `*_grad` configuration options. Setting every `*_grad` to zero makes
+$\Theta$ and $S_A$ **the same functions of $\tilde z$, and therefore of $p$, in
+both columns**. Specific volume is then a function of pressure alone,
+
+$$
+\alpha = \alpha\bigl(\Theta(p), S_A(p), p\bigr) \equiv \alpha(p),
+$$
+
+isobars are level surfaces, and the true HPGA is identically zero everywhere in
+the fluid — for **any** sea-floor shape and **any** tilt of the coordinate
+surfaces. This is what makes both variants valid resting states, and it is the
+discrete analogue of the property §3.7 of the Omega design asserts.
+
+Two configuration choices are therefore forced:
+
+- `temperature_grad`, `salinity_grad` and `z_tilde_grad` are all zero (inherited
+  from the base `horiz_press_grad.cfg`), and `surface_pressure_grad` is zero, so
+  the sea surface is flat.
+- The deepest profile node lies below the deepest reference-grid interface in
+  *either* column, so the PCHIP interpolant is never asked to extrapolate when
+  the tilt makes one column's reference grid deeper than the other's.
+
+### Algorithm Design: What actually tilts the coordinate in a p-star column
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+This is the design's central finding, and it determined the shape of both
+variants.
+
+`init_pstar_vertical_coord` builds each column by clipping a reference 1-D grid
+at that column's `BottomPressure`. In `Init`, the reference grid for column $i$
+is uniform over $[0, -\tilde z^{\text{bot}}_i]$ with a level count fixed by the
+mid-column value, so `z_tilde_bot_grad` **stretches** one column's reference
+grid relative to the other's. The cross-edge offset of interface $k$ then grows
+linearly with depth,
+
+$$
+\Delta \tilde z_k \;=\; \frac{k}{N}\,
+   \bigl(\tilde z^{\text{bot}}_1 - \tilde z^{\text{bot}}_0\bigr),
+$$
+
+which is the tilted-coordinate configuration §3.7 describes. **This is the only
+mechanism in the two-column task that tilts interior coordinate surfaces.**
+
+A sea-floor step does *not* tilt them. With `z_tilde_bot_grad = 0` both columns
+share one reference grid, and moving the sea floor changes only where that grid
+is clipped. Every interior interface sits at an identical pseudo-height — and
+hence an identical pressure — in both columns, so the cross-edge pressure
+difference is exactly zero above the bottom. Offline replication of the Polaris
+`Init` arithmetic confirms this: with a sea-floor gradient of 10–200 m km$^{-1}$
+and a flat coordinate, the RMS HPGA over the interior layers is
+$\sim 10^{-15}$ m s$^{-2}$ (round-off), while the deepest layer valid in both
+columns carries $2\times10^{-6}$ to $8\times10^{-5}$ m s$^{-2}$.
+
+Two consequences follow:
+
+1. `bathymetry_step` is a test of the **bottom partial cell**, not of interior
+   layer tilt, and its whole signal is in the one layer the reference-based
+   analysis discards. Hence the requirement to include that layer.
+2. Its error is **not** a power law in the sea-floor gradient. The signal is set
+   by how the two columns' `maxLevelCell` and clipped bottom thicknesses relate,
+   which changes in steps. Fitting an exponent to it would be meaningless, so
+   the fit is configurable and is disabled for that variant.
+
+### Algorithm Design: The tilt scan and the exponent
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+Because the exact answer is zero there is nothing to converge *to*, so the
+discriminating measurement is not a convergence rate against a reference but a
+scan of the tilt at fixed resolution. For `hydrostatic_consistency` the swept
+parameter is `z_tilde_bot_grad`; the analysis fits
+
+$$
+\log_{10} \lVert \text{HPGA} \rVert_{\text{RMS}}
+   \;=\; q \, \log_{10} (\text{tilt}) + \text{const}
+$$
+
+over the points below `tilt_fit_max`, and reports $q$. The readings are:
+
+| measured $q$ | reading |
+| --- | --- |
+| $q \approx 1$ | $\alpha$ is effectively piecewise constant in pressure — no better than the centered scheme |
+| $q \approx 2$ | consistent with a residual set by the per-cell Taylor expansion point of `PGradHighOrder.md` §3.3 |
+| round-off, independent of tilt | consistent with §3.7 holding as written |
+
+An exponent that is neither, or one that drifts across the sweep, is a real
+possible outcome and would say the mechanism is not one of the three above.
+
+Restricting the fit to `tilt_fit_max` matters for two reasons: at small tilt the
+error approaches the round-off floor and flattens the fit, and at large tilt the
+two columns' `maxLevelCell` values begin to differ, which adds a staircase
+component. This mirrors the existing
+`omega_vs_reference_convergence_fit_max_resolution` option.
+
+The scan is meaningful **immediately**, against the existing `Centered` scheme
+and before any new Omega code exists. Offline replication of the Polaris
+arithmetic gives $q = 1.00$ for the centered scheme, which is the expected
+reading for a scheme that holds $\alpha$ constant within a layer, and which
+calibrates the diagnostic.
+
+### Algorithm Design: Sizing the sweep so that it is severe enough
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+The existing variants use a 500 m water column resolved at 0.5–4 m, which is
+between one and three orders of magnitude finer than the ~250 m layers in the
+deep ocean of a realistic global run. Offline replication of the Polaris `Init`
+arithmetic (which reproduces the recorded $7\times10^{-12}$ m s$^{-2}$ for the
+existing `ztilde_gradient` to within 4%) gives, at a fixed coordinate tilt of
+5 m km$^{-1}$:
+
+| layer thickness | RMS HPGA (centered) |
+| --- | --- |
+| 256 m | $1.6\times10^{-6}$ |
+| 128 m | $5.0\times10^{-7}$ |
+| 64 m | $9.6\times10^{-8}$ |
+| 16 m | $6.4\times10^{-9}$ |
+
+i.e. roughly second order in layer thickness, and only the coarsest rows are
+near the target severity. The new variants therefore use a **deep, coarsely
+resolved column**: a sea floor at $-3500$ m, a reference pseudo-bottom at
+$-4096$ m, and 16, 32 or 64 levels (256, 128 or 64 m). The level counts are
+multiples of 16, which Omega prefers.
+
+The gap between the sea floor and the reference pseudo-bottom is deliberate.
+The p-star iteration converges to a pseudo-bottom depth slightly greater than
+the geometric water-column thickness (because in-situ density exceeds $\rho_0$
+at depth), and the reference grid must extend below it in *both* columns. The
+576 m of head room here permits tilts up to a few hundred m km$^{-1}$; without
+it the shallower column's reference grid runs out, the p-star iteration
+diverges, and the reported HPGA jumps to $O(1)$ m s$^{-2}$ — a failure mode the
+`Init` guard below is designed to catch.
+
+A further measured result shapes the sweep: at a fixed tilt *gradient*, the RMS
+HPGA is **independent of horizontal resolution** to five digits (1.5570e-06 at
+8, 4, 2 and 1 km). The offset and the cell spacing scale together, so the
+difference quotient is unchanged. The horizontal sweep is therefore reduced to
+two resolutions — enough to confirm the same independence holds in Omega, which
+has not been checked — rather than the seven the existing variants use.
+
+### Algorithm Design: The resting-state guard
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+A resting state has a flat sea surface. If the two columns' diagnosed
+sea-surface heights differ, the configuration carries a genuine barotropic
+pressure gradient and the measured HPGA is physics, not error. The analysis
+therefore checks
+
+$$
+\lvert \eta_1 - \eta_0 \rvert \;<\; \texttt{resting\_state\_max\_ssh\_diff}
+$$
+
+at every point in the sweep and fails otherwise.
+
+This is not hypothetical. With `partial_cell_type = partial`, the partial-cell
+snap in `_snap_partial_cells` moves the column bottom to enforce
+`min_pc_fraction`, while the p-star iteration in `run_pstar_init` moves
+`BottomPressure` to enforce the requested bathymetry. For sea-floor steps that
+land near a snapping threshold the two fight, the iteration stalls, and the
+columns converge to sea-surface heights differing by **12 m** — producing an
+apparent "error" of $3\times10^{-2}$ m s$^{-2}$ that is entirely real physics
+from a tilted sea surface. Without the guard this would be read as a
+catastrophic pressure-gradient error.
+
+Both new variants therefore set `partial_cell_type = None`, which leaves the
+requested bathymetry untouched. This does **not** cost partial-cell coverage:
+in a p-star column the reference grid is clipped at the pseudo-bottom depth
+regardless, so the deepest layer is a partial cell either way. The option
+controls only whether the topography is snapped. The guard remains in place so
+that anyone who later enables snapping finds out immediately.
+
+## Implementation
+
+### Implementation: shared metric helpers
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+`analysis.py` holds several private helpers that the new analysis needs
+verbatim: locating the internal edge, RMS over finite values, the log-log power
+law fit, and the netCDF writer. Rather than importing private names across
+step modules, move them to a new dependency-light leaf module
+`polaris/tasks/ocean/horiz_press_grad/metrics.py` with public names
+(`get_internal_edge`, `rms`, `power_law_fit`, `write_metric_dataset`,
+`format_value_list`, `format_value_error_pairs`) and have `analysis.py` import
+them. This commit is a pure refactor with no behaviour change.
+
+### Implementation: the reference-free analysis step
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+Add `polaris/tasks/ocean/horiz_press_grad/resting_analysis.py` defining
+`RestingAnalysis`, a sibling of `Analysis` rather than a mode of it, so the
+existing step is untouched. Per sweep point it:
+
+1. locates the internal edge with `get_internal_edge`;
+2. takes `maxLevelCell` for the two bounding cells and forms the valid range
+   `0 .. min(maxLevelCell) - 1` **inclusive of the deepest common layer**;
+3. reads Omega's `NormalVelocityTend` at that edge and takes its RMS over the
+   valid layers — the truth is zero, so this is the error;
+4. does the same for the Polaris-side `HPGA` from `init.nc`;
+5. RMS-differences the two and applies `omega_vs_polaris_rms_threshold`, which
+   is retained: it confirms Omega implements the discretization Polaris thinks
+   it does, independently of the resting-state property;
+6. applies the resting-state guard to `ssh` from `init.nc`.
+
+It then groups the sweep by resolution pair, fits `power_law_fit` over the
+points with tilt $\le$ `tilt_fit_max` when `tilt_fit` is true, writes
+`resting_state.nc` and `resting_state.png` (log-log, one series per resolution
+pair), logs the exponents, and applies the gates:
+
+- **sensitivity gate** — the largest RMS over the whole sweep must be at least
+  `resting_state_sensitivity_min_rms`; this is a hard prerequisite, and failing
+  it means the sweep must be redesigned before anything is concluded from it;
+- **consistency gate** — RMS below `resting_state_max_rms`, deliberately
+  disabled (`none`) until phase 2 measures a value to set it from;
+- **Omega-vs-Polaris** and **resting-state** checks as above.
+
+### Implementation: the tilt axis and the resting-state task
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+`Init` and `Forward` gain an optional `subdir_suffix`, and `Init` gains optional
+`tilt_option` / `tilt`. When a tilt is given, `Init.run` sets that option in its
+own config before building the columns, exactly as it already sets
+`vertical_grid:vert_levels`. `Init.run` also gains a guard that raises when a
+column's reference pseudo-bottom does not extend below its converged
+pseudo-bottom depth — the divergence mode described above — with an error
+naming the offending column and the head room available.
+
+Task wiring goes in a new module `resting_state_task.py` defining
+`HorizPressGradRestingStateTask`, rather than branching `HorizPressGradTask`.
+The existing task pairs `horiz_resolutions[i]` with `vert_resolutions[i]` and
+keys its step dictionaries by horizontal resolution alone, so it cannot express
+the repeated horizontal resolutions the new sweep needs; the new task keys by
+the `(horiz_res, vert_res, tilt)` triple. `Init` and `Forward` are reused
+unchanged apart from the optional arguments above.
+
+This is a deliberate departure from the working plan, which leaned toward adding
+the tilt axis inside `HorizPressGradTask._setup_steps`. Doing so would have
+required renaming the existing variants' steps to disambiguate the vertical
+resolution, changing their work directories for no benefit to them.
+
+### Implementation: configuration
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+`horiz_press_grad.cfg` gains the resting-state options with defaults that leave
+the four existing variants inert (`resting_state = False`). The new variant
+`.cfg` files set the deep column, the coarse vertical resolutions, the sweep,
+and the gates:
+
+```
+# hydrostatic_consistency.cfg (abridged)
+resting_state = True
+tilt_option = z_tilde_bot_grad
+tilt_values = [0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0]
+tilt_fit = True
+tilt_fit_max = 10.0
+horiz_resolutions = [4.0, 4.0, 4.0, 1.0]
+vert_resolutions = [256.0, 128.0, 64.0, 256.0]
+```
+
+```
+# bathymetry_step.cfg (abridged)
+resting_state = True
+tilt_option = geom_z_bot_grad
+tilt_values = [1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 200.0]
+tilt_fit = False
+horiz_resolutions = [4.0, 4.0]
+vert_resolutions = [256.0, 128.0]
+```
+
+`forward.yaml` is unchanged for phase 1: the new variants run the existing
+`Centered` scheme. It gains a `PressureGrad` block in phase 2, once the Omega
+`FiniteVolume` option exists.
+
+## Testing
+
+### Testing and Validation: the sensitivity gate is the prerequisite
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+Run both variants with `Centered` and confirm the sensitivity gate passes.
+Offline replication of the Polaris arithmetic predicts the centered RMS HPGA
+listed below; the first job of the real run is to confirm Omega agrees, via the
+retained `omega_vs_polaris_rms_threshold` check.
+
+| variant | configuration | predicted centered RMS |
+| --- | --- | --- |
+| `hydrostatic_consistency` | 4 km, 256 m, tilt 50 m km$^{-1}$ | $2.1\times10^{-5}$ |
+| `hydrostatic_consistency` | 4 km, 64 m, tilt 50 m km$^{-1}$ | $9.8\times10^{-7}$ |
+| `bathymetry_step` | 4 km, 256 m, 100 m km$^{-1}$ | $2.3\times10^{-5}$ |
+| `bathymetry_step` | 4 km, 128 m, 25 m km$^{-1}$ | $3.8\times10^{-6}$ |
+
+If the gate fails, the sweep is not exercising the failure mode and must be
+redesigned before the variants are used to judge any scheme. This is the single
+most consequential check in phase 1.
+
+### Testing and Validation: the tilt exponent
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+Confirm that `hydrostatic_consistency` returns $q \approx 1$ for `Centered` at
+every resolution pair, and that the value is stable when `tilt_fit_max` is
+varied. Offline replication gives $q = 0.95$–$1.00$, the droop below 1 coming
+from the largest tilts where `maxLevelCell` starts to differ between columns —
+which is what `tilt_fit_max` is there to exclude. A centered exponent far from 1
+should be understood before the scan is used on the new scheme.
+
+Confirm that `bathymetry_step` produces the expected staircase and that its
+interior layers sit at round-off, isolating the signal to the bottom cell.
+
+### Testing and Validation: resting-state and consistency checks
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+- **Resting-state guard.** Confirm it passes for both variants as configured,
+  and confirm it *fires* for a deliberately broken configuration — set
+  `partial_cell_type = partial` on `bathymetry_step` with a sea-floor gradient
+  of 32 m km$^{-1}$, which offline replication shows drives the two columns'
+  sea-surface heights 12 m apart.
+- **Zero-tilt sanity.** With the swept parameter set to zero the RMS HPGA must
+  be exactly zero (offline replication gives 0.0, not merely round-off), since
+  the two columns become identical.
+- **Omega-vs-Polaris.** The retained check at `omega_vs_polaris_rms_threshold`
+  must pass at every sweep point. Its present value of $10^{-10}$ was tuned for
+  errors of order $10^{-7}$; it may need re-tuning for a signal of order
+  $10^{-5}$ and should be set from the observed differences.
+- **Regression.** Run the four existing variants and confirm their results,
+  step names, and work directories are unchanged.
+
+### Testing and Validation: phase 2 (deferred)
+
+Date last modified: 2026/07/28
+
+Contributors: Xylar Asay-Davis, Claude
+
+Once Omega's `FiniteVolume` option exists in at least its reduced configuration
+(`ReconstructionOrder: 2`, `VerticalReconstruction: constant`,
+`QuadraturePoints: 2`), add the scheme selection to `forward.yaml`, add a Python
+counterpart of the reduced finite-volume kernel to `init.py` so the
+Omega-vs-Polaris check continues to apply, re-run both variants, and record the
+measured exponent and absolute levels. `resting_state_max_rms` is then set from
+what is measured. The result — whichever way it falls — should be written back
+into `PGradHighOrder.md` §2.3, §3.3, §3.7 and §5.2 as a measured property with
+its configuration and tilt range attached, replacing an assertion that currently
+rests on an unchecked analytic argument.

--- a/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
+++ b/docs/design_docs/horiz_press_grad_hydrostatic_consistency.md
@@ -409,31 +409,37 @@ Date last modified: 2026/07/28
 
 Contributors: Xylar Asay-Davis, Claude
 
-`horiz_press_grad.cfg` gains the resting-state options with defaults that leave
-the four existing variants inert (`resting_state = False`). The new variant
-`.cfg` files set the deep column, the coarse vertical resolutions, the sweep,
-and the gates:
+`horiz_press_grad.cfg` gains the resting-state options with inert defaults, so
+the four existing variants are unaffected. Which task class a variant uses is
+decided by name in `__init__.py`, so no separate "this is a resting state" flag
+is needed. The new variant `.cfg` files set the deep column, the coarse
+vertical resolutions, and the sweep:
 
 ```
 # hydrostatic_consistency.cfg (abridged)
-resting_state = True
+geom_z_bot_mid = -3500.0
+z_tilde_bot_mid = -4096.0
+horiz_resolutions = [4.0, 4.0, 4.0, 1.0]
+vert_resolutions = [256.0, 128.0, 64.0, 256.0]
 tilt_option = z_tilde_bot_grad
 tilt_values = [0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0]
 tilt_fit = True
 tilt_fit_max = 10.0
-horiz_resolutions = [4.0, 4.0, 4.0, 1.0]
-vert_resolutions = [256.0, 128.0, 64.0, 256.0]
 ```
 
 ```
 # bathymetry_step.cfg (abridged)
-resting_state = True
+geom_z_bot_mid = -3500.0
+z_tilde_bot_mid = -4096.0
+horiz_resolutions = [4.0, 4.0]
+vert_resolutions = [256.0, 128.0]
 tilt_option = geom_z_bot_grad
 tilt_values = [1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 200.0]
 tilt_fit = False
-horiz_resolutions = [4.0, 4.0]
-vert_resolutions = [256.0, 128.0]
 ```
+
+Both set `partial_cell_type = None` in `[vertical_grid]`, for the reason given
+under the resting-state guard above.
 
 `forward.yaml` is unchanged for phase 1: the new variants run the existing
 `Centered` scheme. It gains a `PressureGrad` block in phase 2, once the Omega

--- a/docs/design_docs/index.md
+++ b/docs/design_docs/index.md
@@ -5,6 +5,7 @@
 ```{toctree}
 :titlesonly: true
 
+horiz_press_grad_hydrostatic_consistency
 horiz_press_grad_reference
 land_locked_cells
 ocean_analysis

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -285,6 +285,12 @@
    resting_state_task.HorizPressGradRestingStateTask
    resting_state_task.HorizPressGradRestingStateTask.configure
 
+   finite_volume.centered_shift
+   finite_volume.hpga_from_shift
+   finite_volume.hydrostatic_scale
+   finite_volume.edge_delta
+   finite_volume.edge_mean
+
    metrics.get_internal_edge
    metrics.rms
    metrics.power_law_fit
@@ -300,6 +306,7 @@
 
    init.Init
    init.Init.run
+   init.Init.build_column_state
 
    forward.Forward
    forward.Forward.setup

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -282,6 +282,16 @@
    task.HorizPressGradTask
    task.HorizPressGradTask.configure
 
+   resting_state_task.HorizPressGradRestingStateTask
+   resting_state_task.HorizPressGradRestingStateTask.configure
+
+   metrics.get_internal_edge
+   metrics.rms
+   metrics.power_law_fit
+   metrics.write_metric_dataset
+   metrics.format_value_list
+   metrics.format_value_error_pairs
+
    reference.ReferenceColumn
    reference.ReferenceColumn.specvol
    reference.ReferenceColumn.dalpha_dx
@@ -297,6 +307,11 @@
    analysis.Analysis
    analysis.Analysis.setup
    analysis.Analysis.run
+
+   resting_analysis.RestingAnalysis
+   resting_analysis.RestingAnalysis.setup
+   resting_analysis.RestingAnalysis.run
+   resting_analysis.sweep_suffix
 ```
 
 ### ice_shelf_2d

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -301,6 +301,10 @@
    finite_volume.hpga_from_shift
    finite_volume.hydrostatic_scale
 
+   reconstruction.linear_slope
+   reconstruction.layer_deviation
+   reconstruction.reconstruct
+
    metrics.get_internal_edge
    metrics.rms
    metrics.power_law_fit

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -305,6 +305,9 @@
    finite_volume.matched_pressure_pieces
    finite_volume.layer_containing_pressure
    finite_volume.delta_specvol_at_pressure
+   finite_volume.anchor_difference
+   finite_volume.column_scan
+   finite_volume.scan_increments
 
    reconstruction.linear_slope
    reconstruction.layer_deviation

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -285,6 +285,10 @@
    resting_state_task.HorizPressGradRestingStateTask
    resting_state_task.HorizPressGradRestingStateTask.configure
 
+   column.get_array_from_mid_grad
+   column.get_pchip_interpolator
+   column.get_pchip_layer_mean
+
    finite_volume.centered_shift
    finite_volume.hpga_from_shift
    finite_volume.hydrostatic_scale

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -308,6 +308,8 @@
    finite_volume.anchor_difference
    finite_volume.column_scan
    finite_volume.scan_increments
+   finite_volume.layer_mean_difference
+   finite_volume.finite_volume_hpga
 
    reconstruction.linear_slope
    reconstruction.layer_deviation

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -298,6 +298,8 @@
    eos_expansion.edge_specvol_layer_mean
 
    finite_volume.centered_shift
+   finite_volume.centered_shift_accumulated
+   finite_volume.shift_increments
    finite_volume.hpga_from_shift
    finite_volume.hydrostatic_scale
 

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -289,11 +289,17 @@
    column.get_pchip_interpolator
    column.get_pchip_layer_mean
 
+   edge.edge_delta
+   edge.edge_mean
+
+   eos_expansion.specvol_coefficients
+   eos_expansion.edge_expansion
+   eos_expansion.edge_specvol
+   eos_expansion.edge_specvol_layer_mean
+
    finite_volume.centered_shift
    finite_volume.hpga_from_shift
    finite_volume.hydrostatic_scale
-   finite_volume.edge_delta
-   finite_volume.edge_mean
 
    metrics.get_internal_edge
    metrics.rms

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -302,6 +302,9 @@
    finite_volume.shift_increments
    finite_volume.hpga_from_shift
    finite_volume.hydrostatic_scale
+   finite_volume.matched_pressure_pieces
+   finite_volume.layer_containing_pressure
+   finite_volume.delta_specvol_at_pressure
 
    reconstruction.linear_slope
    reconstruction.layer_deviation

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -6,12 +6,19 @@ The {py:class}`polaris.tasks.ocean.horiz_press_grad.task.HorizPressGradTask`
 provides two-column Omega tests for pressure-gradient-acceleration (`HPGA`)
 accuracy and convergence across horizontal and vertical resolutions.
 
-The task family includes four variants:
+The task family includes four such variants:
 
 - `salinity_gradient`
 - `temperature_gradient`
 - `ztilde_gradient`
 - `surface_pressure_gradient`
+
+{py:class}`polaris.tasks.ocean.horiz_press_grad.resting_state_task.HorizPressGradRestingStateTask`
+provides two further variants that are exact resting states, in which the true
+HPGA is identically zero and no reference solution is used:
+
+- `hydrostatic_consistency`
+- `bathymetry_step`
 
 ## framework
 
@@ -26,6 +33,15 @@ the code.
 The task dynamically rebuilds `init` and `forward` steps in `configure()` so
 user-supplied `horiz_resolutions` and `vert_resolutions` in config files are
 reflected in the work directory setup.
+
+### metrics
+
+{py:mod}`polaris.tasks.ocean.horiz_press_grad.metrics` is a dependency-light
+leaf module (numpy and xarray only) holding the pieces both analysis steps
+need: `get_internal_edge()`, `rms()`, `power_law_fit()`,
+`write_metric_dataset()`, `format_value_list()` and
+`format_value_error_pairs()`.  It exists so the two step modules can share them
+without importing private names from one another.
 
 ### reference
 
@@ -147,5 +163,69 @@ resolutions.  For each resolution it:
    from `init.nc` HPGA.
 
 The forward solution always comes from `output.nc` via `NormalVelocityTend`.
-Helper routines `_rms_error()` and `_power_law_fit()` produce the convergence
-datasets and plots.
+`rms()` and `power_law_fit()` from `metrics` produce the convergence datasets
+and plots.
+
+## the resting-state variants
+
+{py:class}`polaris.tasks.ocean.horiz_press_grad.resting_state_task.HorizPressGradRestingStateTask`
+is a sibling of `HorizPressGradTask` rather than a mode of it.  The existing
+task pairs each entry of `horiz_resolutions` with one entry of
+`vert_resolutions` and keys its step dictionaries by horizontal resolution
+alone, so it cannot express the repeated horizontal resolutions the tilt sweep
+needs.  The resting-state task keys its steps by the
+`(horiz_res, vert_res, tilt)` triple instead, and builds the outer product of
+the resolution pairs with `tilt_values`.
+
+`Init` and `Forward` are reused unchanged apart from two optional arguments:
+
+- `subdir_suffix` replaces the horizontal resolution in the step name, so
+  repeated horizontal resolutions do not collide.  It is built by
+  `sweep_suffix(horiz_res, vert_res, tilt)`, giving names like
+  `init_4km_256m_tilt0p5`.  When it is not given, the existing
+  `init_<res>` / `forward_<res>` naming is used, so the four gradient variants
+  keep their work directories.
+- `tilt_option` and `tilt` (on `Init` only) name a `[horiz_press_grad]` config
+  option that `Init.run()` sets in its own config before building the columns,
+  in the same way it already sets `vertical_grid:vert_levels`.
+
+`Init.run()` also calls `_check_reference_grid_head_room()` after
+`run_pstar_init()`.  The p-star iteration converges to a pseudo-bottom depth
+somewhat greater than the geometric water-column thickness, because in-situ
+density exceeds `RhoSw` at depth.  If a tilt makes a column's `z_tilde_bot`
+shallower than that, the reference grid cannot span the water column, the
+iteration diverges, and the resulting HPGA is of order 1 m s$^{-2}$ rather than
+the order 1e-5 m s$^{-2}$ being measured.  The guard raises with the head room
+available in each column.
+
+### resting_analysis
+
+{py:class}`polaris.tasks.ocean.horiz_press_grad.resting_analysis.RestingAnalysis`
+replaces `Analysis` for these variants.  Per sweep point it:
+
+1. locates the internal edge with `get_internal_edge()`;
+2. forms the valid layer range `0 .. min(maxLevelCell) - 1`, **inclusive** of
+   the deepest layer valid in both columns — `Analysis` drops that layer, but
+   it is the bottom partial cell and carries the entire `bathymetry_step`
+   signal;
+3. takes the RMS of Omega's `NormalVelocityTend` at that edge over those
+   layers.  The truth is zero, so this is the error, not a difference from a
+   reference;
+4. does the same for the Polaris-side `HPGA` from `init.nc` and RMS-differences
+   the two.
+
+It then groups the sweep by resolution pair, fits the tilt exponent within each
+group over the points at or below `tilt_fit_max` when `tilt_fit` is set, writes
+`resting_state.nc` and `resting_state.png`, and applies four checks:
+
+- `_check_resting_state()` — the two columns' sea-surface heights must agree to
+  `resting_state_max_ssh_diff`.  A larger difference means the vertical-grid
+  construction moved the sea floor off the requested bathymetry, so the
+  measured HPGA is real physics rather than error;
+- `_check_omega_vs_polaris()` — the retained `omega_vs_polaris_rms_threshold`
+  consistency check, which is independent of the resting-state property;
+- `_check_sensitivity()` — the largest RMS anywhere in the sweep must reach
+  `resting_state_sensitivity_min_rms`, or the sweep is not exercising the
+  failure mode and must be redesigned;
+- `_check_max_rms()` — the consistency gate, skipped while
+  `resting_state_max_rms` is `none`.

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -281,12 +281,41 @@ name, and both plots draw the schemes on one panel -- the comparison between
 them at the same resolution is the measurement, so separating them would hide
 it.
 
-The step enforces regression criteria from `[horiz_press_grad]`, applied per
-scheme:
+The step enforces regression criteria from `[horiz_press_grad]`:
 
-- allowed convergence-slope range for Omega-vs-reference,
-- high-resolution RMS threshold for Omega-vs-reference, and
-- RMS threshold for Omega-vs-Python consistency.
+- allowed convergence-slope range for Omega-vs-reference, **per scheme**
+  (`omega_vs_reference_convergence_rate_{min,max}_{scheme}`);
+- high-resolution RMS threshold for Omega-vs-reference, per scheme;
+- RMS threshold for Omega-vs-Python consistency, per scheme; and
+- `omega_vs_reference_accuracy_ratio_min`, the ratio of the centered to the
+  finite-volume RMS error at the **coarsest** resolution.
+
+Three things about the last two are worth knowing, because each was set from
+measurement against a plausible alternative:
+
+- **Bands are per scheme because the schemes genuinely differ in order on one
+  variant.**  Measured offline over 4, 2, 1 and 0.5 km, centered against finite
+  volume: 1.68/1.68 (`temperature_gradient`), 1.77/1.77 (`salinity_gradient`),
+  **0.93/1.98** (`ztilde_gradient`), 2.00/1.99 (`surface_pressure_gradient`).
+  Only `ztilde_gradient` needs its own pair, and it is the one that shows what
+  the scheme is for: the centered scheme is first order there and the
+  finite-volume scheme restores second.
+- **The accuracy gate is a ratio, not a comparison of orders.**  Gating on the
+  new scheme's slope beating the old one would fail on three variants out of
+  four, where the two converge at the same rate and nothing is wrong.
+- **Its default is 0.98, which asserts only "not worse".**  On
+  `temperature_gradient` and `salinity_gradient` the two schemes agree to five
+  digits -- the layers are level there, so matched-pressure and matched-index
+  coincide, and the error is the two-column representation of the tracer
+  gradient, which both schemes share.  Demanding an improvement would fail on a
+  configuration with nothing to improve.  `ztilde_gradient` raises it to 1.5
+  (measured 1.80 at the coarse end) and `surface_pressure_gradient` to 1.8
+  (measured 2.19).
+
+`ztilde_gradient` is also where the design's own guidance needs qualifying: the
+advantage there **widens** under refinement, 1.80x at 4 km against 14.8x at
+0.5 km, because the orders differ.  Elsewhere it is the constant factor the
+design describes.
 
 Implementation-wise, `Analysis.run()` iterates over configured horizontal
 resolutions and, within each, over schemes.  For each resolution it:
@@ -378,4 +407,28 @@ checks:
   higher-order scheme exists to fix, so demanding it of `finite_volume` would
   be requiring the new scheme to fail;
 - `_check_max_rms()` — the consistency gate, applied per scheme and skipped
-  while `resting_state_max_rms` is `none`.
+  while `resting_state_max_rms` is `none`;
+- `_check_improvement()` — the centered RMS divided by the finite-volume RMS
+  must reach `resting_state_improvement_min` at **every** sweep point.  The
+  true HPGA is zero here, so both are pure error and the ratio is a clean
+  statement of what the higher-order scheme buys, with no reference solution
+  and none of its discretization involved.  The ratio is logged whether or not
+  a threshold is set.
+
+The improvement gate is set **per variant** because the advantage spans four
+orders of magnitude, and a shared value would be vacuous at one end and
+unreachable at the other.  Measured offline, the smallest ratio anywhere in
+each sweep:
+
+| variant | worst ratio | at | gate |
+| --- | --- | --- | --- |
+| `hydrostatic_consistency` | 2.58x | 4 km, 128 m, tilt 50 | 1.5 |
+| `hydrostatic_consistency_linear` | 7.71x | 4 km, 64 m, tilt 50 | 4.0 |
+| `bathymetry_step` | 1170x | 4 km, 256 m, grad 200 | 500 |
+| `bathymetry_step_linear` | 58828x | 4 km, 256 m, grad 200 | 20000 |
+
+The ordering is the result, not an accident of the sweeps: the advantage is
+smallest where the profile is curved and only the coordinate tilts, and largest
+where the profile is resolved and the sea floor steps.  Those numbers are
+pinned by `test_improvement_gate_is_below_what_the_kernel_delivers`, so the
+gates and the measurements cannot drift apart silently.

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -221,10 +221,12 @@ It then groups the sweep by resolution pair, fits the tilt exponent within each
 group over the points at or below `tilt_fit_max` when `tilt_fit` is set, writes
 `resting_state.nc` and `resting_state.png`, and applies four checks:
 
-- `_check_resting_state()` — the two columns' sea-surface heights must agree to
-  `resting_state_max_ssh_diff`.  A larger difference means the vertical-grid
-  construction moved the sea floor off the requested bathymetry, so the
-  measured HPGA is real physics rather than error;
+- `_check_bathymetry()` — `bottomDepth` must match the `bottomDepthRequested`
+  written by `Init` to within `resting_state_max_bathy_error`.  The p-star
+  column is anchored at the prescribed sea surface, so `ssh` is exact by
+  construction and cannot reveal a problem; partial-cell snapping instead moves
+  the sea floor, which leaves the state at rest but means the swept tilt is no
+  longer the geometry under test;
 - `_check_omega_vs_polaris()` — the retained `omega_vs_polaris_rms_threshold`
   consistency check, which is independent of the resting-state property;
 - `_check_sensitivity()` — the largest RMS anywhere in the sweep must reach

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -75,8 +75,30 @@ of *each column* that contains that pressure.  Under tilt those are not the
 same layer -- at 50 m/km and 64 m layers the two columns' layer `k` do not
 overlap in pressure at all -- and getting this wrong silently turns the scheme
 into a different one.  `column_scan()` then accumulates the fixed-pressure
-height difference down the column from `anchor_difference()`, and
+height difference along the column from `anchor_difference()`, and
 `finite_volume_hpga()` forms the layer mean and the tendency.
+
+**The scan anchors at the sea floor**, per design §3.7.4, at the deepest
+interface valid in both columns.  This is not a conditioning preference:
+`VertCoord` builds geometric height upward from a prescribed bathymetry by
+accumulating over each column's *own* layers, so two columns partitioned
+differently by a tilt derive sea-surface heights that differ at
+$O(\tilde h^2)$, and a surface anchor would feed that straight into the answer.
+Note that §3.5.1 of the design still describes a surface anchor; §3.7.4 is
+later, gives the argument, and is what Omega implements.
+
+One consequence is worth knowing before reading the tests.  A Polaris initial
+condition pins the *sea surface* and lets the bottom pressure absorb the same
+$O(\tilde h^2)$ discrepancy, which is the opposite end from `VertCoord`.  So on
+these states the sea-floor anchor is **not** zero even on
+`hydrostatic_consistency_linear`: the two columns reach slightly different
+bottom pressures at the same depth, and at a common pressure their heights
+genuinely differ.  The scheme is right to report it.  What the tests assert on
+the exact set is therefore that the scan stays *flat* -- every increment zero
+to round-off -- and that the assembled tendency is the anchor and nothing
+else, which holds to a part in $10^7$ across the sweep.  The
+`anchor_at_surface` guard switches ends so the gap can be measured rather than
+assumed.
 
 The module also retains `centered_shift()` and `centered_shift_accumulated()`.
 These are no longer on the computational path; they are kept as diagnostics,

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -88,6 +88,18 @@ switches, each deliberately breaking one rule of the design.  They exist to
 confirm the test suite can detect a broken implementation; they are not
 supported settings.
 
+The Gauss-Legendre rule these integrals use comes from the `quadrature_points`
+config option, which is the *same* option that fills in Omega's
+`PressureGrad:QuadraturePoints`.  That is deliberate and is not a convenience.
+`omega_vs_polaris_rms_threshold` is the only check in this task family that
+tests Omega's arithmetic against an independent implementation, and it is a
+check on the implementations only if both integrate with the same rule; two
+sides quadrating differently are two algorithms, and their disagreement would
+not be distinguishable from a bug in either.  Exactness itself does not depend
+on the rule -- on the exact set the integrand is zero at every point, so any
+rule integrates it to zero -- which is exactly why a mismatch here would show
+up only off the exact set, where it is hardest to attribute.
+
 ### reference
 
 The class

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -156,8 +156,12 @@ resolutions.  For each resolution it:
 2. identifies the single internal edge via `_get_internal_edge()` and derives
    the forward pseudo-heights via `_get_forward_z_tilde_edge_mid()`;
 3. constructs a `ReferenceColumn` with the mesh-derived `x_sign` and calls
-   `ref.layer_mean_hpga()` on the edge interface pseudo-heights from
-   `init.nc`, dropping the deepest valid layer (which abuts bathymetry);
+   `ref.layer_mean_hpga()` on the edge interface pseudo-heights from `init.nc`,
+   over interfaces `0 .. max_level_index + 1` so that every layer valid in both
+   columns is included, down to and including the bottom partial cell.  An
+   earlier version dropped that layer because the then-current five-column
+   finite-difference reference could not form its stencil there; the analytic
+   single-column reference is valid to the seafloor, so it is now kept;
 4. checks that Python and Omega pseudo-heights agree with
    `_check_vertical_match()`, then computes the Omega-vs-Python RMS difference
    from `init.nc` HPGA.
@@ -205,9 +209,8 @@ replaces `Analysis` for these variants.  Per sweep point it:
 
 1. locates the internal edge with `get_internal_edge()`;
 2. forms the valid layer range `0 .. min(maxLevelCell) - 1`, **inclusive** of
-   the deepest layer valid in both columns — `Analysis` drops that layer, but
-   it is the bottom partial cell and carries the entire `bathymetry_step`
-   signal;
+   the deepest layer valid in both columns — the bottom partial cell, which
+   carries the entire `bathymetry_step` signal.  `Analysis` includes it too;
 3. takes the RMS of Omega's `NormalVelocityTend` at that edge over those
    layers.  The truth is zero, so this is the error, not a difference from a
    reference;

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -87,18 +87,43 @@ $O(\tilde h^2)$, and a surface anchor would feed that straight into the answer.
 Note that §3.5.1 of the design still describes a surface anchor; §3.7.4 is
 later, gives the argument, and is what Omega implements.
 
-One consequence is worth knowing before reading the tests.  A Polaris initial
-condition pins the *sea surface* and lets the bottom pressure absorb the same
-$O(\tilde h^2)$ discrepancy, which is the opposite end from `VertCoord`.  So on
-these states the sea-floor anchor is **not** zero even on
-`hydrostatic_consistency_linear`: the two columns reach slightly different
-bottom pressures at the same depth, and at a common pressure their heights
-genuinely differ.  The scheme is right to report it.  What the tests assert on
-the exact set is therefore that the scan stays *flat* -- every increment zero
-to round-off -- and that the assembled tendency is the anchor and nothing
-else, which holds to a part in $10^7$ across the sweep.  The
-`anchor_at_surface` guard switches ends so the gap can be measured rather than
-assumed.
+One consequence is worth knowing before reading the tests: on these states the
+sea-floor anchor is **not** zero, even on `hydrostatic_consistency_linear`.
+
+The cause is the midpoint rule both codes use to turn pressure into geometric
+height, `geom_thickness = spec_vol * h_tilde * RhoSw`.  At 256 m layers it
+truncates each column's 3500 m integral by $1.096\times10^{-3}$ m.  `Init`
+holds `bottomDepth` at the prescribed bathymetry and solves for
+`BottomPressure`, which is the right assignment of known and unknown, and each
+column converges exactly -- to the bottom pressure that makes *its own*
+midpoint sum 3500 m.  Under tilt the two columns' interfaces fall in different
+places, so their truncation errors differ, by $7.138\times10^{-8}$ m; that
+difference is the anchor, to four significant figures.  At a common pressure
+the two columns' heights genuinely differ by that much, and the scheme is right
+to report it.
+
+Three things follow that are worth stating because each closes off a plausible
+fix:
+
+- **more iterations do not help.**  The iteration is at its exact fixed point;
+  over 6 to 40 iterations the inter-column pressure difference is unchanged to
+  seven digits;
+- **anchoring `pstar_init` at the sea floor would be a no-op.**  It already
+  builds the column sea-floor-anchored and shifts it afterwards, and that shift
+  is exactly zero wherever the iteration converges -- which is everywhere in
+  this task, since these variants set `partial_cell_type = None`;
+- **Polaris must not integrate more accurately.**  The increment is
+  byte-identical to `VertCoord::computeGeomZHeight` on purpose; that is what
+  closes the round trip and gives `omega_vs_polaris` its meaning.  A better
+  quadrature here would break it by ~1 mm to remove $7\times10^{-8}$ m.
+
+What the tests assert on the exact set is therefore that the scan stays *flat*
+-- every increment zero to round-off -- and that the assembled tendency is the
+anchor and nothing else, which holds to a part in $10^7$ across the sweep.  The
+residual is $1.75\times10^{-10}$ m s$^{-2}$, against $9.1\times10^{-8}$ for
+`Centered` on the same state, so it is a ceiling on how exact the test can be
+rather than a limit on the scheme.  The `anchor_at_surface` guard switches ends
+so the gap can be measured rather than assumed.
 
 The module also retains `centered_shift()` and `centered_shift_accumulated()`.
 These are no longer on the computational path; they are kept as diagnostics,

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -203,35 +203,71 @@ holds the p-star coordinate variables written for Omega.
 ### forward
 
 The class {py:class}`polaris.tasks.ocean.horiz_press_grad.forward.Forward`
-defines one model step per horizontal resolution.
+defines one model step per horizontal resolution **and per pressure-gradient
+scheme**, named `forward_<res>_<scheme>`.
 
 It runs Omega from the corresponding `init` output and writes `output.nc`
 (with `NormalVelocityTend` validation), using options from `forward.yaml`.
+`forward.yaml` is a Jinja2 template whose `PressureGrad` block is filled in per
+step from the `scheme` argument and the `quadrature_points` config option.
+
+The schemes are listed by the `pressure_grad_types` config option and named in
+the module-level `SCHEMES` dict, which maps the config spelling to Omega's
+`PressureGradType`.  `SCHEME_HPGA` maps each to the field in `init.nc` that is
+its Polaris counterpart, which is what the analysis steps compare Omega
+against.
+
+Two things about this axis are worth stating, because both were decided
+against plausible alternatives:
+
+- **Both schemes share one `Init` step.**  `Init` is scheme-independent -- it
+  writes `HPGA` and `HPGAFiniteVolume` from the same state -- so duplicating it
+  per scheme would cost run time and, worse, would leave the comparison open to
+  the objection that the two schemes ran on different initial conditions.  The
+  cost is that the scheme label is in every forward step's directory, so
+  baselines recorded before the axis existed do not carry over.
+- **There is no "centered limit" of the finite-volume scheme.**  The two are
+  separate implementations and no setting reduces one to the other, so this is
+  a choice between schemes rather than a parameter of one.  Omega treats an
+  unrecognized `PressureGradType` as fatal rather than falling back to
+  `Centered`, so a typo aborts the run instead of producing centered answers
+  that read as a pass.
 
 ### analysis
 
 The class {py:class}`polaris.tasks.ocean.horiz_press_grad.analysis.Analysis`
 compares each `forward` result with:
 
-- the analytic reference solution (built from `ReferenceColumn`), and
-- the Python-computed HPGA from `init.nc`.
+- the analytic reference solution (built from `ReferenceColumn`), which is a
+  property of the state and so is shared by both schemes, and
+- the Python-computed HPGA from `init.nc` **for the matching scheme**:
+  `HPGA` for `centered`, `HPGAFiniteVolume` for `finite_volume`.  Comparing
+  Omega's finite-volume output against the centered `HPGA` would measure the
+  difference between two schemes and report it as an implementation
+  disagreement.
 
 The step writes:
 
 - `omega_vs_reference.nc` and `omega_vs_reference.png`
 - `omega_vs_python.nc` and `omega_vs_python.png`
 
-and enforces regression criteria from `[horiz_press_grad]`, including:
+Both files carry one series per scheme, as variables suffixed with the scheme
+name, and both plots draw the schemes on one panel -- the comparison between
+them at the same resolution is the measurement, so separating them would hide
+it.
+
+The step enforces regression criteria from `[horiz_press_grad]`, applied per
+scheme:
 
 - allowed convergence-slope range for Omega-vs-reference,
 - high-resolution RMS threshold for Omega-vs-reference, and
 - RMS threshold for Omega-vs-Python consistency.
 
 Implementation-wise, `Analysis.run()` iterates over configured horizontal
-resolutions.  For each resolution it:
+resolutions and, within each, over schemes.  For each resolution it:
 
 1. reads `init_r*.nc`, `culled_mesh_r*.nc`, `vert_coord_r*.nc`, and
-   `output_r*.nc`;
+   `output_r*_<scheme>.nc`;
 2. identifies the single internal edge via `_get_internal_edge()` and derives
    the forward pseudo-heights via `_get_forward_z_tilde_edge_mid()`;
 3. constructs a `ReferenceColumn` with the mesh-derived `x_sign` and calls
@@ -265,9 +301,8 @@ the resolution pairs with `tilt_values`.
 - `subdir_suffix` replaces the horizontal resolution in the step name, so
   repeated horizontal resolutions do not collide.  It is built by
   `sweep_suffix(horiz_res, vert_res, tilt)`, giving names like
-  `init_4km_256m_tilt0p5`.  When it is not given, the existing
-  `init_<res>` / `forward_<res>` naming is used, so the four gradient variants
-  keep their work directories.
+  `init_4km_256m_tilt0p5`.  When it is not given, the horizontal resolution is
+  used, giving `init_<res>` and `forward_<res>_<scheme>`.
 - `tilt_option` and `tilt` (on `Init` only) name a `[horiz_press_grad]` config
   option that `Init.run()` sets in its own config before building the columns,
   in the same way it already sets `vertical_grid:vert_levels`.
@@ -291,14 +326,16 @@ replaces `Analysis` for these variants.  Per sweep point it:
    the deepest layer valid in both columns — the bottom partial cell, which
    carries the entire `bathymetry_step` signal.  `Analysis` includes it too;
 3. takes the RMS of Omega's `NormalVelocityTend` at that edge over those
-   layers.  The truth is zero, so this is the error, not a difference from a
-   reference;
-4. does the same for the Polaris-side `HPGA` from `init.nc` and RMS-differences
-   the two.
+   layers, for each scheme.  The truth is zero, so this is the error, not a
+   difference from a reference;
+4. does the same for the matching Polaris-side field from `init.nc` --
+   `HPGA` or `HPGAFiniteVolume` per `SCHEME_HPGA` -- and RMS-differences the
+   two.
 
 It then groups the sweep by resolution pair, fits the tilt exponent within each
-group over the points at or below `tilt_fit_max` when `tilt_fit` is set, writes
-`resting_state.nc` and `resting_state.png`, and applies four checks:
+group and scheme over the points at or below `tilt_fit_max` when `tilt_fit` is
+set, writes `resting_state.nc` and `resting_state.png`, and applies four
+checks:
 
 - `_check_bathymetry()` — `bottomDepth` must match the `bottomDepthRequested`
   written by `Init` to within `resting_state_max_bathy_error`.  The p-star
@@ -307,9 +344,13 @@ group over the points at or below `tilt_fit_max` when `tilt_fit` is set, writes
   the sea floor, which leaves the state at rest but means the swept tilt is no
   longer the geometry under test;
 - `_check_omega_vs_polaris()` — the retained `omega_vs_polaris_rms_threshold`
-  consistency check, which is independent of the resting-state property;
+  consistency check, applied per scheme and independent of the resting-state
+  property;
 - `_check_sensitivity()` — the largest RMS anywhere in the sweep must reach
   `resting_state_sensitivity_min_rms`, or the sweep is not exercising the
-  failure mode and must be redesigned;
-- `_check_max_rms()` — the consistency gate, skipped while
-  `resting_state_max_rms` is `none`.
+  failure mode and must be redesigned.  This is applied to **`centered` only**:
+  it asks whether the sweep is severe enough to exercise the failure the
+  higher-order scheme exists to fix, so demanding it of `finite_volume` would
+  be requiring the new scheme to fail;
+- `_check_max_rms()` — the consistency gate, applied per scheme and skipped
+  while `resting_state_max_rms` is `none`.

--- a/docs/developers_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/developers_guide/ocean/tasks/horiz_press_grad.md
@@ -43,6 +43,51 @@ need: `get_internal_edge()`, `rms()`, `power_law_fit()`,
 `format_value_error_pairs()`.  It exists so the two step modules can share them
 without importing private names from one another.
 
+### the finite-volume pressure gradient
+
+Four leaf modules implement the `FiniteVolume` scheme of the
+`PGradHighOrder.md` design, as the Python counterpart of Omega's
+`PressureGradFiniteVolume`.  They are written from that design rather than from
+the C++, so that the Omega-vs-Polaris comparison in `analysis` compares two
+independent implementations.
+
+{py:mod}`polaris.tasks.ocean.horiz_press_grad.edge` holds the two-column edge
+operator, `edge_delta()` and `edge_mean()`.  It has no dependencies inside the
+package so the modules below can share it without importing one another.
+
+{py:mod}`polaris.tasks.ocean.horiz_press_grad.eos_expansion` gives the four
+Taylor coefficients of the equation of state from one `gsw` evaluation per cell
+per layer, averages them and the reference state to the edge, and evaluates the
+resulting shared profile.  Note that `gsw.specvol_first_derivatives()` takes
+pressure in dbar but returns the pressure derivative per Pa; the tests assert
+this rather than trusting it.
+
+{py:mod}`polaris.tasks.ocean.horiz_press_grad.reconstruction` builds the
+mean-preserving linear reconstruction of temperature and salinity in pressure.
+The slope is a centred difference of the layer means against *mid-layer
+pressure*, which is what makes it exact on a non-uniform grid.
+
+{py:mod}`polaris.tasks.ocean.horiz_press_grad.finite_volume` assembles the
+scheme.  The essential piece is `delta_specvol_at_pressure()`, which
+differences the integrand at **matched pressure** rather than at matched layer
+index: for each quadrature point, `layer_containing_pressure()` finds the layer
+of *each column* that contains that pressure.  Under tilt those are not the
+same layer -- at 50 m/km and 64 m layers the two columns' layer `k` do not
+overlap in pressure at all -- and getting this wrong silently turns the scheme
+into a different one.  `column_scan()` then accumulates the fixed-pressure
+height difference down the column from `anchor_difference()`, and
+`finite_volume_hpga()` forms the layer mean and the tendency.
+
+The module also retains `centered_shift()` and `centered_shift_accumulated()`.
+These are no longer on the computational path; they are kept as diagnostics,
+because `hpga_from_shift(centered_shift(ds), dx)` reproduces the centered
+scheme's `HPGA` exactly and is the cheapest available regression test of it.
+
+`finite_volume_hpga()` accepts a `guards` argument holding verification-only
+switches, each deliberately breaking one rule of the design.  They exist to
+confirm the test suite can detect a broken implementation; they are not
+supported settings.
+
 ### reference
 
 The class

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -30,11 +30,13 @@ ocean/column/horiz_press_grad/temperature_gradient
 ocean/column/horiz_press_grad/ztilde_gradient
 ocean/column/horiz_press_grad/surface_pressure_gradient
 ocean/column/horiz_press_grad/hydrostatic_consistency
+ocean/column/horiz_press_grad/hydrostatic_consistency_linear
 ocean/column/horiz_press_grad/bathymetry_step
+ocean/column/horiz_press_grad/bathymetry_step_linear
 ```
 
 The first four impose a horizontal gradient and measure convergence toward the
-analytic reference.  The last two are **resting states** whose true HPGA is
+analytic reference.  The last four are **resting states** whose true HPGA is
 identically zero, so the model's HPGA is entirely error and no reference
 solution is involved; see {ref}`ocean-horiz-press-grad-resting`.
 
@@ -302,8 +304,8 @@ option exists.
 (ocean-horiz-press-grad-resting)=
 ## the resting-state variants
 
-The `hydrostatic_consistency` and `bathymetry_step` variants ask a different
-question from the other four.  Rather than measuring convergence toward a
+The four resting-state variants ask a different question from the other
+four.  Rather than measuring convergence toward a
 reference, they place the ocean in a state whose true HPGA is **identically
 zero**, so that whatever the model returns is error.
 
@@ -358,6 +360,43 @@ the same reason `bathymetry_step` sets `tilt_fit = False`: its error changes in
 steps as the two columns' `maxLevelCell` values change, so it is a staircase in
 the sea-floor gradient rather than a power law and a fitted exponent would be
 meaningless.
+
+### the two `_linear` variants
+
+Every resting state has a true HPGA of zero, but that is not the same as being
+a state the finite-volume scheme reproduces *exactly*.  The scheme's exact set
+is set by what its vertical reconstruction can represent, which in Omega's
+Phase 1 is profiles **linear in pressure**.  The two `_linear` variants replace
+the five-node curved temperature and salinity profiles with two-node ones, so
+they are exactly linear in pseudo-height and hence in pressure.  Everything
+else is unchanged.
+
+That separation is what makes them worth running:
+
+| | profile | what tilts |
+| --- | --- | --- |
+| `hydrostatic_consistency` | curved | the coordinate |
+| `hydrostatic_consistency_linear` | exact | the coordinate |
+| `bathymetry_step` | curved | the sea floor |
+| `bathymetry_step_linear` | exact | the sea floor |
+
+On the curved variants the residual mixes the scheme's truncation off the exact
+set with whatever the geometry contributes, and neither can be read alone.  On
+the `_linear` variants the profile contributes nothing, so what is left is the
+geometry's doing.
+
+**`bathymetry_step_linear` is the one to watch.**  It is the only configuration
+in the family that is both inside the exact set and in the geometry that
+matters for the global bottom-layer error — interior coordinate tilt turns out
+to contribute essentially nothing globally, so `hydrostatic_consistency` and
+its `_linear` twin exercise a mechanism that is real but not the one driving
+the problem.  Like `bathymetry_step` it sets `tilt_fit = False`, and for the
+same reason.
+
+It is also where the scheme's advantage is largest: measured offline at 4 km
+and 256 m layers, `HPGAFiniteVolume` is 4.3e-10 m s⁻² against the centered
+9.1e-5 m s⁻² at a 200 m/km sea-floor gradient — a factor of 2e5, against the
+20–1000× the coordinate-tilt variants show.
 
 ### severity, and why the column is deep
 

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -249,22 +249,42 @@ unaffected by the new field.
 `PressureGradFiniteVolume` scheme.  Where the centered scheme compares the two
 columns at a fixed *layer index*, this one compares them at a fixed *pressure*:
 it differences the specific volume of the two columns at matched pressure and
-integrates that difference down the column.  Because the difference is
-identically zero whenever the two columns describe the same water, the scheme
-returns zero for a resting ocean regardless of how the coordinate is tilted.
+integrates that difference along the column from the sea floor.  Because the
+difference is identically zero whenever the two columns describe the same
+water, the scheme contributes nothing of its own for a resting ocean however
+the coordinate is tilted, and what it returns is whatever the state's own
+boundary values imply -- see below.
 
 What that buys, measured on `hydrostatic_consistency_linear` -- the one variant
 whose temperature and salinity are exactly linear in pressure, and so the only
-one where machine precision is the correct expectation:
+one where the scheme's exact set is in play:
 
 | coordinate tilt | `HPGA` (centered) | `HPGAFiniteVolume` |
 | --- | --- | --- |
-| 0.05 m/km | 2.6e-08 m s⁻² | 2.2e-15 m s⁻² |
-| 1 m/km | 5.2e-07 m s⁻² | 7.2e-18 m s⁻² |
-| 50 m/km | 2.1e-05 m s⁻² | 2.3e-18 m s⁻² |
+| 0.05 m/km | 9.1e-08 m s⁻² | 1.8e-10 m s⁻² |
+| 1 m/km | 1.8e-06 m s⁻² | 3.5e-09 m s⁻² |
+| 50 m/km | 6.9e-05 m s⁻² | 2.0e-07 m s⁻² |
 
-at 256 m layers.  The finite-volume values are round-off; they do not grow with
-tilt, which is the property the whole scheme exists for.
+at 256 m layers: a factor of 340 to 520, and 21 to 1050 across the full sweep.
+
+**Why this is not machine precision, though the profile is inside the exact
+set.** The scheme's column scan is anchored at the sea floor, following the
+Omega design, and the anchor is the one quantity in it that comes from the
+state rather than from the scheme's own arithmetic.  Polaris builds its
+p-star column downward from a *prescribed sea surface*, whereas Omega's
+`VertCoord` builds geometric height upward from a *prescribed bathymetry*.
+Those are opposite ends, and the small mismatch between them -- the two
+columns reach very slightly different bottom pressures at the same depth,
+because specific volume is nonlinear in pressure and the tilt partitions the
+two columns differently -- lands in the bottom pressure here rather than in the
+sea-surface height.  At a common pressure the two columns' heights therefore
+genuinely differ, and the scheme reports that difference.
+
+The residual is *entirely* the anchor: every increment of the scan is zero to
+round-off, so the tendency is constant down the column and equals the anchor's
+own contribution to a part in 10⁷.  The property the scheme exists for is
+intact; what these numbers measure at the bottom of the column is the initial
+condition, not the discretization.
 
 Away from that exact set the gain is real but far smaller, because the scheme
 is then second-order accurate rather than exact.  On the curved

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -316,25 +316,36 @@ At a fixed tilt gradient the RMS HPGA is independent of horizontal resolution,
 because the cross-edge offset and the cell spacing scale together.  The
 horizontal sweep is therefore short; the vertical resolution is what matters.
 
-### the resting-state guard
+### the bathymetry guard
 
-A resting state has a level sea surface.  The analysis checks that the two
-columns' sea-surface heights agree to within `resting_state_max_ssh_diff` and
-fails otherwise.
+Both variants set `partial_cell_type = None`, and the analysis checks that the
+sea floor really is where the configuration asked for it, to within
+`resting_state_max_bathy_error`.
 
-This is not hypothetical.  Both variants set `partial_cell_type = None`,
-because partial-cell snapping moves the column bottom to enforce
-`min_pc_fraction` while the p-star iteration moves `BottomPressure` to enforce
-the requested bathymetry.  For sea-floor steps that land near a snapping
-threshold the two fight, and the columns can converge to sea-surface heights
-more than 10 m apart.  The resulting HPGA is then real barotropic physics, not
-discretization error — the guard exists so that this fails loudly instead of
-being read as a catastrophic pressure-gradient error.
+The reason is that partial-cell snapping moves the sea floor to the nearest
+*representable* depth, since `min_pc_fraction` forbids bottom cells thinner
+than a set fraction of a layer.  The p-star column is anchored at the
+prescribed sea surface, so this does **not** break the resting state — the sea
+surface stays exactly level and the state is still exactly at rest.  What it
+breaks is the meaning of the sweep: the tilt actually tested is no longer the
+tilt configured.
+
+That matters most for `bathymetry_step`, where the swept parameter *is* the sea
+floor.  At some gradients snapping moves both columns to the same representable
+depth, so a nominal 400 m step becomes no step at all and the measured RMS HPGA
+drops to round-off — which would read as a spectacular pass rather than a
+configuration that stopped testing anything.
 
 Setting `partial_cell_type = None` does not cost partial-cell coverage: the
 p-star reference grid is clipped at the pseudo-bottom depth regardless, so the
 deepest layer is a partial cell either way.  The option controls only whether
 the topography is snapped.
+
+(Before the p-star column was anchored at the prescribed sea surface, this same
+snapping surfaced as a spurious *sea-surface* tilt of many metres, which was a
+real barotropic pressure gradient masquerading as discretization error.  That
+is fixed in the framework; the guard here is about the geometry under test, not
+about the resting state.)
 
 (ocean-horiz-press-grad-config)=
 ## config options
@@ -424,8 +435,9 @@ resting_state_sensitivity_min_rms = 1.0e-6
 # unenforced
 resting_state_max_rms = none
 
-# maximum allowed difference between the two columns' sea-surface heights
-resting_state_max_ssh_diff = 1.0e-9
+# maximum allowed |bottomDepth - requested|, so the swept tilt describes the
+# geometry actually tested
+resting_state_max_bathy_error = 1.0e-6
 ```
 
 `resting_state_max_rms` is deliberately unset.  The centered scheme is expected

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -268,17 +268,19 @@ one where the scheme's exact set is in play:
 at 256 m layers: a factor of 340 to 520, and 21 to 1050 across the full sweep.
 
 **Why this is not machine precision, though the profile is inside the exact
-set.** The scheme's column scan is anchored at the sea floor, following the
-Omega design, and the anchor is the one quantity in it that comes from the
-state rather than from the scheme's own arithmetic.  Polaris builds its
-p-star column downward from a *prescribed sea surface*, whereas Omega's
-`VertCoord` builds geometric height upward from a *prescribed bathymetry*.
-Those are opposite ends, and the small mismatch between them -- the two
-columns reach very slightly different bottom pressures at the same depth,
-because specific volume is nonlinear in pressure and the tilt partitions the
-two columns differently -- lands in the bottom pressure here rather than in the
-sea-surface height.  At a common pressure the two columns' heights therefore
-genuinely differ, and the scheme reports that difference.
+set.** The scheme's column scan is anchored at the sea floor, and the anchor is
+the one quantity in it that comes from the model's own geometry rather than
+from the scheme's arithmetic.
+
+Both Polaris and Omega turn pressure into geometric height with a midpoint
+rule, summing `rho0 * SpecVol * PseudoThickness` over layers.  At 256 m layers
+that truncates a 3500 m column by about 1.1 mm.  The initial condition holds
+the sea floor at the prescribed bathymetry and solves for the bottom pressure
+that reproduces it, and each column converges exactly -- to the pressure that
+makes *its own* midpoint sum come out at 3500 m.  A tilted coordinate puts the
+two columns' layer interfaces in different places, so their truncation errors
+differ slightly, by 7.1e-8 m.  At a common pressure the two columns' heights
+therefore genuinely differ by that much, and the scheme reports it.
 
 The residual is *entirely* the anchor: every increment of the scan is zero to
 round-off, so the tendency is constant down the column and equals the anchor's

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -237,6 +237,46 @@ This Python HPGA is not the main reference solution.  Instead, it checks
 whether Omega's one-step tendency matches the expected two-column discrete
 calculation from the initialized state.
 
+(ocean-horiz-press-grad-finite-volume)=
+## the finite-volume HPGA
+
+The `init` step also writes a second field, `HPGAFiniteVolume`, alongside
+`HPGA`.  `HPGA` is unchanged in name, meaning and values -- it remains the
+centered scheme, and the recorded baselines for all seven variants are
+unaffected by the new field.
+
+`HPGAFiniteVolume` is the Python counterpart of Omega's higher-order
+`PressureGradFiniteVolume` scheme.  Where the centered scheme compares the two
+columns at a fixed *layer index*, this one compares them at a fixed *pressure*:
+it differences the specific volume of the two columns at matched pressure and
+integrates that difference down the column.  Because the difference is
+identically zero whenever the two columns describe the same water, the scheme
+returns zero for a resting ocean regardless of how the coordinate is tilted.
+
+What that buys, measured on `hydrostatic_consistency_linear` -- the one variant
+whose temperature and salinity are exactly linear in pressure, and so the only
+one where machine precision is the correct expectation:
+
+| coordinate tilt | `HPGA` (centered) | `HPGAFiniteVolume` |
+| --- | --- | --- |
+| 0.05 m/km | 2.6e-08 m s⁻² | 2.2e-15 m s⁻² |
+| 1 m/km | 5.2e-07 m s⁻² | 7.2e-18 m s⁻² |
+| 50 m/km | 2.1e-05 m s⁻² | 2.3e-18 m s⁻² |
+
+at 256 m layers.  The finite-volume values are round-off; they do not grow with
+tilt, which is the property the whole scheme exists for.
+
+Away from that exact set the gain is real but far smaller, because the scheme
+is then second-order accurate rather than exact.  On the curved
+`hydrostatic_consistency` profile it is about six times better than centered at
+256 m layers and about twice as good at 64 m, both converging.  On
+`bathymetry_step`, the variant that most resembles the bottom-layer error seen
+in realistic global runs, it is roughly 400 times better.
+
+Nothing selects between the two fields yet: both are written, and which one the
+analysis steps compare against Omega is decided once the corresponding Omega
+option exists.
+
 (ocean-horiz-press-grad-resting)=
 ## the resting-state variants
 

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -186,9 +186,10 @@ default).
 For comparison with a layer-averaged Omega tendency, the `analysis` step
 averages $a(\tilde z)$ over the model's actual pseudo-height layer bounds using
 4-point Gauss–Legendre quadrature with `reference_quadrature_subdivisions`
-sub-panels per layer.  The deepest valid layer (which abuts the bathymetry) is
-excluded from the RMS error calculation, because partial bottom cells make that
-layer's geometric extent differ from the smooth reference geometry.
+sub-panels per layer.  Every layer valid in both columns is included, down to
+and including the deepest, which abuts the bathymetry.  That layer is the bottom
+partial cell, and it is where pressure-gradient error is largest; excluding it
+would hide exactly what the test should be measuring.
 
 ## python HPGA in the `init` step
 
@@ -450,10 +451,17 @@ The corresponding tabulated data are written to
 
 For the Omega-versus-reference comparison, the analytic reference
 $a(\tilde z)$ is layer-averaged over the model's actual pseudo-height layer
-bounds (from `init.nc`) using 4-point Gauss–Legendre quadrature.  The deepest
-valid layer is excluded from the RMS error calculation because that layer abuts
-the bathymetry, where partial bottom cells make the model layer's geometric
-extent differ from the smooth reference geometry.
+bounds (from `init.nc`) using 4-point Gauss–Legendre quadrature.  All layers
+valid in both columns are included, down to and including the deepest.
+
+Earlier versions excluded that bottom layer.  That was a limitation of the
+*previous* reference solution, which took a fourth-order finite difference
+across five columns and could not form its stencil where a neighbouring column's
+collocation point fell below its own bathymetry.  The reference is now a single
+analytic column evaluated at the edge, valid all the way to the seafloor, so the
+exclusion no longer has a basis and has been removed.  The Omega-versus-Python
+comparison always included the layer, so the two comparisons now agree about
+which layers count.
 
 For the Omega-versus-Python comparison, the analysis uses the HPGA written by
 the `init` step in `init.nc`, so this second metric should be read as an

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -336,10 +336,20 @@ depth, so a nominal 400 m step becomes no step at all and the measured RMS HPGA
 drops to round-off — which would read as a spectacular pass rather than a
 configuration that stopped testing anything.
 
-Setting `partial_cell_type = None` does not cost partial-cell coverage: the
-p-star reference grid is clipped at the pseudo-bottom depth regardless, so the
-deepest layer is a partial cell either way.  The option controls only whether
-the topography is snapped.
+`partial_cell_type = None` does **not** mean "no partial cells", despite how it
+reads.  The p-star reference grid is clipped at each column's pseudo-bottom
+depth unconditionally, so a partial bottom cell is produced either way.  The
+option controls only whether the sea floor is *moved* before that clipping:
+`None` leaves it alone, `partial` moves it so the bottom cell is at least
+`min_pc_fraction` of a full layer, and `full` moves it to a reference boundary
+— `full` is the setting that actually removes partial cells.
+
+The cost of `None` is that there is no minimum-thickness floor, so a sweep can
+include bottom cells thinner than a realistic run would use (as thin as 0.002
+of a layer in the shipped `bathymetry_step` sweep).  The state is exactly at
+rest however thin the cell, so the measurement stays valid; but it is why the
+error tracks the *contrast* in bottom-cell fraction between the two columns
+rather than the nominal gradient, and hence why that variant is a staircase.
 
 (Before the p-star column was anchored at the prescribed sea surface, this same
 snapping surfaced as a spurious *sea-surface* tilt of many metres, which was a

--- a/docs/users_guide/ocean/tasks/horiz_press_grad.md
+++ b/docs/users_guide/ocean/tasks/horiz_press_grad.md
@@ -29,7 +29,14 @@ ocean/column/horiz_press_grad/salinity_gradient
 ocean/column/horiz_press_grad/temperature_gradient
 ocean/column/horiz_press_grad/ztilde_gradient
 ocean/column/horiz_press_grad/surface_pressure_gradient
+ocean/column/horiz_press_grad/hydrostatic_consistency
+ocean/column/horiz_press_grad/bathymetry_step
 ```
+
+The first four impose a horizontal gradient and measure convergence toward the
+analytic reference.  The last two are **resting states** whose true HPGA is
+identically zero, so the model's HPGA is entirely error and no reference
+solution is involved; see {ref}`ocean-horiz-press-grad-resting`.
 
 ```{image} images/horiz_press_grad_salin_grad.png
 :align: center
@@ -229,6 +236,105 @@ This Python HPGA is not the main reference solution.  Instead, it checks
 whether Omega's one-step tendency matches the expected two-column discrete
 calculation from the initialized state.
 
+(ocean-horiz-press-grad-resting)=
+## the resting-state variants
+
+The `hydrostatic_consistency` and `bathymetry_step` variants ask a different
+question from the other four.  Rather than measuring convergence toward a
+reference, they place the ocean in a state whose true HPGA is **identically
+zero**, so that whatever the model returns is error.
+
+The construction is simple.  With every `*_grad` option zero, conservative
+temperature and absolute salinity are the same functions of pseudo-height in
+both columns.  Pseudo-height is a rescaled pressure, so specific volume becomes
+a function of pressure alone,
+
+$$
+\alpha = \alpha\bigl(\Theta(p), S_A(p), p\bigr) \equiv \alpha(p),
+$$
+
+isobars are level surfaces, and the true HPGA vanishes everywhere in the fluid
+— for *any* sea-floor shape and *any* tilt of the coordinate surfaces.  This is
+the property the Omega higher-order pressure-gradient design calls **discrete
+hydrostatic consistency**, and these variants measure how well the discrete
+scheme reproduces it.
+
+Each variant sweeps a tilt at fixed resolution and reports the RMS HPGA as a
+function of that tilt, together with the exponent $q$ in
+$\lVert\text{HPGA}\rVert \sim (\text{tilt})^{q}$:
+
+- $q \approx 1$ — specific volume is effectively piecewise constant in
+  pressure, which is what the current centered scheme does;
+- $q \approx 2$ — consistent with a residual set by a per-cell Taylor expansion
+  of the equation of state;
+- round-off, independent of tilt — the scheme is exactly hydrostatically
+  consistent.
+
+### what actually tilts the coordinate
+
+The two variants tilt different things, and they turn out to probe different
+mechanisms.
+
+`hydrostatic_consistency` sweeps `z_tilde_bot_grad`, which stretches one
+column's p-star reference grid relative to the other's, so the cross-edge
+offset of interface $k$ grows linearly with depth.  **This is the only
+mechanism in the two-column task that tilts interior coordinate surfaces.**
+
+`bathymetry_step` sweeps `geom_z_bot_grad` instead, and it does *not* tilt
+them.  With a single reference grid shared by both columns, moving the sea
+floor changes only where that grid is clipped: every interior interface sits at
+an identical pseudo-height, and hence an identical pressure, in both columns.
+The entire signal is therefore concentrated in the deepest layer valid in both
+columns — the bottom partial cell.  That makes the variant a test of the bottom
+cell rather than of layer tilt, and it is the two-column analogue of the
+bottom-layer error seen in realistic global Omega runs.
+
+Because that layer carries the whole signal, the resting-state analysis
+**keeps** it, unlike the reference-based `analysis` step, which drops it.  For
+the same reason `bathymetry_step` sets `tilt_fit = False`: its error changes in
+steps as the two columns' `maxLevelCell` values change, so it is a staircase in
+the sea-floor gradient rather than a power law and a fitted exponent would be
+meaningless.
+
+### severity, and why the column is deep
+
+The other four variants use a 500 m column resolved at 0.5–4 m.  That is one to
+three orders of magnitude finer than the ~250 m layers in the deep ocean of a
+realistic global run, and the centered scheme passes `ztilde_gradient` there
+with an RMS HPGA of ~7e-12 m s$^{-2}$ — six orders of magnitude below the error
+the resting-state variants exist to measure.  Both new variants therefore use a
+3500 m column resolved at 64–256 m.
+
+The analysis enforces a **sensitivity gate**: the largest RMS HPGA anywhere in
+the sweep must reach `resting_state_sensitivity_min_rms` (1e-6 m s$^{-2}$ by
+default, the order of the global bottom-layer error).  A sweep that falls short
+is not exercising the failure mode at all, and the step fails rather than
+reporting a misleading pass.
+
+At a fixed tilt gradient the RMS HPGA is independent of horizontal resolution,
+because the cross-edge offset and the cell spacing scale together.  The
+horizontal sweep is therefore short; the vertical resolution is what matters.
+
+### the resting-state guard
+
+A resting state has a level sea surface.  The analysis checks that the two
+columns' sea-surface heights agree to within `resting_state_max_ssh_diff` and
+fails otherwise.
+
+This is not hypothetical.  Both variants set `partial_cell_type = None`,
+because partial-cell snapping moves the column bottom to enforce
+`min_pc_fraction` while the p-star iteration moves `BottomPressure` to enforce
+the requested bathymetry.  For sea-floor steps that land near a snapping
+threshold the two fight, and the columns can converge to sea-surface heights
+more than 10 m apart.  The resulting HPGA is then real barotropic physics, not
+discretization error — the guard exists so that this fails loudly instead of
+being read as a catastrophic pressure-gradient error.
+
+Setting `partial_cell_type = None` does not cost partial-cell coverage: the
+p-star reference grid is clipped at the pseudo-bottom depth regardless, so the
+deepest layer is a partial cell either way.  The option controls only whether
+the topography is snapped.
+
 (ocean-horiz-press-grad-config)=
 ## config options
 
@@ -294,6 +400,37 @@ The four task variants each specialize one horizontal gradient field:
 - `surface_pressure_gradient`: nonzero `surface_pressure_mid` and
   `surface_pressure_grad` (with the sea-surface height following the default
   surface-pressure depression), representing an overlying ice shelf
+
+The two resting-state variants use their own set of options, which the four
+gradient variants leave at inert defaults:
+
+```cfg
+# the horiz_press_grad option swept by the resting-state variants
+tilt_option = z_tilde_bot_grad
+
+# values of tilt_option in m/km, swept at every resolution pair
+tilt_values = [0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0]
+
+# whether to fit the exponent q in |HPGA| ~ tilt**q, and the largest tilt
+# included in that fit
+tilt_fit = True
+tilt_fit_max = 10.0
+
+# the largest RMS HPGA anywhere in the sweep must reach at least this value
+resting_state_sensitivity_min_rms = 1.0e-6
+
+# maximum RMS HPGA allowed anywhere in the sweep, or "none" to leave it
+# unenforced
+resting_state_max_rms = none
+
+# maximum allowed difference between the two columns' sea-surface heights
+resting_state_max_ssh_diff = 1.0e-9
+```
+
+`resting_state_max_rms` is deliberately unset.  The centered scheme is expected
+to fail any meaningful value, and the threshold for a hydrostatically
+consistent scheme should be set from what is measured rather than guessed in
+advance.
 
 ## time step and run duration
 

--- a/polaris/tasks/ocean/horiz_press_grad/__init__.py
+++ b/polaris/tasks/ocean/horiz_press_grad/__init__.py
@@ -1,3 +1,6 @@
+from polaris.tasks.ocean.horiz_press_grad.resting_state_task import (
+    HorizPressGradRestingStateTask,
+)
 from polaris.tasks.ocean.horiz_press_grad.task import HorizPressGradTask
 
 
@@ -11,6 +14,8 @@ def add_horiz_press_grad_tasks(component):
     component : polaris.tasks.ocean.Ocean
         the ocean component that the tasks will be added to
     """
+    # variants with a horizontal gradient in a prescribed field, compared
+    # against the quasi-analytic reference solution
     for name in [
         'salinity_gradient',
         'surface_pressure_gradient',
@@ -18,3 +23,13 @@ def add_horiz_press_grad_tasks(component):
         'ztilde_gradient',
     ]:
         component.add_task(HorizPressGradTask(component=component, name=name))
+
+    # exact resting states, in which the true HPGA is identically zero, so the
+    # model's HPGA is the error and no reference solution is needed
+    for name in [
+        'bathymetry_step',
+        'hydrostatic_consistency',
+    ]:
+        component.add_task(
+            HorizPressGradRestingStateTask(component=component, name=name)
+        )

--- a/polaris/tasks/ocean/horiz_press_grad/__init__.py
+++ b/polaris/tasks/ocean/horiz_press_grad/__init__.py
@@ -25,12 +25,14 @@ def add_horiz_press_grad_tasks(component):
         component.add_task(HorizPressGradTask(component=component, name=name))
 
     # exact resting states, in which the true HPGA is identically zero, so the
-    # model's HPGA is the error and no reference solution is needed.
-    # hydrostatic_consistency_linear is additionally in the finite-volume
-    # scheme's exact set, so it is the only one of these where machine
-    # precision is the correct expectation.
+    # model's HPGA is the error and no reference solution is needed.  The two
+    # _linear variants are additionally inside the finite-volume scheme's exact
+    # set, so their residual is the scheme's own rather than the profile's;
+    # bathymetry_step_linear is the only one that is both exact and in the
+    # geometry that matters globally.
     for name in [
         'bathymetry_step',
+        'bathymetry_step_linear',
         'hydrostatic_consistency',
         'hydrostatic_consistency_linear',
     ]:

--- a/polaris/tasks/ocean/horiz_press_grad/__init__.py
+++ b/polaris/tasks/ocean/horiz_press_grad/__init__.py
@@ -25,10 +25,14 @@ def add_horiz_press_grad_tasks(component):
         component.add_task(HorizPressGradTask(component=component, name=name))
 
     # exact resting states, in which the true HPGA is identically zero, so the
-    # model's HPGA is the error and no reference solution is needed
+    # model's HPGA is the error and no reference solution is needed.
+    # hydrostatic_consistency_linear is additionally in the finite-volume
+    # scheme's exact set, so it is the only one of these where machine
+    # precision is the correct expectation.
     for name in [
         'bathymetry_step',
         'hydrostatic_consistency',
+        'hydrostatic_consistency_linear',
     ]:
         component.add_task(
             HorizPressGradRestingStateTask(component=component, name=name)

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -204,13 +204,21 @@ class Analysis(OceanIOStep):
                 + ds_init.ZTildeInterface.isel(Time=0, nCells=cell1).values
             )
 
-            # Interfaces for valid layers (0..max_level_index), then drop
-            # the deepest valid layer (abuts bathymetry): keep
-            # max_level_index layers using max_level_index+1 interfaces.
-            z_tilde_inter_for_ref = z_tilde_inter_edge[: max_level_index + 1]
+            # All layers valid in both columns (0..max_level_index), bounded
+            # by interfaces 0..max_level_index+1.  The deepest of these abuts
+            # the bathymetry and is deliberately kept: it is the bottom
+            # partial cell, where pressure-gradient error concentrates.  It
+            # was excluded when the reference was a cross-column
+            # finite-difference stencil that could not be formed there; the
+            # reference is now a single analytic column at the edge (see
+            # ReferenceColumn), valid to the seafloor, so the exclusion no
+            # longer has a basis.
+            z_tilde_inter_for_ref = z_tilde_inter_edge[: max_level_index + 2]
 
             ref_layer_mean = ref.layer_mean_hpga(z_tilde_inter_for_ref)
-            hpga_ref_diff = hpga_forward[:max_level_index] - ref_layer_mean
+            hpga_ref_diff = (
+                hpga_forward[: max_level_index + 1] - ref_layer_mean
+            )
             ref_errors.append(rms(hpga_ref_diff))
 
             z_tilde_init = (

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -4,6 +4,14 @@ import xarray as xr
 
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical.ztilde import Gravity, RhoSw
+from polaris.tasks.ocean.horiz_press_grad.metrics import (
+    format_value_error_pairs,
+    format_value_list,
+    get_internal_edge,
+    power_law_fit,
+    rms,
+    write_metric_dataset,
+)
 from polaris.tasks.ocean.horiz_press_grad.reference import ReferenceColumn
 from polaris.viz import mplstyle_context
 
@@ -149,7 +157,7 @@ class Analysis(OceanIOStep):
                 decode_times=False,
             )
 
-            edge_index, cells_on_edge = _get_internal_edge(ds_mesh)
+            edge_index, cells_on_edge = get_internal_edge(ds_mesh)
             cell0, cell1 = cells_on_edge
 
             z_tilde_forward = _get_forward_z_tilde_edge_mid(
@@ -203,7 +211,7 @@ class Analysis(OceanIOStep):
 
             ref_layer_mean = ref.layer_mean_hpga(z_tilde_inter_for_ref)
             hpga_ref_diff = hpga_forward[:max_level_index] - ref_layer_mean
-            ref_errors.append(_rms_error(hpga_ref_diff))
+            ref_errors.append(rms(hpga_ref_diff))
 
             z_tilde_init = (
                 0.5
@@ -224,7 +232,7 @@ class Analysis(OceanIOStep):
 
             hpga_init = ds_init.HPGA.isel(Time=0).values
             hpga_diff = hpga_forward - hpga_init
-            py_errors.append(_rms_error(hpga_diff[forward_valid_mask]))
+            py_errors.append(rms(hpga_diff[forward_valid_mask]))
 
         resolution_array = np.asarray(horiz_resolutions, dtype=float)
         ref_error_array = np.asarray(ref_errors, dtype=float)
@@ -235,13 +243,13 @@ class Analysis(OceanIOStep):
             <= omega_vs_reference_convergence_fit_max_resolution
         )
 
-        ref_fit, ref_slope, ref_intercept = _power_law_fit(
+        ref_fit, ref_slope, ref_intercept = power_law_fit(
             x=resolution_array,
             y=ref_error_array,
             fit_mask=fit_mask,
         )
 
-        _write_dataset(
+        write_metric_dataset(
             filename='omega_vs_reference.nc',
             resolution_km=resolution_array,
             rms_error=ref_error_array,
@@ -251,7 +259,7 @@ class Analysis(OceanIOStep):
             y_name='rms_error_vs_reference',
             y_units='m s-2',
         )
-        _write_dataset(
+        write_metric_dataset(
             filename='omega_vs_python.nc',
             resolution_km=resolution_array,
             rms_error=py_error_array,
@@ -279,9 +287,9 @@ class Analysis(OceanIOStep):
         logger.info(f'Omega-vs-reference convergence slope: {ref_slope:1.3f}')
         logger.info(
             'Omega-vs-reference fit uses resolutions (km): '
-            f'{_format_resolution_list(resolution_array[fit_mask])}'
+            f'{format_value_list(resolution_array[fit_mask])}'
         )
-        res_error_pairs = _format_resolution_error_pairs(
+        res_error_pairs = format_value_error_pairs(
             resolution_array, ref_error_array
         )
         logger.info(
@@ -332,33 +340,6 @@ class Analysis(OceanIOStep):
                 f'[{omega_vs_reference_convergence_rate_min:.3f}, '
                 f'{omega_vs_reference_convergence_rate_max:.3f}]'
             )
-
-
-def _get_internal_edge(ds_mesh: xr.Dataset) -> tuple[int, tuple[int, int]]:
-    """
-    Determine the edge that connects the two valid cells in the two-column
-    mesh.
-    """
-    if 'cellsOnEdge' not in ds_mesh:
-        raise ValueError('cellsOnEdge is required in culled_mesh.nc')
-
-    cells_on_edge = ds_mesh.cellsOnEdge.values.astype(int)
-    if cells_on_edge.ndim != 2 or cells_on_edge.shape[1] != 2:
-        raise ValueError('cellsOnEdge must have shape (nEdges, 2).')
-
-    valid = np.logical_and(cells_on_edge[:, 0] > 0, cells_on_edge[:, 1] > 0)
-    valid_edges = np.where(valid)[0]
-    if len(valid_edges) != 1:
-        raise ValueError(
-            'Expected exactly one edge with two valid cells in the '
-            f'two-column mesh, found {len(valid_edges)}.'
-        )
-
-    edge_index = int(valid_edges[0])
-    # convert from 1-based MPAS indexing to 0-based indexing
-    cell0 = int(cells_on_edge[edge_index, 0] - 1)
-    cell1 = int(cells_on_edge[edge_index, 1] - 1)
-    return edge_index, (cell0, cell1)
 
 
 def _get_forward_z_tilde_edge_mid(
@@ -415,115 +396,6 @@ def _check_vertical_match(
         raise ValueError(
             f'{msg}: max |dz| = {float(np.max(diff))}, exceeds tolerance.'
         )
-
-
-def _rms_error(values: np.ndarray) -> float:
-    """
-    Compute RMS over finite values.
-    """
-    values = np.asarray(values, dtype=float)
-    valid = np.isfinite(values)
-    if not np.any(valid):
-        raise ValueError('No finite values available for RMS error.')
-    return float(np.sqrt(np.mean(values[valid] ** 2)))
-
-
-def _format_resolution_list(resolution_km: np.ndarray) -> str:
-    """
-    Format a resolution array as a compact list of floats.
-    """
-    values = [f'{float(resolution):g}' for resolution in resolution_km]
-    return f'[{", ".join(values)}]'
-
-
-def _format_resolution_error_pairs(
-    resolution_km: np.ndarray,
-    rms_error: np.ndarray,
-) -> str:
-    """
-    Format resolution/error pairs as readable key-value text.
-    """
-    pairs = [
-        f'{float(resolution):g} km: {float(error):.3e}'
-        for resolution, error in zip(resolution_km, rms_error, strict=True)
-    ]
-    return '; '.join(pairs)
-
-
-def _power_law_fit(
-    x: np.ndarray,
-    y: np.ndarray,
-    fit_mask: np.ndarray | None = None,
-) -> tuple[np.ndarray, float, float]:
-    """
-    Fit y = 10**b * x**m in log10 space.
-    """
-    x = np.asarray(x, dtype=float)
-    y = np.asarray(y, dtype=float)
-    valid = np.logical_and.reduce(
-        (np.isfinite(x), np.isfinite(y), x > 0.0, y > 0.0)
-    )
-    if fit_mask is not None:
-        fit_mask = np.asarray(fit_mask, dtype=bool)
-        if fit_mask.shape != x.shape:
-            raise ValueError(
-                'fit_mask must have the same shape as x and y for '
-                'power-law fitting.'
-            )
-        valid = np.logical_and(valid, fit_mask)
-
-    if np.count_nonzero(valid) < 2:
-        raise ValueError(
-            'At least two positive finite points are required for fit.'
-        )
-
-    poly = np.polyfit(np.log10(x[valid]), np.log10(y[valid]), 1)
-    slope = float(poly[0])
-    intercept = float(poly[1])
-    fit = x**slope * 10.0**intercept
-    return fit, slope, intercept
-
-
-def _write_dataset(
-    filename: str,
-    resolution_km: np.ndarray,
-    rms_error: np.ndarray,
-    y_name: str,
-    y_units: str,
-    fit: np.ndarray | None = None,
-    slope: float | None = None,
-    intercept: float | None = None,
-) -> None:
-    """
-    Write data used in a convergence plot to netCDF.
-    """
-    nres = len(resolution_km)
-    ds = xr.Dataset()
-    ds['resolution_km'] = xr.DataArray(
-        data=resolution_km,
-        dims=['nResolutions'],
-        attrs={'long_name': 'horizontal resolution', 'units': 'km'},
-    )
-    ds[y_name] = xr.DataArray(
-        data=rms_error,
-        dims=['nResolutions'],
-        attrs={'long_name': y_name.replace('_', ' '), 'units': y_units},
-    )
-    if fit is not None:
-        ds['power_law_fit'] = xr.DataArray(
-            data=fit,
-            dims=['nResolutions'],
-            attrs={
-                'long_name': 'power-law fit to rms error',
-                'units': y_units,
-            },
-        )
-    if slope is not None:
-        ds.attrs['fit_slope'] = slope
-    if intercept is not None:
-        ds.attrs['fit_intercept_log10'] = intercept
-    ds.attrs['nResolutions'] = nres
-    ds.to_netcdf(filename)
 
 
 def _plot_errors(

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -113,18 +113,28 @@ class Analysis(OceanIOStep):
             'The "horiz_resolutions" configuration option must be set in '
             'the "horiz_press_grad" section.'
         )
-        omega_vs_reference_convergence_rate_min = section.getfloat(
-            'omega_vs_reference_convergence_rate_min'
+        # bands are per scheme: on ztilde_gradient the centered scheme is first
+        # order and the finite-volume scheme second, so one band cannot hold
+        # both
+        rate_min: dict[str, float] = {}
+        rate_max: dict[str, float] = {}
+        for scheme in self.schemes:
+            for bound, target in (('min', rate_min), ('max', rate_max)):
+                option = (
+                    f'omega_vs_reference_convergence_rate_{bound}_{scheme}'
+                )
+                value = section.getfloat(option)
+                assert value is not None, (
+                    f'The "{option}" configuration option must be set in the '
+                    '"horiz_press_grad" section.'
+                )
+                target[scheme] = value
+
+        accuracy_ratio_min = section.getfloat(
+            'omega_vs_reference_accuracy_ratio_min'
         )
-        assert omega_vs_reference_convergence_rate_min is not None, (
-            'The "omega_vs_reference_convergence_rate_min" configuration '
-            'option must be set in the "horiz_press_grad" section.'
-        )
-        omega_vs_reference_convergence_rate_max = section.getfloat(
-            'omega_vs_reference_convergence_rate_max'
-        )
-        assert omega_vs_reference_convergence_rate_max is not None, (
-            'The "omega_vs_reference_convergence_rate_max" configuration '
+        assert accuracy_ratio_min is not None, (
+            'The "omega_vs_reference_accuracy_ratio_min" configuration '
             'option must be set in the "horiz_press_grad" section.'
         )
         omega_vs_reference_convergence_fit_max_resolution = section.getfloat(
@@ -382,17 +392,39 @@ class Analysis(OceanIOStep):
                 )
 
             ref_slope = ref_slopes[scheme]
-            if not (
-                omega_vs_reference_convergence_rate_min
-                <= ref_slope
-                <= omega_vs_reference_convergence_rate_max
-            ):
+            if not (rate_min[scheme] <= ref_slope <= rate_max[scheme]):
                 raise ValueError(
                     f'{scheme}: Omega-vs-reference convergence slope is '
                     'outside the allowed range: '
                     f'{ref_slope:.3f} not in '
-                    f'[{omega_vs_reference_convergence_rate_min:.3f}, '
-                    f'{omega_vs_reference_convergence_rate_max:.3f}]'
+                    f'[{rate_min[scheme]:.3f}, {rate_max[scheme]:.3f}]'
+                )
+
+        # Accuracy gate, at the coarsest resolution.  Deliberately a ratio of
+        # errors rather than a comparison of convergence orders: on a smooth
+        # profile the two schemes converge at the same rate, so an
+        # order-based gate would fail where nothing is wrong.  The coarse end
+        # is used because that is where the advantage is smallest on the one
+        # variant whose schemes differ in order.
+        if 'centered' in ref_error_arrays and (
+            'finite_volume' in ref_error_arrays
+        ):
+            coarsest = int(np.argmax(resolution_array))
+            centered_error = float(ref_error_arrays['centered'][coarsest])
+            finite_error = float(ref_error_arrays['finite_volume'][coarsest])
+            ratio = centered_error / finite_error
+            logger.info(
+                f'centered / finite_volume RMS at '
+                f'{resolution_array[coarsest]:g} km: {ratio:.2f}x'
+            )
+            if ratio < accuracy_ratio_min:
+                raise ValueError(
+                    'The finite-volume scheme is not as accurate as '
+                    'omega_vs_reference_accuracy_ratio_min requires at the '
+                    f'coarsest resolution ({resolution_array[coarsest]:g} '
+                    f'km): centered {centered_error:.3e} over finite_volume '
+                    f'{finite_error:.3e} is {ratio:.3f}, below '
+                    f'{accuracy_ratio_min:.3f}'
                 )
 
 

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical.ztilde import Gravity, RhoSw
+from polaris.tasks.ocean.horiz_press_grad.forward import SCHEME_HPGA
 from polaris.tasks.ocean.horiz_press_grad.metrics import (
     format_value_error_pairs,
     format_value_list,
@@ -30,10 +31,14 @@ class Analysis(OceanIOStep):
             Mapping from horizontal resolution (km) to ``Init`` step
 
         forward : dict
-            Mapping from horizontal resolution (km) to ``Forward`` step
+            Mapping from ``(horizontal resolution, scheme)`` to ``Forward``
+            step
+
+    schemes : list of str
+        The pressure-gradient schemes being compared
     """
 
-    def __init__(self, component, indir, dependencies):
+    def __init__(self, component, indir, dependencies, schemes):
         """
         Create the analysis step
 
@@ -48,10 +53,14 @@ class Analysis(OceanIOStep):
 
         dependencies : dict
             A dictionary of dependent steps
+
+        schemes : list of str
+            The pressure-gradient schemes being compared
         """
         super().__init__(component=component, name='analysis', indir=indir)
 
         self.dependencies_dict = dependencies
+        self.schemes = list(schemes)
 
         self.add_output_file('omega_vs_reference.png')
         self.add_output_file('omega_vs_reference.nc')
@@ -72,14 +81,9 @@ class Analysis(OceanIOStep):
         forward_steps = self.dependencies_dict['forward']
         for resolution in horiz_resolutions:
             init = init_steps[resolution]
-            forward = forward_steps[resolution]
             self.add_input_file(
                 filename=f'init_r{resolution:02g}.nc',
                 work_dir_target=f'{init.path}/init.nc',
-            )
-            self.add_input_file(
-                filename=f'output_r{resolution:02g}.nc',
-                work_dir_target=f'{forward.path}/output.nc',
             )
             self.add_input_file(
                 filename=f'culled_mesh_r{resolution:02g}.nc',
@@ -89,6 +93,12 @@ class Analysis(OceanIOStep):
                 filename=f'vert_coord_r{resolution:02g}.nc',
                 work_dir_target=f'{init.path}/vert_coord.nc',
             )
+            for scheme in self.schemes:
+                forward = forward_steps[resolution, scheme]
+                self.add_input_file(
+                    filename=f'output_r{resolution:02g}_{scheme}.nc',
+                    work_dir_target=f'{forward.path}/output.nc',
+                )
 
     def run(self):
         """
@@ -141,8 +151,12 @@ class Analysis(OceanIOStep):
             'must be set in the "horiz_press_grad" section.'
         )
 
-        ref_errors = []
-        py_errors = []
+        ref_errors: dict[str, list[float]] = {
+            scheme: [] for scheme in self.schemes
+        }
+        py_errors: dict[str, list[float]] = {
+            scheme: [] for scheme in self.schemes
+        }
 
         for resolution in horiz_resolutions:
             ds_init = self.open_model_dataset(
@@ -151,23 +165,9 @@ class Analysis(OceanIOStep):
             ds_mesh = self.open_model_dataset(
                 f'culled_mesh_r{resolution:02g}.nc', self.config
             )
-            ds_out = self.open_model_dataset(
-                f'output_r{resolution:02g}.nc',
-                self.config,
-                decode_times=False,
-            )
 
             edge_index, cells_on_edge = get_internal_edge(ds_mesh)
             cell0, cell1 = cells_on_edge
-
-            z_tilde_forward = _get_forward_z_tilde_edge_mid(
-                ds_out=ds_out,
-                cell0=cell0,
-                cell1=cell1,
-            )
-            hpga_forward = ds_out.NormalVelocityTend.isel(
-                Time=0, nEdges=edge_index
-            ).values
 
             # maxLevelCell is one-based (Fortran indexing), convert to
             # zero-based and use the shallowest valid bottom among the two
@@ -186,11 +186,10 @@ class Analysis(OceanIOStep):
                     f'resolution {resolution:g} km.'
                 )
 
-            forward_valid_mask = np.zeros_like(hpga_forward, dtype=bool)
-            forward_valid_mask[: max_level_index + 1] = True
-
             # Build reference evaluator: x_sign aligns config +x with the
-            # edge normal (from cell0 toward cell1).
+            # edge normal (from cell0 toward cell1).  The reference is a
+            # property of the state, not of the scheme, so it is built once
+            # and both schemes are measured against the same one.
             x_sign = float(
                 np.sign(
                     ds_mesh.xCell.values[cell1] - ds_mesh.xCell.values[cell0]
@@ -214,12 +213,7 @@ class Analysis(OceanIOStep):
             # ReferenceColumn), valid to the seafloor, so the exclusion no
             # longer has a basis.
             z_tilde_inter_for_ref = z_tilde_inter_edge[: max_level_index + 2]
-
             ref_layer_mean = ref.layer_mean_hpga(z_tilde_inter_for_ref)
-            hpga_ref_diff = (
-                hpga_forward[: max_level_index + 1] - ref_layer_mean
-            )
-            ref_errors.append(rms(hpga_ref_diff))
 
             z_tilde_init = (
                 0.5
@@ -228,126 +222,178 @@ class Analysis(OceanIOStep):
                     + ds_init.ZTildeMid.isel(Time=0, nCells=cell1)
                 ).values
             )
-            _check_vertical_match(
-                z_ref=z_tilde_init,
-                z_test=z_tilde_forward,
-                msg=(
-                    'ZTilde mismatch between Python init and Omega forward '
-                    f'at resolution {resolution:g} km'
-                ),
-                valid_mask=forward_valid_mask,
-            )
 
-            hpga_init = ds_init.HPGA.isel(Time=0).values
-            hpga_diff = hpga_forward - hpga_init
-            py_errors.append(rms(hpga_diff[forward_valid_mask]))
+            for scheme in self.schemes:
+                ds_out = self.open_model_dataset(
+                    f'output_r{resolution:02g}_{scheme}.nc',
+                    self.config,
+                    decode_times=False,
+                )
+
+                z_tilde_forward = _get_forward_z_tilde_edge_mid(
+                    ds_out=ds_out,
+                    cell0=cell0,
+                    cell1=cell1,
+                )
+                hpga_forward = ds_out.NormalVelocityTend.isel(
+                    Time=0, nEdges=edge_index
+                ).values
+
+                forward_valid_mask = np.zeros_like(hpga_forward, dtype=bool)
+                forward_valid_mask[: max_level_index + 1] = True
+
+                hpga_ref_diff = (
+                    hpga_forward[: max_level_index + 1] - ref_layer_mean
+                )
+                ref_errors[scheme].append(rms(hpga_ref_diff))
+
+                _check_vertical_match(
+                    z_ref=z_tilde_init,
+                    z_test=z_tilde_forward,
+                    msg=(
+                        'ZTilde mismatch between Python init and Omega '
+                        f'forward at resolution {resolution:g} km, '
+                        f'{scheme} scheme'
+                    ),
+                    valid_mask=forward_valid_mask,
+                )
+
+                # each scheme is compared against its OWN Polaris counterpart;
+                # comparing Omega's finite-volume output against the centered
+                # HPGA would measure the difference between two schemes and
+                # report it as an implementation disagreement
+                hpga_init = ds_init[SCHEME_HPGA[scheme]].isel(Time=0).values
+                hpga_diff = hpga_forward - hpga_init
+                py_errors[scheme].append(rms(hpga_diff[forward_valid_mask]))
 
         resolution_array = np.asarray(horiz_resolutions, dtype=float)
-        ref_error_array = np.asarray(ref_errors, dtype=float)
-        py_error_array = np.asarray(py_errors, dtype=float)
+        ref_error_arrays = {
+            scheme: np.asarray(values, dtype=float)
+            for scheme, values in ref_errors.items()
+        }
+        py_error_arrays = {
+            scheme: np.asarray(values, dtype=float)
+            for scheme, values in py_errors.items()
+        }
 
         fit_mask = (
             resolution_array
             <= omega_vs_reference_convergence_fit_max_resolution
         )
 
-        ref_fit, ref_slope, ref_intercept = power_law_fit(
-            x=resolution_array,
-            y=ref_error_array,
-            fit_mask=fit_mask,
-        )
+        ref_fits = {}
+        ref_slopes = {}
+        ref_intercepts = {}
+        for scheme, values in ref_error_arrays.items():
+            fit, slope, intercept = power_law_fit(
+                x=resolution_array, y=values, fit_mask=fit_mask
+            )
+            ref_fits[scheme] = fit
+            ref_slopes[scheme] = slope
+            ref_intercepts[scheme] = intercept
 
         write_metric_dataset(
             filename='omega_vs_reference.nc',
             resolution_km=resolution_array,
-            rms_error=ref_error_array,
-            fit=ref_fit,
-            slope=ref_slope,
-            intercept=ref_intercept,
+            rms_error=ref_error_arrays,
+            fit=ref_fits,
+            slope=ref_slopes,
+            intercept=ref_intercepts,
             y_name='rms_error_vs_reference',
             y_units='m s-2',
         )
         write_metric_dataset(
             filename='omega_vs_python.nc',
             resolution_km=resolution_array,
-            rms_error=py_error_array,
+            rms_error=py_error_arrays,
             y_name='rms_error_vs_python',
             y_units='m s-2',
         )
 
         _plot_errors(
             resolution_km=resolution_array,
-            rms_error=ref_error_array,
-            fit=ref_fit,
-            slope=ref_slope,
+            rms_error=ref_error_arrays,
+            fit=ref_fits,
+            slope=ref_slopes,
             y_label='RMS error in HPGA (m s-2)',
             title='Omega HPGA Error vs Reference Solution',
             output='omega_vs_reference.png',
         )
         _plot_errors(
             resolution_km=resolution_array,
-            rms_error=py_error_array,
+            rms_error=py_error_arrays,
             y_label='RMS difference in HPGA (m s-2)',
             title='Omega vs Polaris HPGA RMS Difference',
             output='omega_vs_python.png',
         )
 
-        logger.info(f'Omega-vs-reference convergence slope: {ref_slope:1.3f}')
         logger.info(
             'Omega-vs-reference fit uses resolutions (km): '
             f'{format_value_list(resolution_array[fit_mask])}'
         )
-        res_error_pairs = format_value_error_pairs(
-            resolution_array, ref_error_array
-        )
-        logger.info(
-            'Omega-vs-Polaris RMS differences by resolution: '
-            f'{res_error_pairs}'
-        )
-        failing_polaris = py_error_array > omega_vs_polaris_rms_threshold
-        if np.any(failing_polaris):
-            failing_text = ', '.join(
-                [
-                    f'{resolution_array[index]:g} km: '
-                    f'{py_error_array[index]:.3e}'
-                    for index in np.where(failing_polaris)[0]
-                ]
+        for scheme in self.schemes:
+            logger.info(
+                f'{scheme}: convergence slope {ref_slopes[scheme]:1.3f}; '
+                'RMS vs reference '
+                + format_value_error_pairs(
+                    resolution_array, ref_error_arrays[scheme]
+                )
             )
-            raise ValueError(
-                'Omega-vs-Polaris RMS difference exceeds '
-                f'omega_vs_polaris_rms_threshold='
-                f'{omega_vs_polaris_rms_threshold:.3e} at: {failing_text}'
+            logger.info(
+                f'{scheme}: Omega-vs-Polaris RMS differences '
+                + format_value_error_pairs(
+                    resolution_array, py_error_arrays[scheme]
+                )
             )
 
         highest_resolution_index = int(np.argmin(resolution_array))
         highest_resolution = float(resolution_array[highest_resolution_index])
-        highest_resolution_ref_error = float(
-            ref_error_array[highest_resolution_index]
-        )
-        if (
-            highest_resolution_ref_error
-            > omega_vs_reference_high_res_rms_threshold
-        ):
-            raise ValueError(
-                'Omega-vs-reference RMS error at highest resolution '
-                f'({highest_resolution:g} km) is '
-                f'{highest_resolution_ref_error:.3e}, which exceeds '
-                'omega_vs_reference_high_res_rms_threshold '
-                f'({omega_vs_reference_high_res_rms_threshold:.3e}).'
-            )
 
-        if not (
-            omega_vs_reference_convergence_rate_min
-            <= ref_slope
-            <= omega_vs_reference_convergence_rate_max
-        ):
-            raise ValueError(
-                'Omega-vs-reference convergence slope is outside the '
-                'allowed range: '
-                f'{ref_slope:.3f} not in '
-                f'[{omega_vs_reference_convergence_rate_min:.3f}, '
-                f'{omega_vs_reference_convergence_rate_max:.3f}]'
+        for scheme in self.schemes:
+            py_error_array = py_error_arrays[scheme]
+            failing_polaris = py_error_array > omega_vs_polaris_rms_threshold
+            if np.any(failing_polaris):
+                failing_text = ', '.join(
+                    [
+                        f'{resolution_array[index]:g} km: '
+                        f'{py_error_array[index]:.3e}'
+                        for index in np.where(failing_polaris)[0]
+                    ]
+                )
+                raise ValueError(
+                    f'{scheme}: Omega-vs-Polaris RMS difference exceeds '
+                    f'omega_vs_polaris_rms_threshold='
+                    f'{omega_vs_polaris_rms_threshold:.3e} at: {failing_text}'
+                )
+
+            highest_resolution_ref_error = float(
+                ref_error_arrays[scheme][highest_resolution_index]
             )
+            if (
+                highest_resolution_ref_error
+                > omega_vs_reference_high_res_rms_threshold
+            ):
+                raise ValueError(
+                    f'{scheme}: Omega-vs-reference RMS error at highest '
+                    f'resolution ({highest_resolution:g} km) is '
+                    f'{highest_resolution_ref_error:.3e}, which exceeds '
+                    'omega_vs_reference_high_res_rms_threshold '
+                    f'({omega_vs_reference_high_res_rms_threshold:.3e}).'
+                )
+
+            ref_slope = ref_slopes[scheme]
+            if not (
+                omega_vs_reference_convergence_rate_min
+                <= ref_slope
+                <= omega_vs_reference_convergence_rate_max
+            ):
+                raise ValueError(
+                    f'{scheme}: Omega-vs-reference convergence slope is '
+                    'outside the allowed range: '
+                    f'{ref_slope:.3f} not in '
+                    f'[{omega_vs_reference_convergence_rate_min:.3f}, '
+                    f'{omega_vs_reference_convergence_rate_max:.3f}]'
+                )
 
 
 def _get_forward_z_tilde_edge_mid(
@@ -408,32 +454,36 @@ def _check_vertical_match(
 
 def _plot_errors(
     resolution_km: np.ndarray,
-    rms_error: np.ndarray,
+    rms_error: dict[str, np.ndarray],
     y_label: str,
     title: str,
     output: str,
-    fit: np.ndarray | None = None,
-    slope: float | None = None,
+    fit: dict[str, np.ndarray] | None = None,
+    slope: dict[str, float] | None = None,
 ) -> None:
     """
-    Plot RMS error vs. horizontal resolution with a power-law fit.
+    Plot RMS error vs. horizontal resolution, one series per scheme, with a
+    power-law fit per scheme.
     """
     with mplstyle_context():
         fig = plt.figure()
         ax = fig.add_subplot(111)
 
-        if fit is not None:
-            if slope is None:
-                raise ValueError(
-                    'slope must be provided when fit is provided.'
+        for index, (scheme, values) in enumerate(rms_error.items()):
+            color = f'C{index}'
+            if fit is not None and scheme in fit:
+                if slope is None or scheme not in slope:
+                    raise ValueError(
+                        'slope must be provided for every scheme in fit.'
+                    )
+                ax.loglog(
+                    resolution_km,
+                    fit[scheme],
+                    '-',
+                    color=color,
+                    label=f'{scheme} fit (slope={slope[scheme]:1.3f})',
                 )
-            ax.loglog(
-                resolution_km,
-                fit,
-                'k',
-                label=f'power-law fit (slope={slope:1.3f})',
-            )
-        ax.loglog(resolution_km, rms_error, 'o', label='RMS error')
+            ax.loglog(resolution_km, values, 'o', color=color, label=scheme)
 
         ax.set_xlabel('Horizontal resolution (km)')
         ax.set_ylabel(y_label)

--- a/polaris/tasks/ocean/horiz_press_grad/bathymetry_step.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/bathymetry_step.cfg
@@ -87,3 +87,10 @@ tilt_values = [1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 200.0]
 # error is a staircase in the sea-floor gradient rather than a power law and a
 # fitted exponent would be meaningless.
 tilt_fit = False
+
+# Improvement gate. Measured offline, the smallest advantage anywhere in this
+# sweep is 1170x, at 4 km / 256 m / grad 200 -- three orders beyond what the
+# coordinate-tilt variants show. The bottom partial cell is where the centered
+# scheme is worst and where comparing at matched pressure helps most, and this
+# is the variant that resembles the global bottom-layer error.
+resting_state_improvement_min = 500.0

--- a/polaris/tasks/ocean/horiz_press_grad/bathymetry_step.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/bathymetry_step.cfg
@@ -1,0 +1,74 @@
+# Options related to the vertical grid
+[vertical_grid]
+
+# No partial-cell snapping. The p-star reference grid is clipped at each
+# column's pseudo-bottom depth regardless, so the deepest layer is a partial
+# cell either way; this option controls only whether the topography is snapped
+# to a minimum cell fraction. Snapping fights the p-star iteration: for
+# sea-floor steps landing near a snapping threshold the two converge to
+# sea-surface heights over 10 m apart, which is a real barotropic pressure
+# gradient rather than a discretization error. The resting-state guard in the
+# analysis step will catch that if anyone re-enables it.
+partial_cell_type = None
+
+
+# config options for the bathymetry-step two-column test
+[horiz_press_grad]
+
+# The same deep, coarsely resolved column as hydrostatic_consistency, but with
+# a flat coordinate and a stepped sea floor.
+#
+# In a p-star column with a single reference grid, a sea-floor step does NOT
+# tilt interior coordinate surfaces: every interior interface sits at an
+# identical pseudo-height, and therefore an identical pressure, in both
+# columns. Moving the sea floor changes only where that grid is clipped. The
+# entire signal is therefore in the deepest layer valid in both columns -- the
+# bottom partial cell -- which the reference-based Analysis step drops and the
+# RestingAnalysis step keeps.
+#
+# This makes the variant the two-column analogue of the bottom-layer error
+# seen in realistic global Omega runs, and it is a test of the bottom cell
+# rather than of layer tilt.
+geom_z_bot_mid = -3500.0
+# m / km; overridden per step by the sweep
+geom_z_bot_grad = 0.0
+
+# Head room below the sea floor for the p-star reference grid, as in
+# hydrostatic_consistency. The deepest step in the sweep moves the sea floor
+# by 400 m, so the gap must accommodate that as well as the excess of
+# pseudo-depth over geometric depth.
+z_tilde_bot_mid = -4096.0
+# m / km
+z_tilde_bot_grad = 0.0
+
+# Horizontally uniform temperature and salinity against pseudo-height, exactly
+# as in hydrostatic_consistency: this is what makes the configuration an exact
+# resting state, for any sea-floor shape.
+z_tilde_mid = [0.0, -100.0, -500.0, -1500.0, -3000.0, -6144.0]
+# m / km
+z_tilde_grad = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+temperature_mid = [22.0, 18.0, 8.0, 4.0, 2.0, 1.0]
+# deg C / km
+temperature_grad = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+salinity_mid = [35.6, 35.4, 34.9, 34.72, 34.68, 34.66]
+# g/kg / km
+salinity_grad = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+horiz_resolutions = [4.0, 4.0]
+# vertical resolution in m
+vert_resolutions = [256.0, 128.0]
+
+# Step the sea floor rather than tilting the coordinate.
+tilt_option = geom_z_bot_grad
+
+# m / km. At 4 km between columns these are sea-floor steps of 4 to 800 m,
+# spanning the range from well below one layer thickness to several.
+tilt_values = [1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 200.0]
+
+# No exponent fit. The signal is set by how the two columns' maxLevelCell
+# values and clipped bottom thicknesses relate, which changes in steps, so the
+# error is a staircase in the sea-floor gradient rather than a power law and a
+# fitted exponent would be meaningless.
+tilt_fit = False

--- a/polaris/tasks/ocean/horiz_press_grad/bathymetry_step.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/bathymetry_step.cfg
@@ -4,11 +4,14 @@
 # No partial-cell snapping. The p-star reference grid is clipped at each
 # column's pseudo-bottom depth regardless, so the deepest layer is a partial
 # cell either way; this option controls only whether the topography is snapped
-# to a minimum cell fraction. Snapping fights the p-star iteration: for
-# sea-floor steps landing near a snapping threshold the two converge to
-# sea-surface heights over 10 m apart, which is a real barotropic pressure
-# gradient rather than a discretization error. The resting-state guard in the
-# analysis step will catch that if anyone re-enables it.
+# to a minimum cell fraction.
+#
+# This matters more here than for hydrostatic_consistency, because the swept
+# parameter IS the sea floor. Snapping moves it to the nearest representable
+# depth, and at some gradients that moves both columns to the same depth: a
+# nominal 400 m step becomes no step at all and the measured RMS HPGA falls to
+# round-off, which would read as a spectacular pass. The bathymetry guard in
+# the analysis step catches that if anyone re-enables snapping.
 partial_cell_type = None
 
 

--- a/polaris/tasks/ocean/horiz_press_grad/bathymetry_step.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/bathymetry_step.cfg
@@ -1,17 +1,29 @@
 # Options related to the vertical grid
 [vertical_grid]
 
-# No partial-cell snapping. The p-star reference grid is clipped at each
-# column's pseudo-bottom depth regardless, so the deepest layer is a partial
-# cell either way; this option controls only whether the topography is snapped
-# to a minimum cell fraction.
+# Do NOT read "None" as "no partial cells" -- it means "leave the topography
+# alone". A partial bottom cell is produced either way: the p-star reference
+# grid is clipped at each column's pseudo-bottom depth unconditionally, in
+# _compute_ref_pseudo_thickness. This option controls only whether the sea
+# floor is MOVED before that clipping:
+#     None    -- leave it; the bottom cell is whatever the bathymetry implies
+#     partial -- move it so the bottom cell is at least min_pc_fraction thick
+#     full    -- move it to a reference boundary; this is the setting that
+#                actually removes partial cells
 #
-# This matters more here than for hydrostatic_consistency, because the swept
-# parameter IS the sea floor. Snapping moves it to the nearest representable
-# depth, and at some gradients that moves both columns to the same depth: a
-# nominal 400 m step becomes no step at all and the measured RMS HPGA falls to
-# round-off, which would read as a spectacular pass. The bathymetry guard in
-# the analysis step catches that if anyone re-enables snapping.
+# Leaving it off matters more here than for hydrostatic_consistency, because
+# the swept parameter IS the sea floor. Snapping moves it to the nearest
+# representable depth, and at some gradients that moves both columns to the
+# same depth: a nominal 400 m step becomes no step at all and the measured RMS
+# HPGA falls to round-off, which would read as a spectacular pass. The
+# bathymetry guard in the analysis step catches that if anyone enables it.
+#
+# The cost of leaving it off is that there is no minimum-thickness floor, so
+# the sweep includes bottom cells thinner than a realistic run would use
+# (0.002 of a layer at geom_z_bot_grad = 100). The state is exactly at rest
+# regardless, so the measurement is still valid; but the error tracks the
+# contrast in bottom-cell fraction between the columns rather than the nominal
+# gradient, which is why this variant is a staircase and sets tilt_fit = False.
 partial_cell_type = None
 
 

--- a/polaris/tasks/ocean/horiz_press_grad/bathymetry_step_linear.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/bathymetry_step_linear.cfg
@@ -1,0 +1,85 @@
+# Options related to the vertical grid
+[vertical_grid]
+
+# Left alone for the same reason as in bathymetry_step: the swept parameter IS
+# the sea floor, and snapping would move it to the nearest representable depth,
+# at some gradients collapsing the step to nothing. See that file for the full
+# explanation of what this option does and does not do.
+partial_cell_type = None
+
+
+# config options for the linear-in-pressure bathymetry-step test
+[horiz_press_grad]
+
+# This variant is bathymetry_step with hydrostatic_consistency_linear's
+# profile: a stepped sea floor, a flat coordinate, and temperature and salinity
+# exactly linear in pressure.
+#
+# It is the only configuration in the family that is BOTH inside the
+# finite-volume scheme's exact set and in the geometry that matters globally.
+# The other three resting-state variants give up one or the other:
+# hydrostatic_consistency_linear is exact but tilts only the coordinate, which
+# phase-2 analysis showed contributes essentially nothing to the global
+# bottom-layer error; bathymetry_step has the right geometry but a curved
+# profile, so its residual mixes the scheme's truncation off the exact set with
+# whatever the geometry contributes and neither can be read alone.
+#
+# Separating those is the point. With the profile resolved exactly, every
+# increment of the column scan is zero to round-off, so anything left is the
+# anchor -- and the anchor is where the scheme reads the model's own geometry.
+# That makes this the variant that measures what a bathymetry step costs the
+# scheme, as opposed to what an unresolved profile costs it.
+#
+# Measured offline at 4 km / 256 m, the scan stays flat to 1.4e-15 m at every
+# gradient below, including 100 and 200 m/km where the two columns' maxLevelCell
+# differ and the deepest edge layer evaluates one column's reconstruction below
+# its own floor. So the below-floor rule does not break the cancellation in the
+# geometry it was most doubted in.
+#
+# What the anchor costs is a staircase rather than a power law -- 1.9e-12,
+# 2.6e-8, 5.6e-12 and 1.7e-7 m at 1, 25, 100 and 200 m/km -- so tilt_fit is
+# False here as it is for bathymetry_step. Against Centered the scheme is
+# ahead by a factor of 2e5 at 200 m/km.
+
+# The same deep column as bathymetry_step and hydrostatic_consistency_linear.
+geom_z_bot_mid = -3500.0
+# m / km; overridden per step by the sweep
+geom_z_bot_grad = 0.0
+
+z_tilde_bot_mid = -4096.0
+# m / km
+z_tilde_bot_grad = 0.0
+
+# Two nodes, so the PCHIP interpolant is a straight line in pseudo-height, and
+# pressure is exactly proportional to pseudo-height. The layer mean of a linear
+# profile is its value at the layer midpoint, so the initial condition is in the
+# exact set however the layers are distributed -- including in the bottom
+# partial cell, whose thickness is what this variant varies.
+z_tilde_mid = [0.0, -6144.0]
+# m / km
+z_tilde_grad = [0.0, 0.0]
+
+temperature_mid = [22.0, 1.0]
+# deg C / km
+temperature_grad = [0.0, 0.0]
+
+salinity_mid = [35.6, 34.66]
+# g/kg / km
+salinity_grad = [0.0, 0.0]
+
+# The same resolution pairs as bathymetry_step, so the two can be compared
+# point for point and the difference read as the cost of the curved profile.
+horiz_resolutions = [4.0, 4.0]
+# vertical resolution in m
+vert_resolutions = [256.0, 128.0]
+
+# the sea floor, not the coordinate
+tilt_option = geom_z_bot_grad
+
+# m / km
+tilt_values = [1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 200.0]
+
+# A sea-floor step changes maxLevelCell in jumps and moves the bottom partial
+# cell's thickness non-monotonically, so the residual is a staircase and a
+# fitted exponent would be meaningless.
+tilt_fit = False

--- a/polaris/tasks/ocean/horiz_press_grad/bathymetry_step_linear.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/bathymetry_step_linear.cfg
@@ -83,3 +83,9 @@ tilt_values = [1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 200.0]
 # cell's thickness non-monotonically, so the residual is a staircase and a
 # fitted exponent would be meaningless.
 tilt_fit = False
+
+# Improvement gate. Measured offline, the smallest advantage anywhere in this
+# sweep is 58828x, at 4 km / 256 m / grad 200 -- the largest in the task, since
+# this is the only variant that is both inside the exact set and in the
+# geometry where the centered scheme is worst.
+resting_state_improvement_min = 20000.0

--- a/polaris/tasks/ocean/horiz_press_grad/column.py
+++ b/polaris/tasks/ocean/horiz_press_grad/column.py
@@ -5,6 +5,10 @@ from scipy.interpolate import PchipInterpolator
 
 from polaris.config import PolarisConfigParser
 
+# Abscissa offset of the two-point Gauss-Legendre rule on [-1, 1], which is
+# exact through cubics and therefore exact for a PCHIP piece.
+_GAUSS_OFFSET = 1.0 / np.sqrt(3.0)
+
 
 def get_array_from_mid_grad(
     config: PolarisConfigParser, name: str, x: np.ndarray
@@ -60,6 +64,144 @@ def get_array_from_mid_grad(
     return array
 
 
+def get_pchip_layer_mean(
+    z_tilde_nodes: np.ndarray,
+    values_nodes: np.ndarray,
+    name: str,
+) -> Callable[[np.ndarray, np.ndarray], np.ndarray]:
+    """
+    Create a function giving the exact layer mean of a monotone PCHIP profile
+    over a layer's pseudo-height range.
+
+    Omega's prognostic conservative temperature and absolute salinity are layer
+    *means*, and the higher-order pressure gradient reconstructs them as
+    mean-preserving polynomials in pressure, so the initial condition must
+    supply layer means rather than samples at layer midpoints.  Within a column
+    pressure is exactly linear in pseudo-height, so a mean over a layer's
+    pseudo-height range is also its mean over the layer's pressure range and
+    there is no ambiguity about which variable to average in.
+
+    The mean is computed by two-point Gauss-Legendre quadrature over each
+    profile-node interval the layer overlaps.  PCHIP is piecewise cubic and a
+    two-point Gauss rule is exact through cubics, so this is exact rather than
+    approximate, and it is preferred over differencing the interpolant's
+    antiderivative -- also exact in principle -- because that differences two
+    large numbers and so loses precision as the layers thin.  Measured on the
+    linear profile of ``hydrostatic_consistency_linear``, the antiderivative
+    form departs from the exact layer mean by an amount growing like 1/h
+    (7e-14 at 256 m layers, 1.3e-12 at 32 m) while this form sits at 0.9 * eps
+    of the salinity itself at every resolution.  That matters because the
+    departure limits how exactly the initial condition sits in the scheme's
+    exact set, and hence the floor of the machine-precision test.
+
+    Parameters
+    ----------
+    z_tilde_nodes : np.ndarray
+        One-dimensional z-tilde node locations. Must be strictly monotonic
+        (increasing or decreasing).
+    values_nodes : np.ndarray
+        One-dimensional values at ``z_tilde_nodes``.
+    name : str
+        A descriptive name used in error messages.
+
+    Returns
+    -------
+    layer_mean : callable
+        A function of ``(z_tilde_top, z_tilde_bot)`` -- the pseudo-height of
+        each layer's upper and lower interface -- returning the layer means.
+        Layers must lie within the node range, but interfaces are allowed to
+        fall a round-off distance outside it, which is unavoidable because a
+        column's outermost interfaces sit exactly on the outermost nodes in
+        several configurations.
+    """
+    z_tilde_nodes, values_nodes = _check_pchip_nodes(
+        z_tilde_nodes, values_nodes, name
+    )
+
+    # work in pseudo-depth, which increases downward, so that a layer runs from
+    # a smaller to a larger coordinate whichever way the nodes were given
+    depth_nodes = -z_tilde_nodes
+    order = np.argsort(depth_nodes)
+    depth_nodes = depth_nodes[order]
+
+    interpolator = PchipInterpolator(
+        depth_nodes, values_nodes[order], extrapolate=False
+    )
+
+    depth_min = depth_nodes[0]
+    depth_max = depth_nodes[-1]
+    # generous against round-off in a column summed over thousands of metres,
+    # and tiny against any real configuration error
+    depth_tol = 1.0e-9 * (depth_max - depth_min)
+
+    def _layer_mean(
+        z_tilde_top: np.ndarray, z_tilde_bot: np.ndarray
+    ) -> np.ndarray:
+        z_tilde_top = np.asarray(z_tilde_top, dtype=float)
+        z_tilde_bot = np.asarray(z_tilde_bot, dtype=float)
+        if z_tilde_top.shape != z_tilde_bot.shape:
+            raise ValueError(
+                'z_tilde_top and z_tilde_bot must have the same shape.'
+            )
+        if np.any(~np.isfinite(z_tilde_top)) or np.any(
+            ~np.isfinite(z_tilde_bot)
+        ):
+            raise ValueError('Layer interface z_tilde values must be finite.')
+
+        depth_top = -z_tilde_top
+        depth_bot = -z_tilde_bot
+        if np.any(depth_bot <= depth_top):
+            raise ValueError(
+                f'Each layer must have positive thickness for {name}: '
+                'z_tilde_bot must lie below z_tilde_top.'
+            )
+        if np.any(depth_top < depth_min - depth_tol) or np.any(
+            depth_bot > depth_max + depth_tol
+        ):
+            raise ValueError(
+                f'Layers for {name} must fall within the node range; '
+                'extrapolation is not supported.'
+            )
+
+        # Absorb the round-off excursion allowed above.  This has to happen
+        # before the thickness is taken, so that the interval the quadrature
+        # covers and the thickness it is divided by are the same interval; a
+        # layer genuinely outside the node range has already been rejected.
+        depth_top = np.clip(depth_top, depth_min, depth_max)
+        depth_bot = np.clip(depth_bot, depth_min, depth_max)
+
+        # Sum each layer's overlap with each node interval.  Clipping the two
+        # interfaces into the interval makes a non-overlapping interval
+        # contribute exactly zero width and keeps every quadrature point inside
+        # the node range.
+        integral = np.zeros(depth_top.shape, dtype=float)
+        for interval_top, interval_bot in zip(
+            depth_nodes[:-1], depth_nodes[1:], strict=True
+        ):
+            overlap_top = np.clip(depth_top, interval_top, interval_bot)
+            overlap_bot = np.clip(depth_bot, interval_top, interval_bot)
+            width = overlap_bot - overlap_top
+            middle = 0.5 * (overlap_top + overlap_bot)
+            offset = 0.5 * width * _GAUSS_OFFSET
+            integral += (
+                0.5
+                * width
+                * (
+                    interpolator(middle - offset)
+                    + interpolator(middle + offset)
+                )
+            )
+
+        means = integral / (depth_bot - depth_top)
+        if np.any(~np.isfinite(means)):
+            raise ValueError(
+                f'PCHIP layer averaging produced non-finite values for {name}.'
+            )
+        return means
+
+    return _layer_mean
+
+
 def get_pchip_interpolator(
     z_tilde_nodes: np.ndarray,
     values_nodes: np.ndarray,
@@ -84,27 +226,11 @@ def get_pchip_interpolator(
         A function that maps target z-tilde values to interpolated values.
         Targets must lie within the node range; extrapolation is not allowed.
     """
-    z_tilde_nodes = np.asarray(z_tilde_nodes, dtype=float)
-    values_nodes = np.asarray(values_nodes, dtype=float)
+    z_tilde_nodes, values_nodes = _check_pchip_nodes(
+        z_tilde_nodes, values_nodes, name
+    )
 
-    if z_tilde_nodes.ndim != 1 or values_nodes.ndim != 1:
-        raise ValueError('z_tilde_nodes and values_nodes must be 1-D arrays.')
-    if len(z_tilde_nodes) != len(values_nodes):
-        raise ValueError(
-            f'Lengths of z_tilde_nodes and {name} nodes must match.'
-        )
-    if len(z_tilde_nodes) < 2:
-        raise ValueError('At least two z_tilde nodes are required.')
-
-    dz = np.diff(z_tilde_nodes)
-    is_increasing = np.all(dz > 0.0)
-    is_decreasing = np.all(dz < 0.0)
-    if not (is_increasing or is_decreasing):
-        raise ValueError(
-            'z_tilde_nodes must be strictly monotonic (increasing or '
-            'decreasing).'
-        )
-
+    is_decreasing = z_tilde_nodes[1] < z_tilde_nodes[0]
     if is_decreasing:
         x = -z_tilde_nodes
     else:
@@ -136,3 +262,34 @@ def get_pchip_interpolator(
         return values
 
     return _interp
+
+
+def _check_pchip_nodes(
+    z_tilde_nodes: np.ndarray,
+    values_nodes: np.ndarray,
+    name: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Validate a set of profile nodes shared by :py:func:`get_pchip_interpolator`
+    and :py:func:`get_pchip_layer_mean`, returning them as float arrays.
+    """
+    z_tilde_nodes = np.asarray(z_tilde_nodes, dtype=float)
+    values_nodes = np.asarray(values_nodes, dtype=float)
+
+    if z_tilde_nodes.ndim != 1 or values_nodes.ndim != 1:
+        raise ValueError('z_tilde_nodes and values_nodes must be 1-D arrays.')
+    if len(z_tilde_nodes) != len(values_nodes):
+        raise ValueError(
+            f'Lengths of z_tilde_nodes and {name} nodes must match.'
+        )
+    if len(z_tilde_nodes) < 2:
+        raise ValueError('At least two z_tilde nodes are required.')
+
+    dz = np.diff(z_tilde_nodes)
+    if not (np.all(dz > 0.0) or np.all(dz < 0.0)):
+        raise ValueError(
+            'z_tilde_nodes must be strictly monotonic (increasing or '
+            'decreasing).'
+        )
+
+    return z_tilde_nodes, values_nodes

--- a/polaris/tasks/ocean/horiz_press_grad/edge.py
+++ b/polaris/tasks/ocean/horiz_press_grad/edge.py
@@ -1,0 +1,68 @@
+"""
+The two-column edge operator for the ``horiz_press_grad`` configurations.
+
+The mesh has exactly two cells and one internal edge, and the edge normal
+points from cell 0 to cell 1, so the TRiSK gradient of the design's
+``[edge-grad]`` reduces to ``Delta_e f = f_1 - f_0``, with
+``[grad_n f]_e = Delta_e f / d_e``.  That is the convention
+``Init._compute_montgomery_and_hpga`` uses.
+
+This is a leaf module with no dependencies inside the package, so that both
+:py:mod:`~polaris.tasks.ocean.horiz_press_grad.eos_expansion` and
+:py:mod:`~polaris.tasks.ocean.horiz_press_grad.finite_volume` can use it
+without importing one another.
+"""
+
+import xarray as xr
+
+__all__ = ['edge_delta', 'edge_mean']
+
+
+def edge_delta(field: xr.DataArray) -> xr.DataArray:
+    """
+    The two-column edge difference ``Delta_e f = f_1 - f_0``, the numerator of
+    the TRiSK gradient operator for the single internal edge.
+
+    Parameters
+    ----------
+    field : xarray.DataArray
+        A field with an ``nCells`` dimension of size 2.
+
+    Returns
+    -------
+    delta : xarray.DataArray
+        The difference, with ``nCells`` contracted away.
+    """
+    _check_two_columns(field)
+    return field.isel(nCells=1) - field.isel(nCells=0)
+
+
+def edge_mean(field: xr.DataArray) -> xr.DataArray:
+    """
+    The two-column edge average ``0.5 * (f_0 + f_1)``.
+
+    Parameters
+    ----------
+    field : xarray.DataArray
+        A field with an ``nCells`` dimension of size 2.
+
+    Returns
+    -------
+    mean : xarray.DataArray
+        The average, with ``nCells`` contracted away.
+    """
+    _check_two_columns(field)
+    return 0.5 * (field.isel(nCells=0) + field.isel(nCells=1))
+
+
+def _check_two_columns(field: xr.DataArray) -> None:
+    """
+    Verify that ``field`` spans exactly the two columns the edge operator is
+    defined for.
+    """
+    ncells = field.sizes.get('nCells', 0)
+    if ncells != 2:
+        raise ValueError(
+            'The two-column edge operator requires exactly 2 cells, but the '
+            f'field has {ncells}.'
+        )

--- a/polaris/tasks/ocean/horiz_press_grad/eos_expansion.py
+++ b/polaris/tasks/ocean/horiz_press_grad/eos_expansion.py
@@ -1,0 +1,345 @@
+"""
+Reference-state expansion of the equation of state, shared across the edge.
+
+This is §3.3 of ``PGradHighOrder.md``.  The finite-volume pressure gradient
+never integrates TEOS-10; it expands specific volume to first order about a
+reference state, ``[alpha-taylor]``,
+
+.. math::
+
+    \\hat\\alpha(\\Theta, S, p) = \\alpha_0
+    + \\alpha_\\Theta (\\Theta - \\Theta_{\\rm ref})
+    + \\alpha_S (S - S_{\\rm ref})
+    + \\alpha_p (p - p_{\\rm ref}),
+
+so that :math:`\\hat\\alpha` is a low-order polynomial in pressure once
+:math:`\\Theta` and :math:`S` are reconstructed as polynomials in pressure, and
+every integral the scheme needs is available in closed form.
+
+**The expansion point is shared across the edge** (§3.3.1, ``[edge-ref]``).
+The four coefficients are computed once per cell per layer at that cell's own
+state and are then averaged to the edge, together with the reference state
+itself, and *both* columns are evaluated with the single resulting set.  If
+instead each column expanded about its own state, the two would be using two
+different approximations to the same equation of state; their specific-volume
+profiles would disagree even for a resting ocean the reconstruction reproduces
+perfectly, and the scheme would generate spurious flow from nothing but its own
+equation of state.  Under the reduced target of §3.2 this is the *only*
+remaining way for exactness to fail on a resolved profile, so it is
+load-bearing rather than a refinement.
+
+Note on cost: Requirement 2.2 bounds the number of TEOS-10 *calls*, and the
+design's claim is that one evaluation yields all four coefficients because the
+derivatives are analytic derivatives of the same polynomial at the same
+normalized state.  The Python here necessarily makes two calls, because
+``gsw.specvol_first_derivatives`` returns the derivatives without the value.
+That is a limitation of the Python bindings and says nothing about Omega's call
+count; do not read this module as evidence about cost.
+"""
+
+import gsw
+import numpy as np
+import xarray as xr
+
+from polaris.tasks.ocean.horiz_press_grad.edge import edge_mean
+
+__all__ = [
+    'specvol_coefficients',
+    'edge_expansion',
+    'edge_specvol',
+    'edge_specvol_layer_mean',
+]
+
+# gsw takes pressure in dbar and returns the pressure derivative of specific
+# volume per Pa -- the convention of neither argument.  Asserted in
+# tests/ocean/horiz_press_grad/test_eos_expansion.py rather than trusted.
+_PA_TO_DBAR = 1.0e-4
+
+
+def specvol_coefficients(
+    temperature: xr.DataArray,
+    salinity: xr.DataArray,
+    pressure: xr.DataArray,
+) -> xr.Dataset:
+    """
+    The four coefficients of ``[alpha-derivs]``, evaluated at each cell's own
+    layer-mean state.
+
+    Parameters
+    ----------
+    temperature : xarray.DataArray
+        Conservative temperature in degC.  Invalid layers may be ``NaN`` and
+        stay ``NaN``.
+
+    salinity : xarray.DataArray
+        Absolute salinity in g kg-1, on the same points.
+
+    pressure : xarray.DataArray
+        Sea gauge pressure in **Pa**, on the same points.  This module follows
+        the rest of Polaris in using Pa, and converts to dbar at the ``gsw``
+        call.
+
+    Returns
+    -------
+    coefficients : xarray.Dataset
+        ``alpha_0`` (m3 kg-1), ``alpha_theta`` (m3 kg-1 degC-1), ``alpha_s``
+        (m3 kg-1 / (g kg-1)) and ``alpha_p`` (m3 kg-1 Pa-1), on the dims of the
+        inputs.
+    """
+    conservative_temperature = np.asarray(temperature.values, dtype=float)
+    absolute_salinity = np.asarray(salinity.values, dtype=float)
+    pressure_pa = np.asarray(pressure.values, dtype=float)
+
+    if not (
+        conservative_temperature.shape
+        == absolute_salinity.shape
+        == pressure_pa.shape
+    ):
+        raise ValueError(
+            'temperature, salinity and pressure must have the same shape; got '
+            f'{conservative_temperature.shape}, {absolute_salinity.shape} and '
+            f'{pressure_pa.shape}.'
+        )
+
+    valid = (
+        np.isfinite(conservative_temperature)
+        & np.isfinite(absolute_salinity)
+        & np.isfinite(pressure_pa)
+    )
+
+    coefficients = {
+        name: np.full(conservative_temperature.shape, np.nan)
+        for name in ['alpha_0', 'alpha_theta', 'alpha_s', 'alpha_p']
+    }
+
+    if np.any(valid):
+        pressure_dbar = pressure_pa[valid] * _PA_TO_DBAR
+        coefficients['alpha_0'][valid] = gsw.specvol(
+            absolute_salinity[valid],
+            conservative_temperature[valid],
+            pressure_dbar,
+        )
+        alpha_s, alpha_theta, alpha_p = gsw.specvol_first_derivatives(
+            absolute_salinity[valid],
+            conservative_temperature[valid],
+            pressure_dbar,
+        )
+        coefficients['alpha_theta'][valid] = alpha_theta
+        coefficients['alpha_s'][valid] = alpha_s
+        coefficients['alpha_p'][valid] = alpha_p
+
+    units = {
+        'alpha_0': 'm3 kg-1',
+        'alpha_theta': 'm3 kg-1 degC-1',
+        'alpha_s': 'm3 kg-1 kg g-1',
+        'alpha_p': 'm3 kg-1 Pa-1',
+    }
+    long_names = {
+        'alpha_0': 'specific volume at the reference state',
+        'alpha_theta': 'derivative of specific volume with respect to '
+        'conservative temperature',
+        'alpha_s': 'derivative of specific volume with respect to absolute '
+        'salinity',
+        'alpha_p': 'derivative of specific volume with respect to pressure',
+    }
+
+    return xr.Dataset(
+        {
+            name: xr.DataArray(
+                data=values,
+                dims=temperature.dims,
+                attrs={
+                    'long_name': long_names[name],
+                    'units': units[name],
+                },
+            )
+            for name, values in coefficients.items()
+        }
+    )
+
+
+def edge_expansion(
+    temperature: xr.DataArray,
+    salinity: xr.DataArray,
+    pressure: xr.DataArray,
+) -> xr.Dataset:
+    """
+    The edge-shared expansion of ``[edge-ref]``: the four coefficients and the
+    reference state, each averaged over the two cells of the edge.
+
+    Parameters
+    ----------
+    temperature : xarray.DataArray
+        Layer-mean conservative temperature in degC, with an ``nCells``
+        dimension of size 2.
+
+    salinity : xarray.DataArray
+        Layer-mean absolute salinity in g kg-1, on the same points.
+
+    pressure : xarray.DataArray
+        Layer-mean sea gauge pressure in Pa (``PressureMid``), on the same
+        points.
+
+    Returns
+    -------
+    expansion : xarray.Dataset
+        ``alpha_0``, ``alpha_theta``, ``alpha_s``, ``alpha_p`` and the
+        reference
+        state ``theta_ref``, ``s_ref``, ``p_ref``, with ``nCells`` contracted
+        away by the edge average.
+
+        Note that ``alpha_0`` is the *average of the two cells' specific
+        volumes*, each evaluated at its own state -- not specific volume
+        evaluated at the averaged state.  The difference is second order in the
+        cross-edge contrast, and is exactly what source 4 of the remainder
+        accounts for.
+    """
+    coefficients = specvol_coefficients(
+        temperature=temperature, salinity=salinity, pressure=pressure
+    )
+
+    expansion = xr.Dataset(
+        {
+            name: edge_mean(coefficients[name]).assign_attrs(
+                coefficients[name].attrs
+            )
+            for name in coefficients.data_vars
+        }
+    )
+
+    for name, field, long_name, units in [
+        ('theta_ref', temperature, 'conservative temperature', 'degC'),
+        ('s_ref', salinity, 'absolute salinity', 'g kg-1'),
+        ('p_ref', pressure, 'sea gauge pressure', 'Pa'),
+    ]:
+        expansion[name] = edge_mean(field).assign_attrs(
+            {
+                'long_name': f'edge-shared expansion point, {long_name}',
+                'units': units,
+            }
+        )
+
+    return expansion
+
+
+def edge_specvol(
+    expansion: xr.Dataset,
+    temperature: xr.DataArray | float,
+    salinity: xr.DataArray | float,
+    pressure: xr.DataArray | float,
+) -> xr.DataArray:
+    """
+    Evaluate the edge-shared profile ``[alpha-taylor]`` at a given state.
+
+    The arguments may carry an ``nCells`` dimension while ``expansion`` does
+    not, in which case both columns are evaluated with the one shared set of
+    coefficients -- which is the whole point of ``[edge-ref]``.
+
+    Parameters
+    ----------
+    expansion : xarray.Dataset
+        The edge-shared expansion from :py:func:`edge_expansion`.
+
+    temperature : xarray.DataArray or float
+        Conservative temperature in degC at which to evaluate.
+
+    salinity : xarray.DataArray or float
+        Absolute salinity in g kg-1 at which to evaluate.
+
+    pressure : xarray.DataArray or float
+        Sea gauge pressure in Pa at which to evaluate.
+
+    Returns
+    -------
+    specvol : xarray.DataArray
+        :math:`\\hat\\alpha^{(e)}` in m3 kg-1, with the dimensions of the state
+        arguments in their original order.
+    """
+    specvol = (
+        expansion.alpha_0
+        + expansion.alpha_theta * (temperature - expansion.theta_ref)
+        + expansion.alpha_s * (salinity - expansion.s_ref)
+        + expansion.alpha_p * (pressure - expansion.p_ref)
+    )
+
+    # ``expansion`` has no nCells dimension, so xarray broadcasts it to the end
+    # and the result comes back with the state's dimensions permuted.  Restore
+    # the caller's order: a field written to init.nc or masked by index with
+    # silently transposed dimensions is a hard bug to see.
+    template = _template(temperature, salinity, pressure)
+    if template is not None:
+        specvol = specvol.transpose(*template.dims, ...)
+
+    return specvol.assign_attrs(
+        {
+            'long_name': 'edge-shared specific volume',
+            'units': 'm3 kg-1',
+        }
+    )
+
+
+def edge_specvol_layer_mean(
+    expansion: xr.Dataset,
+    temperature: xr.DataArray,
+    salinity: xr.DataArray,
+    pressure: xr.DataArray,
+) -> xr.DataArray:
+    """
+    The layer mean of the edge-shared profile, ``[alpha-edge-layer-mean]``.
+
+    This is :py:func:`edge_specvol` evaluated at the *layer-mean* state, and it
+    is the same arithmetic for a reason worth stating rather than leaving to be
+    rediscovered: ``[alpha-taylor]`` is linear in :math:`\\Theta`, :math:`S`
+    and :math:`p` jointly, so the layer mean of :math:`\\hat\\alpha^{(e)}` is
+    :math:`\\hat\\alpha^{(e)}` evaluated at the layer means of its arguments.
+    The reconstruction of §3.4 is mean-preserving, so the layer means of
+    :math:`\\Theta(p)` and :math:`S(p)` are the prognostic layer means; and
+    ``PressureMid`` is the exact arithmetic midpoint of the two interface
+    pressures, so the layer mean of :math:`p` is ``PressureMid``.  The shape of
+    the reconstruction inside the layer therefore cannot affect this quantity.
+
+    It is source 4 of the remainder that needs it: the mismatch against
+    ``VertCoord``'s own increment, ``[eos-remainder]``, is the second-order
+    Taylor remainder of the equation of state across the edge.
+
+    Parameters
+    ----------
+    expansion : xarray.Dataset
+        The edge-shared expansion from :py:func:`edge_expansion`.
+
+    temperature : xarray.DataArray
+        Layer-mean conservative temperature in degC.
+
+    salinity : xarray.DataArray
+        Layer-mean absolute salinity in g kg-1.
+
+    pressure : xarray.DataArray
+        Layer-mean sea gauge pressure in Pa (``PressureMid``).
+
+    Returns
+    -------
+    specvol : xarray.DataArray
+        The layer mean of :math:`\\hat\\alpha^{(e)}` in m3 kg-1.
+    """
+    return edge_specvol(
+        expansion=expansion,
+        temperature=temperature,
+        salinity=salinity,
+        pressure=pressure,
+    ).assign_attrs(
+        {
+            'long_name': 'layer mean of the edge-shared specific volume',
+            'units': 'm3 kg-1',
+        }
+    )
+
+
+def _template(*values: xr.DataArray | float) -> xr.DataArray | None:
+    """
+    The first argument that is a ``DataArray``, whose dimension order
+    :py:func:`edge_specvol` restores, or ``None`` if all are scalars.
+    """
+    for value in values:
+        if isinstance(value, xr.DataArray):
+            return value
+    return None

--- a/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
+++ b/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
@@ -51,6 +51,7 @@ __all__ = [
     'hydrostatic_scale',
     'matched_pressure_pieces',
     'anchor_difference',
+    'anchor_index',
     'column_scan',
     'scan_increments',
     'layer_mean_difference',
@@ -453,9 +454,9 @@ def matched_pressure_pieces(
         'interface': interface,
         'deepest': deepest,
         'edge_interface': 0.5 * (interface[0, :] + interface[1, :]),
-        'surface_height': ds.GeomZInterface.isel(
-            Time=0, nVertLevelsP1=0
-        ).values,
+        # every interface, not just the sea surface: the scan anchors at the
+        # sea floor, whose index depends on maxLevelCell
+        'interface_height': ds.GeomZInterface.isel(Time=0).values,
     }
 
 
@@ -585,29 +586,81 @@ def delta_specvol_at_pressure(
     return total
 
 
+def anchor_index(pieces: dict, guards: set[str] | None = None) -> int:
+    """
+    The interface the column scan is anchored at.
+
+    The **sea floor** -- the deepest interface valid in both columns -- unless
+    the ``anchor_at_surface`` guard selects the sea surface.  See
+    :py:func:`anchor_difference` for why the two ends are not equivalent.
+
+    Parameters
+    ----------
+    pieces : dict
+        From :py:func:`matched_pressure_pieces`.
+
+    guards : set of str, optional
+        Verification-only switches; see :py:func:`finite_volume_hpga`.
+
+    Returns
+    -------
+    index : int
+        The interface index, in ``[0, min(maxLevelCell)]``.
+
+    """
+    guards = guards if guards is not None else pieces.get('guards', set())
+    if 'anchor_at_surface' in guards:
+        return 0
+    return int(min(pieces['deepest'])) + 1
+
+
 def anchor_difference(
     pieces: dict, order: int = 2, guards: set[str] | None = None
 ) -> float:
     """
     The design's ``[anchor]``: the fixed-pressure height difference at the
-    edge's topmost interface.
+    interface the scan starts from.
 
     .. math::
 
-        D_1 = \\Delta_e Z_1 - \\frac{1}{g}\\,\\Delta_e
-        \\int_{p^{\\rm surf}_i}^{\\bar q_1} \\hat\\alpha^{(e)}_i(p)\\,dp
+        D_{K+1} = \\Delta_e Z_{K+1} - \\frac{1}{g}\\,\\Delta_e
+        \\int_{p_{i,K+1}}^{\\bar q_{K+1}} \\hat\\alpha^{(e)}_i(p)\\,dp
 
-    The two columns sit at different surface pressures, so this is the
-    sea-surface height difference corrected to the common pressure
-    :math:`\\bar q_1`.  The two short integrals are over *different* pressure
-    ranges and so cannot be combined into a matched-pressure difference the way
-    the interior can; each is taken inside that column's own top layer.
+    The two columns' interfaces sit at different pressures, so this is their
+    geometric height difference corrected to the common pressure
+    :math:`\\bar q_{K+1}`.  The two short integrals are over *different*
+    pressure ranges and so cannot be combined into a matched-pressure
+    difference the way the interior can; each is taken inside that column's own
+    outermost layer.
 
-    For a resting ocean whose sea surface satisfies the inverse-barometer
-    relation this is zero, and **exactness of the whole scheme inherits that**
-    (design §3.5.1).  It is the one place the scheme's robustness depends on
-    something outside the pressure gradient, namely the consistency of the
-    initialized sea-surface height with the surface pressure.
+    **The anchor is at the sea floor** (design §3.7.4), :math:`K` being the
+    deepest layer valid in both columns.  Which end it sits at is not a free
+    choice and not merely a conditioning preference:
+
+    * `VertCoord` builds geometric height *upward* from a prescribed
+      bathymetry, accumulating :math:`\\rho_0\\alpha_{i,k}\\tilde h_{i,k}` over
+      each column's **own** layers.  On a profile the reconstruction does not
+      resolve, two columns with different layer partitions give sums differing
+      at :math:`O(\\tilde h^2)`, so their *derived* sea-surface heights differ
+      by that much even when the two columns hold the same water.  Anchored at
+      the surface that discrepancy enters :math:`D_1` directly and exactness is
+      lost; anchored at the sea floor over a flat floor :math:`\\Delta_e Z` is
+      exact input and vanishes identically.
+    * The two ends therefore agree only for profiles inside the exact set,
+      where both columns' sums agree term by term.  The ``anchor_at_surface``
+      guard exists to measure the gap rather than assume it.
+
+    Where the two columns have different ``maxLevelCell`` this needs no special
+    case: the anchor sits at the deepest interface index valid in *both*, which
+    is the shallower column's own floor and an interior interface of the
+    deeper one, and each column is shifted to the common pressure from
+    whichever interface pressure it has there.
+
+    The anchor is **computed, not assumed**.  It is whatever the model's
+    geometric heights and interface pressures imply, evaluated at a common
+    pressure, and it is the deepest instance of the same fixed-pressure
+    comparison the recurrence makes at every other interface.  A state only
+    approximately at rest carries a real gradient, and the scheme reports it.
 
     Parameters
     ----------
@@ -619,28 +672,35 @@ def anchor_difference(
         The integrand is linear in pressure within a layer, so 2 integrates it
         exactly.
 
+    guards : set of str, optional
+        Verification-only switches; see :py:func:`finite_volume_hpga`.
+
     Returns
     -------
     anchor : float
-        :math:`D_1` in m.
-
+        :math:`D` at :py:func:`anchor_index`, in m.
 
     """
     guards = guards if guards is not None else pieces.get('guards', set())
-    delta_z = pieces['surface_height'][1] - pieces['surface_height'][0]
+    interface = anchor_index(pieces, guards=guards)
+    height = pieces['interface_height'][:, interface]
+    delta_z = height[1] - height[0]
     if 'anchor_delta_z_only' in guards:
-        # guard: the sea-surface height difference without correcting to a
+        # guard: the geometric height difference without correcting to a
         # common pressure
         return float(delta_z)
 
     nodes, weights = np.polynomial.legendre.leggauss(order)
-    common = pieces['edge_interface'][0]
+    common = pieces['edge_interface'][interface]
+    # the edge layer adjacent to the anchor interface supplies the shared
+    # coefficients, as it does for every other interface in the scan
+    edge_layer = max(interface - 1, 0)
 
     correction = np.empty(2)
     for icell in range(2):
-        surface = pieces['interface'][icell, 0]
-        middle = 0.5 * (surface + common)
-        half = 0.5 * (common - surface)
+        own = pieces['interface'][icell, interface]
+        middle = 0.5 * (own + common)
+        half = 0.5 * (common - own)
         probe = middle + half * nodes
         level = layer_containing_pressure(pieces, icell, probe)
         theta = pieces['theta'][icell, level] + pieces['slope_theta'][
@@ -649,7 +709,7 @@ def anchor_difference(
         salinity = pieces['salinity'][icell, level] + pieces['slope_salinity'][
             icell, level
         ] * (probe - pieces['pressure_mid'][icell, level])
-        expansion = pieces['expansion'].isel(nVertLevels=0)
+        expansion = pieces['expansion'].isel(nVertLevels=edge_layer)
         specvol = (
             float(expansion.alpha_0)
             + float(expansion.alpha_theta)
@@ -667,12 +727,17 @@ def column_scan(
 ) -> np.ndarray:
     """
     The design's ``[d-recurrence]``: :math:`D_k = \\Delta_e z(\\bar q_k)`
-    accumulated down the edge's column from the sea surface.
+    accumulated along the edge's column from :py:func:`anchor_difference`,
+    which sits at the **sea floor**.
 
     .. math::
 
         D_{k+1} = D_k - \\frac{1}{g}
         \\int_{\\bar q_k}^{\\bar q_{k+1}} \\Delta_e\\hat\\alpha(p)\\,dp
+
+    Anchored at the floor the recurrence is run in the direction
+    :math:`D_k = D_{k+1} + \\frac{1}{g}\\int`, upward; the integrals are the
+    same ones either way.
 
     Every quantity here is small.  :math:`D_k` is a fixed-pressure height
     difference -- order :math:`10^{-1}` m for a realistic baroclinic column and
@@ -694,26 +759,32 @@ def column_scan(
     -------
     difference : numpy.ndarray
         :math:`D_k` at every edge interface valid in both columns, in m, with
-        ``difference[0]`` the anchor.
+        ``difference[anchor_index(pieces)]`` the anchor.
 
 
     """
     nodes, weights = np.polynomial.legendre.leggauss(order)
     edges = pieces['edge_interface']
     deepest = int(min(pieces['deepest']))
+    anchor = anchor_index(pieces, guards=guards)
 
-    difference = np.empty(deepest + 2)
-    difference[0] = anchor_difference(pieces, order=order, guards=guards)
+    increment = np.empty(deepest + 1)
     for edge_layer in range(deepest + 1):
         top, bot = edges[edge_layer], edges[edge_layer + 1]
         middle, half = 0.5 * (top + bot), 0.5 * (bot - top)
         contrast = delta_specvol_at_pressure(
             pieces, edge_layer, middle + half * nodes, guards=guards
         )
-        integral = half * float(np.sum(weights * contrast))
-        difference[edge_layer + 1] = (
-            difference[edge_layer] - integral / Gravity
+        increment[edge_layer] = (
+            half * float(np.sum(weights * contrast)) / Gravity
         )
+
+    difference = np.empty(deepest + 2)
+    difference[anchor] = anchor_difference(pieces, order=order, guards=guards)
+    for k in range(anchor - 1, -1, -1):
+        difference[k] = difference[k + 1] + increment[k]
+    for k in range(anchor + 1, deepest + 2):
+        difference[k] = difference[k - 1] - increment[k - 1]
 
     return difference
 
@@ -751,18 +822,25 @@ def layer_mean_difference(
     The layer mean of :math:`\\Delta_e z(p)` over each edge layer.
 
     Within an edge layer ``[qbar_k, qbar_{k+1}]``,
-    :math:`\\Delta_e z(p) = D_k - \\frac{1}{g}\\int_{\\bar q_k}^{p}
+    :math:`\\Delta_e z(p) = D_{k+1} + \\frac{1}{g}\\int_{p}^{\\bar q_{k+1}}
     \\Delta_e\\hat\\alpha`, so averaging over the layer and integrating the
     double integral by parts gives
 
     .. math::
 
-        \\langle\\Delta_e z\\rangle_k = D_k - \\frac{1}{g\\,\\Delta p_{e,k}}
+        \\langle\\Delta_e z\\rangle_k = D_{k+1}
+        + \\frac{1}{g\\,\\Delta p_{e,k}}
         \\int_{\\bar q_k}^{\\bar q_{k+1}}
-        (\\bar q_{k+1} - p)\\,\\Delta_e\\hat\\alpha(p)\\,dp
+        (p - \\bar q_k)\\,\\Delta_e\\hat\\alpha(p)\\,dp
 
     which is the "second moment of the same integrand over the same interval"
     of design §3.5.1, on the same quadrature points as the scan.
+
+    The moment is taken about the layer's **top** interface and paired with
+    :math:`D_{k+1}` at its **bottom** one, the end nearer the sea-floor anchor
+    (design §4.1.3).  The mirror form -- :math:`D_k` with a moment about
+    the bottom -- is the same number in exact arithmetic and a different one at
+    finite quadrature, so it is not an interchangeable way to write this.
 
     Parameters
     ----------
@@ -795,8 +873,8 @@ def layer_mean_difference(
         contrast = delta_specvol_at_pressure(
             pieces, edge_layer, probe, guards=guards
         )
-        moment = half * float(np.sum(weights * (bot - probe) * contrast))
-        mean[edge_layer] = difference[edge_layer] - moment / (
+        moment = half * float(np.sum(weights * (probe - top) * contrast))
+        mean[edge_layer] = difference[edge_layer + 1] + moment / (
             Gravity * (bot - top)
         )
 
@@ -846,8 +924,14 @@ def finite_volume_hpga(
             evaluate each column at its own layer ``k`` instead of the layer
             containing the pressure.
         ``'anchor_delta_z_only'``
-            take the anchor as ``Delta_e Z_1`` alone, dropping the correction
+            take the anchor as ``Delta_e Z`` alone, dropping the correction
             to a common pressure.
+        ``'anchor_at_surface'``
+            anchor the column scan at the sea surface instead of the sea
+            floor.  Not a mistake in the arithmetic but a different choice of
+            end, which the design settles in favour of the floor; see
+            :py:func:`anchor_difference`.  It exists so the gap between the two
+            can be measured rather than assumed.
 
     Returns
     -------

--- a/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
+++ b/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
@@ -50,6 +50,9 @@ __all__ = [
     'hpga_from_shift',
     'hydrostatic_scale',
     'matched_pressure_pieces',
+    'anchor_difference',
+    'column_scan',
+    'scan_increments',
     'layer_containing_pressure',
     'delta_specvol_at_pressure',
 ]
@@ -89,6 +92,7 @@ def centered_shift(ds: xr.Dataset) -> xr.DataArray:
     shift : xarray.DataArray
         ``S_{e,k}`` at layer midpoints, in m, with the ``nCells`` dimension
         contracted away by the edge operator.
+
 
 
     """
@@ -137,6 +141,7 @@ def hpga_from_shift(shift: xr.DataArray, dx: float) -> xr.DataArray:
         The edge-normal pressure-gradient acceleration in m s-2.
 
 
+
     """
     if dx == 0.0:
         raise ValueError('dx must be non-zero for finite differences.')
@@ -174,6 +179,7 @@ def hydrostatic_scale(ds: xr.Dataset) -> float:
         an acceleration.
 
 
+
     """
     q = pressure_from_z_tilde(ds.ZTildeInterface)
     z_magnitude = float(np.abs(ds.GeomZInterface).max())
@@ -186,6 +192,7 @@ def _layer_top(field: xr.DataArray) -> xr.DataArray:
     The value at each layer's top interface, as a layer-indexed field.
 
 
+
     """
     return field.isel(nVertLevelsP1=slice(0, -1)).rename(
         {'nVertLevelsP1': 'nVertLevels'}
@@ -195,6 +202,7 @@ def _layer_top(field: xr.DataArray) -> xr.DataArray:
 def _layer_bot(field: xr.DataArray) -> xr.DataArray:
     """
     The value at each layer's bottom interface, as a layer-indexed field.
+
 
 
     """
@@ -246,6 +254,7 @@ def centered_shift_accumulated(
     -------
     shift : xarray.DataArray
         ``S_{e,k}`` at layer midpoints, in m.
+
 
 
     """
@@ -318,6 +327,7 @@ def shift_increments(ds: xr.Dataset) -> xr.Dataset:
         (``Delta_e Z`` at interfaces) to scale them against.  All in m.
 
 
+
     """
     pieces = _shift_pieces(ds)
     return xr.Dataset(
@@ -332,6 +342,7 @@ def shift_increments(ds: xr.Dataset) -> xr.Dataset:
 def _shift_pieces(ds: xr.Dataset) -> dict:
     """The increments and anchors of ``[gamma-increments]``, and the mask of
     layers valid in both columns.
+
 
     """
     q = pressure_from_z_tilde(ds.ZTildeInterface)
@@ -411,6 +422,7 @@ def matched_pressure_pieces(ds: xr.Dataset) -> dict:
         ``deepest`` valid layer, and the edge-layer interface pressures
         ``edge_interface``.
 
+
     """
     interface = pressure_from_z_tilde(ds.ZTildeInterface).isel(Time=0).values
     deepest = ds.maxLevelCell.values.astype(int) - 1
@@ -431,6 +443,9 @@ def matched_pressure_pieces(ds: xr.Dataset) -> dict:
         'interface': interface,
         'deepest': deepest,
         'edge_interface': 0.5 * (interface[0, :] + interface[1, :]),
+        'surface_height': ds.GeomZInterface.isel(
+            Time=0, nVertLevelsP1=0
+        ).values,
     }
 
 
@@ -471,6 +486,7 @@ def layer_containing_pressure(
     -------
     index : numpy.ndarray
         Zero-based layer indices, in ``[0, maxLevelCell - 1]``.
+
 
     """
     deepest = int(pieces['deepest'][icell])
@@ -519,6 +535,7 @@ def delta_specvol_at_pressure(
     delta_specvol : numpy.ndarray
         :math:`\\Delta_e\\hat\\alpha(p)` in m3 kg-1.
 
+
     """
     pressure = np.atleast_1d(np.asarray(pressure, dtype=float))
     expansion = pieces['expansion'].isel(nVertLevels=edge_layer)
@@ -537,3 +554,145 @@ def delta_specvol_at_pressure(
         float(expansion.alpha_theta) * contrast['theta']
         + float(expansion.alpha_s) * contrast['salinity']
     )
+
+
+def anchor_difference(pieces: dict, order: int = 4) -> float:
+    """
+    The design's ``[anchor]``: the fixed-pressure height difference at the
+    edge's topmost interface.
+
+    .. math::
+
+        D_1 = \\Delta_e Z_1 - \\frac{1}{g}\\,\\Delta_e
+        \\int_{p^{\\rm surf}_i}^{\\bar q_1} \\hat\\alpha^{(e)}_i(p)\\,dp
+
+    The two columns sit at different surface pressures, so this is the
+    sea-surface height difference corrected to the common pressure
+    :math:`\\bar q_1`.  The two short integrals are over *different* pressure
+    ranges and so cannot be combined into a matched-pressure difference the way
+    the interior can; each is taken inside that column's own top layer.
+
+    For a resting ocean whose sea surface satisfies the inverse-barometer
+    relation this is zero, and **exactness of the whole scheme inherits that**
+    (design §3.5.1).  It is the one place the scheme's robustness depends on
+    something outside the pressure gradient, namely the consistency of the
+    initialized sea-surface height with the surface pressure.
+
+    Parameters
+    ----------
+    pieces : dict
+        From :py:func:`matched_pressure_pieces`.
+
+    order : int
+        Gauss-Legendre order.  The integrand is linear in pressure within a
+        layer, so 2 already integrates it exactly; the default is the same rule
+        the scan uses.
+
+    Returns
+    -------
+    anchor : float
+        :math:`D_1` in m.
+
+    """
+    nodes, weights = np.polynomial.legendre.leggauss(order)
+    common = pieces['edge_interface'][0]
+
+    correction = np.empty(2)
+    for icell in range(2):
+        surface = pieces['interface'][icell, 0]
+        middle = 0.5 * (surface + common)
+        half = 0.5 * (common - surface)
+        probe = middle + half * nodes
+        level = layer_containing_pressure(pieces, icell, probe)
+        theta = pieces['theta'][icell, level] + pieces['slope_theta'][
+            icell, level
+        ] * (probe - pieces['pressure_mid'][icell, level])
+        salinity = pieces['salinity'][icell, level] + pieces['slope_salinity'][
+            icell, level
+        ] * (probe - pieces['pressure_mid'][icell, level])
+        expansion = pieces['expansion'].isel(nVertLevels=0)
+        specvol = (
+            float(expansion.alpha_0)
+            + float(expansion.alpha_theta)
+            * (theta - float(expansion.theta_ref))
+            + float(expansion.alpha_s) * (salinity - float(expansion.s_ref))
+            + float(expansion.alpha_p) * (probe - float(expansion.p_ref))
+        )
+        correction[icell] = half * float(np.sum(weights * specvol))
+
+    delta_z = pieces['surface_height'][1] - pieces['surface_height'][0]
+    return float(delta_z - (correction[1] - correction[0]) / Gravity)
+
+
+def column_scan(pieces: dict, order: int = 4) -> np.ndarray:
+    """
+    The design's ``[d-recurrence]``: :math:`D_k = \\Delta_e z(\\bar q_k)`
+    accumulated down the edge's column from the sea surface.
+
+    .. math::
+
+        D_{k+1} = D_k - \\frac{1}{g}
+        \\int_{\\bar q_k}^{\\bar q_{k+1}} \\Delta_e\\hat\\alpha(p)\\,dp
+
+    Every quantity here is small.  :math:`D_k` is a fixed-pressure height
+    difference -- order :math:`10^{-1}` m for a realistic baroclinic column and
+    zero for a resting one -- against the :math:`10^{2}` m height differences
+    at fixed layer index that a scheme comparing at fixed index has to form and
+    cancel.  The increments are smaller still, being integrals of a horizontal
+    contrast.  There is no cancellation of large quantities anywhere.
+
+    Parameters
+    ----------
+    pieces : dict
+        From :py:func:`matched_pressure_pieces`.
+
+    order : int
+        Gauss-Legendre order for the layer integrals.
+
+    Returns
+    -------
+    difference : numpy.ndarray
+        :math:`D_k` at every edge interface valid in both columns, in m, with
+        ``difference[0]`` the anchor.
+
+    """
+    nodes, weights = np.polynomial.legendre.leggauss(order)
+    edges = pieces['edge_interface']
+    deepest = int(min(pieces['deepest']))
+
+    difference = np.empty(deepest + 2)
+    difference[0] = anchor_difference(pieces, order=order)
+    for edge_layer in range(deepest + 1):
+        top, bot = edges[edge_layer], edges[edge_layer + 1]
+        middle, half = 0.5 * (top + bot), 0.5 * (bot - top)
+        contrast = delta_specvol_at_pressure(
+            pieces, edge_layer, middle + half * nodes
+        )
+        integral = half * float(np.sum(weights * contrast))
+        difference[edge_layer + 1] = (
+            difference[edge_layer] - integral / Gravity
+        )
+
+    return difference
+
+
+def scan_increments(pieces: dict, order: int = 4) -> np.ndarray:
+    """
+    The per-layer increments of :py:func:`column_scan`, for the smallness
+    assertion of §3.7.5.
+
+    Parameters
+    ----------
+    pieces : dict
+        From :py:func:`matched_pressure_pieces`.
+
+    order : int
+        Gauss-Legendre order.
+
+    Returns
+    -------
+    increments : numpy.ndarray
+        ``D_{k+1} - D_k`` for each edge layer, in m.
+
+    """
+    return np.diff(column_scan(pieces, order=order))

--- a/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
+++ b/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
@@ -22,26 +22,23 @@ trapezoid-averaged over the layer's two interfaces.  It is exactly what the
 centered scheme computes, so ``R_{e,k}`` is the whole difference between the
 two schemes.  Only ``S`` is implemented so far.
 
-Every horizontal difference here is the two-column edge operator.  The mesh has
-exactly two cells and one internal edge, and the edge normal points from cell 0
-to cell 1, so ``Delta_e f = f_1 - f_0`` and ``[grad_n f]_e = Delta_e f / d_e``.
-That is the convention
+Every horizontal difference here is the two-column edge operator of
+:py:mod:`~polaris.tasks.ocean.horiz_press_grad.edge`.  The identity in
+:py:func:`centered_shift` holds against
 :py:meth:`polaris.tasks.ocean.horiz_press_grad.init.Init._compute_montgomery_and_hpga`
-uses, and the identity in :py:func:`centered_shift` holds against that function
-and not against an idealized centered form.
+itself, not against an idealized centered form.
 """
 
 import numpy as np
 import xarray as xr
 
 from polaris.ocean.vertical.ztilde import Gravity, pressure_from_z_tilde
+from polaris.tasks.ocean.horiz_press_grad.edge import edge_delta, edge_mean
 
 __all__ = [
     'centered_shift',
     'hpga_from_shift',
     'hydrostatic_scale',
-    'edge_delta',
-    'edge_mean',
 ]
 
 
@@ -163,56 +160,6 @@ def hydrostatic_scale(ds: xr.Dataset) -> float:
     z_magnitude = float(np.abs(ds.GeomZInterface).max())
     pressure_magnitude = float(ds.SpecVol.max() * np.abs(q).max() / Gravity)
     return z_magnitude + pressure_magnitude
-
-
-def edge_delta(field: xr.DataArray) -> xr.DataArray:
-    """
-    The two-column edge difference ``Delta_e f = f_1 - f_0``, the numerator of
-    the TRiSK gradient operator for the single internal edge.
-
-    Parameters
-    ----------
-    field : xarray.DataArray
-        A field with an ``nCells`` dimension of size 2.
-
-    Returns
-    -------
-    delta : xarray.DataArray
-        The difference, with ``nCells`` contracted away.
-    """
-    _check_two_columns(field)
-    return field.isel(nCells=1) - field.isel(nCells=0)
-
-
-def edge_mean(field: xr.DataArray) -> xr.DataArray:
-    """
-    The two-column edge average ``0.5 * (f_0 + f_1)``.
-
-    Parameters
-    ----------
-    field : xarray.DataArray
-        A field with an ``nCells`` dimension of size 2.
-
-    Returns
-    -------
-    mean : xarray.DataArray
-        The average, with ``nCells`` contracted away.
-    """
-    _check_two_columns(field)
-    return 0.5 * (field.isel(nCells=0) + field.isel(nCells=1))
-
-
-def _check_two_columns(field: xr.DataArray) -> None:
-    """
-    Verify that ``field`` spans exactly the two columns the edge operator is
-    defined for.
-    """
-    ncells = field.sizes.get('nCells', 0)
-    if ncells != 2:
-        raise ValueError(
-            'The two-column edge operator requires exactly 2 cells, but the '
-            f'field has {ncells}.'
-        )
 
 
 def _layer_top(field: xr.DataArray) -> xr.DataArray:

--- a/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
+++ b/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
@@ -1,0 +1,233 @@
+"""
+The ``FiniteVolume`` horizontal pressure gradient for the two-column
+``horiz_press_grad`` configurations.
+
+This is the Python counterpart of Omega's ``PressureGradFiniteVolume``.  It is
+written from the ``PGradHighOrder.md`` design document rather than from the
+C++, so that the Omega-vs-Polaris comparison in the analysis steps compares two
+independent implementations of the same mathematics.
+
+The scheme evaluates the exact edge-normal acceleration -- the layer mean of
+the geopotential difference taken at *fixed pressure* -- as the centered scheme
+plus a remainder::
+
+    T^p_{e,k} = -(g / d_e) * (S_{e,k} + R_{e,k})
+
+The tidal-potential and self-attraction-and-loading terms of the design's
+``[ho-discrete]`` are identically zero in these configurations and are omitted.
+
+``S_{e,k}`` (:py:func:`centered_shift`) is the first-order conversion of a
+height difference taken at fixed layer index into one taken at fixed pressure,
+trapezoid-averaged over the layer's two interfaces.  It is exactly what the
+centered scheme computes, so ``R_{e,k}`` is the whole difference between the
+two schemes.  Only ``S`` is implemented so far.
+
+Every horizontal difference here is the two-column edge operator.  The mesh has
+exactly two cells and one internal edge, and the edge normal points from cell 0
+to cell 1, so ``Delta_e f = f_1 - f_0`` and ``[grad_n f]_e = Delta_e f / d_e``.
+That is the convention
+:py:meth:`polaris.tasks.ocean.horiz_press_grad.init.Init._compute_montgomery_and_hpga`
+uses, and the identity in :py:func:`centered_shift` holds against that function
+and not against an idealized centered form.
+"""
+
+import numpy as np
+import xarray as xr
+
+from polaris.ocean.vertical.ztilde import Gravity, pressure_from_z_tilde
+
+__all__ = [
+    'centered_shift',
+    'hpga_from_shift',
+    'hydrostatic_scale',
+    'edge_delta',
+    'edge_mean',
+]
+
+
+def centered_shift(ds: xr.Dataset) -> xr.DataArray:
+    """
+    The first-order fixed-pressure shift ``S_{e,k}`` of the design's
+    ``[centered-shift]``,
+
+    .. math::
+
+        S_{e,k} = \\tfrac{1}{2}\\left(\\Delta_e Z_{k}
+        + \\Delta_e Z_{k+1}\\right)
+        + \\frac{\\bar\\alpha_{e,k}}{2g}\\left(\\Delta_e q_{k}
+        + \\Delta_e q_{k+1}\\right),
+
+    where :math:`Z` is the geometric height at layer interfaces, :math:`q` the
+    gauge pressure at layer interfaces, and :math:`\\bar\\alpha_{e,k}` the edge
+    average of the layer-mean specific volume.
+
+    The centered scheme's entire Montgomery-potential apparatus is this
+    conversion and nothing else, so
+    ``hpga_from_shift(centered_shift(ds), dx)`` reproduces the ``HPGA`` field
+    written by :py:class:`~polaris.tasks.ocean.horiz_press_grad.init.Init` to
+    round-off, at any coordinate tilt.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The two-column state, which must contain ``GeomZInterface``,
+        ``ZTildeInterface`` and ``SpecVol``.  Invalid layers are ``NaN`` and
+        propagate as ``NaN``.
+
+    Returns
+    -------
+    shift : xarray.DataArray
+        ``S_{e,k}`` at layer midpoints, in m, with the ``nCells`` dimension
+        contracted away by the edge operator.
+    """
+    # PressureInterface is not carried in the dataset; pseudo-height is, and
+    # p = -rho0 * g * z_tilde is an exact identity rather than a conversion.
+    q = pressure_from_z_tilde(ds.ZTildeInterface)
+
+    delta_z = edge_delta(ds.GeomZInterface)
+    delta_q = edge_delta(q)
+    alpha_bar = edge_mean(ds.SpecVol)
+
+    geometric = 0.5 * (_layer_top(delta_z) + _layer_bot(delta_z))
+    pressure = (
+        alpha_bar
+        / (2.0 * Gravity)
+        * (_layer_top(delta_q) + _layer_bot(delta_q))
+    )
+
+    shift = geometric + pressure
+    return shift.assign_attrs(
+        {
+            'long_name': 'first-order fixed-pressure height shift at layer '
+            'midpoints',
+            'units': 'm',
+        }
+    )
+
+
+def hpga_from_shift(shift: xr.DataArray, dx: float) -> xr.DataArray:
+    """
+    Convert a fixed-pressure height shift into an edge-normal acceleration,
+    ``-(g / d_e) * shift``.
+
+    Parameters
+    ----------
+    shift : xarray.DataArray
+        A fixed-pressure height shift in m, such as
+        :py:func:`centered_shift` returns.
+
+    dx : float
+        The distance ``d_e`` between the two columns in m.
+
+    Returns
+    -------
+    hpga : xarray.DataArray
+        The edge-normal pressure-gradient acceleration in m s-2.
+    """
+    if dx == 0.0:
+        raise ValueError('dx must be non-zero for finite differences.')
+
+    hpga = -(Gravity / dx) * shift
+    return hpga.assign_attrs(
+        {
+            'long_name': 'along-layer pressure gradient acceleration at layer '
+            'midpoints',
+            'units': 'm s-2',
+        }
+    )
+
+
+def hydrostatic_scale(ds: xr.Dataset) -> float:
+    """
+    An upper bound on the magnitude of the two hydrostatic terms that cancel
+    in :py:func:`centered_shift`.
+
+    At 3500 m those terms are each of order 3500 m and they cancel to
+    millimetres or less, so an absolute tolerance says nothing about whether a
+    cancellation is at machine precision.  Every round-off assertion against
+    this scheme should be written as a multiple of this scale instead
+    (``PGradHighOrder.md`` §3.7.5).
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The two-column state, as for :py:func:`centered_shift`.
+
+    Returns
+    -------
+    scale : float
+        The bound, in m.  Multiply by ``Gravity / dx`` to scale a tolerance on
+        an acceleration.
+    """
+    q = pressure_from_z_tilde(ds.ZTildeInterface)
+    z_magnitude = float(np.abs(ds.GeomZInterface).max())
+    pressure_magnitude = float(ds.SpecVol.max() * np.abs(q).max() / Gravity)
+    return z_magnitude + pressure_magnitude
+
+
+def edge_delta(field: xr.DataArray) -> xr.DataArray:
+    """
+    The two-column edge difference ``Delta_e f = f_1 - f_0``, the numerator of
+    the TRiSK gradient operator for the single internal edge.
+
+    Parameters
+    ----------
+    field : xarray.DataArray
+        A field with an ``nCells`` dimension of size 2.
+
+    Returns
+    -------
+    delta : xarray.DataArray
+        The difference, with ``nCells`` contracted away.
+    """
+    _check_two_columns(field)
+    return field.isel(nCells=1) - field.isel(nCells=0)
+
+
+def edge_mean(field: xr.DataArray) -> xr.DataArray:
+    """
+    The two-column edge average ``0.5 * (f_0 + f_1)``.
+
+    Parameters
+    ----------
+    field : xarray.DataArray
+        A field with an ``nCells`` dimension of size 2.
+
+    Returns
+    -------
+    mean : xarray.DataArray
+        The average, with ``nCells`` contracted away.
+    """
+    _check_two_columns(field)
+    return 0.5 * (field.isel(nCells=0) + field.isel(nCells=1))
+
+
+def _check_two_columns(field: xr.DataArray) -> None:
+    """
+    Verify that ``field`` spans exactly the two columns the edge operator is
+    defined for.
+    """
+    ncells = field.sizes.get('nCells', 0)
+    if ncells != 2:
+        raise ValueError(
+            'The two-column edge operator requires exactly 2 cells, but the '
+            f'field has {ncells}.'
+        )
+
+
+def _layer_top(field: xr.DataArray) -> xr.DataArray:
+    """
+    The value at each layer's top interface, as a layer-indexed field.
+    """
+    return field.isel(nVertLevelsP1=slice(0, -1)).rename(
+        {'nVertLevelsP1': 'nVertLevels'}
+    )
+
+
+def _layer_bot(field: xr.DataArray) -> xr.DataArray:
+    """
+    The value at each layer's bottom interface, as a layer-indexed field.
+    """
+    return field.isel(nVertLevelsP1=slice(1, None)).rename(
+        {'nVertLevelsP1': 'nVertLevels'}
+    )

--- a/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
+++ b/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
@@ -586,7 +586,7 @@ def delta_specvol_at_pressure(
 
 
 def anchor_difference(
-    pieces: dict, order: int = 4, guards: set[str] | None = None
+    pieces: dict, order: int = 2, guards: set[str] | None = None
 ) -> float:
     """
     The design's ``[anchor]``: the fixed-pressure height difference at the
@@ -615,9 +615,9 @@ def anchor_difference(
         From :py:func:`matched_pressure_pieces`.
 
     order : int
-        Gauss-Legendre order.  The integrand is linear in pressure within a
-        layer, so 2 already integrates it exactly; the default is the same rule
-        the scan uses.
+        Number of Gauss-Legendre points, matching Omega's ``QuadraturePoints``.
+        The integrand is linear in pressure within a layer, so 2 integrates it
+        exactly.
 
     Returns
     -------
@@ -663,7 +663,7 @@ def anchor_difference(
 
 
 def column_scan(
-    pieces: dict, order: int = 4, guards: set[str] | None = None
+    pieces: dict, order: int = 2, guards: set[str] | None = None
 ) -> np.ndarray:
     """
     The design's ``[d-recurrence]``: :math:`D_k = \\Delta_e z(\\bar q_k)`
@@ -687,7 +687,8 @@ def column_scan(
         From :py:func:`matched_pressure_pieces`.
 
     order : int
-        Gauss-Legendre order for the layer integrals.
+        Number of Gauss-Legendre points for the layer integrals, matching
+        Omega's ``QuadraturePoints``.
 
     Returns
     -------
@@ -718,7 +719,7 @@ def column_scan(
 
 
 def scan_increments(
-    pieces: dict, order: int = 4, guards: set[str] | None = None
+    pieces: dict, order: int = 2, guards: set[str] | None = None
 ) -> np.ndarray:
     """
     The per-layer increments of :py:func:`column_scan`, for the smallness
@@ -730,7 +731,8 @@ def scan_increments(
         From :py:func:`matched_pressure_pieces`.
 
     order : int
-        Gauss-Legendre order.
+        Number of Gauss-Legendre points, matching Omega's
+        ``QuadraturePoints``.
 
     Returns
     -------
@@ -743,7 +745,7 @@ def scan_increments(
 
 
 def layer_mean_difference(
-    pieces: dict, order: int = 4, guards: set[str] | None = None
+    pieces: dict, order: int = 2, guards: set[str] | None = None
 ) -> np.ndarray:
     """
     The layer mean of :math:`\\Delta_e z(p)` over each edge layer.
@@ -768,7 +770,8 @@ def layer_mean_difference(
         From :py:func:`matched_pressure_pieces`.
 
     order : int
-        Gauss-Legendre order.
+        Number of Gauss-Legendre points, matching Omega's
+        ``QuadraturePoints``.
 
     guards : set of str, optional
         Verification-only switches; see :py:func:`finite_volume_hpga`.
@@ -803,7 +806,7 @@ def layer_mean_difference(
 def finite_volume_hpga(
     ds: xr.Dataset,
     dx: float,
-    order: int = 4,
+    order: int = 2,
     guards: set[str] | None = None,
 ) -> xr.DataArray:
     """
@@ -826,8 +829,13 @@ def finite_volume_hpga(
         The distance ``d_e`` between the two columns in m.
 
     order : int
-        Gauss-Legendre order.  Exactness does not depend on it (design §3.5,
-        consequence 2), so this is an ordinary accuracy knob.
+        Number of Gauss-Legendre points, matching Omega's ``QuadraturePoints``.
+        Exactness does not depend on it (design §3.5, consequence 2), so it is
+        an ordinary accuracy knob -- but it is **not** a free one: Omega and
+        Polaris must integrate with the same rule, or
+        ``omega_vs_polaris_rms_threshold`` compares two different algorithms
+        rather than two implementations of one.  Both are driven by the
+        ``quadrature_points`` config option.
 
     guards : set of str, optional
         Verification-only switches, each deliberately breaking one rule:

--- a/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
+++ b/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
@@ -53,6 +53,8 @@ __all__ = [
     'anchor_difference',
     'column_scan',
     'scan_increments',
+    'layer_mean_difference',
+    'finite_volume_hpga',
     'layer_containing_pressure',
     'delta_specvol_at_pressure',
 ]
@@ -92,8 +94,6 @@ def centered_shift(ds: xr.Dataset) -> xr.DataArray:
     shift : xarray.DataArray
         ``S_{e,k}`` at layer midpoints, in m, with the ``nCells`` dimension
         contracted away by the edge operator.
-
-
 
     """
     # PressureInterface is not carried in the dataset; pseudo-height is, and
@@ -140,8 +140,6 @@ def hpga_from_shift(shift: xr.DataArray, dx: float) -> xr.DataArray:
     hpga : xarray.DataArray
         The edge-normal pressure-gradient acceleration in m s-2.
 
-
-
     """
     if dx == 0.0:
         raise ValueError('dx must be non-zero for finite differences.')
@@ -178,8 +176,6 @@ def hydrostatic_scale(ds: xr.Dataset) -> float:
         The bound, in m.  Multiply by ``Gravity / dx`` to scale a tolerance on
         an acceleration.
 
-
-
     """
     q = pressure_from_z_tilde(ds.ZTildeInterface)
     z_magnitude = float(np.abs(ds.GeomZInterface).max())
@@ -191,8 +187,6 @@ def _layer_top(field: xr.DataArray) -> xr.DataArray:
     """
     The value at each layer's top interface, as a layer-indexed field.
 
-
-
     """
     return field.isel(nVertLevelsP1=slice(0, -1)).rename(
         {'nVertLevelsP1': 'nVertLevels'}
@@ -202,8 +196,6 @@ def _layer_top(field: xr.DataArray) -> xr.DataArray:
 def _layer_bot(field: xr.DataArray) -> xr.DataArray:
     """
     The value at each layer's bottom interface, as a layer-indexed field.
-
-
 
     """
     return field.isel(nVertLevelsP1=slice(1, None)).rename(
@@ -254,8 +246,6 @@ def centered_shift_accumulated(
     -------
     shift : xarray.DataArray
         ``S_{e,k}`` at layer midpoints, in m.
-
-
 
     """
     if anchor not in ('surface', 'bathymetry'):
@@ -326,8 +316,6 @@ def shift_increments(ds: xr.Dataset) -> xr.Dataset:
         (``Gamma_{k+1} - Gamma^+_k``), and ``delta_z_interface``
         (``Delta_e Z`` at interfaces) to scale them against.  All in m.
 
-
-
     """
     pieces = _shift_pieces(ds)
     return xr.Dataset(
@@ -342,7 +330,6 @@ def shift_increments(ds: xr.Dataset) -> xr.Dataset:
 def _shift_pieces(ds: xr.Dataset) -> dict:
     """The increments and anchors of ``[gamma-increments]``, and the mask of
     layers valid in both columns.
-
 
     """
     q = pressure_from_z_tilde(ds.ZTildeInterface)
@@ -403,7 +390,9 @@ def _at_valid_end(
     return xr.DataArray(data=result, dims=field.dims[:-1])
 
 
-def matched_pressure_pieces(ds: xr.Dataset) -> dict:
+def matched_pressure_pieces(
+    ds: xr.Dataset, guards: set[str] | None = None
+) -> dict:
     """
     Everything the matched-pressure integrand needs, computed once per state.
 
@@ -422,15 +411,36 @@ def matched_pressure_pieces(ds: xr.Dataset) -> dict:
         ``deepest`` valid layer, and the edge-layer interface pressures
         ``edge_interface``.
 
-
     """
     interface = pressure_from_z_tilde(ds.ZTildeInterface).isel(Time=0).values
     deepest = ds.maxLevelCell.values.astype(int) - 1
 
+    guards = guards or set()
+    expansion = eos_expansion.edge_expansion(
+        ds.temperature, ds.salinity, ds.pressure
+    ).isel(Time=0)
+    # The cell-local coefficients are always built, even though only the
+    # ``cell_local_expansion`` guard reads them: making them conditional on the
+    # guard means a guard passed to an evaluation function but not to this one
+    # fails with an AttributeError instead of doing what it says.  One extra
+    # equation-of-state evaluation per state is not worth that trap.
+    coefficients = eos_expansion.specvol_coefficients(
+        ds.temperature, ds.salinity, ds.pressure
+    ).isel(Time=0)
+    cell_local = xr.Dataset(
+        {
+            name: coefficients[name]
+            for name in ['alpha_0', 'alpha_theta', 'alpha_s', 'alpha_p']
+        }
+    )
+    cell_local['theta_ref'] = ds.temperature.isel(Time=0)
+    cell_local['s_ref'] = ds.salinity.isel(Time=0)
+    cell_local['p_ref'] = ds.pressure.isel(Time=0)
+
     return {
-        'expansion': eos_expansion.edge_expansion(
-            ds.temperature, ds.salinity, ds.pressure
-        ).isel(Time=0),
+        'guards': guards,
+        'cell_local': cell_local,
+        'expansion': expansion,
         'theta': ds.temperature.isel(Time=0).values,
         'salinity': ds.salinity.isel(Time=0).values,
         'slope_theta': reconstruction.linear_slope(ds.temperature, ds.pressure)
@@ -487,7 +497,6 @@ def layer_containing_pressure(
     index : numpy.ndarray
         Zero-based layer indices, in ``[0, maxLevelCell - 1]``.
 
-
     """
     deepest = int(pieces['deepest'][icell])
     interface = pieces['interface'][icell, : deepest + 2]
@@ -496,7 +505,10 @@ def layer_containing_pressure(
 
 
 def delta_specvol_at_pressure(
-    pieces: dict, edge_layer: int, pressure: np.ndarray
+    pieces: dict,
+    edge_layer: int,
+    pressure: np.ndarray,
+    guards: set[str] | None = None,
 ) -> np.ndarray:
     """
     The design's ``[dalpha]``: the fixed-pressure contrast in specific volume.
@@ -535,28 +547,47 @@ def delta_specvol_at_pressure(
     delta_specvol : numpy.ndarray
         :math:`\\Delta_e\\hat\\alpha(p)` in m3 kg-1.
 
-
     """
     pressure = np.atleast_1d(np.asarray(pressure, dtype=float))
-    expansion = pieces['expansion'].isel(nVertLevels=edge_layer)
+    if guards is None:
+        guards = pieces.get('guards', set())
 
-    contrast = {}
+    level = {}
+    for icell in range(2):
+        if 'state_by_index' in guards:
+            # guard: assume edge layer k means column layer k
+            level[icell] = np.full(
+                len(pressure),
+                min(edge_layer, int(pieces['deepest'][icell])),
+            )
+        else:
+            level[icell] = layer_containing_pressure(pieces, icell, pressure)
+
+    state = {}
     for name in ['theta', 'salinity']:
         values = np.empty((2, len(pressure)))
         for icell in range(2):
-            level = layer_containing_pressure(pieces, icell, pressure)
-            values[icell] = pieces[name][icell, level] + pieces[
+            index = level[icell]
+            values[icell] = pieces[name][icell, index] + pieces[
                 f'slope_{name}'
-            ][icell, level] * (pressure - pieces['pressure_mid'][icell, level])
-        contrast[name] = values[1] - values[0]
+            ][icell, index] * (pressure - pieces['pressure_mid'][icell, index])
+        state[name] = values
 
-    return (
-        float(expansion.alpha_theta) * contrast['theta']
-        + float(expansion.alpha_s) * contrast['salinity']
-    )
+    total = np.zeros(len(pressure))
+    for icell, sign in [(0, -1.0), (1, 1.0)]:
+        coefficients = _coefficients_for(
+            pieces, edge_layer, icell, level[icell], guards
+        )
+        total = total + sign * (
+            coefficients['alpha_theta'] * state['theta'][icell]
+            + coefficients['alpha_s'] * state['salinity'][icell]
+        )
+    return total
 
 
-def anchor_difference(pieces: dict, order: int = 4) -> float:
+def anchor_difference(
+    pieces: dict, order: int = 4, guards: set[str] | None = None
+) -> float:
     """
     The design's ``[anchor]``: the fixed-pressure height difference at the
     edge's topmost interface.
@@ -593,7 +624,15 @@ def anchor_difference(pieces: dict, order: int = 4) -> float:
     anchor : float
         :math:`D_1` in m.
 
+
     """
+    guards = guards if guards is not None else pieces.get('guards', set())
+    delta_z = pieces['surface_height'][1] - pieces['surface_height'][0]
+    if 'anchor_delta_z_only' in guards:
+        # guard: the sea-surface height difference without correcting to a
+        # common pressure
+        return float(delta_z)
+
     nodes, weights = np.polynomial.legendre.leggauss(order)
     common = pieces['edge_interface'][0]
 
@@ -620,11 +659,12 @@ def anchor_difference(pieces: dict, order: int = 4) -> float:
         )
         correction[icell] = half * float(np.sum(weights * specvol))
 
-    delta_z = pieces['surface_height'][1] - pieces['surface_height'][0]
     return float(delta_z - (correction[1] - correction[0]) / Gravity)
 
 
-def column_scan(pieces: dict, order: int = 4) -> np.ndarray:
+def column_scan(
+    pieces: dict, order: int = 4, guards: set[str] | None = None
+) -> np.ndarray:
     """
     The design's ``[d-recurrence]``: :math:`D_k = \\Delta_e z(\\bar q_k)`
     accumulated down the edge's column from the sea surface.
@@ -655,18 +695,19 @@ def column_scan(pieces: dict, order: int = 4) -> np.ndarray:
         :math:`D_k` at every edge interface valid in both columns, in m, with
         ``difference[0]`` the anchor.
 
+
     """
     nodes, weights = np.polynomial.legendre.leggauss(order)
     edges = pieces['edge_interface']
     deepest = int(min(pieces['deepest']))
 
     difference = np.empty(deepest + 2)
-    difference[0] = anchor_difference(pieces, order=order)
+    difference[0] = anchor_difference(pieces, order=order, guards=guards)
     for edge_layer in range(deepest + 1):
         top, bot = edges[edge_layer], edges[edge_layer + 1]
         middle, half = 0.5 * (top + bot), 0.5 * (bot - top)
         contrast = delta_specvol_at_pressure(
-            pieces, edge_layer, middle + half * nodes
+            pieces, edge_layer, middle + half * nodes, guards=guards
         )
         integral = half * float(np.sum(weights * contrast))
         difference[edge_layer + 1] = (
@@ -676,7 +717,9 @@ def column_scan(pieces: dict, order: int = 4) -> np.ndarray:
     return difference
 
 
-def scan_increments(pieces: dict, order: int = 4) -> np.ndarray:
+def scan_increments(
+    pieces: dict, order: int = 4, guards: set[str] | None = None
+) -> np.ndarray:
     """
     The per-layer increments of :py:func:`column_scan`, for the smallness
     assertion of §3.7.5.
@@ -694,5 +737,164 @@ def scan_increments(pieces: dict, order: int = 4) -> np.ndarray:
     increments : numpy.ndarray
         ``D_{k+1} - D_k`` for each edge layer, in m.
 
+
     """
-    return np.diff(column_scan(pieces, order=order))
+    return np.diff(column_scan(pieces, order=order, guards=guards))
+
+
+def layer_mean_difference(
+    pieces: dict, order: int = 4, guards: set[str] | None = None
+) -> np.ndarray:
+    """
+    The layer mean of :math:`\\Delta_e z(p)` over each edge layer.
+
+    Within an edge layer ``[qbar_k, qbar_{k+1}]``,
+    :math:`\\Delta_e z(p) = D_k - \\frac{1}{g}\\int_{\\bar q_k}^{p}
+    \\Delta_e\\hat\\alpha`, so averaging over the layer and integrating the
+    double integral by parts gives
+
+    .. math::
+
+        \\langle\\Delta_e z\\rangle_k = D_k - \\frac{1}{g\\,\\Delta p_{e,k}}
+        \\int_{\\bar q_k}^{\\bar q_{k+1}}
+        (\\bar q_{k+1} - p)\\,\\Delta_e\\hat\\alpha(p)\\,dp
+
+    which is the "second moment of the same integrand over the same interval"
+    of design §3.5.1, on the same quadrature points as the scan.
+
+    Parameters
+    ----------
+    pieces : dict
+        From :py:func:`matched_pressure_pieces`.
+
+    order : int
+        Gauss-Legendre order.
+
+    guards : set of str, optional
+        Verification-only switches; see :py:func:`finite_volume_hpga`.
+
+    Returns
+    -------
+    mean : numpy.ndarray
+        :math:`\\langle\\Delta_e z\\rangle_k` in m, one per edge layer.
+
+    """
+    nodes, weights = np.polynomial.legendre.leggauss(order)
+    edges = pieces['edge_interface']
+    difference = column_scan(pieces, order=order, guards=guards)
+    deepest = int(min(pieces['deepest']))
+
+    mean = np.empty(deepest + 1)
+    for edge_layer in range(deepest + 1):
+        top, bot = edges[edge_layer], edges[edge_layer + 1]
+        middle, half = 0.5 * (top + bot), 0.5 * (bot - top)
+        probe = middle + half * nodes
+        contrast = delta_specvol_at_pressure(
+            pieces, edge_layer, probe, guards=guards
+        )
+        moment = half * float(np.sum(weights * (bot - probe) * contrast))
+        mean[edge_layer] = difference[edge_layer] - moment / (
+            Gravity * (bot - top)
+        )
+
+    return mean
+
+
+def finite_volume_hpga(
+    ds: xr.Dataset,
+    dx: float,
+    order: int = 4,
+    guards: set[str] | None = None,
+) -> xr.DataArray:
+    """
+    The assembled ``FiniteVolume`` horizontal pressure-gradient acceleration,
+    design ``[ho-exact]``.
+
+    .. math::
+
+        T^p_{e,k} = -\\frac{g}{d_e}\\,\\langle\\Delta_e z\\rangle_k
+
+    The tidal-potential and self-attraction-and-loading terms are identically
+    zero in these configurations and are omitted.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The two-column state.
+
+    dx : float
+        The distance ``d_e`` between the two columns in m.
+
+    order : int
+        Gauss-Legendre order.  Exactness does not depend on it (design §3.5,
+        consequence 2), so this is an ordinary accuracy knob.
+
+    guards : set of str, optional
+        Verification-only switches, each deliberately breaking one rule:
+
+        ``'cell_local_expansion'``
+            expand about each cell's own state instead of the edge-shared one.
+        ``'state_by_index'``
+            evaluate each column at its own layer ``k`` instead of the layer
+            containing the pressure.
+        ``'anchor_delta_z_only'``
+            take the anchor as ``Delta_e Z_1`` alone, dropping the correction
+            to a common pressure.
+
+    Returns
+    -------
+    hpga : xarray.DataArray
+        The edge-normal acceleration in m s-2, at layer midpoints, ``NaN``
+        where a layer is not valid in both columns.
+
+    """
+    if dx == 0.0:
+        raise ValueError('dx must be non-zero for finite differences.')
+
+    pieces = matched_pressure_pieces(ds, guards=guards)
+    mean = layer_mean_difference(pieces, order=order, guards=guards)
+
+    values = np.full(ds.sizes['nVertLevels'], np.nan)
+    values[: len(mean)] = -(Gravity / dx) * mean
+
+    hpga = xr.DataArray(
+        data=values[np.newaxis, :],
+        dims=['Time', 'nVertLevels'],
+        attrs={
+            'long_name': 'along-layer pressure gradient acceleration at layer '
+            'midpoints, finite-volume scheme',
+            'units': 'm s-2',
+        },
+    )
+    return hpga
+
+
+def _coefficients_for(
+    pieces: dict,
+    edge_layer: int,
+    icell: int,
+    level: np.ndarray,
+    guards: set[str],
+) -> dict:
+    """
+    The equation-of-state coefficients a column uses at a set of pressures.
+
+    Correctly, both columns use the edge-shared set of the *edge* layer.  The
+    ``cell_local_expansion`` guard breaks the *sharing*, and that does break
+    exactness: design §3.5 consequence 1 says the shared coefficients may take
+    any value, not that the two columns may use different ones.  ``[dalpha]``
+    only collapses to a coefficient times a contrast when one coefficient set
+    multiplies both columns.
+
+    """
+    if 'cell_local_expansion' in guards:
+        source = pieces['cell_local'].isel(nCells=icell)
+        return {
+            'alpha_theta': source.alpha_theta.values[level],
+            'alpha_s': source.alpha_s.values[level],
+        }
+    source = pieces['expansion'].isel(nVertLevels=edge_layer)
+    return {
+        'alpha_theta': float(source.alpha_theta),
+        'alpha_s': float(source.alpha_s),
+    }

--- a/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
+++ b/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
@@ -37,6 +37,10 @@ from polaris.ocean.vertical.ztilde import (
     RhoSw,
     pressure_from_z_tilde,
 )
+from polaris.tasks.ocean.horiz_press_grad import (
+    eos_expansion,
+    reconstruction,
+)
 from polaris.tasks.ocean.horiz_press_grad.edge import edge_delta, edge_mean
 
 __all__ = [
@@ -45,6 +49,9 @@ __all__ = [
     'shift_increments',
     'hpga_from_shift',
     'hydrostatic_scale',
+    'matched_pressure_pieces',
+    'layer_containing_pressure',
+    'delta_specvol_at_pressure',
 ]
 
 
@@ -82,6 +89,7 @@ def centered_shift(ds: xr.Dataset) -> xr.DataArray:
     shift : xarray.DataArray
         ``S_{e,k}`` at layer midpoints, in m, with the ``nCells`` dimension
         contracted away by the edge operator.
+
 
     """
     # PressureInterface is not carried in the dataset; pseudo-height is, and
@@ -128,6 +136,7 @@ def hpga_from_shift(shift: xr.DataArray, dx: float) -> xr.DataArray:
     hpga : xarray.DataArray
         The edge-normal pressure-gradient acceleration in m s-2.
 
+
     """
     if dx == 0.0:
         raise ValueError('dx must be non-zero for finite differences.')
@@ -164,6 +173,7 @@ def hydrostatic_scale(ds: xr.Dataset) -> float:
         The bound, in m.  Multiply by ``Gravity / dx`` to scale a tolerance on
         an acceleration.
 
+
     """
     q = pressure_from_z_tilde(ds.ZTildeInterface)
     z_magnitude = float(np.abs(ds.GeomZInterface).max())
@@ -175,6 +185,7 @@ def _layer_top(field: xr.DataArray) -> xr.DataArray:
     """
     The value at each layer's top interface, as a layer-indexed field.
 
+
     """
     return field.isel(nVertLevelsP1=slice(0, -1)).rename(
         {'nVertLevelsP1': 'nVertLevels'}
@@ -184,6 +195,7 @@ def _layer_top(field: xr.DataArray) -> xr.DataArray:
 def _layer_bot(field: xr.DataArray) -> xr.DataArray:
     """
     The value at each layer's bottom interface, as a layer-indexed field.
+
 
     """
     return field.isel(nVertLevelsP1=slice(1, None)).rename(
@@ -234,6 +246,7 @@ def centered_shift_accumulated(
     -------
     shift : xarray.DataArray
         ``S_{e,k}`` at layer midpoints, in m.
+
 
     """
     if anchor not in ('surface', 'bathymetry'):
@@ -304,6 +317,7 @@ def shift_increments(ds: xr.Dataset) -> xr.Dataset:
         (``Gamma_{k+1} - Gamma^+_k``), and ``delta_z_interface``
         (``Delta_e Z`` at interfaces) to scale them against.  All in m.
 
+
     """
     pieces = _shift_pieces(ds)
     return xr.Dataset(
@@ -318,6 +332,7 @@ def shift_increments(ds: xr.Dataset) -> xr.Dataset:
 def _shift_pieces(ds: xr.Dataset) -> dict:
     """The increments and anchors of ``[gamma-increments]``, and the mask of
     layers valid in both columns.
+
     """
     q = pressure_from_z_tilde(ds.ZTildeInterface)
     delta_q = edge_delta(q)
@@ -375,3 +390,150 @@ def _at_valid_end(
             continue
         result[index] = values[index][levels[0 if first else -1]]
     return xr.DataArray(data=result, dims=field.dims[:-1])
+
+
+def matched_pressure_pieces(ds: xr.Dataset) -> dict:
+    """
+    Everything the matched-pressure integrand needs, computed once per state.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The two-column state, which must contain ``temperature``, ``salinity``,
+        ``pressure``, ``ZTildeInterface`` and ``maxLevelCell``.
+
+    Returns
+    -------
+    pieces : dict
+        ``expansion`` (the edge-shared coefficients per edge layer),
+        ``theta``/``salinity`` and their reconstruction ``slope``s and
+        ``pressure_mid``, each column's ``interface`` pressures and its
+        ``deepest`` valid layer, and the edge-layer interface pressures
+        ``edge_interface``.
+
+    """
+    interface = pressure_from_z_tilde(ds.ZTildeInterface).isel(Time=0).values
+    deepest = ds.maxLevelCell.values.astype(int) - 1
+
+    return {
+        'expansion': eos_expansion.edge_expansion(
+            ds.temperature, ds.salinity, ds.pressure
+        ).isel(Time=0),
+        'theta': ds.temperature.isel(Time=0).values,
+        'salinity': ds.salinity.isel(Time=0).values,
+        'slope_theta': reconstruction.linear_slope(ds.temperature, ds.pressure)
+        .isel(Time=0)
+        .values,
+        'slope_salinity': reconstruction.linear_slope(ds.salinity, ds.pressure)
+        .isel(Time=0)
+        .values,
+        'pressure_mid': ds.pressure.isel(Time=0).values,
+        'interface': interface,
+        'deepest': deepest,
+        'edge_interface': 0.5 * (interface[0, :] + interface[1, :]),
+    }
+
+
+def layer_containing_pressure(
+    pieces: dict, icell: int, pressure: np.ndarray
+) -> np.ndarray:
+    """
+    The index of *column* ``icell``'s own layer containing each pressure.
+
+    This is the lookup the whole scheme turns on, and writing it as a lookup
+    rather than assuming "edge layer ``k`` means column layer ``k``" is the
+    difference between comparing at matched pressure and comparing at matched
+    index.  Under tilt the two columns' layer ``k`` span different pressure
+    ranges -- at 50 m/km and 64 m layers they are offset by nearly three layer
+    thicknesses and do not overlap at all -- so assuming the index is not a
+    small approximation, it is a different scheme, and it is the defect that
+    the previous formulation failed on.
+
+    Pressures above the column's surface or below its floor are clamped to the
+    outermost valid layer, which extrapolates that layer's reconstruction.
+    Exactness does not depend on this (design §3.5, consequence 3): an
+    extrapolated reconstruction still reproduces a profile it resolves, so the
+    difference is still zero on the exact set.  What it costs off the exact set
+    is deliverable D8'.
+
+    Parameters
+    ----------
+    pieces : dict
+        From :py:func:`matched_pressure_pieces`.
+
+    icell : int
+        Which column.
+
+    pressure : numpy.ndarray
+        Sea gauge pressures in Pa.
+
+    Returns
+    -------
+    index : numpy.ndarray
+        Zero-based layer indices, in ``[0, maxLevelCell - 1]``.
+
+    """
+    deepest = int(pieces['deepest'][icell])
+    interface = pieces['interface'][icell, : deepest + 2]
+    index = np.searchsorted(interface, np.asarray(pressure), side='right') - 1
+    return np.clip(index, 0, deepest)
+
+
+def delta_specvol_at_pressure(
+    pieces: dict, edge_layer: int, pressure: np.ndarray
+) -> np.ndarray:
+    """
+    The design's ``[dalpha]``: the fixed-pressure contrast in specific volume.
+
+    .. math::
+
+        \\Delta_e\\hat\\alpha(p) =
+        \\bar\\alpha_\\Theta^{e,k}\\,\\Delta_e\\Theta(p)
+        + \\bar\\alpha_S^{e,k}\\,\\Delta_e S(p)
+
+    Both columns use the edge-shared coefficients of **edge layer**
+    ``edge_layer``, and each supplies its own :math:`\\Theta(p)`, :math:`S(p)`
+    from whichever of *its own* layers contains ``p``.  The
+    :math:`\\bar\\alpha_0` and :math:`\\bar\\alpha_p(p-\\bar p^e)` terms are
+    the same numbers in both columns and cancel, so they are not formed at all.
+
+    This is the central property of the scheme: the result is a coefficient
+    times a horizontal contrast at matched pressure, so it is **identically
+    zero pointwise** whenever the two columns' reconstructions describe the
+    same water -- independently of the coefficients, of the quadrature, and of
+    whether the interfaces line up.
+
+    Parameters
+    ----------
+    pieces : dict
+        From :py:func:`matched_pressure_pieces`.
+
+    edge_layer : int
+        The edge layer whose shared coefficient set to use.
+
+    pressure : numpy.ndarray
+        Sea gauge pressures in Pa, all within edge layer ``edge_layer``.
+
+    Returns
+    -------
+    delta_specvol : numpy.ndarray
+        :math:`\\Delta_e\\hat\\alpha(p)` in m3 kg-1.
+
+    """
+    pressure = np.atleast_1d(np.asarray(pressure, dtype=float))
+    expansion = pieces['expansion'].isel(nVertLevels=edge_layer)
+
+    contrast = {}
+    for name in ['theta', 'salinity']:
+        values = np.empty((2, len(pressure)))
+        for icell in range(2):
+            level = layer_containing_pressure(pieces, icell, pressure)
+            values[icell] = pieces[name][icell, level] + pieces[
+                f'slope_{name}'
+            ][icell, level] * (pressure - pieces['pressure_mid'][icell, level])
+        contrast[name] = values[1] - values[0]
+
+    return (
+        float(expansion.alpha_theta) * contrast['theta']
+        + float(expansion.alpha_s) * contrast['salinity']
+    )

--- a/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
+++ b/polaris/tasks/ocean/horiz_press_grad/finite_volume.py
@@ -32,11 +32,17 @@ itself, not against an idealized centered form.
 import numpy as np
 import xarray as xr
 
-from polaris.ocean.vertical.ztilde import Gravity, pressure_from_z_tilde
+from polaris.ocean.vertical.ztilde import (
+    Gravity,
+    RhoSw,
+    pressure_from_z_tilde,
+)
 from polaris.tasks.ocean.horiz_press_grad.edge import edge_delta, edge_mean
 
 __all__ = [
     'centered_shift',
+    'centered_shift_accumulated',
+    'shift_increments',
     'hpga_from_shift',
     'hydrostatic_scale',
 ]
@@ -76,6 +82,7 @@ def centered_shift(ds: xr.Dataset) -> xr.DataArray:
     shift : xarray.DataArray
         ``S_{e,k}`` at layer midpoints, in m, with the ``nCells`` dimension
         contracted away by the edge operator.
+
     """
     # PressureInterface is not carried in the dataset; pseudo-height is, and
     # p = -rho0 * g * z_tilde is an exact identity rather than a conversion.
@@ -120,6 +127,7 @@ def hpga_from_shift(shift: xr.DataArray, dx: float) -> xr.DataArray:
     -------
     hpga : xarray.DataArray
         The edge-normal pressure-gradient acceleration in m s-2.
+
     """
     if dx == 0.0:
         raise ValueError('dx must be non-zero for finite differences.')
@@ -155,6 +163,7 @@ def hydrostatic_scale(ds: xr.Dataset) -> float:
     scale : float
         The bound, in m.  Multiply by ``Gravity / dx`` to scale a tolerance on
         an acceleration.
+
     """
     q = pressure_from_z_tilde(ds.ZTildeInterface)
     z_magnitude = float(np.abs(ds.GeomZInterface).max())
@@ -165,6 +174,7 @@ def hydrostatic_scale(ds: xr.Dataset) -> float:
 def _layer_top(field: xr.DataArray) -> xr.DataArray:
     """
     The value at each layer's top interface, as a layer-indexed field.
+
     """
     return field.isel(nVertLevelsP1=slice(0, -1)).rename(
         {'nVertLevelsP1': 'nVertLevels'}
@@ -174,7 +184,194 @@ def _layer_top(field: xr.DataArray) -> xr.DataArray:
 def _layer_bot(field: xr.DataArray) -> xr.DataArray:
     """
     The value at each layer's bottom interface, as a layer-indexed field.
+
     """
     return field.isel(nVertLevelsP1=slice(1, None)).rename(
         {'nVertLevelsP1': 'nVertLevels'}
     )
+
+
+def centered_shift_accumulated(
+    ds: xr.Dataset, anchor: str = 'surface'
+) -> xr.DataArray:
+    """
+    ``S_{e,k}`` accumulated down the column through ``[gamma-increments]``.
+
+    Mathematically identical to :py:func:`centered_shift`, but it never forms
+    the two large terms that cancel there.  With
+    ``Gamma_{e,k} = Delta_e Z_k + (alphabar_{e,k}/g) Delta_e q_k`` and
+    ``Gamma^+_{e,k}`` the same at interface ``k+1``, so that
+    ``S_{e,k} = (Gamma + Gamma^+)/2``, the design's ``[gamma-increments]``
+    gives
+
+        Gamma^+_{e,k} - Gamma_{e,k}
+            = -rho0 * htildebar_{e,k} * Delta_e alpha_k
+        Gamma_{e,k+1} - Gamma^+_{e,k}
+            = (Delta_e q_{k+1}/g) * (alphabar_{e,k+1} - alphabar_{e,k})
+
+    Both increments are a small factor times a bounded one -- the *horizontal*
+    contrast in specific volume within a layer, and the *vertical* contrast
+    between adjacent layers -- so the walk introduces no cancellation of large
+    numbers anywhere.  The starting value is the inverse-barometer residual at
+    the sea surface, itself small for a state at rest.
+
+    Per §3.7.5 this is why a single-precision build might pass at all: the
+    round-off exposure of the centered scheme lives entirely in the two ~3500 m
+    terms of ``[centered-shift]``, and this form never builds them.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The two-column state, as for :py:func:`centered_shift`.
+
+    anchor : {'surface', 'bathymetry'}
+        Which end of the column to accumulate from.  §3.7.4 leaves this open as
+        a round-off question rather than a consistency one; the two agree to
+        round-off in double precision, which
+        ``tests/ocean/horiz_press_grad/test_finite_volume.py`` measures.
+
+    Returns
+    -------
+    shift : xarray.DataArray
+        ``S_{e,k}`` at layer midpoints, in m.
+
+    """
+    if anchor not in ('surface', 'bathymetry'):
+        raise ValueError(
+            f"anchor must be 'surface' or 'bathymetry'; got {anchor!r}."
+        )
+
+    pieces = _shift_pieces(ds)
+    within = pieces['within_layer'].values
+    between = pieces['between_layers'].values
+    gamma_top = pieces['gamma_surface'].values
+    gamma_bottom = pieces['gamma_bathymetry'].values
+    valid = pieces['valid'].values
+
+    shift = np.full(within.shape, np.nan)
+    for index in np.ndindex(within.shape[:-1]):
+        levels = np.where(valid[index])[0]
+        if len(levels) == 0:
+            continue
+        column_within = within[index][levels]
+        # between_layers[k] is the step from layer k to layer k+1
+        column_between = between[index][levels]
+
+        if anchor == 'surface':
+            gamma = gamma_top[index]
+            for position, level in enumerate(levels):
+                gamma_plus = gamma + column_within[position]
+                shift[index + (level,)] = 0.5 * (gamma + gamma_plus)
+                gamma = gamma_plus + column_between[position]
+        else:
+            gamma_plus = gamma_bottom[index]
+            for position in range(len(levels) - 1, -1, -1):
+                level = levels[position]
+                gamma = gamma_plus - column_within[position]
+                shift[index + (level,)] = 0.5 * (gamma + gamma_plus)
+                if position > 0:
+                    gamma_plus = gamma - column_between[position - 1]
+
+    return xr.DataArray(
+        data=shift,
+        dims=pieces['within_layer'].dims,
+        attrs={
+            'long_name': 'first-order fixed-pressure height shift at layer '
+            'midpoints, accumulated',
+            'units': 'm',
+        },
+    )
+
+
+def shift_increments(ds: xr.Dataset) -> xr.Dataset:
+    """
+    The two increments of ``[gamma-increments]``, for the D7 measurement.
+
+    Deliverable D7 of the plan asks how much precision the accumulation saves,
+    and the quantitative form of "no large-number cancellation occurs" is the
+    ratio of the largest increment to the largest of ``Delta_e Z`` -- the
+    quantity ``[centered-shift]`` differences directly.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The two-column state, as for :py:func:`centered_shift`.
+
+    Returns
+    -------
+    increments : xarray.Dataset
+        ``within_layer`` (``Gamma^+_k - Gamma_k``), ``between_layers``
+        (``Gamma_{k+1} - Gamma^+_k``), and ``delta_z_interface``
+        (``Delta_e Z`` at interfaces) to scale them against.  All in m.
+
+    """
+    pieces = _shift_pieces(ds)
+    return xr.Dataset(
+        {
+            'within_layer': pieces['within_layer'],
+            'between_layers': pieces['between_layers'],
+            'delta_z_interface': pieces['delta_z_interface'],
+        }
+    )
+
+
+def _shift_pieces(ds: xr.Dataset) -> dict:
+    """The increments and anchors of ``[gamma-increments]``, and the mask of
+    layers valid in both columns.
+    """
+    q = pressure_from_z_tilde(ds.ZTildeInterface)
+    delta_q = edge_delta(q)
+    delta_z = edge_delta(ds.GeomZInterface)
+    alpha_bar = edge_mean(ds.SpecVol)
+    delta_alpha = edge_delta(ds.SpecVol)
+    thickness_bar = edge_mean(ds.PseudoThickness)
+
+    within = -RhoSw * thickness_bar * delta_alpha
+
+    # the step from layer k to layer k+1, stored at k; the deepest layer has no
+    # neighbour below and its entry is never read
+    alpha_below = alpha_bar.shift(nVertLevels=-1)
+    between = _layer_bot(delta_q) / Gravity * (alpha_below - alpha_bar)
+    between = between.fillna(0.0)
+
+    valid = within.copy(data=np.isfinite(within.values))
+
+    gamma_surface = _first_valid(
+        _layer_top(delta_z) + alpha_bar / Gravity * _layer_top(delta_q), valid
+    )
+    gamma_bathymetry = _last_valid(
+        _layer_bot(delta_z) + alpha_bar / Gravity * _layer_bot(delta_q), valid
+    )
+
+    return {
+        'within_layer': within.assign_attrs({'units': 'm'}),
+        'between_layers': between.assign_attrs({'units': 'm'}),
+        'delta_z_interface': delta_z.assign_attrs({'units': 'm'}),
+        'gamma_surface': gamma_surface,
+        'gamma_bathymetry': gamma_bathymetry,
+        'valid': valid,
+    }
+
+
+def _first_valid(field: xr.DataArray, valid: xr.DataArray) -> xr.DataArray:
+    """The value in the shallowest layer valid in both columns."""
+    return _at_valid_end(field, valid, first=True)
+
+
+def _last_valid(field: xr.DataArray, valid: xr.DataArray) -> xr.DataArray:
+    """The value in the deepest layer valid in both columns."""
+    return _at_valid_end(field, valid, first=False)
+
+
+def _at_valid_end(
+    field: xr.DataArray, valid: xr.DataArray, first: bool
+) -> xr.DataArray:
+    values = field.values
+    mask = valid.values
+    result = np.full(values.shape[:-1], np.nan)
+    for index in np.ndindex(values.shape[:-1]):
+        levels = np.where(mask[index])[0]
+        if len(levels) == 0:
+            continue
+        result[index] = values[index][levels[0 if first else -1]]
+    return xr.DataArray(data=result, dims=field.dims[:-1])

--- a/polaris/tasks/ocean/horiz_press_grad/forward.py
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.py
@@ -1,15 +1,44 @@
 from polaris.ocean.model import OceanModelStep
 from polaris.resolution import resolution_to_string
 
+# The pressure-gradient schemes a variant can be run with, mapping the config
+# spelling to Omega's PressureGradType.  There is no "centered limit" of the
+# finite-volume scheme: the two are separate implementations and no setting
+# reduces one to the other, so this is a choice between them rather than a
+# parameter of one.
+SCHEMES = {
+    'centered': 'Centered',
+    'finite_volume': 'FiniteVolume',
+}
+
+# Which field in init.nc is the Polaris counterpart of each scheme's output.
+# omega_vs_polaris compares Omega against the matching one; comparing against
+# the wrong one would measure the difference between two schemes and call it
+# an implementation disagreement.
+SCHEME_HPGA = {
+    'centered': 'HPGA',
+    'finite_volume': 'HPGAFiniteVolume',
+}
+
 
 class Forward(OceanModelStep):
     """
     This step performs a forward run for a single time step, writing out
     the normal-velocity tendency (which is just the pressure gradient
     acceleration) along with other diagnostics.
+
+    Attributes
+    ----------
+    horiz_res : float
+        The horizontal resolution in km
+
+    scheme : str
+        The pressure-gradient scheme, a key of :py:data:`SCHEMES`
     """
 
-    def __init__(self, component, horiz_res, init, indir, subdir_suffix=None):
+    def __init__(
+        self, component, horiz_res, init, indir, scheme, subdir_suffix=None
+    ):
         """
         Create the step
 
@@ -28,18 +57,27 @@ class Forward(OceanModelStep):
             The subdirectory that the task belongs to, that this step will
             go into a subdirectory of
 
+        scheme : str
+            The pressure-gradient scheme to run, a key of :py:data:`SCHEMES`
+
         subdir_suffix : str, optional
             A suffix used in place of the horizontal resolution in the step
             name, for sweeps that repeat a horizontal resolution
         """
+        if scheme not in SCHEMES:
+            raise ValueError(
+                f'Unknown pressure-gradient scheme {scheme!r}; expected one '
+                f'of {sorted(SCHEMES)}.'
+            )
         self.horiz_res = horiz_res
+        self.scheme = scheme
         if subdir_suffix is None:
-            name = f'forward_{resolution_to_string(horiz_res)}'
+            suffix = resolution_to_string(horiz_res)
         else:
-            name = f'forward_{subdir_suffix}'
+            suffix = subdir_suffix
         super().__init__(
             component=component,
-            name=name,
+            name=f'forward_{suffix}_{scheme}',
             indir=indir,
             ntasks=1,
             min_tasks=1,
@@ -63,7 +101,14 @@ class Forward(OceanModelStep):
         """
         super().setup()
 
+        quadrature_points = self.config.getint(
+            'horiz_press_grad', 'quadrature_points'
+        )
         self.add_yaml_file(
             'polaris.tasks.ocean.horiz_press_grad',
             'forward.yaml',
+            template_replacements=dict(
+                pressure_grad_type=SCHEMES[self.scheme],
+                quadrature_points=quadrature_points,
+            ),
         )

--- a/polaris/tasks/ocean/horiz_press_grad/forward.py
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.py
@@ -9,7 +9,7 @@ class Forward(OceanModelStep):
     acceleration) along with other diagnostics.
     """
 
-    def __init__(self, component, horiz_res, init, indir):
+    def __init__(self, component, horiz_res, init, indir, subdir_suffix=None):
         """
         Create the step
 
@@ -27,9 +27,16 @@ class Forward(OceanModelStep):
         indir : str
             The subdirectory that the task belongs to, that this step will
             go into a subdirectory of
+
+        subdir_suffix : str, optional
+            A suffix used in place of the horizontal resolution in the step
+            name, for sweeps that repeat a horizontal resolution
         """
         self.horiz_res = horiz_res
-        name = f'forward_{resolution_to_string(horiz_res)}'
+        if subdir_suffix is None:
+            name = f'forward_{resolution_to_string(horiz_res)}'
+        else:
+            name = f'forward_{subdir_suffix}'
         super().__init__(
             component=component,
             name=name,

--- a/polaris/tasks/ocean/horiz_press_grad/forward.yaml
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.yaml
@@ -1,4 +1,15 @@
 Omega:
+  PressureGrad:
+    # HorzOrder and VerticalReconstruction are left at Omega's defaults of 2
+    # and 'linear', which are the only Phase 1 values; the Phase 2 values exist
+    # as keys but are rejected with an error, so a configuration written for
+    # Phase 2 cannot quietly run as Phase 1.  An unrecognized PressureGradType
+    # is likewise fatal rather than falling back to Centered, so a typo aborts
+    # the run instead of producing centered answers that read as a pass.
+    PressureGradType: {{ pressure_grad_type }}
+    # the same config option that sets the Python kernel's Gauss rule, so that
+    # omega_vs_polaris compares two implementations rather than two algorithms
+    QuadraturePoints: {{ quadrature_points }}
   TimeIntegration:
     TimeStep: 0000_00:00:01
     StartTime: 0001-01-01_00:00:00

--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -106,3 +106,51 @@ omega_vs_reference_convergence_rate_max = 2.1
 # Maximum horizontal resolution (km) included in the power-law fit. All
 # resolutions are still shown in output plots.
 omega_vs_reference_convergence_fit_max_resolution = 4.0
+
+
+# The options below apply only to the resting-state variants
+# (hydrostatic_consistency, bathymetry_step), which are exact resting states
+# whose true HPGA is identically zero. The four gradient variants leave them at
+# the inert defaults set here.
+
+# The horiz_press_grad config option swept by a resting-state variant. Use
+# z_tilde_bot_grad to tilt the p-star coordinate (the only thing that tilts
+# interior coordinate surfaces in a two-column p-star setup) or geom_z_bot_grad
+# to step the sea floor (which tilts nothing in the interior and acts only on
+# the bottom partial cell).
+tilt_option = z_tilde_bot_grad
+
+# Values of tilt_option in m/km, swept at every (horizontal, vertical)
+# resolution pair
+tilt_values = [0.0]
+
+# Whether to fit the exponent q in |HPGA| ~ tilt**q. Meaningful only when the
+# tilt enters continuously; a sea-floor step changes maxLevelCell in jumps and
+# produces a staircase rather than a power law.
+tilt_fit = True
+
+# Largest tilt (m/km) included in the exponent fit. Larger tilts are still run
+# and plotted but excluded from the fit, where the two columns' maxLevelCell
+# values begin to differ and add a staircase component.
+tilt_fit_max = 10.0
+
+# Sensitivity gate: the largest RMS HPGA (m s-2) anywhere in the sweep must
+# reach at least this value. 1e-6 is the order of the bottom-layer HPGA error
+# seen in realistic global Omega runs with a uniform temperature and salinity
+# state. A sweep that falls short is not exercising the failure mode the
+# higher-order scheme is meant to fix and must be redesigned.
+resting_state_sensitivity_min_rms = 1.0e-6
+
+# Consistency gate: maximum RMS HPGA (m s-2) allowed anywhere in the sweep, or
+# "none" to leave it unenforced. It is deliberately unset: the centered scheme
+# is expected to fail any meaningful value, and the threshold for the
+# higher-order scheme should be set from what phase 2 measures rather than
+# guessed in advance.
+resting_state_max_rms = none
+
+# A resting state has a level sea surface. A larger difference between the two
+# columns' sea-surface heights (m) means the vertical-grid construction moved
+# the sea floor away from the requested bathymetry -- partial-cell snapping
+# fighting the p-star iteration will do this -- so the configuration is no
+# longer a resting state and the measured HPGA is real physics.
+resting_state_max_ssh_diff = 1.0e-9

--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -148,9 +148,10 @@ resting_state_sensitivity_min_rms = 1.0e-6
 # guessed in advance.
 resting_state_max_rms = none
 
-# A resting state has a level sea surface. A larger difference between the two
-# columns' sea-surface heights (m) means the vertical-grid construction moved
-# the sea floor away from the requested bathymetry -- partial-cell snapping
-# fighting the p-star iteration will do this -- so the configuration is no
-# longer a resting state and the measured HPGA is real physics.
-resting_state_max_ssh_diff = 1.0e-9
+# Maximum allowed |bottomDepth - requested| (m). The p-star column is anchored
+# at the prescribed sea surface, so ssh is exact by construction and cannot
+# reveal a problem; partial-cell snapping instead moves the sea floor to the
+# nearest representable depth. That leaves the state exactly at rest, but the
+# swept tilt stops describing the geometry actually tested -- and at some
+# gradients it collapses the step between the two columns to nothing.
+resting_state_max_bathy_error = 1.0e-6

--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -88,6 +88,23 @@ reference_quadrature_subdivisions = 4
 # dSA/dx and dCT/dx at fixed z̃ in ReferenceColumn
 reference_horiz_eps_km = 1.0e-3
 
+# Number of Gauss-Legendre points per edge layer in the finite-volume scheme.
+# This drives BOTH Omega's PressureGrad:QuadraturePoints and the Python
+# counterpart in finite_volume.py, and it is deliberately one option rather
+# than two. Exactness does not depend on it -- the matched-pressure integrand is
+# zero at every point on the exact set, so any rule integrates it to zero -- but
+# omega_vs_polaris_rms_threshold is only a check on Omega's arithmetic if the
+# two sides integrate with the same rule. Two sides quadrating differently are
+# two algorithms, and their difference is not distinguishable from a bug in
+# either.
+#
+# 2 is Omega's Phase 1 default and is exact for the piecewise-linear integrand
+# within a sub-interval. More is worth considering only where the two columns'
+# interfaces are strongly offset, since the integrand is piecewise linear with
+# breakpoints at the union of the two columns' interfaces and a fixed rule does
+# not resolve those breaks.
+quadrature_points = 2
+
 # Maximum RMS difference allowed between Omega forward and Polaris/Python
 # init HPGA at each resolution
 omega_vs_polaris_rms_threshold = 1.0e-10

--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -122,11 +122,32 @@ omega_vs_polaris_rms_threshold = 1.0e-10
 # and ~7e-12 (ztilde); 1e-6 keeps a comfortable margin.
 omega_vs_reference_high_res_rms_threshold = 1.0e-6
 
-# Allowed range for the Omega-vs-reference convergence slope from the
-# power-law fit. Observed slopes are ~1.6 (temperature), ~1.8 (salinity) and
-# ~2.0 (ztilde) for the surface-anchored reference.
-omega_vs_reference_convergence_rate_min = 1.5
-omega_vs_reference_convergence_rate_max = 2.1
+# Allowed range for the Omega-vs-reference convergence slope from the power-law
+# fit, PER SCHEME. Two bands rather than one because the schemes do not converge
+# alike everywhere: on ztilde_gradient the centered scheme is first order and
+# the finite-volume scheme is second, so a single band cannot hold both. On the
+# other three they agree closely and share these defaults.
+#
+# Measured offline (4, 2, 1, 0.5 km): 1.68/1.68 (temperature), 1.77/1.77
+# (salinity), 0.93/1.98 (ztilde), 2.00/1.99 (surface pressure), centered first.
+omega_vs_reference_convergence_rate_min_centered = 1.5
+omega_vs_reference_convergence_rate_max_centered = 2.1
+omega_vs_reference_convergence_rate_min_finite_volume = 1.5
+omega_vs_reference_convergence_rate_max_finite_volume = 2.1
+
+# Accuracy gate: the ratio of the centered to the finite-volume RMS error at the
+# COARSEST resolution must be at least this. A ratio, not a convergence-order
+# comparison -- gating on relative order fails where nothing is wrong, since on
+# a smooth profile the two schemes converge at the same rate.
+#
+# The default is just below 1, which asserts only that the new scheme is not
+# WORSE. That is the right default because on temperature_gradient and
+# salinity_gradient the two schemes agree to five digits: the layers are level
+# there, so matched-pressure and matched-index coincide and the error is the
+# two-column representation of the tracer gradient, which both schemes share.
+# Demanding an improvement there would fail on a configuration where there is
+# nothing to improve. Variants with a real advantage raise this.
+omega_vs_reference_accuracy_ratio_min = 0.98
 
 # Maximum horizontal resolution (km) included in the power-law fit. All
 # resolutions are still shown in output plots.
@@ -165,6 +186,17 @@ tilt_fit_max = 10.0
 # state. A sweep that falls short is not exercising the failure mode the
 # higher-order scheme is meant to fix and must be redesigned.
 resting_state_sensitivity_min_rms = 1.0e-6
+
+# Improvement gate: at every point of the sweep, the centered RMS HPGA divided
+# by the finite-volume RMS HPGA must be at least this, or "none" to leave it
+# unenforced. The true HPGA is zero here, so both are pure error and the ratio
+# is a clean statement of what the higher-order scheme buys.
+#
+# Set per variant rather than shared: the advantage ranges over four orders of
+# magnitude across the four resting-state variants, so one value would be
+# either vacuous or wrong. The default is "none" so that the option is inert
+# unless a variant opts in.
+resting_state_improvement_min = none
 
 # Consistency gate: maximum RMS HPGA (m s-2) allowed anywhere in the sweep, or
 # "none" to leave it unenforced. It is deliberately unset: the centered scheme

--- a/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/horiz_press_grad.cfg
@@ -88,6 +88,14 @@ reference_quadrature_subdivisions = 4
 # dSA/dx and dCT/dx at fixed z̃ in ReferenceColumn
 reference_horiz_eps_km = 1.0e-3
 
+# The pressure-gradient schemes to run. Each variant builds one forward step
+# per scheme over a single shared init step, so the two are compared at an
+# identical state -- which is the clearest single measure of what the
+# higher-order scheme buys. There is no "centered limit" of the finite-volume
+# scheme; they are separate implementations and no setting reduces one to the
+# other, so this is a choice between them rather than a parameter of one.
+pressure_grad_types = ['centered', 'finite_volume']
+
 # Number of Gauss-Legendre points per edge layer in the finite-volume scheme.
 # This drives BOTH Omega's PressureGrad:QuadraturePoints and the Python
 # counterpart in finite_volume.py, and it is deliberately one option rather

--- a/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency.cfg
@@ -1,0 +1,85 @@
+# Options related to the vertical grid
+[vertical_grid]
+
+# No partial-cell snapping. The p-star reference grid is clipped at each
+# column's pseudo-bottom depth regardless, so the deepest layer is a partial
+# cell either way; this option controls only whether the topography is snapped
+# to a minimum cell fraction. Snapping fights the p-star iteration, moves the
+# sea floor away from the requested bathymetry, and destroys the resting state
+# this variant depends on.
+partial_cell_type = None
+
+
+# config options for the hydrostatic-consistency two-column test
+[horiz_press_grad]
+
+# A deep, coarsely resolved column. The existing gradient variants use a 500 m
+# column at 0.5-4 m, one to three orders of magnitude finer than the ~250 m
+# layers in the deep ocean of a realistic global run, and the centered scheme
+# passes there with an RMS HPGA of ~7e-12 m s-2 -- six orders of magnitude
+# below the error this test exists to measure.
+#
+# The 596 m gap between the sea floor and the reference pseudo-bottom is
+# deliberate head room: the p-star iteration converges to a pseudo-bottom
+# depth greater than the geometric water-column thickness, and the reference
+# grid must extend below it in BOTH columns for every tilt in the sweep.
+geom_z_bot_mid = -3500.0
+# m / km
+geom_z_bot_grad = 0.0
+
+# Pseudo-height of the bottom of the reference grid. Vertical resolutions
+# below divide it into 16, 32 or 64 levels, all multiples of 16 as Omega
+# prefers.
+z_tilde_bot_mid = -4096.0
+# m / km; overridden per step by the tilt sweep
+z_tilde_bot_grad = 0.0
+
+# Horizontally uniform temperature and salinity, specified against
+# pseudo-height. This is what makes the configuration an exact resting state:
+# specific volume becomes a function of pressure alone, isobars are level, and
+# the true HPGA is identically zero for any coordinate tilt.
+#
+# The deepest node lies well below the reference pseudo-bottom so that the
+# PCHIP interpolant is never asked to extrapolate when a tilt makes one
+# column's reference grid deeper than the other's.
+z_tilde_mid = [0.0, -100.0, -500.0, -1500.0, -3000.0, -6144.0]
+# m / km
+z_tilde_grad = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+temperature_mid = [22.0, 18.0, 8.0, 4.0, 2.0, 1.0]
+# deg C / km
+temperature_grad = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+salinity_mid = [35.6, 35.4, 34.9, 34.72, 34.68, 34.66]
+# g/kg / km
+salinity_grad = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+# Resolution pairs. At a fixed tilt gradient the RMS HPGA is independent of
+# horizontal resolution -- the cross-edge offset and the cell spacing scale
+# together -- so the horizontal sweep carries no information and is reduced to
+# two resolutions, enough to confirm that independence holds in Omega too. The
+# vertical resolution is what matters, and the error is roughly second order
+# in layer thickness.
+horiz_resolutions = [4.0, 4.0, 4.0, 1.0]
+# vertical resolution in m
+vert_resolutions = [256.0, 128.0, 64.0, 256.0]
+
+# Tilt the p-star coordinate. This stretches one column's reference grid
+# relative to the other's, so the cross-edge interface offset grows linearly
+# with depth. It is the only mechanism in the two-column task that tilts
+# interior coordinate surfaces.
+tilt_option = z_tilde_bot_grad
+
+# m / km, spanning roughly three decades
+tilt_values = [0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0]
+
+# Fit the exponent q in |HPGA| ~ tilt**q. q ~ 1 means specific volume is
+# effectively piecewise constant in pressure (no better than centered); q ~ 2
+# is consistent with a residual set by a per-cell Taylor expansion point;
+# round-off independent of tilt means the scheme is exactly hydrostatically
+# consistent.
+tilt_fit = True
+
+# The largest tilts are excluded from the fit, where the two columns'
+# maxLevelCell values begin to differ and add a staircase component.
+tilt_fit_max = 10.0

--- a/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency.cfg
@@ -92,3 +92,12 @@ tilt_fit = True
 # The largest tilts are excluded from the fit, where the two columns'
 # maxLevelCell values begin to differ and add a staircase component.
 tilt_fit_max = 10.0
+
+# Improvement gate. Measured offline, the smallest advantage anywhere in this
+# sweep is 2.58x, at 4 km / 128 m / tilt 50. It is the weakest of the four
+# resting-state variants, and that is expected rather than disappointing: the
+# profile is curved, so it sits outside the finite-volume scheme's exact set and
+# the scheme is second-order accurate here rather than exact. Compare
+# hydrostatic_consistency_linear, which is the same geometry with a resolved
+# profile.
+resting_state_improvement_min = 1.5

--- a/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency.cfg
@@ -4,9 +4,13 @@
 # No partial-cell snapping. The p-star reference grid is clipped at each
 # column's pseudo-bottom depth regardless, so the deepest layer is a partial
 # cell either way; this option controls only whether the topography is snapped
-# to a minimum cell fraction. Snapping fights the p-star iteration, moves the
-# sea floor away from the requested bathymetry, and destroys the resting state
-# this variant depends on.
+# to a minimum cell fraction.
+#
+# Snapping moves the sea floor to the nearest representable depth. That leaves
+# the state exactly at rest -- the p-star column is anchored at the prescribed
+# sea surface, so ssh stays exact -- but it means the swept tilt no longer
+# describes the geometry actually being tested. Keeping it off makes the
+# configured value the value under test.
 partial_cell_type = None
 
 

--- a/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency.cfg
@@ -1,15 +1,20 @@
 # Options related to the vertical grid
 [vertical_grid]
 
-# No partial-cell snapping. The p-star reference grid is clipped at each
-# column's pseudo-bottom depth regardless, so the deepest layer is a partial
-# cell either way; this option controls only whether the topography is snapped
-# to a minimum cell fraction.
+# Do NOT read "None" as "no partial cells" -- it means "leave the topography
+# alone". A partial bottom cell is produced either way: the p-star reference
+# grid is clipped at each column's pseudo-bottom depth unconditionally, in
+# _compute_ref_pseudo_thickness. This option controls only whether the sea
+# floor is MOVED before that clipping:
+#     None    -- leave it; the bottom cell is whatever the bathymetry implies
+#     partial -- move it so the bottom cell is at least min_pc_fraction thick
+#     full    -- move it to a reference boundary; this is the setting that
+#                actually removes partial cells
 #
-# Snapping moves the sea floor to the nearest representable depth. That leaves
-# the state exactly at rest -- the p-star column is anchored at the prescribed
-# sea surface, so ssh stays exact -- but it means the swept tilt no longer
-# describes the geometry actually being tested. Keeping it off makes the
+# Snapping would move the sea floor to the nearest representable depth. That
+# leaves the state exactly at rest -- the p-star column is anchored at the
+# prescribed sea surface, so ssh stays exact -- but it means the swept tilt no
+# longer describes the geometry actually being tested. Leaving it off makes the
 # configured value the value under test.
 partial_cell_type = None
 

--- a/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency_linear.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency_linear.cfg
@@ -85,3 +85,11 @@ tilt_fit = True
 # The largest tilts are excluded from the fit, where the two columns'
 # maxLevelCell values begin to differ and add a staircase component.
 tilt_fit_max = 10.0
+
+# Improvement gate. Measured offline, the smallest advantage anywhere in this
+# sweep is 7.71x, at 4 km / 64 m / tilt 50. Larger than the curved variant's
+# 2.58x because the profile is inside the exact set, but far short of the
+# machine precision that would once have been expected: what remains is the
+# anchor, which on a Polaris-initialized state carries the midpoint rule's
+# partition dependence. See the developer guide.
+resting_state_improvement_min = 4.0

--- a/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency_linear.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/hydrostatic_consistency_linear.cfg
@@ -1,0 +1,87 @@
+# Options related to the vertical grid
+[vertical_grid]
+
+# Left alone for the same reason as in hydrostatic_consistency: snapping would
+# move the sea floor to the nearest representable depth, which leaves the state
+# exactly at rest but means the swept tilt no longer describes the geometry
+# being tested. See that file for the full explanation of what this option
+# does and does not do.
+partial_cell_type = None
+
+
+# config options for the linear-in-pressure hydrostatic-consistency test
+[horiz_press_grad]
+
+# This variant is hydrostatic_consistency with the temperature and salinity
+# profiles reduced to two nodes, which makes them exactly linear in
+# pseudo-height and therefore exactly linear in pressure.
+#
+# That distinction is the whole point of the variant. Both variants are exact
+# resting states, so the true HPGA is identically zero in both. But the
+# finite-volume scheme's exact set is set by what its vertical reconstruction
+# can reproduce, not by whether the state is at rest: with linear
+# reconstructions it is exact for profiles linear in pressure and only
+# second-order accurate for a generally curved one. hydrostatic_consistency's
+# five-segment profile is curved, so machine precision is NOT the correct
+# expectation there. This variant is the configuration in the family where it
+# is, and it is therefore the discriminating measurement for the whole
+# higher-order effort.
+#
+# With the centered scheme it behaves much like hydrostatic_consistency, since
+# centered is only first order for any stratified profile: at 256 m layers and
+# 50 m/km of tilt the RMS HPGA is 2.07e-5 m s-2 here against 1.95e-5 m s-2
+# there. So this variant is not a weaker test of the centered scheme, and it
+# clears resting_state_sensitivity_min_rms comfortably.
+
+# The same column as hydrostatic_consistency.
+geom_z_bot_mid = -3500.0
+# m / km
+geom_z_bot_grad = 0.0
+
+z_tilde_bot_mid = -4096.0
+# m / km; overridden per step by the tilt sweep
+z_tilde_bot_grad = 0.0
+
+# Two nodes, so the PCHIP interpolant is a straight line in pseudo-height.
+# Pressure is exactly proportional to pseudo-height, so the profile is exactly
+# linear in pressure; and the layer mean of a linear profile is its value at the
+# layer midpoint, so the initial condition is in the exact set however the
+# layers are distributed.
+#
+# The endpoints are those of hydrostatic_consistency's profile, so the two
+# variants span the same temperature and salinity range and differ only in
+# curvature. The deepest node stays well below the reference pseudo-bottom so
+# that the interpolant is never asked to extrapolate when a tilt makes one
+# column's grid deeper than the other's.
+z_tilde_mid = [0.0, -6144.0]
+# m / km
+z_tilde_grad = [0.0, 0.0]
+
+temperature_mid = [22.0, 1.0]
+# deg C / km
+temperature_grad = [0.0, 0.0]
+
+salinity_mid = [35.6, 34.66]
+# g/kg / km
+salinity_grad = [0.0, 0.0]
+
+# The same resolution pairs and tilt sweep as hydrostatic_consistency, so the
+# two can be compared point for point.
+horiz_resolutions = [4.0, 4.0, 4.0, 1.0]
+# vertical resolution in m
+vert_resolutions = [256.0, 128.0, 64.0, 256.0]
+
+tilt_option = z_tilde_bot_grad
+
+# m / km, spanning roughly three decades
+tilt_values = [0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0]
+
+# Fit the exponent q in |HPGA| ~ tilt**q. For the centered scheme q ~ 1 is
+# expected here as in hydrostatic_consistency. For the finite-volume scheme the
+# expectation is different and stronger than in any other variant: round-off
+# independent of tilt, because this configuration is in the exact set.
+tilt_fit = True
+
+# The largest tilts are excluded from the fit, where the two columns'
+# maxLevelCell values begin to differ and add a staircase component.
+tilt_fit_max = 10.0

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -104,7 +104,6 @@ class Init(PStarInitStep, OceanIOStep):
         """
         logger = self.logger
         config = self.config
-        hpg_section = config['horiz_press_grad']
         if config.get('ocean', 'model') != 'omega':
             raise ValueError(
                 'The horiz_press_grad test case is only supported for the '
@@ -112,41 +111,10 @@ class Init(PStarInitStep, OceanIOStep):
             )
 
         horiz_res = self.horiz_res
-        vert_res = self.vert_res
-
-        # a tilt sweep overrides one config option per step, in the same way
-        # vert_levels is set from the vertical resolution below
-        if self.tilt_option is not None:
-            config.set('horiz_press_grad', self.tilt_option, str(self.tilt))
-            logger.info(
-                f'Setting horiz_press_grad:{self.tilt_option} = {self.tilt}'
-            )
-
-        z_tilde_bot_mid = hpg_section.getfloat('z_tilde_bot_mid')
-
-        assert z_tilde_bot_mid is not None, (
-            'The "z_tilde_bot_mid" configuration option must be set in the '
-            '"horiz_press_grad" section.'
-        )
-
-        # it needs to be an error if the full water column can't be evenly
-        # divided by the resolution, because the later analysis will fail
-        if (-z_tilde_bot_mid / vert_res) % 1 != 0:
-            raise ValueError(
-                'The "z_tilde_bot_mid" value must be an integer multiple of '
-                'the vertical resolution to ensure that the vertical grid can '
-                'be evenly divided into layers. Currently, z_tilde_bot_mid = '
-                f'{z_tilde_bot_mid} and vert_res = {vert_res}, which results '
-                f'in {-z_tilde_bot_mid / vert_res} layers.'
-            )
-        vert_levels = int(-z_tilde_bot_mid / vert_res)
-
-        config.set('vertical_grid', 'vert_levels', str(vert_levels))
 
         nx = 2
         ny = 2
         dc = 1e3 * horiz_res
-        dx = 1e3 * horiz_res
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=True, nonperiodic_y=True
         )
@@ -173,6 +141,84 @@ class Init(PStarInitStep, OceanIOStep):
                 f'2 cells, but the culled mesh has '
                 f'{ncells} cells.'
             )
+
+        ds = self.build_column_state(ds_mesh)
+
+        nvertlevels = ds.sizes['nVertLevels']
+        nedges = ds_mesh.sizes['nEdges']
+
+        ds['normalVelocity'] = xr.DataArray(
+            data=np.zeros((1, nedges, nvertlevels), dtype=float),
+            dims=['Time', 'nEdges', 'nVertLevels'],
+            attrs={
+                'long_name': 'normal velocity',
+                'units': 'm s-1',
+            },
+        )
+        ds.attrs['nx'] = nx
+        ds.attrs['ny'] = ny
+        ds.attrs['dc'] = dc
+
+        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)
+
+    def build_column_state(self, ds_mesh: xr.Dataset) -> xr.Dataset:
+        """
+        Build the two-column state on ``ds_mesh``: the p-star vertical
+        coordinate, the tracers, specific volume, pressure, geometric height,
+        and the diagnostic Montgomery potential and HPGA.
+
+        :py:meth:`run` calls this once the mesh exists.  It is separate from
+        :py:meth:`run` so that unit tests can build the same state from a
+        minimal two-cell mesh dataset, without mesh generation or file I/O.
+
+        Parameters
+        ----------
+        ds_mesh : xarray.Dataset
+            The horizontal mesh, which must have exactly 2 cells.  Only the
+            ``nCells`` dimension is required, so a stub dataset is enough for
+            testing.
+
+        Returns
+        -------
+        ds : xarray.Dataset
+            The two-column state.
+        """
+        logger = self.logger
+        config = self.config
+        horiz_res = self.horiz_res
+        vert_res = self.vert_res
+        dx = 1e3 * horiz_res
+
+        # a tilt sweep overrides one config option per step, in the same way
+        # vert_levels is set from the vertical resolution below
+        if self.tilt_option is not None:
+            config.set('horiz_press_grad', self.tilt_option, str(self.tilt))
+            logger.info(
+                f'Setting horiz_press_grad:{self.tilt_option} = {self.tilt}'
+            )
+
+        hpg_section = config['horiz_press_grad']
+        z_tilde_bot_mid = hpg_section.getfloat('z_tilde_bot_mid')
+
+        assert z_tilde_bot_mid is not None, (
+            'The "z_tilde_bot_mid" configuration option must be set in the '
+            '"horiz_press_grad" section.'
+        )
+
+        # it needs to be an error if the full water column can't be evenly
+        # divided by the resolution, because the later analysis will fail
+        if (-z_tilde_bot_mid / vert_res) % 1 != 0:
+            raise ValueError(
+                'The "z_tilde_bot_mid" value must be an integer multiple of '
+                'the vertical resolution to ensure that the vertical grid can '
+                'be evenly divided into layers. Currently, z_tilde_bot_mid = '
+                f'{z_tilde_bot_mid} and vert_res = {vert_res}, which results '
+                f'in {-z_tilde_bot_mid / vert_res} layers.'
+            )
+        vert_levels = int(-z_tilde_bot_mid / vert_res)
+
+        config.set('vertical_grid', 'vert_levels', str(vert_levels))
 
         x = horiz_res * np.array([-0.5, 0.5], dtype=float)
         # Store x so init_tracers and _build_pstar_coord_ds can access it
@@ -211,25 +257,9 @@ class Init(PStarInitStep, OceanIOStep):
         ds.Density.attrs['long_name'] = 'density'
         ds.Density.attrs['units'] = 'kg m-3'
 
-        nvertlevels = ds.sizes['nVertLevels']
-        nedges = ds_mesh.sizes['nEdges']
-
-        ds['normalVelocity'] = xr.DataArray(
-            data=np.zeros((1, nedges, nvertlevels), dtype=float),
-            dims=['Time', 'nEdges', 'nVertLevels'],
-            attrs={
-                'long_name': 'normal velocity',
-                'units': 'm s-1',
-            },
-        )
-        ds.attrs['nx'] = nx
-        ds.attrs['ny'] = ny
-        ds.attrs['dc'] = dc
-
         self._compute_montgomery_and_hpga(ds=ds, dx=dx, p_mid=ds.pressure)
 
-        self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
-        self.write_initial_state_dataset(ds, 'init.nc', config)
+        return ds
 
     def init_tracers(
         self, ds: xr.Dataset

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -266,9 +266,20 @@ class Init(PStarInitStep, OceanIOStep):
         # than in place of it: HPGA keeps its name, its meaning and its values,
         # so the four gradient variants and the resting-state sweeps are
         # unaffected and their recorded baselines stay valid.  Which of the two
-        # the analysis steps compare is decided in step 10, once the Omega-side
-        # option exists.
-        ds['HPGAFiniteVolume'] = finite_volume_hpga(ds=ds, dx=dx)
+        # an analysis step compares against is set by the scheme its forward
+        # step ran.
+        #
+        # quadrature_points is the same option that fills in Omega's
+        # PressureGrad:QuadraturePoints, so the two sides integrate with one
+        # rule.  Reading it here rather than defaulting is what keeps
+        # omega_vs_polaris_rms_threshold a check on Omega's arithmetic instead
+        # of a measure of the gap between two quadratures.
+        quadrature_points = config.getint(
+            'horiz_press_grad', 'quadrature_points'
+        )
+        ds['HPGAFiniteVolume'] = finite_volume_hpga(
+            ds=ds, dx=dx, order=quadrature_points
+        )
 
         return ds
 

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -29,12 +29,29 @@ class Init(PStarInitStep, OceanIOStep):
     vert_res : float
         The vertical resolution in m
 
+    tilt_option : str or None
+        The name of a ``horiz_press_grad`` config option to override with
+        ``tilt`` before building the columns, or ``None`` to leave the
+        configuration alone.
+
+    tilt : float or None
+        The value to give ``tilt_option`` in m/km.
+
     x : numpy.ndarray
         The x-coordinates of the two columns in km, used by
         :py:meth:`init_tracers` and :py:meth:`_build_pstar_coord_ds`.
     """
 
-    def __init__(self, component, horiz_res, vert_res, indir):
+    def __init__(
+        self,
+        component,
+        horiz_res,
+        vert_res,
+        indir,
+        subdir_suffix=None,
+        tilt_option=None,
+        tilt=None,
+    ):
         """
         Create the step
 
@@ -52,11 +69,27 @@ class Init(PStarInitStep, OceanIOStep):
         indir : str
             The subdirectory that the task belongs to, that this step will
             go into a subdirectory of
+
+        subdir_suffix : str, optional
+            A suffix used in place of the horizontal resolution in the step
+            name, for sweeps that repeat a horizontal resolution
+
+        tilt_option : str, optional
+            The name of a ``horiz_press_grad`` config option to override with
+            ``tilt`` before building the columns
+
+        tilt : float, optional
+            The value to give ``tilt_option`` in m/km
         """
         self.horiz_res = horiz_res
         self.vert_res = vert_res
+        self.tilt_option = tilt_option
+        self.tilt = tilt
         self.x: np.ndarray = np.array([])
-        name = f'init_{resolution_to_string(horiz_res)}'
+        if subdir_suffix is None:
+            name = f'init_{resolution_to_string(horiz_res)}'
+        else:
+            name = f'init_{subdir_suffix}'
         super().__init__(component=component, name=name, indir=indir)
 
     def setup(self):
@@ -80,6 +113,14 @@ class Init(PStarInitStep, OceanIOStep):
 
         horiz_res = self.horiz_res
         vert_res = self.vert_res
+
+        # a tilt sweep overrides one config option per step, in the same way
+        # vert_levels is set from the vertical resolution below
+        if self.tilt_option is not None:
+            config.set('horiz_press_grad', self.tilt_option, str(self.tilt))
+            logger.info(
+                f'Setting horiz_press_grad:{self.tilt_option} = {self.tilt}'
+            )
 
         z_tilde_bot_mid = hpg_section.getfloat('z_tilde_bot_mid')
 
@@ -153,6 +194,8 @@ class Init(PStarInitStep, OceanIOStep):
             surface_pressure=surface_pressure,
             sea_surface_height=geom_ssh,
         )
+
+        self._check_reference_grid_head_room(ds=ds, x=x)
 
         ds['Density'] = 1.0 / ds['SpecVol']
         ds.Density.attrs['long_name'] = 'density'
@@ -385,6 +428,43 @@ class Init(PStarInitStep, OceanIOStep):
             'long_name': 'Gradient of absolute salinity at layer midpoints',
             'units': 'g kg-1 m-1',
         }
+
+    def _check_reference_grid_head_room(
+        self, ds: xr.Dataset, x: np.ndarray
+    ) -> None:
+        """
+        Verify that each column's reference pseudo-grid extends below its
+        converged pseudo-bottom depth.
+
+        The p-star iteration converges to a pseudo-bottom depth somewhat
+        greater than the geometric water-column thickness, because in-situ
+        density exceeds ``RhoSw`` at depth.  When a tilt makes one column's
+        ``z_tilde_bot`` shallower than that, the reference grid cannot span
+        the water column, the iteration diverges, and the resulting HPGA is
+        meaningless (order 1 m s-2 rather than the order 1e-5 m s-2 the test
+        measures).  Fail with a clear message rather than reporting nonsense.
+        """
+        z_tilde_bot = get_array_from_mid_grad(self.config, 'z_tilde_bot', x)
+        pseudo_bottom_depth = (
+            ds.BottomPressure / (RhoSw * Gravity)
+        ).values.ravel()
+
+        head_room = -np.asarray(z_tilde_bot) - pseudo_bottom_depth
+        if np.all(head_room > 0.0):
+            return
+
+        details = '; '.join(
+            f'column {icell}: |z_tilde_bot| = {-z_tilde_bot[icell]:.3f} m, '
+            f'pseudo-bottom depth = {pseudo_bottom_depth[icell]:.3f} m, '
+            f'head room = {head_room[icell]:.3f} m'
+            for icell in range(len(head_room))
+        )
+        raise ValueError(
+            'The p-star reference grid does not extend below the converged '
+            'pseudo-bottom depth in every column, so the vertical coordinate '
+            'cannot span the water column. Deepen "z_tilde_bot_mid", make '
+            '"geom_z_bot_mid" shallower, or reduce the tilt. ' + details
+        )
 
     def _get_geom_z_bot(self, x: np.ndarray) -> xr.DataArray:
         """

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -12,7 +12,7 @@ from polaris.ocean.vertical.ztilde import Gravity, RhoSw
 from polaris.resolution import resolution_to_string
 from polaris.tasks.ocean.horiz_press_grad.column import (
     get_array_from_mid_grad,
-    get_pchip_interpolator,
+    get_pchip_layer_mean,
 )
 
 
@@ -265,10 +265,12 @@ class Init(PStarInitStep, OceanIOStep):
         self, ds: xr.Dataset
     ) -> tuple[xr.DataArray, xr.DataArray]:
         """
-        Interpolate conservative temperature and absolute salinity from
-        piecewise pseudo-height profiles defined in the configuration.
+        Compute layer-mean conservative temperature and absolute salinity from
+        the piecewise pseudo-height profiles defined in the configuration.
         """
-        return self._interpolate_t_s(ds=ds, z_tilde_mid=ds.ZTildeMid, x=self.x)
+        return self._interpolate_t_s(
+            ds=ds, z_tilde_interface=ds.ZTildeInterface, x=self.x
+        )
 
     def _build_pstar_coord_ds(
         self,
@@ -595,12 +597,20 @@ class Init(PStarInitStep, OceanIOStep):
     def _interpolate_t_s(
         self,
         ds: xr.Dataset,
-        z_tilde_mid: xr.DataArray,
+        z_tilde_interface: xr.DataArray,
         x: np.ndarray,
     ) -> tuple[xr.DataArray, xr.DataArray]:
         """
-        Interpolate temperature and salinity to p-star layer midpoints using
+        Average temperature and salinity over each p-star layer, using the
         piecewise pseudo-height profiles from configuration.
+
+        Omega's prognostic temperature and salinity are layer means, and the
+        higher-order pressure gradient reconstructs them as mean-preserving
+        polynomials in pressure, so the initial condition supplies layer means
+        rather than samples at layer midpoints.  The two coincide exactly for a
+        profile that is linear in pressure and differ at O(h^2) otherwise, so
+        the choice does not affect a configuration in the scheme's exact set
+        but does affect the residual measured off it.
         """
         z_tilde_node, t_node, s_node = self._get_z_tilde_t_s_nodes(x)
 
@@ -626,11 +636,17 @@ class Init(PStarInitStep, OceanIOStep):
                 'number of mesh columns.'
             )
 
+        z_tilde_top = z_tilde_interface.isel(
+            Time=0, nVertLevelsP1=slice(0, -1)
+        ).values
+        z_tilde_bot = z_tilde_interface.isel(
+            Time=0, nVertLevelsP1=slice(1, None)
+        ).values
+
         for icell in range(ncells):
             z_tilde = z_tilde_node[icell, :]
             temperatures = t_node[icell, :]
             salinities = s_node[icell, :]
-            z_tilde_mid_col = z_tilde_mid.isel(Time=0, nCells=icell).values
 
             if len(z_tilde) < 2:
                 raise ValueError(
@@ -638,24 +654,27 @@ class Init(PStarInitStep, OceanIOStep):
                     'define piecewise linear initial conditions.'
                 )
 
-            t_interp = get_pchip_interpolator(
+            t_mean = get_pchip_layer_mean(
                 z_tilde_nodes=z_tilde,
                 values_nodes=temperatures,
                 name='temperature',
             )
-            s_interp = get_pchip_interpolator(
+            s_mean = get_pchip_layer_mean(
                 z_tilde_nodes=z_tilde,
                 values_nodes=salinities,
                 name='salinity',
             )
-            valid = np.isfinite(z_tilde_mid_col)
+            top = z_tilde_top[icell, :]
+            bot = z_tilde_bot[icell, :]
+            # a layer is valid only where both of its interfaces are
+            valid = np.logical_and(np.isfinite(top), np.isfinite(bot))
             temperature_np[0, icell, :] = np.nan
             salinity_np[0, icell, :] = np.nan
             if np.any(valid):
-                temperature_np[0, icell, valid] = t_interp(
-                    z_tilde_mid_col[valid]
+                temperature_np[0, icell, valid] = t_mean(
+                    top[valid], bot[valid]
                 )
-                salinity_np[0, icell, valid] = s_interp(z_tilde_mid_col[valid])
+                salinity_np[0, icell, valid] = s_mean(top[valid], bot[valid])
 
         temperature = xr.DataArray(
             data=temperature_np,

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -197,6 +197,16 @@ class Init(PStarInitStep, OceanIOStep):
 
         self._check_reference_grid_head_room(ds=ds, x=x)
 
+        # The requested bathymetry, kept alongside the achieved bottomDepth so
+        # analysis can tell whether the vertical-grid construction moved the
+        # sea floor (partial-cell snapping does).  bottomDepth itself is a
+        # vert-coord variable and is written to vert_coord.nc, not init.nc.
+        ds['bottomDepthRequested'] = -geom_z_bot
+        ds.bottomDepthRequested.attrs = {
+            'long_name': 'requested seafloor geometric depth',
+            'units': 'm',
+        }
+
         ds['Density'] = 1.0 / ds['SpecVol']
         ds.Density.attrs['long_name'] = 'density'
         ds.Density.attrs['units'] = 'kg m-3'

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -14,6 +14,9 @@ from polaris.tasks.ocean.horiz_press_grad.column import (
     get_array_from_mid_grad,
     get_pchip_layer_mean,
 )
+from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
+    finite_volume_hpga,
+)
 
 
 class Init(PStarInitStep, OceanIOStep):
@@ -258,6 +261,14 @@ class Init(PStarInitStep, OceanIOStep):
         ds.Density.attrs['units'] = 'kg m-3'
 
         self._compute_montgomery_and_hpga(ds=ds, dx=dx, p_mid=ds.pressure)
+
+        # The finite-volume scheme, written alongside the centered one rather
+        # than in place of it: HPGA keeps its name, its meaning and its values,
+        # so the four gradient variants and the resting-state sweeps are
+        # unaffected and their recorded baselines stay valid.  Which of the two
+        # the analysis steps compare is decided in step 10, once the Omega-side
+        # option exists.
+        ds['HPGAFiniteVolume'] = finite_volume_hpga(ds=ds, dx=dx)
 
         return ds
 

--- a/polaris/tasks/ocean/horiz_press_grad/metrics.py
+++ b/polaris/tasks/ocean/horiz_press_grad/metrics.py
@@ -1,0 +1,258 @@
+"""
+Shared error metrics and small formatting helpers for the two-column
+``horiz_press_grad`` analysis steps.
+
+This module is deliberately dependency-light (numpy and xarray only) so that
+both the reference-based :py:class:`~polaris.tasks.ocean.horiz_press_grad.
+analysis.Analysis` step and the reference-free
+:py:class:`~polaris.tasks.ocean.horiz_press_grad.resting_analysis.
+RestingAnalysis` step can use it without importing one another.
+"""
+
+import numpy as np
+import xarray as xr
+
+__all__ = [
+    'get_internal_edge',
+    'rms',
+    'power_law_fit',
+    'write_metric_dataset',
+    'format_value_list',
+    'format_value_error_pairs',
+]
+
+
+def get_internal_edge(ds_mesh: xr.Dataset) -> tuple[int, tuple[int, int]]:
+    """
+    Determine the edge that connects the two valid cells in the two-column
+    mesh.
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        The culled horizontal mesh, which must contain ``cellsOnEdge``.
+
+    Returns
+    -------
+    edge_index : int
+        The zero-based index of the single internal edge.
+
+    cells_on_edge : tuple of int
+        The zero-based indices of the two cells bounding that edge.
+    """
+    if 'cellsOnEdge' not in ds_mesh:
+        raise ValueError('cellsOnEdge is required in culled_mesh.nc')
+
+    cells_on_edge = ds_mesh.cellsOnEdge.values.astype(int)
+    if cells_on_edge.ndim != 2 or cells_on_edge.shape[1] != 2:
+        raise ValueError('cellsOnEdge must have shape (nEdges, 2).')
+
+    valid = np.logical_and(cells_on_edge[:, 0] > 0, cells_on_edge[:, 1] > 0)
+    valid_edges = np.where(valid)[0]
+    if len(valid_edges) != 1:
+        raise ValueError(
+            'Expected exactly one edge with two valid cells in the '
+            f'two-column mesh, found {len(valid_edges)}.'
+        )
+
+    edge_index = int(valid_edges[0])
+    # convert from 1-based MPAS indexing to 0-based indexing
+    cell0 = int(cells_on_edge[edge_index, 0] - 1)
+    cell1 = int(cells_on_edge[edge_index, 1] - 1)
+    return edge_index, (cell0, cell1)
+
+
+def rms(values: np.ndarray) -> float:
+    """
+    Compute the root mean square over finite values.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        The values to reduce.  Non-finite entries are ignored.
+
+    Returns
+    -------
+    float
+        The RMS of the finite entries.
+    """
+    values = np.asarray(values, dtype=float)
+    valid = np.isfinite(values)
+    if not np.any(valid):
+        raise ValueError('No finite values available for RMS error.')
+    return float(np.sqrt(np.mean(values[valid] ** 2)))
+
+
+def power_law_fit(
+    x: np.ndarray,
+    y: np.ndarray,
+    fit_mask: np.ndarray | None = None,
+) -> tuple[np.ndarray, float, float]:
+    """
+    Fit ``y = 10**b * x**m`` in log10 space.
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        The abscissa (resolution or tilt).  Only positive, finite entries
+        take part in the fit.
+
+    y : numpy.ndarray
+        The ordinate (an error metric).  Only positive, finite entries take
+        part in the fit.
+
+    fit_mask : numpy.ndarray, optional
+        An additional boolean mask restricting which points are fit.
+
+    Returns
+    -------
+    fit : numpy.ndarray
+        The fitted curve evaluated at every entry of ``x``.
+
+    slope : float
+        The fitted exponent ``m``.
+
+    intercept : float
+        The fitted ``log10`` intercept ``b``.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    valid = np.logical_and.reduce(
+        (np.isfinite(x), np.isfinite(y), x > 0.0, y > 0.0)
+    )
+    if fit_mask is not None:
+        fit_mask = np.asarray(fit_mask, dtype=bool)
+        if fit_mask.shape != x.shape:
+            raise ValueError(
+                'fit_mask must have the same shape as x and y for '
+                'power-law fitting.'
+            )
+        valid = np.logical_and(valid, fit_mask)
+
+    if np.count_nonzero(valid) < 2:
+        raise ValueError(
+            'At least two positive finite points are required for fit.'
+        )
+
+    poly = np.polyfit(np.log10(x[valid]), np.log10(y[valid]), 1)
+    slope = float(poly[0])
+    intercept = float(poly[1])
+    fit = x**slope * 10.0**intercept
+    return fit, slope, intercept
+
+
+def write_metric_dataset(
+    filename: str,
+    resolution_km: np.ndarray,
+    rms_error: np.ndarray,
+    y_name: str,
+    y_units: str,
+    fit: np.ndarray | None = None,
+    slope: float | None = None,
+    intercept: float | None = None,
+) -> None:
+    """
+    Write the data used in a convergence plot to netCDF.
+
+    Parameters
+    ----------
+    filename : str
+        The netCDF file to write.
+
+    resolution_km : numpy.ndarray
+        The horizontal resolutions in km.
+
+    rms_error : numpy.ndarray
+        The error metric at each resolution.
+
+    y_name : str
+        The variable name to give ``rms_error``.
+
+    y_units : str
+        The units of ``rms_error``.
+
+    fit : numpy.ndarray, optional
+        A fitted curve to include.
+
+    slope : float, optional
+        The fitted exponent, stored as a global attribute.
+
+    intercept : float, optional
+        The fitted ``log10`` intercept, stored as a global attribute.
+    """
+    nres = len(resolution_km)
+    ds = xr.Dataset()
+    ds['resolution_km'] = xr.DataArray(
+        data=resolution_km,
+        dims=['nResolutions'],
+        attrs={'long_name': 'horizontal resolution', 'units': 'km'},
+    )
+    ds[y_name] = xr.DataArray(
+        data=rms_error,
+        dims=['nResolutions'],
+        attrs={'long_name': y_name.replace('_', ' '), 'units': y_units},
+    )
+    if fit is not None:
+        ds['power_law_fit'] = xr.DataArray(
+            data=fit,
+            dims=['nResolutions'],
+            attrs={
+                'long_name': 'power-law fit to rms error',
+                'units': y_units,
+            },
+        )
+    if slope is not None:
+        ds.attrs['fit_slope'] = slope
+    if intercept is not None:
+        ds.attrs['fit_intercept_log10'] = intercept
+    ds.attrs['nResolutions'] = nres
+    ds.to_netcdf(filename)
+
+
+def format_value_list(values: np.ndarray) -> str:
+    """
+    Format an array as a compact list of floats.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        The values to format.
+
+    Returns
+    -------
+    str
+        A bracketed, comma-separated list.
+    """
+    formatted = [f'{float(value):g}' for value in values]
+    return f'[{", ".join(formatted)}]'
+
+
+def format_value_error_pairs(
+    values: np.ndarray,
+    errors: np.ndarray,
+    units: str = 'km',
+) -> str:
+    """
+    Format value/error pairs as readable key-value text.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        The abscissa values.
+
+    errors : numpy.ndarray
+        The error metric at each value.
+
+    units : str, optional
+        The units to label ``values`` with.
+
+    Returns
+    -------
+    str
+        A semicolon-separated list of ``value units: error`` pairs.
+    """
+    pairs = [
+        f'{float(value):g} {units}: {float(error):.3e}'
+        for value, error in zip(values, errors, strict=True)
+    ]
+    return '; '.join(pairs)

--- a/polaris/tasks/ocean/horiz_press_grad/metrics.py
+++ b/polaris/tasks/ocean/horiz_press_grad/metrics.py
@@ -144,15 +144,21 @@ def power_law_fit(
 def write_metric_dataset(
     filename: str,
     resolution_km: np.ndarray,
-    rms_error: np.ndarray,
+    rms_error: dict[str, np.ndarray],
     y_name: str,
     y_units: str,
-    fit: np.ndarray | None = None,
-    slope: float | None = None,
-    intercept: float | None = None,
+    fit: dict[str, np.ndarray] | None = None,
+    slope: dict[str, float] | None = None,
+    intercept: dict[str, float] | None = None,
 ) -> None:
     """
-    Write the data used in a convergence plot to netCDF.
+    Write the data used in a convergence plot to netCDF, one series per
+    pressure-gradient scheme.
+
+    Series are written as separate variables suffixed with the scheme name
+    rather than stacked along a scheme dimension, so that a file stays readable
+    when the set of schemes changes and so that the two schemes' fits can carry
+    their own attributes.
 
     Parameters
     ----------
@@ -162,23 +168,23 @@ def write_metric_dataset(
     resolution_km : numpy.ndarray
         The horizontal resolutions in km.
 
-    rms_error : numpy.ndarray
-        The error metric at each resolution.
+    rms_error : dict
+        The error metric at each resolution, keyed by scheme.
 
     y_name : str
-        The variable name to give ``rms_error``.
+        The variable name to give ``rms_error``, suffixed by the scheme.
 
     y_units : str
         The units of ``rms_error``.
 
-    fit : numpy.ndarray, optional
-        A fitted curve to include.
+    fit : dict, optional
+        A fitted curve to include, keyed by scheme.
 
-    slope : float, optional
-        The fitted exponent, stored as a global attribute.
+    slope : dict, optional
+        The fitted exponent per scheme, stored as global attributes.
 
-    intercept : float, optional
-        The fitted ``log10`` intercept, stored as a global attribute.
+    intercept : dict, optional
+        The fitted ``log10`` intercept per scheme, stored as global attributes.
     """
     nres = len(resolution_km)
     ds = xr.Dataset()
@@ -187,24 +193,29 @@ def write_metric_dataset(
         dims=['nResolutions'],
         attrs={'long_name': 'horizontal resolution', 'units': 'km'},
     )
-    ds[y_name] = xr.DataArray(
-        data=rms_error,
-        dims=['nResolutions'],
-        attrs={'long_name': y_name.replace('_', ' '), 'units': y_units},
-    )
-    if fit is not None:
-        ds['power_law_fit'] = xr.DataArray(
-            data=fit,
+    for scheme, values in rms_error.items():
+        ds[f'{y_name}_{scheme}'] = xr.DataArray(
+            data=values,
             dims=['nResolutions'],
             attrs={
-                'long_name': 'power-law fit to rms error',
+                'long_name': f'{y_name.replace("_", " ")}, {scheme} scheme',
                 'units': y_units,
             },
         )
-    if slope is not None:
-        ds.attrs['fit_slope'] = slope
-    if intercept is not None:
-        ds.attrs['fit_intercept_log10'] = intercept
+        if fit is not None and scheme in fit:
+            ds[f'power_law_fit_{scheme}'] = xr.DataArray(
+                data=fit[scheme],
+                dims=['nResolutions'],
+                attrs={
+                    'long_name': 'power-law fit to rms error, '
+                    f'{scheme} scheme',
+                    'units': y_units,
+                },
+            )
+        if slope is not None and scheme in slope:
+            ds.attrs[f'fit_slope_{scheme}'] = slope[scheme]
+        if intercept is not None and scheme in intercept:
+            ds.attrs[f'fit_intercept_log10_{scheme}'] = intercept[scheme]
     ds.attrs['nResolutions'] = nres
     ds.to_netcdf(filename)
 

--- a/polaris/tasks/ocean/horiz_press_grad/reconstruction.py
+++ b/polaris/tasks/ocean/horiz_press_grad/reconstruction.py
@@ -1,0 +1,190 @@
+"""
+Mean-preserving vertical reconstruction of temperature and salinity.
+
+This is §3.4 of ``PGradHighOrder.md``.  Within layer ``k`` of column ``i`` the
+prognostic layer mean is supplemented by a deviation that integrates to zero
+over the layer, ``[vert-recon]``::
+
+    Theta(p) = Theta_{i,k} + slope_{i,k} * (p - p^mid_{i,k})
+
+Phase 1 uses linear deviations, so the reconstruction is exact for profiles
+that vary linearly with pressure -- which is what sets the scheme's exact set
+in §3.7.3, and is why ``hydrostatic_consistency_linear`` exists.  There is no
+limiter: the reconstruction feeds an integral rather than an advective flux,
+and a limiter active on smooth data would break the cancellation of §3.7.2
+precisely where the profile is well resolved.
+
+Two properties carry the weight, and both are tested.
+
+**Mean-preserving.** ``p^mid`` is the exact arithmetic midpoint of the two
+interface pressures, so ``\\int (p - p^mid) dp = 0`` over the layer and the
+deviation cannot move the layer mean.  ``[z-increment-exact]`` rests on this:
+it is what makes ``VertCoord``'s midpoint rule the exact layer integral of a
+Phase 1 reconstruction, and hence what spares ``VertCoord`` any change.
+
+**Exact on a non-uniform grid.** For a profile linear in pressure the layer
+means lie exactly on the line *as a function of mid-layer pressure*, because
+the mean over a layer of a linear function is its value at the layer's
+midpoint.  So a centred difference of the layer means with respect to ``p^mid``
+recovers the slope exactly, for any distribution of layer thicknesses.  This is
+why the estimator differences against the actual mid-layer pressures and not
+against layer index: a formula that assumed uniform thickness would pass a
+uniform-thickness test and fail on Omega's grid.
+"""
+
+import numpy as np
+import xarray as xr
+
+__all__ = ['linear_slope', 'reconstruct', 'layer_deviation']
+
+
+def linear_slope(
+    values: xr.DataArray,
+    pressure_mid: xr.DataArray,
+) -> xr.DataArray:
+    """
+    The slope of the mean-preserving linear reconstruction, per layer.
+
+    A centred difference of the layer means with respect to mid-layer
+    pressure, one-sided in the shallowest and deepest valid layer of each
+    column.  Exact for a profile linear in pressure on an arbitrary grid;
+    second-order accurate otherwise.
+
+    The one-sided branches are not an edge case here.  The deepest valid layer
+    is a partial cell in both columns and carries the whole signal for the
+    ``bathymetry_step`` configuration, so the one-sided branch is exercised
+    exactly where the interesting behaviour is.
+
+    Parameters
+    ----------
+    values : xarray.DataArray
+        Layer-mean conservative temperature or absolute salinity, with
+        ``nVertLevels`` last.  Invalid layers are ``NaN``.
+
+    pressure_mid : xarray.DataArray
+        Mid-layer sea gauge pressure in Pa, on the same points.
+
+    Returns
+    -------
+    slope : xarray.DataArray
+        The slope per Pa, ``NaN`` in invalid layers and zero in a column with
+        only one valid layer.
+    """
+    if values.dims != pressure_mid.dims:
+        raise ValueError(
+            'values and pressure_mid must have the same dimensions; got '
+            f'{values.dims} and {pressure_mid.dims}.'
+        )
+    if values.dims[-1] != 'nVertLevels':
+        raise ValueError(
+            f"the last dimension must be 'nVertLevels'; got {values.dims[-1]}."
+        )
+
+    value_array = np.asarray(values.values, dtype=float)
+    pressure_array = np.asarray(pressure_mid.values, dtype=float)
+    slope = np.full(value_array.shape, np.nan)
+
+    for index in np.ndindex(value_array.shape[:-1]):
+        column_values = value_array[index]
+        column_pressure = pressure_array[index]
+        valid = np.logical_and(
+            np.isfinite(column_values), np.isfinite(column_pressure)
+        )
+        levels = np.where(valid)[0]
+        if len(levels) == 0:
+            continue
+        if len(levels) == 1:
+            # nothing to difference against; a constant is the only
+            # mean-preserving reconstruction available
+            slope[index + (levels,)] = 0.0
+            continue
+
+        interior_values = column_values[levels]
+        interior_pressure = column_pressure[levels]
+        column_slope = np.empty(len(levels))
+        # centred in the interior, against the actual mid-layer pressures
+        column_slope[1:-1] = (interior_values[2:] - interior_values[:-2]) / (
+            interior_pressure[2:] - interior_pressure[:-2]
+        )
+        # one-sided at the two ends of the valid column
+        column_slope[0] = (interior_values[1] - interior_values[0]) / (
+            interior_pressure[1] - interior_pressure[0]
+        )
+        column_slope[-1] = (interior_values[-1] - interior_values[-2]) / (
+            interior_pressure[-1] - interior_pressure[-2]
+        )
+        slope[index + (levels,)] = column_slope
+
+    return xr.DataArray(
+        data=slope,
+        dims=values.dims,
+        attrs={
+            'long_name': 'slope of the mean-preserving linear reconstruction',
+            'units': f'{values.attrs.get("units", "1")} Pa-1',
+        },
+    )
+
+
+def layer_deviation(
+    slope: xr.DataArray,
+    pressure_mid: xr.DataArray,
+    pressure: xr.DataArray | float,
+) -> xr.DataArray:
+    """
+    The deviation from the layer mean, ``slope * (p - p^mid)``.
+
+    This is the ``Theta'`` of ``[vert-recon]``.  It integrates to zero over the
+    layer because ``pressure_mid`` is the exact arithmetic midpoint of the two
+    interface pressures.
+
+    Parameters
+    ----------
+    slope : xarray.DataArray
+        The slope from :py:func:`linear_slope`.
+
+    pressure_mid : xarray.DataArray
+        Mid-layer sea gauge pressure in Pa.
+
+    pressure : xarray.DataArray or float
+        The pressure at which to evaluate, in Pa.
+
+    Returns
+    -------
+    deviation : xarray.DataArray
+        The deviation from the layer mean.
+    """
+    return slope * (pressure - pressure_mid)
+
+
+def reconstruct(
+    values: xr.DataArray,
+    slope: xr.DataArray,
+    pressure_mid: xr.DataArray,
+    pressure: xr.DataArray | float,
+) -> xr.DataArray:
+    """
+    Evaluate the reconstruction ``[vert-recon]`` at a pressure.
+
+    Parameters
+    ----------
+    values : xarray.DataArray
+        The prognostic layer means.
+
+    slope : xarray.DataArray
+        The slope from :py:func:`linear_slope`.
+
+    pressure_mid : xarray.DataArray
+        Mid-layer sea gauge pressure in Pa.
+
+    pressure : xarray.DataArray or float
+        The pressure at which to evaluate, in Pa.
+
+    Returns
+    -------
+    reconstructed : xarray.DataArray
+        The reconstructed profile.  Equal to ``values`` at ``pressure_mid``, by
+        construction.
+    """
+    return values + layer_deviation(
+        slope=slope, pressure_mid=pressure_mid, pressure=pressure
+    )

--- a/polaris/tasks/ocean/horiz_press_grad/resting_analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/resting_analysis.py
@@ -115,7 +115,7 @@ class RestingAnalysis(OceanIOStep):
         sensitivity_min_rms = section.getfloat(
             'resting_state_sensitivity_min_rms'
         )
-        max_ssh_diff = section.getfloat('resting_state_max_ssh_diff')
+        max_bathy_error = section.getfloat('resting_state_max_bathy_error')
         omega_vs_polaris_rms_threshold = section.getfloat(
             'omega_vs_polaris_rms_threshold'
         )
@@ -125,7 +125,7 @@ class RestingAnalysis(OceanIOStep):
         omega_rms = []
         polaris_rms = []
         diff_rms = []
-        ssh_diff = []
+        bathy_error = []
         n_layers = []
 
         for key in self.sweep_keys:
@@ -168,14 +168,27 @@ class RestingAnalysis(OceanIOStep):
             polaris_rms.append(rms(hpga_polaris))
             diff_rms.append(rms(hpga_omega - hpga_polaris))
 
-            ssh = ds_init.ssh.isel(Time=0).values
-            ssh_diff.append(abs(float(ssh[cell1] - ssh[cell0])))
+            # The p-star column is anchored at the prescribed sea surface,
+            # so ssh is exact by construction and cannot reveal a problem.
+            # Partial-cell snapping instead moves the sea floor, which
+            # silently changes the geometry being swept -- see
+            # _check_bathymetry.
+            bathy_error.append(
+                float(
+                    np.max(
+                        np.abs(
+                            ds_vc.bottomDepth.values.ravel()
+                            - ds_init.bottomDepthRequested.values.ravel()
+                        )
+                    )
+                )
+            )
 
         tilts = np.array([key[2] for key in self.sweep_keys], dtype=float)
         omega_rms = np.asarray(omega_rms, dtype=float)
         polaris_rms = np.asarray(polaris_rms, dtype=float)
         diff_rms = np.asarray(diff_rms, dtype=float)
-        ssh_diff = np.asarray(ssh_diff, dtype=float)
+        bathy_error = np.asarray(bathy_error, dtype=float)
 
         groups = _group_by_resolution(self.sweep_keys)
         exponents = _fit_exponents(
@@ -192,7 +205,7 @@ class RestingAnalysis(OceanIOStep):
             omega_rms=omega_rms,
             polaris_rms=polaris_rms,
             diff_rms=diff_rms,
-            ssh_diff=ssh_diff,
+            bathy_error=bathy_error,
             n_layers=np.asarray(n_layers, dtype=int),
             exponents=exponents,
             tilt_option=tilt_option,
@@ -220,29 +233,35 @@ class RestingAnalysis(OceanIOStep):
                     f'{format_value_list(tilts[indices][tilts[indices] <= tilt_fit_max])}'  # noqa: E501
                 )
 
-        self._check_resting_state(ssh_diff, max_ssh_diff)
+        self._check_bathymetry(bathy_error, max_bathy_error)
         self._check_omega_vs_polaris(diff_rms, omega_vs_polaris_rms_threshold)
         self._check_sensitivity(omega_rms, sensitivity_min_rms)
         self._check_max_rms(omega_rms, max_rms)
 
-    def _check_resting_state(self, ssh_diff, max_ssh_diff):
+    def _check_bathymetry(self, bathy_error, max_bathy_error):
         """
-        Fail if the two columns' sea surfaces are not level, which means the
-        configuration is not the resting state the analysis assumes.
+        Fail if the sea floor is not where the configuration asked for it.
+
+        The resting-state property survives a moved sea floor -- the state is
+        still exactly at rest -- but the swept parameter stops meaning what it
+        says, because the geometry actually tested is no longer the configured
+        one.  Partial-cell snapping moves the sea floor to the nearest
+        representable depth, and at some gradients that collapses the step
+        between the two columns to nothing, so the test would report a
+        near-zero error for a configuration nominally carrying a large step.
         """
-        failing = ssh_diff > max_ssh_diff
+        failing = bathy_error > max_bathy_error
         if not np.any(failing):
             return
         raise ValueError(
-            'The two columns do not have a level sea surface, so this is not '
-            'a resting state and the measured HPGA is real physics rather '
-            'than discretization error. This usually means the vertical-grid '
-            'construction moved the sea floor away from the requested '
-            'bathymetry (for example partial-cell snapping fighting the '
-            'p-star iteration). Max |ssh difference| = '
-            f'{float(np.max(ssh_diff)):.3e} m exceeds '
-            f'resting_state_max_ssh_diff={max_ssh_diff:.3e} m at: '
-            f'{self._failing_text(failing, ssh_diff)}'
+            'The sea floor is not at the requested depth, so the swept tilt '
+            'is not the geometry actually being tested. This means the '
+            'vertical-grid construction moved the bathymetry -- normally '
+            'partial-cell snapping to the nearest representable depth. Set '
+            '"partial_cell_type = None" for resting-state variants. Max '
+            f'|bottomDepth - requested| = {float(np.max(bathy_error)):.3e} m '
+            f'exceeds resting_state_max_bathy_error={max_bathy_error:.3e} m '
+            f'at: {self._failing_text(failing, bathy_error)}'
         )
 
     def _check_omega_vs_polaris(self, diff_rms, threshold):
@@ -376,7 +395,7 @@ def _write_resting_dataset(
     omega_rms,
     polaris_rms,
     diff_rms,
-    ssh_diff,
+    bathy_error,
     n_layers,
     exponents,
     tilt_option,
@@ -424,12 +443,11 @@ def _write_resting_dataset(
             'units': 'm s-2',
         },
     )
-    ds['ssh_difference'] = xr.DataArray(
-        data=ssh_diff,
+    ds['bathymetry_error'] = xr.DataArray(
+        data=bathy_error,
         dims=['nSweep'],
         attrs={
-            'long_name': 'absolute sea-surface height difference between the '
-            'two columns',
+            'long_name': 'max |bottomDepth - requested| over the two columns',
             'units': 'm',
         },
     )

--- a/polaris/tasks/ocean/horiz_press_grad/resting_analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/resting_analysis.py
@@ -1,0 +1,483 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
+from polaris.ocean.model import OceanIOStep
+from polaris.tasks.ocean.horiz_press_grad.metrics import (
+    format_value_error_pairs,
+    format_value_list,
+    get_internal_edge,
+    power_law_fit,
+    rms,
+)
+from polaris.viz import mplstyle_context
+
+
+class RestingAnalysis(OceanIOStep):
+    """
+    A step for analyzing the two-column HPGA in an exact resting state, where
+    the true HPGA is identically zero and no reference solution is needed.
+
+    Unlike :py:class:`~polaris.tasks.ocean.horiz_press_grad.analysis.Analysis`,
+    which measures convergence toward a quasi-analytic reference, this step
+    measures the absolute HPGA (which is entirely error) as a function of a
+    swept coordinate or bathymetric tilt, and fits the exponent ``q`` in
+    ``|HPGA| ~ tilt**q``.
+
+    It also includes the deepest layer valid in both columns bounding the
+    edge, which ``Analysis`` deliberately drops.  That layer is the bottom
+    partial cell, and in a p-star column with a stepped sea floor it carries
+    the entire signal.
+
+    Attributes
+    ----------
+    dependencies_dict : dict
+        A dictionary of dependent steps:
+
+        init : dict
+            Mapping from ``(horiz_res, vert_res, tilt)`` to ``Init`` step
+
+        forward : dict
+            Mapping from ``(horiz_res, vert_res, tilt)`` to ``Forward`` step
+
+    sweep_keys : list of tuple
+        The ``(horiz_res, vert_res, tilt)`` triples in the sweep, in the order
+        they are analyzed.
+    """
+
+    def __init__(self, component, indir, dependencies, sweep_keys):
+        """
+        Create the analysis step
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        indir : str
+            The subdirectory that the task belongs to, that this step will
+            go into a subdirectory of
+
+        dependencies : dict
+            A dictionary of dependent steps
+
+        sweep_keys : list of tuple
+            The ``(horiz_res, vert_res, tilt)`` triples in the sweep
+        """
+        super().__init__(component=component, name='analysis', indir=indir)
+
+        self.dependencies_dict = dependencies
+        self.sweep_keys = list(sweep_keys)
+
+        self.add_output_file('resting_state.png')
+        self.add_output_file('resting_state.nc')
+
+    def setup(self):
+        """
+        Add inputs from init and forward steps
+        """
+        super().setup()
+
+        init_steps = self.dependencies_dict['init']
+        forward_steps = self.dependencies_dict['forward']
+        for key in self.sweep_keys:
+            init = init_steps[key]
+            forward = forward_steps[key]
+            suffix = sweep_suffix(*key)
+            self.add_input_file(
+                filename=f'init_{suffix}.nc',
+                work_dir_target=f'{init.path}/init.nc',
+            )
+            self.add_input_file(
+                filename=f'output_{suffix}.nc',
+                work_dir_target=f'{forward.path}/output.nc',
+            )
+            self.add_input_file(
+                filename=f'culled_mesh_{suffix}.nc',
+                work_dir_target=f'{init.path}/culled_mesh.nc',
+            )
+            self.add_vert_coord_input_file(
+                filename=f'vert_coord_{suffix}.nc',
+                work_dir_target=f'{init.path}/vert_coord.nc',
+            )
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        logger = self.logger
+        config = self.config
+
+        section = config['horiz_press_grad']
+        tilt_option = section.get('tilt_option')
+        tilt_fit = section.getboolean('tilt_fit')
+        tilt_fit_max = section.getfloat('tilt_fit_max')
+        sensitivity_min_rms = section.getfloat(
+            'resting_state_sensitivity_min_rms'
+        )
+        max_ssh_diff = section.getfloat('resting_state_max_ssh_diff')
+        omega_vs_polaris_rms_threshold = section.getfloat(
+            'omega_vs_polaris_rms_threshold'
+        )
+        max_rms_text = section.get('resting_state_max_rms').strip().lower()
+        max_rms = None if max_rms_text == 'none' else float(max_rms_text)
+
+        omega_rms = []
+        polaris_rms = []
+        diff_rms = []
+        ssh_diff = []
+        n_layers = []
+
+        for key in self.sweep_keys:
+            suffix = sweep_suffix(*key)
+            ds_init = self.open_model_dataset(f'init_{suffix}.nc', config)
+            ds_mesh = self.open_model_dataset(
+                f'culled_mesh_{suffix}.nc', config
+            )
+            ds_out = self.open_model_dataset(
+                f'output_{suffix}.nc', config, decode_times=False
+            )
+            ds_vc = self.open_vert_coord_dataset(
+                ds_init, vert_coord_filename=f'vert_coord_{suffix}.nc'
+            )
+
+            edge_index, (cell0, cell1) = get_internal_edge(ds_mesh)
+
+            # maxLevelCell is 1-based; the deepest layer valid in BOTH columns
+            # has 0-based index min(maxLevelCell) - 1.  It is kept: it is the
+            # bottom partial cell, where the resting-state error concentrates.
+            max_level_cells = ds_vc.maxLevelCell.isel(
+                nCells=[cell0, cell1]
+            ).values.astype(int)
+            n_valid = int(np.min(max_level_cells))
+            if n_valid < 1:
+                raise ValueError(
+                    f'Invalid maxLevelCell values {max_level_cells} for '
+                    f'sweep point {suffix}.'
+                )
+            n_layers.append(n_valid)
+
+            hpga_omega = ds_out.NormalVelocityTend.isel(
+                Time=0, nEdges=edge_index
+            ).values[:n_valid]
+            hpga_polaris = ds_init.HPGA.isel(Time=0).values[:n_valid]
+
+            # the true HPGA is identically zero, so the model's HPGA is the
+            # error and no reference solution is involved
+            omega_rms.append(rms(hpga_omega))
+            polaris_rms.append(rms(hpga_polaris))
+            diff_rms.append(rms(hpga_omega - hpga_polaris))
+
+            ssh = ds_init.ssh.isel(Time=0).values
+            ssh_diff.append(abs(float(ssh[cell1] - ssh[cell0])))
+
+        tilts = np.array([key[2] for key in self.sweep_keys], dtype=float)
+        omega_rms = np.asarray(omega_rms, dtype=float)
+        polaris_rms = np.asarray(polaris_rms, dtype=float)
+        diff_rms = np.asarray(diff_rms, dtype=float)
+        ssh_diff = np.asarray(ssh_diff, dtype=float)
+
+        groups = _group_by_resolution(self.sweep_keys)
+        exponents = _fit_exponents(
+            groups=groups,
+            tilts=tilts,
+            values=omega_rms,
+            tilt_fit=tilt_fit,
+            tilt_fit_max=tilt_fit_max,
+        )
+
+        _write_resting_dataset(
+            filename='resting_state.nc',
+            sweep_keys=self.sweep_keys,
+            omega_rms=omega_rms,
+            polaris_rms=polaris_rms,
+            diff_rms=diff_rms,
+            ssh_diff=ssh_diff,
+            n_layers=np.asarray(n_layers, dtype=int),
+            exponents=exponents,
+            tilt_option=tilt_option,
+        )
+        _plot_resting(
+            output='resting_state.png',
+            groups=groups,
+            tilts=tilts,
+            values=omega_rms,
+            exponents=exponents,
+            tilt_option=tilt_option,
+            sensitivity_min_rms=sensitivity_min_rms,
+        )
+
+        logger.info(f'Resting-state sweep over {tilt_option} (m/km):')
+        for label, indices in groups.items():
+            logger.info(
+                f'  {label}: '
+                f'{format_value_error_pairs(tilts[indices], omega_rms[indices], units="m/km")}'  # noqa: E501
+            )
+            if label in exponents:
+                logger.info(
+                    f'  {label}: fitted tilt exponent q = '
+                    f'{exponents[label]:.3f} over tilts '
+                    f'{format_value_list(tilts[indices][tilts[indices] <= tilt_fit_max])}'  # noqa: E501
+                )
+
+        self._check_resting_state(ssh_diff, max_ssh_diff)
+        self._check_omega_vs_polaris(diff_rms, omega_vs_polaris_rms_threshold)
+        self._check_sensitivity(omega_rms, sensitivity_min_rms)
+        self._check_max_rms(omega_rms, max_rms)
+
+    def _check_resting_state(self, ssh_diff, max_ssh_diff):
+        """
+        Fail if the two columns' sea surfaces are not level, which means the
+        configuration is not the resting state the analysis assumes.
+        """
+        failing = ssh_diff > max_ssh_diff
+        if not np.any(failing):
+            return
+        raise ValueError(
+            'The two columns do not have a level sea surface, so this is not '
+            'a resting state and the measured HPGA is real physics rather '
+            'than discretization error. This usually means the vertical-grid '
+            'construction moved the sea floor away from the requested '
+            'bathymetry (for example partial-cell snapping fighting the '
+            'p-star iteration). Max |ssh difference| = '
+            f'{float(np.max(ssh_diff)):.3e} m exceeds '
+            f'resting_state_max_ssh_diff={max_ssh_diff:.3e} m at: '
+            f'{self._failing_text(failing, ssh_diff)}'
+        )
+
+    def _check_omega_vs_polaris(self, diff_rms, threshold):
+        """
+        Fail if Omega and Polaris disagree about the same discrete scheme.
+        """
+        failing = diff_rms > threshold
+        if not np.any(failing):
+            return
+        raise ValueError(
+            'Omega-vs-Polaris RMS difference exceeds '
+            f'omega_vs_polaris_rms_threshold={threshold:.3e} at: '
+            f'{self._failing_text(failing, diff_rms)}'
+        )
+
+    def _check_sensitivity(self, omega_rms, sensitivity_min_rms):
+        """
+        Fail if the sweep never drives the scheme hard enough to be
+        informative about the failure mode it is meant to probe.
+        """
+        largest = float(np.max(omega_rms))
+        if largest >= sensitivity_min_rms:
+            return
+        raise ValueError(
+            'The resting-state sweep is not severe enough to exercise the '
+            'pressure-gradient error it exists to measure: the largest RMS '
+            f'HPGA anywhere in the sweep is {largest:.3e} m s-2, below '
+            f'resting_state_sensitivity_min_rms={sensitivity_min_rms:.3e} '
+            'm s-2. The sweep must be made more severe (coarser layers or '
+            'larger tilt) before any conclusion is drawn from it.'
+        )
+
+    def _check_max_rms(self, omega_rms, max_rms):
+        """
+        Fail if the scheme exceeds the consistency threshold, when one is set.
+        """
+        if max_rms is None:
+            return
+        failing = omega_rms > max_rms
+        if not np.any(failing):
+            return
+        raise ValueError(
+            'RMS HPGA in the resting state exceeds '
+            f'resting_state_max_rms={max_rms:.3e} m s-2 at: '
+            f'{self._failing_text(failing, omega_rms)}'
+        )
+
+    def _failing_text(self, failing, values):
+        """
+        Format the sweep points where a check failed.
+        """
+        return ', '.join(
+            f'{sweep_suffix(*self.sweep_keys[index])}: {values[index]:.3e}'
+            for index in np.where(failing)[0]
+        )
+
+
+def sweep_suffix(horiz_res, vert_res, tilt):
+    """
+    Build a filename- and directory-safe suffix for one sweep point.
+
+    Parameters
+    ----------
+    horiz_res : float
+        The horizontal resolution in km
+
+    vert_res : float
+        The vertical resolution in m
+
+    tilt : float
+        The swept tilt in m/km
+
+    Returns
+    -------
+    str
+        A suffix such as ``4km_256m_tilt0p5``
+    """
+    return (
+        f'{_number_to_string(horiz_res)}km_'
+        f'{_number_to_string(vert_res)}m_'
+        f'tilt{_number_to_string(tilt)}'
+    )
+
+
+def _number_to_string(value):
+    """
+    Format a number compactly, with ``p`` standing in for the decimal point.
+    """
+    return f'{float(value):g}'.replace('.', 'p').replace('-', 'm')
+
+
+def _group_by_resolution(sweep_keys):
+    """
+    Group sweep indices by their ``(horiz_res, vert_res)`` pair, preserving
+    the order in which the pairs first appear.
+    """
+    groups: dict[str, list[int]] = {}
+    for index, (horiz_res, vert_res, _) in enumerate(sweep_keys):
+        label = f'{horiz_res:g} km, {vert_res:g} m'
+        groups.setdefault(label, []).append(index)
+    return {label: np.asarray(indices) for label, indices in groups.items()}
+
+
+def _fit_exponents(groups, tilts, values, tilt_fit, tilt_fit_max):
+    """
+    Fit the tilt exponent within each resolution group, skipping groups with
+    too few usable points rather than raising.
+    """
+    exponents: dict[str, float] = {}
+    if not tilt_fit:
+        return exponents
+    for label, indices in groups.items():
+        group_tilts = tilts[indices]
+        group_values = values[indices]
+        fit_mask = group_tilts <= tilt_fit_max
+        usable = np.logical_and.reduce(
+            (fit_mask, group_tilts > 0.0, group_values > 0.0)
+        )
+        if np.count_nonzero(usable) < 2:
+            continue
+        _, slope, _ = power_law_fit(
+            x=group_tilts, y=group_values, fit_mask=fit_mask
+        )
+        exponents[label] = slope
+    return exponents
+
+
+def _write_resting_dataset(
+    filename,
+    sweep_keys,
+    omega_rms,
+    polaris_rms,
+    diff_rms,
+    ssh_diff,
+    n_layers,
+    exponents,
+    tilt_option,
+):
+    """
+    Write the resting-state sweep results to netCDF.
+    """
+    ds = xr.Dataset()
+    ds['horiz_resolution'] = xr.DataArray(
+        data=np.array([key[0] for key in sweep_keys], dtype=float),
+        dims=['nSweep'],
+        attrs={'long_name': 'horizontal resolution', 'units': 'km'},
+    )
+    ds['vert_resolution'] = xr.DataArray(
+        data=np.array([key[1] for key in sweep_keys], dtype=float),
+        dims=['nSweep'],
+        attrs={'long_name': 'vertical resolution', 'units': 'm'},
+    )
+    ds['tilt'] = xr.DataArray(
+        data=np.array([key[2] for key in sweep_keys], dtype=float),
+        dims=['nSweep'],
+        attrs={'long_name': f'swept {tilt_option}', 'units': 'm km-1'},
+    )
+    ds['rms_hpga_omega'] = xr.DataArray(
+        data=omega_rms,
+        dims=['nSweep'],
+        attrs={
+            'long_name': 'RMS HPGA from Omega (the error; truth is zero)',
+            'units': 'm s-2',
+        },
+    )
+    ds['rms_hpga_polaris'] = xr.DataArray(
+        data=polaris_rms,
+        dims=['nSweep'],
+        attrs={
+            'long_name': 'RMS HPGA from the Polaris initial condition',
+            'units': 'm s-2',
+        },
+    )
+    ds['rms_omega_vs_polaris'] = xr.DataArray(
+        data=diff_rms,
+        dims=['nSweep'],
+        attrs={
+            'long_name': 'RMS difference between Omega and Polaris HPGA',
+            'units': 'm s-2',
+        },
+    )
+    ds['ssh_difference'] = xr.DataArray(
+        data=ssh_diff,
+        dims=['nSweep'],
+        attrs={
+            'long_name': 'absolute sea-surface height difference between the '
+            'two columns',
+            'units': 'm',
+        },
+    )
+    ds['n_layers'] = xr.DataArray(
+        data=n_layers,
+        dims=['nSweep'],
+        attrs={
+            'long_name': 'number of layers valid in both columns',
+            'units': '1',
+        },
+    )
+    ds.attrs['tilt_option'] = tilt_option
+    for label, slope in exponents.items():
+        ds.attrs[f'tilt_exponent ({label})'] = slope
+    ds.to_netcdf(filename)
+
+
+def _plot_resting(
+    output,
+    groups,
+    tilts,
+    values,
+    exponents,
+    tilt_option,
+    sensitivity_min_rms,
+):
+    """
+    Plot RMS HPGA against the swept tilt, one series per resolution pair.
+    """
+    with mplstyle_context():
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+
+        for label, indices in groups.items():
+            legend = label
+            if label in exponents:
+                legend = f'{label} (q={exponents[label]:.2f})'
+            ax.loglog(tilts[indices], values[indices], 'o-', label=legend)
+
+        ax.axhline(
+            sensitivity_min_rms,
+            color='k',
+            linestyle='--',
+            label=f'sensitivity gate ({sensitivity_min_rms:g})',
+        )
+        ax.set_xlabel(f'{tilt_option} (m km-1)')
+        ax.set_ylabel('RMS HPGA in a resting state (m s-2)')
+        ax.set_title('Resting-State HPGA vs Tilt (true HPGA is zero)')
+        ax.legend(loc='best')
+        fig.savefig(output, bbox_inches='tight', pad_inches=0.1)
+        plt.close()

--- a/polaris/tasks/ocean/horiz_press_grad/resting_analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/resting_analysis.py
@@ -3,6 +3,7 @@ import numpy as np
 import xarray as xr
 
 from polaris.ocean.model import OceanIOStep
+from polaris.tasks.ocean.horiz_press_grad.forward import SCHEME_HPGA
 from polaris.tasks.ocean.horiz_press_grad.metrics import (
     format_value_error_pairs,
     format_value_list,
@@ -38,14 +39,18 @@ class RestingAnalysis(OceanIOStep):
             Mapping from ``(horiz_res, vert_res, tilt)`` to ``Init`` step
 
         forward : dict
-            Mapping from ``(horiz_res, vert_res, tilt)`` to ``Forward`` step
+            Mapping from ``((horiz_res, vert_res, tilt), scheme)`` to
+            ``Forward`` step
 
     sweep_keys : list of tuple
         The ``(horiz_res, vert_res, tilt)`` triples in the sweep, in the order
         they are analyzed.
+
+    schemes : list of str
+        The pressure-gradient schemes being compared
     """
 
-    def __init__(self, component, indir, dependencies, sweep_keys):
+    def __init__(self, component, indir, dependencies, sweep_keys, schemes):
         """
         Create the analysis step
 
@@ -63,11 +68,15 @@ class RestingAnalysis(OceanIOStep):
 
         sweep_keys : list of tuple
             The ``(horiz_res, vert_res, tilt)`` triples in the sweep
+
+        schemes : list of str
+            The pressure-gradient schemes being compared
         """
         super().__init__(component=component, name='analysis', indir=indir)
 
         self.dependencies_dict = dependencies
         self.sweep_keys = list(sweep_keys)
+        self.schemes = list(schemes)
 
         self.add_output_file('resting_state.png')
         self.add_output_file('resting_state.nc')
@@ -82,15 +91,10 @@ class RestingAnalysis(OceanIOStep):
         forward_steps = self.dependencies_dict['forward']
         for key in self.sweep_keys:
             init = init_steps[key]
-            forward = forward_steps[key]
             suffix = sweep_suffix(*key)
             self.add_input_file(
                 filename=f'init_{suffix}.nc',
                 work_dir_target=f'{init.path}/init.nc',
-            )
-            self.add_input_file(
-                filename=f'output_{suffix}.nc',
-                work_dir_target=f'{forward.path}/output.nc',
             )
             self.add_input_file(
                 filename=f'culled_mesh_{suffix}.nc',
@@ -100,6 +104,12 @@ class RestingAnalysis(OceanIOStep):
                 filename=f'vert_coord_{suffix}.nc',
                 work_dir_target=f'{init.path}/vert_coord.nc',
             )
+            for scheme in self.schemes:
+                forward = forward_steps[key, scheme]
+                self.add_input_file(
+                    filename=f'output_{suffix}_{scheme}.nc',
+                    work_dir_target=f'{forward.path}/output.nc',
+                )
 
     def run(self):
         """
@@ -122,9 +132,15 @@ class RestingAnalysis(OceanIOStep):
         max_rms_text = section.get('resting_state_max_rms').strip().lower()
         max_rms = None if max_rms_text == 'none' else float(max_rms_text)
 
-        omega_rms = []
-        polaris_rms = []
-        diff_rms = []
+        omega_rms: dict[str, list[float]] = {
+            scheme: [] for scheme in self.schemes
+        }
+        polaris_rms: dict[str, list[float]] = {
+            scheme: [] for scheme in self.schemes
+        }
+        diff_rms: dict[str, list[float]] = {
+            scheme: [] for scheme in self.schemes
+        }
         bathy_error = []
         n_layers = []
 
@@ -133,9 +149,6 @@ class RestingAnalysis(OceanIOStep):
             ds_init = self.open_model_dataset(f'init_{suffix}.nc', config)
             ds_mesh = self.open_model_dataset(
                 f'culled_mesh_{suffix}.nc', config
-            )
-            ds_out = self.open_model_dataset(
-                f'output_{suffix}.nc', config, decode_times=False
             )
             ds_vc = self.open_vert_coord_dataset(
                 ds_init, vert_coord_filename=f'vert_coord_{suffix}.nc'
@@ -157,16 +170,25 @@ class RestingAnalysis(OceanIOStep):
                 )
             n_layers.append(n_valid)
 
-            hpga_omega = ds_out.NormalVelocityTend.isel(
-                Time=0, nEdges=edge_index
-            ).values[:n_valid]
-            hpga_polaris = ds_init.HPGA.isel(Time=0).values[:n_valid]
+            for scheme in self.schemes:
+                ds_out = self.open_model_dataset(
+                    f'output_{suffix}_{scheme}.nc', config, decode_times=False
+                )
 
-            # the true HPGA is identically zero, so the model's HPGA is the
-            # error and no reference solution is involved
-            omega_rms.append(rms(hpga_omega))
-            polaris_rms.append(rms(hpga_polaris))
-            diff_rms.append(rms(hpga_omega - hpga_polaris))
+                hpga_omega = ds_out.NormalVelocityTend.isel(
+                    Time=0, nEdges=edge_index
+                ).values[:n_valid]
+                # each scheme against its own Polaris counterpart; see
+                # Analysis for why the pairing matters
+                hpga_polaris = (
+                    ds_init[SCHEME_HPGA[scheme]].isel(Time=0).values[:n_valid]
+                )
+
+                # the true HPGA is identically zero, so the model's HPGA is
+                # the error and no reference solution is involved
+                omega_rms[scheme].append(rms(hpga_omega))
+                polaris_rms[scheme].append(rms(hpga_polaris))
+                diff_rms[scheme].append(rms(hpga_omega - hpga_polaris))
 
             # The p-star column is anchored at the prescribed sea surface,
             # so ssh is exact by construction and cannot reveal a problem.
@@ -185,27 +207,39 @@ class RestingAnalysis(OceanIOStep):
             )
 
         tilts = np.array([key[2] for key in self.sweep_keys], dtype=float)
-        omega_rms = np.asarray(omega_rms, dtype=float)
-        polaris_rms = np.asarray(polaris_rms, dtype=float)
-        diff_rms = np.asarray(diff_rms, dtype=float)
-        bathy_error = np.asarray(bathy_error, dtype=float)
+        omega = {
+            scheme: np.asarray(values, dtype=float)
+            for scheme, values in omega_rms.items()
+        }
+        polaris = {
+            scheme: np.asarray(values, dtype=float)
+            for scheme, values in polaris_rms.items()
+        }
+        difference = {
+            scheme: np.asarray(values, dtype=float)
+            for scheme, values in diff_rms.items()
+        }
+        bathy_errors = np.asarray(bathy_error, dtype=float)
 
         groups = _group_by_resolution(self.sweep_keys)
-        exponents = _fit_exponents(
-            groups=groups,
-            tilts=tilts,
-            values=omega_rms,
-            tilt_fit=tilt_fit,
-            tilt_fit_max=tilt_fit_max,
-        )
+        exponents = {
+            scheme: _fit_exponents(
+                groups=groups,
+                tilts=tilts,
+                values=omega[scheme],
+                tilt_fit=tilt_fit,
+                tilt_fit_max=tilt_fit_max,
+            )
+            for scheme in self.schemes
+        }
 
         _write_resting_dataset(
             filename='resting_state.nc',
             sweep_keys=self.sweep_keys,
-            omega_rms=omega_rms,
-            polaris_rms=polaris_rms,
-            diff_rms=diff_rms,
-            bathy_error=bathy_error,
+            omega_rms=omega,
+            polaris_rms=polaris,
+            diff_rms=difference,
+            bathy_error=bathy_errors,
             n_layers=np.asarray(n_layers, dtype=int),
             exponents=exponents,
             tilt_option=tilt_option,
@@ -214,29 +248,39 @@ class RestingAnalysis(OceanIOStep):
             output='resting_state.png',
             groups=groups,
             tilts=tilts,
-            values=omega_rms,
+            values=omega,
             exponents=exponents,
             tilt_option=tilt_option,
             sensitivity_min_rms=sensitivity_min_rms,
         )
 
         logger.info(f'Resting-state sweep over {tilt_option} (m/km):')
-        for label, indices in groups.items():
-            logger.info(
-                f'  {label}: '
-                f'{format_value_error_pairs(tilts[indices], omega_rms[indices], units="m/km")}'  # noqa: E501
-            )
-            if label in exponents:
+        for scheme in self.schemes:
+            for label, indices in groups.items():
                 logger.info(
-                    f'  {label}: fitted tilt exponent q = '
-                    f'{exponents[label]:.3f} over tilts '
-                    f'{format_value_list(tilts[indices][tilts[indices] <= tilt_fit_max])}'  # noqa: E501
+                    f'  {scheme}, {label}: '
+                    f'{format_value_error_pairs(tilts[indices], omega[scheme][indices], units="m/km")}'  # noqa: E501
                 )
+                if label in exponents[scheme]:
+                    logger.info(
+                        f'  {scheme}, {label}: fitted tilt exponent q = '
+                        f'{exponents[scheme][label]:.3f} over tilts '
+                        f'{format_value_list(tilts[indices][tilts[indices] <= tilt_fit_max])}'  # noqa: E501
+                    )
 
-        self._check_bathymetry(bathy_error, max_bathy_error)
-        self._check_omega_vs_polaris(diff_rms, omega_vs_polaris_rms_threshold)
-        self._check_sensitivity(omega_rms, sensitivity_min_rms)
-        self._check_max_rms(omega_rms, max_rms)
+        self._check_bathymetry(bathy_errors, max_bathy_error)
+        for scheme in self.schemes:
+            self._check_omega_vs_polaris(
+                difference[scheme], omega_vs_polaris_rms_threshold, scheme
+            )
+            self._check_max_rms(omega[scheme], max_rms, scheme)
+
+        # the sensitivity gate is a statement about the CENTERED scheme: it
+        # asks whether the sweep is severe enough to exercise the failure the
+        # higher-order scheme is meant to fix.  Applying it to finite_volume
+        # would demand that the new scheme fail, which is backwards.
+        if 'centered' in omega:
+            self._check_sensitivity(omega['centered'], sensitivity_min_rms)
 
     def _check_bathymetry(self, bathy_error, max_bathy_error):
         """
@@ -264,7 +308,7 @@ class RestingAnalysis(OceanIOStep):
             f'at: {self._failing_text(failing, bathy_error)}'
         )
 
-    def _check_omega_vs_polaris(self, diff_rms, threshold):
+    def _check_omega_vs_polaris(self, diff_rms, threshold, scheme):
         """
         Fail if Omega and Polaris disagree about the same discrete scheme.
         """
@@ -272,7 +316,7 @@ class RestingAnalysis(OceanIOStep):
         if not np.any(failing):
             return
         raise ValueError(
-            'Omega-vs-Polaris RMS difference exceeds '
+            f'{scheme}: Omega-vs-Polaris RMS difference exceeds '
             f'omega_vs_polaris_rms_threshold={threshold:.3e} at: '
             f'{self._failing_text(failing, diff_rms)}'
         )
@@ -294,7 +338,7 @@ class RestingAnalysis(OceanIOStep):
             'larger tilt) before any conclusion is drawn from it.'
         )
 
-    def _check_max_rms(self, omega_rms, max_rms):
+    def _check_max_rms(self, omega_rms, max_rms, scheme):
         """
         Fail if the scheme exceeds the consistency threshold, when one is set.
         """
@@ -304,7 +348,7 @@ class RestingAnalysis(OceanIOStep):
         if not np.any(failing):
             return
         raise ValueError(
-            'RMS HPGA in the resting state exceeds '
+            f'{scheme}: RMS HPGA in the resting state exceeds '
             f'resting_state_max_rms={max_rms:.3e} m s-2 at: '
             f'{self._failing_text(failing, omega_rms)}'
         )
@@ -419,30 +463,34 @@ def _write_resting_dataset(
         dims=['nSweep'],
         attrs={'long_name': f'swept {tilt_option}', 'units': 'm km-1'},
     )
-    ds['rms_hpga_omega'] = xr.DataArray(
-        data=omega_rms,
-        dims=['nSweep'],
-        attrs={
-            'long_name': 'RMS HPGA from Omega (the error; truth is zero)',
-            'units': 'm s-2',
-        },
-    )
-    ds['rms_hpga_polaris'] = xr.DataArray(
-        data=polaris_rms,
-        dims=['nSweep'],
-        attrs={
-            'long_name': 'RMS HPGA from the Polaris initial condition',
-            'units': 'm s-2',
-        },
-    )
-    ds['rms_omega_vs_polaris'] = xr.DataArray(
-        data=diff_rms,
-        dims=['nSweep'],
-        attrs={
-            'long_name': 'RMS difference between Omega and Polaris HPGA',
-            'units': 'm s-2',
-        },
-    )
+    for scheme in omega_rms:
+        ds[f'rms_hpga_omega_{scheme}'] = xr.DataArray(
+            data=omega_rms[scheme],
+            dims=['nSweep'],
+            attrs={
+                'long_name': 'RMS HPGA from Omega (the error; truth is zero), '
+                f'{scheme} scheme',
+                'units': 'm s-2',
+            },
+        )
+        ds[f'rms_hpga_polaris_{scheme}'] = xr.DataArray(
+            data=polaris_rms[scheme],
+            dims=['nSweep'],
+            attrs={
+                'long_name': 'RMS HPGA from the Polaris initial condition, '
+                f'{scheme} scheme',
+                'units': 'm s-2',
+            },
+        )
+        ds[f'rms_omega_vs_polaris_{scheme}'] = xr.DataArray(
+            data=diff_rms[scheme],
+            dims=['nSweep'],
+            attrs={
+                'long_name': 'RMS difference between Omega and Polaris HPGA, '
+                f'{scheme} scheme',
+                'units': 'm s-2',
+            },
+        )
     ds['bathymetry_error'] = xr.DataArray(
         data=bathy_error,
         dims=['nSweep'],
@@ -460,8 +508,9 @@ def _write_resting_dataset(
         },
     )
     ds.attrs['tilt_option'] = tilt_option
-    for label, slope in exponents.items():
-        ds.attrs[f'tilt_exponent ({label})'] = slope
+    for scheme, per_group in exponents.items():
+        for label, slope in per_group.items():
+            ds.attrs[f'tilt_exponent ({scheme}, {label})'] = slope
     ds.to_netcdf(filename)
 
 
@@ -475,17 +524,29 @@ def _plot_resting(
     sensitivity_min_rms,
 ):
     """
-    Plot RMS HPGA against the swept tilt, one series per resolution pair.
+    Plot RMS HPGA against the swept tilt, one series per resolution pair and
+    scheme.  The schemes share a panel deliberately: the comparison between
+    them at the same sweep point is the measurement, so putting them on
+    separate axes would hide it.
     """
     with mplstyle_context():
         fig = plt.figure()
         ax = fig.add_subplot(111)
 
-        for label, indices in groups.items():
-            legend = label
-            if label in exponents:
-                legend = f'{label} (q={exponents[label]:.2f})'
-            ax.loglog(tilts[indices], values[indices], 'o-', label=legend)
+        markers = ['o-', 's--', '^:', 'v-.']
+        for scheme_index, scheme in enumerate(values):
+            marker = markers[scheme_index % len(markers)]
+            for group_index, (label, indices) in enumerate(groups.items()):
+                legend = f'{scheme}, {label}'
+                if label in exponents[scheme]:
+                    legend = f'{legend} (q={exponents[scheme][label]:.2f})'
+                ax.loglog(
+                    tilts[indices],
+                    values[scheme][indices],
+                    marker,
+                    color=f'C{group_index}',
+                    label=legend,
+                )
 
         ax.axhline(
             sensitivity_min_rms,

--- a/polaris/tasks/ocean/horiz_press_grad/resting_analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/resting_analysis.py
@@ -131,6 +131,12 @@ class RestingAnalysis(OceanIOStep):
         )
         max_rms_text = section.get('resting_state_max_rms').strip().lower()
         max_rms = None if max_rms_text == 'none' else float(max_rms_text)
+        improvement_text = (
+            section.get('resting_state_improvement_min').strip().lower()
+        )
+        improvement_min = (
+            None if improvement_text == 'none' else float(improvement_text)
+        )
 
         omega_rms: dict[str, list[float]] = {
             scheme: [] for scheme in self.schemes
@@ -282,6 +288,14 @@ class RestingAnalysis(OceanIOStep):
         if 'centered' in omega:
             self._check_sensitivity(omega['centered'], sensitivity_min_rms)
 
+        if 'centered' in omega and 'finite_volume' in omega:
+            self._check_improvement(
+                centered=omega['centered'],
+                finite_volume=omega['finite_volume'],
+                improvement_min=improvement_min,
+                logger=logger,
+            )
+
     def _check_bathymetry(self, bathy_error, max_bathy_error):
         """
         Fail if the sea floor is not where the configuration asked for it.
@@ -351,6 +365,46 @@ class RestingAnalysis(OceanIOStep):
             f'{scheme}: RMS HPGA in the resting state exceeds '
             f'resting_state_max_rms={max_rms:.3e} m s-2 at: '
             f'{self._failing_text(failing, omega_rms)}'
+        )
+
+    def _check_improvement(
+        self, centered, finite_volume, improvement_min, logger
+    ):
+        """
+        Fail if the finite-volume scheme is not enough better than centered.
+
+        The true HPGA is identically zero here, so both are pure error and
+        their ratio is a clean statement of what the higher-order scheme buys
+        -- no reference solution and none of its discretization enters.
+
+        The ratio is reported whether or not a threshold is set, because it is
+        the headline number for these variants and is worth having in the log
+        even before anyone decides what to require of it.
+        """
+        with np.errstate(divide='ignore', invalid='ignore'):
+            ratio = np.where(
+                finite_volume > 0.0, centered / finite_volume, np.inf
+            )
+
+        finite = np.isfinite(ratio)
+        if np.any(finite):
+            worst_index = int(np.argmin(np.where(finite, ratio, np.inf)))
+            logger.info(
+                'centered / finite_volume RMS HPGA: smallest is '
+                f'{ratio[worst_index]:.2f}x at '
+                f'{sweep_suffix(*self.sweep_keys[worst_index])}'
+            )
+
+        if improvement_min is None:
+            return
+
+        failing = ratio < improvement_min
+        if not np.any(failing):
+            return
+        raise ValueError(
+            'The finite-volume scheme is not enough better than the centered '
+            f'one: resting_state_improvement_min={improvement_min:.3e} is not '
+            f'met at: {self._failing_text(failing, ratio)}'
         )
 
     def _failing_text(self, failing, values):

--- a/polaris/tasks/ocean/horiz_press_grad/resting_state_task.py
+++ b/polaris/tasks/ocean/horiz_press_grad/resting_state_task.py
@@ -83,7 +83,12 @@ class HorizPressGradRestingStateTask(Task):
         vert_resolutions = section.getexpression('vert_resolutions')
         tilt_values = section.getexpression('tilt_values')
         tilt_option = section.get('tilt_option')
+        schemes = section.getexpression('pressure_grad_types')
 
+        assert schemes, (
+            'The "pressure_grad_types" configuration option must be set in '
+            'the "horiz_press_grad" section.'
+        )
         assert horiz_resolutions is not None, (
             'The "horiz_resolutions" configuration option must be set in the '
             '"horiz_press_grad" section.'
@@ -134,15 +139,19 @@ class HorizPressGradRestingStateTask(Task):
                 self.add_step(init_step)
                 init_steps[key] = init_step
 
-                forward_step = Forward(
-                    component=self.component,
-                    horiz_res=horiz_res,
-                    init=init_step,
-                    indir=self.subdir,
-                    subdir_suffix=suffix,
-                )
-                self.add_step(forward_step)
-                forward_steps[key] = forward_step
+                # one forward step per scheme over the shared init step; see
+                # HorizPressGradTask for why Init is not duplicated
+                for scheme in schemes:
+                    forward_step = Forward(
+                        component=self.component,
+                        horiz_res=horiz_res,
+                        init=init_step,
+                        indir=self.subdir,
+                        scheme=scheme,
+                        subdir_suffix=suffix,
+                    )
+                    self.add_step(forward_step)
+                    forward_steps[key, scheme] = forward_step
 
                 sweep_keys.append(key)
 
@@ -157,5 +166,6 @@ class HorizPressGradRestingStateTask(Task):
                     'forward': forward_steps,
                 },
                 sweep_keys=sweep_keys,
+                schemes=schemes,
             )
         )

--- a/polaris/tasks/ocean/horiz_press_grad/resting_state_task.py
+++ b/polaris/tasks/ocean/horiz_press_grad/resting_state_task.py
@@ -1,0 +1,161 @@
+import os
+
+from polaris import Task
+from polaris.tasks.ocean.horiz_press_grad.forward import Forward
+from polaris.tasks.ocean.horiz_press_grad.init import Init
+from polaris.tasks.ocean.horiz_press_grad.resting_analysis import (
+    RestingAnalysis,
+    sweep_suffix,
+)
+
+
+class HorizPressGradRestingStateTask(Task):
+    """
+    A two-column test of discrete hydrostatic consistency: conservative
+    temperature and absolute salinity are horizontally uniform functions of
+    pseudo-height, so specific volume is a function of pressure alone, isobars
+    are level, and the true horizontal pressure-gradient acceleration (HPGA)
+    is identically zero however the coordinate surfaces or the sea floor are
+    tilted between the columns.
+
+    Whatever HPGA the model returns is therefore error.  The task sweeps a
+    tilt (``z_tilde_bot_grad`` for a tilted coordinate, ``geom_z_bot_grad``
+    for a stepped sea floor) at each of several resolution pairs, and the
+    analysis step measures the absolute error and the exponent with which it
+    grows with tilt.
+
+    This is a sibling of
+    :py:class:`~polaris.tasks.ocean.horiz_press_grad.task.HorizPressGradTask`
+    rather than a mode of it.  That task pairs each horizontal resolution with
+    one vertical resolution and keys its steps by horizontal resolution alone,
+    so it cannot express the repeated horizontal resolutions this sweep needs.
+
+    Attributes
+    ----------
+    sweep_keys : list of tuple
+        The ``(horiz_res, vert_res, tilt)`` triples in the sweep
+    """
+
+    def __init__(self, component, name):
+        """
+        Create the test case
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component that this task belongs to
+
+        name : str
+            The name of the test case, which must have a corresponding
+            <name>.cfg config file in the horiz_press_grad package that
+            specifies the resting-state sweep.
+        """
+        subdir = os.path.join('column', 'horiz_press_grad', name)
+        super().__init__(component=component, name=name, subdir=subdir)
+
+        self.sweep_keys: list[tuple[float, float, float]] = []
+
+        self.config.add_from_package(
+            'polaris.tasks.ocean.horiz_press_grad', 'horiz_press_grad.cfg'
+        )
+        self.config.add_from_package(
+            'polaris.tasks.ocean.horiz_press_grad',
+            f'{name}.cfg',
+        )
+
+        self._setup_steps()
+
+    def configure(self):
+        """
+        Set config options for the test case
+        """
+        super().configure()
+
+        # set up the steps again in case a user has provided a new sweep
+        self._setup_steps()
+
+    def _setup_steps(self):
+        """
+        setup steps given the resolution pairs and the tilt sweep
+        """
+        section = self.config['horiz_press_grad']
+        horiz_resolutions = section.getexpression('horiz_resolutions')
+        vert_resolutions = section.getexpression('vert_resolutions')
+        tilt_values = section.getexpression('tilt_values')
+        tilt_option = section.get('tilt_option')
+
+        assert horiz_resolutions is not None, (
+            'The "horiz_resolutions" configuration option must be set in the '
+            '"horiz_press_grad" section.'
+        )
+        assert vert_resolutions is not None, (
+            'The "vert_resolutions" configuration option must be set in the '
+            '"horiz_press_grad" section.'
+        )
+        assert tilt_values is not None, (
+            'The "tilt_values" configuration option must be set in the '
+            '"horiz_press_grad" section.'
+        )
+        assert len(horiz_resolutions) == len(vert_resolutions), (
+            'The "horiz_resolutions" and "vert_resolutions" configuration '
+            'options must have the same length.'
+        )
+
+        # start fresh with no steps
+        for step in list(self.steps.values()):
+            self.remove_step(step)
+
+        init_steps = dict()
+        forward_steps = dict()
+        sweep_keys = []
+
+        for horiz_res, vert_res in zip(
+            horiz_resolutions, vert_resolutions, strict=True
+        ):
+            for tilt in tilt_values:
+                key = (float(horiz_res), float(vert_res), float(tilt))
+                if key in init_steps:
+                    raise ValueError(
+                        'Duplicate sweep point '
+                        f'{sweep_suffix(*key)} in the "horiz_press_grad" '
+                        'resolution and tilt sweeps.'
+                    )
+                suffix = sweep_suffix(*key)
+
+                init_step = Init(
+                    component=self.component,
+                    horiz_res=horiz_res,
+                    vert_res=vert_res,
+                    indir=self.subdir,
+                    subdir_suffix=suffix,
+                    tilt_option=tilt_option,
+                    tilt=tilt,
+                )
+                self.add_step(init_step)
+                init_steps[key] = init_step
+
+                forward_step = Forward(
+                    component=self.component,
+                    horiz_res=horiz_res,
+                    init=init_step,
+                    indir=self.subdir,
+                    subdir_suffix=suffix,
+                )
+                self.add_step(forward_step)
+                forward_steps[key] = forward_step
+
+                sweep_keys.append(key)
+
+        self.sweep_keys = sweep_keys
+
+        self.add_step(
+            RestingAnalysis(
+                component=self.component,
+                indir=self.subdir,
+                dependencies={
+                    'init': init_steps,
+                    'forward': forward_steps,
+                },
+                sweep_keys=sweep_keys,
+            )
+        )

--- a/polaris/tasks/ocean/horiz_press_grad/surface_pressure_gradient.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/surface_pressure_gradient.cfg
@@ -10,3 +10,10 @@ surface_pressure_mid = 8.99e5
 #   917 * 9.80665 * 1 ~= 8.99e3 Pa/km
 # Pa / km
 surface_pressure_grad = 8.99e3
+
+# The finite-volume scheme is about 2.2x more accurate here at every
+# resolution, measured offline: 2.19x at 4 km and 2.18x at 0.5 km. Unlike
+# ztilde_gradient the two schemes converge at the same rate (2.00 against
+# 1.99), so this really is the constant factor the design describes, and the
+# gate is the same at either end of the sweep.
+omega_vs_reference_accuracy_ratio_min = 1.8

--- a/polaris/tasks/ocean/horiz_press_grad/task.py
+++ b/polaris/tasks/ocean/horiz_press_grad/task.py
@@ -68,7 +68,12 @@ class HorizPressGradTask(Task):
         section = self.config['horiz_press_grad']
         horiz_resolutions = section.getexpression('horiz_resolutions')
         vert_resolutions = section.getexpression('vert_resolutions')
+        schemes = section.getexpression('pressure_grad_types')
 
+        assert schemes, (
+            'The "pressure_grad_types" configuration option must be set in '
+            'the "horiz_press_grad" section.'
+        )
         assert horiz_resolutions is not None, (
             'The "horiz_resolutions" configuration option must be set in the '
             '"horiz_press_grad" section.'
@@ -101,15 +106,21 @@ class HorizPressGradTask(Task):
             self.add_step(init_step)
             init_steps[horiz_res] = init_step
 
+        # one forward step per scheme over the shared init step: Init is
+        # scheme-independent, writing both schemes' Polaris-side HPGA from the
+        # same state, so running it once is both cheaper and what lets the
+        # analysis compare the schemes at an identical initial condition
         for horiz_res in horiz_resolutions:
-            forward_step = Forward(
-                component=self.component,
-                horiz_res=horiz_res,
-                init=init_steps[horiz_res],
-                indir=self.subdir,
-            )
-            self.add_step(forward_step)
-            forward_steps[horiz_res] = forward_step
+            for scheme in schemes:
+                forward_step = Forward(
+                    component=self.component,
+                    horiz_res=horiz_res,
+                    init=init_steps[horiz_res],
+                    indir=self.subdir,
+                    scheme=scheme,
+                )
+                self.add_step(forward_step)
+                forward_steps[horiz_res, scheme] = forward_step
 
         self.add_step(
             Analysis(
@@ -119,5 +130,6 @@ class HorizPressGradTask(Task):
                     'init': init_steps,
                     'forward': forward_steps,
                 },
+                schemes=schemes,
             )
         )

--- a/polaris/tasks/ocean/horiz_press_grad/ztilde_gradient.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/ztilde_gradient.cfg
@@ -24,8 +24,26 @@ z_tilde_bot_grad = 0.5
 # ReferenceColumn offline, with the Polaris HPGA standing in for Omega's
 # tendency (offline slope 1.119). They must be re-tuned from the first real
 # Omega run.
-omega_vs_reference_convergence_rate_min = 0.9
-omega_vs_reference_convergence_rate_max = 1.4
+omega_vs_reference_convergence_rate_min_centered = 0.9
+omega_vs_reference_convergence_rate_max_centered = 1.4
+
+# The finite-volume scheme restores SECOND order here, which is the single
+# clearest demonstration in the task of what it buys. This variant tilts the
+# coordinate while holding the water uniform, so the centered scheme's
+# first-order-in-layer-thickness behaviour is exposed with nothing else mixed
+# in; the finite-volume scheme compares the columns at matched pressure and the
+# first-order term disappears.
+#
+# Measured offline over 4, 2, 1 and 0.5 km: 0.931 centered, 1.978 finite
+# volume. The band is wide enough for the seven-resolution fit the analysis
+# actually runs to land somewhere slightly different.
+omega_vs_reference_convergence_rate_min_finite_volume = 1.7
+omega_vs_reference_convergence_rate_max_finite_volume = 2.2
+
+# Because the orders differ, the advantage WIDENS under refinement rather than
+# staying a constant factor: 1.80x at 4 km against 14.8x at 0.5 km, measured
+# offline. The gate is set at the coarse end, where the advantage is smallest.
+omega_vs_reference_accuracy_ratio_min = 1.5
 
 # Observed RMS at 0.5 km rises from ~7e-12 to ~5e-11 with the bottom layer
 # included; the shared 1e-6 threshold still has an enormous margin.

--- a/polaris/tasks/ocean/horiz_press_grad/ztilde_gradient.cfg
+++ b/polaris/tasks/ocean/horiz_press_grad/ztilde_gradient.cfg
@@ -7,3 +7,25 @@
 z_tilde_bot_mid = -576.0
 # m / km
 z_tilde_bot_grad = 0.5
+
+# This variant needs its own convergence band. It is the only one of the four
+# whose coordinate is tilted, so its two columns clip the bottom layer at
+# different thicknesses, and the resulting bottom-cell error converges at
+# roughly first order rather than second. Now that the bottom layer is included
+# in the RMS (it used to be dropped; see the user's guide), that first-order
+# term dominates and pulls the fitted slope down from ~2.0 to ~1.1.
+#
+# This is a real property of the centered scheme in the bottom partial cell,
+# not a regression: the exclusion was hiding it. It is the same first-order
+# behaviour the hydrostatic_consistency variant measures directly, and it is
+# what the higher-order pressure gradient is meant to fix.
+#
+# PROVISIONAL. These values come from running the Polaris Init arithmetic and
+# ReferenceColumn offline, with the Polaris HPGA standing in for Omega's
+# tendency (offline slope 1.119). They must be re-tuned from the first real
+# Omega run.
+omega_vs_reference_convergence_rate_min = 0.9
+omega_vs_reference_convergence_rate_max = 1.4
+
+# Observed RMS at 0.5 km rises from ~7e-12 to ~5e-11 with the bottom layer
+# included; the shared 1e-6 threshold still has an enormous margin.

--- a/tests/ocean/horiz_press_grad/test_column.py
+++ b/tests/ocean/horiz_press_grad/test_column.py
@@ -1,0 +1,228 @@
+"""
+Unit tests for the profile helpers in
+:py:mod:`polaris.tasks.ocean.horiz_press_grad.column`.
+
+These are pure numpy/scipy tests: no config, no dataset, no file I/O.
+"""
+
+import numpy as np
+import pytest
+
+from polaris.tasks.ocean.horiz_press_grad.column import (
+    get_pchip_interpolator,
+    get_pchip_layer_mean,
+)
+
+# A deliberately non-uniform set of layers.  A formula that quietly assumes
+# uniform thickness, or that averages in the wrong variable, passes on a
+# uniform grid and fails here.
+_NON_UNIFORM = np.array([0.0, -10.0, -35.0, -100.0, -300.0, -1000.0])
+
+# Nodes of a curved profile, decreasing in z_tilde as the configs write them.
+_CURVED_Z = np.array([0.0, -100.0, -250.0, -500.0, -1000.0])
+_CURVED_T = np.array([22.0, 18.0, 8.0, 4.0, 1.0])
+
+
+def _fine_mean(z_nodes, values, z_top, z_bot, n=200001):
+    """A brute-force layer mean, for comparison with the exact one."""
+    interp = get_pchip_interpolator(z_nodes, values, 'temperature')
+    z = np.linspace(z_top, z_bot, n)
+    return np.trapezoid(interp(z), z) / (z_bot - z_top)
+
+
+def test_layer_mean_exact_for_linear_profile():
+    """For a linear profile the layer mean is the midpoint value, exactly.
+
+    This is the property that makes the choice between layer averaging and
+    midpoint sampling irrelevant on the scheme's exact set, so it is worth
+    pinning down rather than assuming.
+    """
+    z_nodes = np.array([0.0, -1000.0])
+    t_nodes = np.array([22.0, 2.0])
+    layer_mean = get_pchip_layer_mean(z_nodes, t_nodes, 'temperature')
+
+    top = _NON_UNIFORM[:-1]
+    bot = _NON_UNIFORM[1:]
+    means = layer_mean(top, bot)
+
+    z_mid = 0.5 * (top + bot)
+    expected = 22.0 + (2.0 - 22.0) * (z_mid - 0.0) / (-1000.0 - 0.0)
+    np.testing.assert_allclose(means, expected, rtol=1e-14)
+
+
+def test_layer_mean_matches_brute_force_on_curved_profile():
+    """On a curved profile the exact mean matches a fine numerical average."""
+    layer_mean = get_pchip_layer_mean(_CURVED_Z, _CURVED_T, 'temperature')
+
+    top = _NON_UNIFORM[:-1]
+    bot = _NON_UNIFORM[1:]
+    means = layer_mean(top, bot)
+
+    expected = np.array(
+        [
+            _fine_mean(_CURVED_Z, _CURVED_T, z_top, z_bot)
+            for z_top, z_bot in zip(top, bot, strict=True)
+        ]
+    )
+    np.testing.assert_allclose(means, expected, rtol=1e-8)
+
+
+def test_layer_mean_differs_from_midpoint_on_curved_profile():
+    """The curved case is not a no-op: means and midpoint samples differ.
+
+    Without this the test above could pass for an implementation that had
+    silently gone back to sampling at midpoints.
+    """
+    layer_mean = get_pchip_layer_mean(_CURVED_Z, _CURVED_T, 'temperature')
+    interp = get_pchip_interpolator(_CURVED_Z, _CURVED_T, 'temperature')
+
+    top = _NON_UNIFORM[:-1]
+    bot = _NON_UNIFORM[1:]
+    means = layer_mean(top, bot)
+    midpoints = interp(0.5 * (top + bot))
+
+    assert np.max(np.abs(means - midpoints)) > 1e-3
+
+
+def test_layer_mean_is_mean_preserving():
+    """Thickness-weighted layer means reproduce the whole-column integral.
+
+    ``[z-increment-exact]`` in the design rests on the reconstruction
+    integrating to the layer mean, which in turn requires the layer means the
+    initial condition supplies to be consistent with the profile they came
+    from.
+    """
+    layer_mean = get_pchip_layer_mean(_CURVED_Z, _CURVED_T, 'temperature')
+
+    top = _NON_UNIFORM[:-1]
+    bot = _NON_UNIFORM[1:]
+    thickness = top - bot
+    total = float(np.sum(layer_mean(top, bot) * thickness))
+
+    expected = _fine_mean(
+        _CURVED_Z, _CURVED_T, _NON_UNIFORM[0], _NON_UNIFORM[-1]
+    ) * (_NON_UNIFORM[0] - _NON_UNIFORM[-1])
+    np.testing.assert_allclose(total, expected, rtol=1e-8)
+
+
+def test_layer_mean_precision_does_not_degrade_with_thin_layers():
+    """The layer mean stays at a few eps however thin the layers are.
+
+    Computing the mean by differencing the interpolant's antiderivative is
+    exact in principle but differences two large numbers, so its error grows
+    like 1/h -- reaching ~1e-13 of the salinity at the 8 m layers used here and
+    3.7e-14 at 32 m.  That would put a floor under how exactly the initial
+    sits in the finite-volume scheme's exact set, and hence under the
+    machine-precision test the whole scheme is judged by.  Quadrature per node
+    interval has no such cancellation.
+    """
+    z_nodes = np.array([0.0, -6144.0])
+    s_nodes = np.array([35.6, 34.66])
+    layer_mean = get_pchip_layer_mean(z_nodes, s_nodes, 'salinity')
+
+    edges = -np.arange(0.0, 4096.0 + 8.0, 8.0)
+    top = edges[:-1]
+    bot = edges[1:]
+    means = layer_mean(top, bot)
+
+    # exact for a linear profile: the value at the layer midpoint
+    z_mid = 0.5 * (top + bot)
+    expected = 35.6 + (34.66 - 35.6) * z_mid / (-6144.0)
+    np.testing.assert_allclose(means, expected, rtol=1e-15)
+
+
+@pytest.mark.parametrize('nudge', [0.0, 1.0e-12, -1.0e-12])
+def test_layer_mean_at_the_outermost_nodes(nudge):
+    """Interfaces on, or a round-off distance outside, the outermost nodes.
+
+    Every configuration puts its shallowest node at ``z_tilde = 0`` while the
+    column is summed upward from the sea floor, and the gradient variants put
+    the deepest node exactly at the pseudo-bottom, so both outermost interfaces
+    land on a node up to round-off.  Two things must hold there.
+
+    Extrapolating must not be an error and must not produce a NaN: a NaN in
+    the top or bottom layer feeds back through the p-star iteration and
+    corrupts the whole column state without raising anything.
+
+    And the round-off excursion must be absorbed *consistently* -- the interval
+    the quadrature covers and the thickness it is divided by must be the same
+    interval.  Clipping one but not the other scales the outermost layer's mean
+    by ``h / (h + nudge)``, which is invisible on a thick layer and is why the
+    layers here are thin.
+    """
+    layer_mean = get_pchip_layer_mean(_CURVED_Z, _CURVED_T, 'temperature')
+
+    thin = 8.0
+    top = np.array([0.0 + nudge, -1000.0 + thin])
+    bot = np.array([-thin, -1000.0 + nudge])
+    means = layer_mean(top, bot)
+
+    assert np.all(np.isfinite(means))
+    reference = layer_mean(
+        np.array([0.0, -1000.0 + thin]), np.array([-thin, -1000.0])
+    )
+    np.testing.assert_allclose(means, reference, rtol=1e-15)
+
+
+def test_layer_mean_rejects_real_extrapolation():
+    """A layer genuinely outside the node range raises rather than clipping."""
+    layer_mean = get_pchip_layer_mean(_CURVED_Z, _CURVED_T, 'temperature')
+
+    with pytest.raises(ValueError, match='node range'):
+        layer_mean(np.array([-900.0]), np.array([-1100.0]))
+    with pytest.raises(ValueError, match='node range'):
+        layer_mean(np.array([10.0]), np.array([-100.0]))
+
+
+def test_layer_mean_node_order_does_not_matter():
+    """Increasing and decreasing node order give the same layer means."""
+    decreasing = get_pchip_layer_mean(_CURVED_Z, _CURVED_T, 'temperature')
+    increasing = get_pchip_layer_mean(
+        _CURVED_Z[::-1], _CURVED_T[::-1], 'temperature'
+    )
+
+    top = _NON_UNIFORM[:-1]
+    bot = _NON_UNIFORM[1:]
+    np.testing.assert_allclose(
+        increasing(top, bot), decreasing(top, bot), rtol=1e-14
+    )
+
+
+def test_layer_mean_rejects_non_positive_thickness():
+    """A layer whose interfaces are equal or inverted raises."""
+    layer_mean = get_pchip_layer_mean(_CURVED_Z, _CURVED_T, 'temperature')
+
+    with pytest.raises(ValueError, match='positive thickness'):
+        layer_mean(np.array([-100.0]), np.array([-100.0]))
+    with pytest.raises(ValueError, match='positive thickness'):
+        layer_mean(np.array([-200.0]), np.array([-100.0]))
+
+
+def test_layer_mean_rejects_non_finite_interfaces():
+    """Invalid layers must be masked out by the caller, not passed through."""
+    layer_mean = get_pchip_layer_mean(_CURVED_Z, _CURVED_T, 'temperature')
+
+    with pytest.raises(ValueError, match='finite'):
+        layer_mean(np.array([0.0, np.nan]), np.array([-100.0, -200.0]))
+
+
+def test_layer_mean_rejects_mismatched_shapes():
+    """``z_tilde_top`` and ``z_tilde_bot`` must describe the same layers."""
+    layer_mean = get_pchip_layer_mean(_CURVED_Z, _CURVED_T, 'temperature')
+
+    with pytest.raises(ValueError, match='same shape'):
+        layer_mean(np.array([0.0, -100.0]), np.array([-100.0]))
+
+
+def test_layer_mean_validates_nodes():
+    """Node validation is shared with ``get_pchip_interpolator``."""
+    with pytest.raises(ValueError, match='strictly monotonic'):
+        get_pchip_layer_mean(
+            np.array([0.0, -100.0, -50.0]),
+            np.array([22.0, 18.0, 8.0]),
+            'temperature',
+        )
+    with pytest.raises(ValueError, match='At least two'):
+        get_pchip_layer_mean(np.array([0.0]), np.array([22.0]), 'temperature')
+    with pytest.raises(ValueError, match='must match'):
+        get_pchip_layer_mean(_CURVED_Z, _CURVED_T[:-1], 'temperature')

--- a/tests/ocean/horiz_press_grad/test_eos_expansion.py
+++ b/tests/ocean/horiz_press_grad/test_eos_expansion.py
@@ -1,0 +1,401 @@
+"""
+Unit tests for the edge-shared equation-of-state expansion.
+
+Mostly self-contained: hand-built two-column DataArrays for the algebra, plus
+the real two-column states from :py:mod:`two_column` for the size of the
+second-order remainder.  No file I/O either way.
+"""
+
+import gsw
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.tasks.ocean.horiz_press_grad.eos_expansion import (
+    edge_expansion,
+    edge_specvol,
+    edge_specvol_layer_mean,
+    specvol_coefficients,
+)
+
+from .two_column import build_state
+
+_DIMS = ['Time', 'nCells', 'nVertLevels']
+
+# A two-column state with a real horizontal contrast in both tracers and a
+# realistic pressure range, so the expansion is worked rather than exercised at
+# a single point.
+_THETA = np.array([[[22.0, 12.0, 4.0, 1.5], [19.0, 10.0, 3.0, 1.0]]])
+_SALINITY = np.array([[[35.6, 35.0, 34.7, 34.66], [35.2, 34.8, 34.6, 34.55]]])
+_PRESSURE = np.array(
+    [[[1.0e6, 1.0e7, 2.5e7, 4.0e7], [1.1e6, 1.05e7, 2.6e7, 4.1e7]]]
+)
+
+
+def _state(
+    theta=_THETA, salinity=_SALINITY, pressure=_PRESSURE
+) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray]:
+    return (
+        xr.DataArray(theta, dims=_DIMS),
+        xr.DataArray(salinity, dims=_DIMS),
+        xr.DataArray(pressure, dims=_DIMS),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coefficients, and the units convention
+# ---------------------------------------------------------------------------
+
+
+def test_alpha_0_is_gsw_specvol():
+    """``alpha_0`` is exactly the specific volume Polaris already computes."""
+    theta, salinity, pressure = _state()
+    coefficients = specvol_coefficients(theta, salinity, pressure)
+
+    expected = gsw.specvol(
+        salinity.values, theta.values, pressure.values * 1.0e-4
+    )
+    np.testing.assert_allclose(
+        coefficients.alpha_0.values, expected, rtol=1e-15
+    )
+
+
+@pytest.mark.parametrize(
+    'name, index, step',
+    [
+        ('alpha_theta', 0, 1.0e-4),  # degC
+        ('alpha_s', 1, 1.0e-4),  # g/kg
+        ('alpha_p', 2, 1.0e2),  # Pa
+    ],
+)
+def test_derivatives_match_centred_finite_differences(name, index, step):
+    """Each derivative matches a centred difference of ``gsw.specvol``.
+
+    This is also the units check, and it is the reason the check exists.
+    ``gsw.specvol_first_derivatives`` takes pressure in dbar but returns the
+    pressure derivative per **Pa** -- the convention of neither argument -- so
+    ``alpha_p`` must match a finite difference taken in Pa, and would be wrong
+    by exactly 1e4 if the note were misread.  The other two follow the units of
+    their arguments.
+    """
+    theta, salinity, pressure = _state()
+    coefficients = specvol_coefficients(theta, salinity, pressure)
+
+    arguments = [theta.values, salinity.values, pressure.values]
+    plus = [value.copy() for value in arguments]
+    minus = [value.copy() for value in arguments]
+    plus[index] = plus[index] + step
+    minus[index] = minus[index] - step
+
+    def specvol(values):
+        return gsw.specvol(values[1], values[0], values[2] * 1.0e-4)
+
+    finite_difference = (specvol(plus) - specvol(minus)) / (2.0 * step)
+
+    # gsw's analytic derivatives are self-consistent with gsw.specvol to about
+    # 1e-5 relative; the tolerance is set by that, not by the differencing.
+    np.testing.assert_allclose(
+        coefficients[name].values, finite_difference, rtol=2e-5
+    )
+
+
+def test_alpha_p_is_per_pascal_not_per_dbar():
+    """Pin the units of ``alpha_p`` directly, in the form that can go wrong."""
+    theta, salinity, pressure = _state()
+    alpha_p = specvol_coefficients(theta, salinity, pressure).alpha_p.values
+
+    step_pa = 1.0e2
+    high = gsw.specvol(
+        salinity.values, theta.values, (pressure.values + step_pa) * 1.0e-4
+    )
+    low = gsw.specvol(
+        salinity.values, theta.values, (pressure.values - step_pa) * 1.0e-4
+    )
+    per_pascal = (high - low) / (2.0 * step_pa)
+
+    np.testing.assert_allclose(alpha_p, per_pascal, rtol=2e-5)
+    # and emphatically not per dbar
+    # atol must be zero: these values are ~4e-13, far below the default
+    # atol, so a default-tolerance comparison passes against anything
+    assert not np.allclose(alpha_p, per_pascal * 1.0e4, rtol=1e-2, atol=0.0)
+
+
+def test_invalid_layers_stay_invalid():
+    """``NaN`` in the state gives ``NaN`` in every coefficient, not a crash."""
+    theta, salinity, pressure = _state()
+    theta = theta.copy()
+    theta[0, 1, 3] = np.nan
+
+    coefficients = specvol_coefficients(theta, salinity, pressure)
+    for name in coefficients.data_vars:
+        values = coefficients[name].values
+        assert np.isnan(values[0, 1, 3])
+        assert np.all(np.isfinite(np.delete(values.ravel(), 7)))
+
+
+def test_mismatched_shapes_are_rejected():
+    theta, salinity, pressure = _state()
+    with pytest.raises(ValueError, match='same shape'):
+        specvol_coefficients(theta, salinity, pressure.isel(nVertLevels=0))
+
+
+# ---------------------------------------------------------------------------
+# The edge-shared expansion
+# ---------------------------------------------------------------------------
+
+
+def test_expansion_is_the_edge_average_of_the_coefficients():
+    """``[edge-ref]``: coefficients and reference state are edge averages."""
+    theta, salinity, pressure = _state()
+    coefficients = specvol_coefficients(theta, salinity, pressure)
+    expansion = edge_expansion(theta, salinity, pressure)
+
+    for name in coefficients.data_vars:
+        expected = 0.5 * (
+            coefficients[name].isel(nCells=0)
+            + coefficients[name].isel(nCells=1)
+        )
+        np.testing.assert_allclose(
+            expansion[name].values, expected.values, rtol=1e-15
+        )
+    for name, field in [
+        ('theta_ref', theta),
+        ('s_ref', salinity),
+        ('p_ref', pressure),
+    ]:
+        expected = 0.5 * (field.isel(nCells=0) + field.isel(nCells=1))
+        np.testing.assert_allclose(
+            expansion[name].values, expected.values, rtol=1e-15
+        )
+    assert 'nCells' not in expansion.dims
+
+
+def test_expansion_is_symmetric_under_swapping_the_columns():
+    """The edge sees one equation of state, so column order cannot matter."""
+    theta, salinity, pressure = _state()
+    forward = edge_expansion(theta, salinity, pressure)
+    swapped = edge_expansion(
+        theta.isel(nCells=[1, 0]),
+        salinity.isel(nCells=[1, 0]),
+        pressure.isel(nCells=[1, 0]),
+    )
+
+    for name in forward.data_vars:
+        np.testing.assert_allclose(
+            forward[name].values, swapped[name].values, rtol=1e-15
+        )
+
+
+def test_edge_specvol_at_the_expansion_point_returns_alpha_0():
+    """Evaluated at its own expansion point the profile returns ``alpha_0``.
+
+    Worth pinning because ``alpha_0`` is the *mean of the two cells' specific
+    volumes*, not specific volume at the mean state; an implementation that
+    conflated the two would still pass a smoothness check.
+    """
+    theta, salinity, pressure = _state()
+    expansion = edge_expansion(theta, salinity, pressure)
+
+    at_reference = edge_specvol(
+        expansion,
+        expansion.theta_ref,
+        expansion.s_ref,
+        expansion.p_ref,
+    )
+    np.testing.assert_allclose(
+        at_reference.values, expansion.alpha_0.values, rtol=1e-15
+    )
+
+
+def test_both_columns_share_one_profile():
+    """The same function of pressure is used on both sides of the edge.
+
+    Condition 1 of §3.7.2.  Evaluating the profile with each column's own state
+    must differ *only* through that state, never through the coefficients, so
+    feeding the two columns identical states must give identical answers even
+    though the expansion was built from a contrast.
+    """
+    theta, salinity, pressure = _state()
+    expansion = edge_expansion(theta, salinity, pressure)
+
+    probe_theta = xr.DataArray(np.full((1, 2, 4), 8.0), dims=_DIMS)
+    probe_salinity = xr.DataArray(np.full((1, 2, 4), 34.9), dims=_DIMS)
+    probe_pressure = xr.DataArray(np.full((1, 2, 4), 1.5e7), dims=_DIMS)
+
+    specvol = edge_specvol(
+        expansion, probe_theta, probe_salinity, probe_pressure
+    )
+    np.testing.assert_allclose(
+        specvol.isel(nCells=0).values,
+        specvol.isel(nCells=1).values,
+        rtol=1e-15,
+    )
+
+
+def test_expansion_reduces_to_the_exact_eos_when_the_columns_coincide():
+    """With identical columns the profile returns exact TEOS-10 at that state.
+
+    Then ``alpha_0`` is the cell's own specific volume and the reference state
+    is the cell's own state, so the second-order remainder that source 4 of the
+    remainder accounts for is identically zero.
+    """
+    theta, salinity, pressure = _state()
+    # isel with a list moves nCells to the end, so put it back
+    uniform = [
+        field.isel(nCells=[0, 0]).transpose(*_DIMS)
+        for field in (theta, salinity, pressure)
+    ]
+    expansion = edge_expansion(*uniform)
+
+    layer_mean = edge_specvol_layer_mean(expansion, *uniform)
+    exact = gsw.specvol(
+        uniform[1].values, uniform[0].values, uniform[2].values * 1.0e-4
+    )
+    np.testing.assert_allclose(layer_mean.values, exact, rtol=1e-15)
+
+
+# ---------------------------------------------------------------------------
+# The layer mean
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('shape', ['linear', 'quadratic'])
+def test_layer_mean_matches_a_direct_average_of_the_profile(shape):
+    """``[alpha-edge-layer-mean]`` equals a numerical average of the profile.
+
+    The identity depends only on the layer *means* of the reconstruction, and
+    not on its shape, because ``[alpha-taylor]`` is linear in its arguments.
+    The quadratic case is the point: a mean-preserving parabola has the same
+    mean as the line, so it must give the same answer, and an implementation
+    that had smuggled in a nonlinear term would fail it while passing the
+    linear
+    case.
+    """
+    theta, salinity, pressure = _state()
+    expansion = edge_expansion(theta, salinity, pressure)
+
+    closed_form = edge_specvol_layer_mean(expansion, theta, salinity, pressure)
+
+    # A mean-preserving profile across one layer, in pressure.  The integrand
+    # is
+    # a polynomial of degree at most 2 in pressure, so a four-point
+    # Gauss-Legendre rule integrates it exactly and the comparison is limited
+    # by
+    # round-off rather than by quadrature -- which a trapezoid rule on the
+    # quadratic case is not, by about 1e-11 relative.
+    thickness = 2.0e6
+    nodes, weights = np.polynomial.legendre.leggauss(4)
+    nodes = 0.5 * nodes
+    weights = 0.5 * weights
+    theta_slope = 3.0e-6  # degC / Pa
+    salinity_slope = 2.0e-8
+
+    direct = np.zeros_like(closed_form.values)
+    for icell in range(2):
+        for level in range(4):
+            centre = pressure.values[0, icell, level]
+            probe = centre + nodes * thickness
+            offset = probe - centre
+            if shape == 'linear':
+                theta_profile = (
+                    theta.values[0, icell, level] + theta_slope * offset
+                )
+                salinity_profile = (
+                    salinity.values[0, icell, level] + salinity_slope * offset
+                )
+            else:
+                # mean-preserving parabola: <offset^2 - h^2/12> = 0
+                bump = offset**2 - thickness**2 / 12.0
+                theta_profile = (
+                    theta.values[0, icell, level] + theta_slope * bump / 1.0e6
+                )
+                salinity_profile = (
+                    salinity.values[0, icell, level]
+                    + salinity_slope * bump / 1.0e6
+                )
+            profile = edge_specvol(
+                expansion.isel(nVertLevels=level, Time=0),
+                xr.DataArray(theta_profile, dims=['probe']),
+                xr.DataArray(salinity_profile, dims=['probe']),
+                xr.DataArray(probe, dims=['probe']),
+            )
+            direct[0, icell, level] = float(np.sum(weights * profile.values))
+
+    np.testing.assert_allclose(direct, closed_form.values, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# On real two-column states: how hard is the expansion being worked?
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'variant, horiz_res, vert_res, tilt',
+    [
+        ('hydrostatic_consistency', 4.0, 256.0, 50.0),
+        ('hydrostatic_consistency_linear', 4.0, 256.0, 50.0),
+        ('bathymetry_step', 4.0, 256.0, 200.0),
+        ('temperature_gradient', 4.0, 4.0, None),
+        ('temperature_gradient', 0.5, 0.5, None),
+        ('salinity_gradient', 4.0, 4.0, None),
+        ('ztilde_gradient', 4.0, 4.0, None),
+        ('surface_pressure_gradient', 4.0, 4.0, None),
+    ],
+)
+def test_second_order_eos_remainder_is_small(
+    variant, horiz_res, vert_res, tilt
+):
+    """The first-order expansion is not being worked beyond its usefulness.
+
+    ``[eos-remainder]`` is the mismatch between each cell's exact specific
+    volume and the layer mean of the edge-shared profile, and §3.5 identifies
+    it
+    as precisely the *second-order* Taylor remainder of the equation of state
+    across the edge.  It is source 4 of the remainder and the direct diagnostic
+    the design asks for against assumption A2 (§3.7.6): if it were not small,
+    the second-order expansion option of §3.3 would be needed.
+
+    Measured relative to specific volume, the largest value over these
+    configurations is 8.0e-6, in ``temperature_gradient`` at 4 km -- a 12 degC
+    contrast across the edge, which is the hardest case in the family. Every
+    other configuration is at 2.8e-9 or below, and the resting-state variants,
+    being horizontally uniform in temperature and salinity, are at 2e-9 or
+    below. The bound here is loose enough not to be a tripwire on round-off and
+    tight enough to catch the expansion being applied across a contrast it
+    cannot represent.
+    """
+    ds = build_state(variant, horiz_res, vert_res, tilt)
+    expansion = edge_expansion(ds.temperature, ds.salinity, ds.pressure)
+    layer_mean = edge_specvol_layer_mean(
+        expansion, ds.temperature, ds.salinity, ds.pressure
+    )
+
+    remainder = (ds.SpecVol - layer_mean) / ds.SpecVol
+    largest = float(np.abs(remainder).max())
+    assert largest < 1.0e-4, (
+        f'{variant} at horiz_res={horiz_res} km, vert_res={vert_res} m, '
+        f'tilt={tilt}: second-order EOS remainder reaches {largest:.3e} of '
+        'specific volume'
+    )
+
+
+def test_eos_remainder_vanishes_without_a_horizontal_contrast():
+    """With no cross-edge contrast the remainder is identically zero.
+
+    Guards the test above: it would pass trivially for an implementation whose
+    remainder was always tiny for the wrong reason.
+    """
+    ds = build_state('hydrostatic_consistency', 4.0, 256.0, 0.05)
+    # force the two columns to coincide exactly
+    uniform = {
+        name: ds[name].isel(nCells=[0, 0]).transpose(*ds[name].dims)
+        for name in ['temperature', 'salinity', 'pressure']
+    }
+    expansion = edge_expansion(**uniform)
+    layer_mean = edge_specvol_layer_mean(expansion, **uniform)
+    exact = specvol_coefficients(**uniform).alpha_0
+
+    difference = float(np.abs((layer_mean - exact)).max())
+    assert difference == 0.0, (
+        f'remainder is {difference:.3e} for two identical columns'
+    )

--- a/tests/ocean/horiz_press_grad/test_finite_volume.py
+++ b/tests/ocean/horiz_press_grad/test_finite_volume.py
@@ -9,13 +9,10 @@ build.  Each builds the same two-column state
 compares the new code against the ``HPGA`` field that step already produces.
 """
 
-import logging
-
 import numpy as np
 import pytest
 import xarray as xr
 
-from polaris.config import PolarisConfigParser
 from polaris.ocean.vertical.ztilde import Gravity
 from polaris.tasks.ocean.horiz_press_grad.column import (
     get_array_from_mid_grad,
@@ -25,35 +22,16 @@ from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
     hpga_from_shift,
     hydrostatic_scale,
 )
-from polaris.tasks.ocean.horiz_press_grad.init import Init
 
-_HPG_PKG = 'polaris.tasks.ocean.horiz_press_grad'
-
-# The resting-state variants and their sweeps.  These are the configurations
-# whose true HPGA is identically zero, so whatever the centered scheme returns
-# there is error, and they are the only ones that sweep a tilt.
-_VARIANTS = [
-    'hydrostatic_consistency',
-    'hydrostatic_consistency_linear',
-    'bathymetry_step',
-]
-
-# The one variant whose profile is linear in pressure, and so the only one in
-# the finite-volume scheme's exact set.
-_LINEAR_VARIANT = 'hydrostatic_consistency_linear'
-
-# The four gradient variants, which sweep resolution rather than tilt.  They
-# add nothing to the algebra but a good deal to the states it is checked on:
-# temperature and salinity contrasts across the edge, pseudo-height nodes that
-# move with x, and -- in surface_pressure_gradient -- a different surface
-# pressure in the two columns, so that Delta_e q is nonzero at the top
-# interface and not only in the interior.
-_GRADIENT_VARIANTS = [
-    'temperature_gradient',
-    'salinity_gradient',
-    'ztilde_gradient',
-    'surface_pressure_gradient',
-]
+from .two_column import (
+    GRADIENT_VARIANTS,
+    LINEAR_VARIANT,
+    VARIANTS,
+    build_state,
+    make_config,
+    resolution_pairs,
+    sweep,
+)
 
 # Machine-precision tolerance, as a multiple of the hydrostatic scale rather
 # than as an absolute number (``PGradHighOrder.md`` §3.7.5).  The largest
@@ -71,90 +49,9 @@ _ROUNDOFF_TOL = 1.0e-14
 # magnitude above this.
 _LINEARITY_TOL = 1.0e-13
 
-# Built states are reused across tests, at roughly 0.25 s each.
-_STATE_CACHE: dict[tuple[str, float, float, float | None], xr.Dataset] = {}
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_config(variant: str) -> PolarisConfigParser:
-    """Load the packaged config for one variant of the task."""
-    config = PolarisConfigParser()
-    config.add_from_package('polaris.ocean', 'ocean.cfg')
-    config.add_from_package(_HPG_PKG, 'horiz_press_grad.cfg')
-    config.add_from_package(_HPG_PKG, f'{variant}.cfg')
-    return config
-
-
-def _sweep(variant: str) -> list[tuple[float, float, float]]:
-    """The ``(horiz_res, vert_res, tilt)`` points of a variant's sweep."""
-    section = _make_config(variant)['horiz_press_grad']
-    horiz_resolutions = section.getexpression('horiz_resolutions')
-    vert_resolutions = section.getexpression('vert_resolutions')
-    tilt_values = section.getexpression('tilt_values')
-    return [
-        (float(horiz_res), float(vert_res), float(tilt))
-        for horiz_res, vert_res in zip(
-            horiz_resolutions, vert_resolutions, strict=True
-        )
-        for tilt in tilt_values
-    ]
-
-
-def _resolution_pairs(variant: str) -> list[tuple[float, float]]:
-    """The coarsest and finest ``(horiz_res, vert_res)`` pairs of a sweep."""
-    section = _make_config(variant)['horiz_press_grad']
-    pairs = [
-        (float(horiz_res), float(vert_res))
-        for horiz_res, vert_res in zip(
-            section.getexpression('horiz_resolutions'),
-            section.getexpression('vert_resolutions'),
-            strict=True,
-        )
-    ]
-    return [pairs[0], pairs[-1]]
-
-
-def _build_state(
-    variant: str, horiz_res: float, vert_res: float, tilt: float | None
-) -> xr.Dataset:
-    """
-    Build (or return a cached) two-column state for one sweep point.
-
-    ``tilt`` is the value of the variant's ``tilt_option``, or ``None`` for the
-    gradient variants, which override no option -- exactly as
-    :py:class:`~polaris.tasks.ocean.horiz_press_grad.task.HorizPressGradTask`
-    constructs the step.
-
-    The Polaris ``Step`` constructor is bypassed, as in
-    ``tests/ocean/vertical/test_pstar_init.py``, so that no component, work
-    directory or config file is needed.
-    """
-    key = (variant, horiz_res, vert_res, tilt)
-    if key in _STATE_CACHE:
-        return _STATE_CACHE[key]
-
-    config = _make_config(variant)
-    step = object.__new__(Init)
-    step.config = config
-    step.logger = logging.getLogger('test_finite_volume')
-    step.horiz_res = horiz_res
-    step.vert_res = vert_res
-    if tilt is None:
-        step.tilt_option = None
-    else:
-        step.tilt_option = config.get('horiz_press_grad', 'tilt_option')
-    step.tilt = tilt
-    step.x = np.array([])
-
-    ds_mesh = xr.Dataset({'xCell': xr.DataArray(np.zeros(2), dims=['nCells'])})
-    ds = step.build_column_state(ds_mesh)
-
-    _STATE_CACHE[key] = ds
-    return ds
 
 
 def _valid_hpga(
@@ -178,7 +75,7 @@ def _valid_hpga(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize('horiz_res, vert_res, tilt', _sweep(_LINEAR_VARIANT))
+@pytest.mark.parametrize('horiz_res, vert_res, tilt', sweep(LINEAR_VARIANT))
 def test_linear_variant_is_in_the_exact_set(horiz_res, vert_res, tilt):
     """``hydrostatic_consistency_linear`` puts the state in the exact set.
 
@@ -199,7 +96,7 @@ def test_linear_variant_is_in_the_exact_set(horiz_res, vert_res, tilt):
     on a configuration that cannot show exactness -- which is finding F-P1, and
     is the case for the curved ``hydrostatic_consistency`` variant.
     """
-    ds = _build_state(_LINEAR_VARIANT, horiz_res, vert_res, tilt)
+    ds = build_state(LINEAR_VARIANT, horiz_res, vert_res, tilt)
 
     for field in ['temperature', 'salinity']:
         # tolerances are relative to the size of the values being differenced,
@@ -249,7 +146,7 @@ def test_linear_variant_is_in_the_exact_set(horiz_res, vert_res, tilt):
 
 @pytest.mark.parametrize(
     'variant, horiz_res, vert_res, tilt',
-    [(variant, *point) for variant in _VARIANTS for point in _sweep(variant)],
+    [(variant, *point) for variant in VARIANTS for point in sweep(variant)],
 )
 def test_centered_shift_reproduces_centered_hpga(
     variant, horiz_res, vert_res, tilt
@@ -267,7 +164,7 @@ def test_centered_shift_reproduces_centered_hpga(
     Run at every tilt because the identity is claimed to be exact at any tilt;
     a single-tilt check could pass by coincidence.
     """
-    ds = _build_state(variant, horiz_res, vert_res, tilt)
+    ds = build_state(variant, horiz_res, vert_res, tilt)
     hpga, reference, tol = _valid_hpga(ds, horiz_res)
 
     max_diff = float(np.max(np.abs(hpga - reference)))
@@ -282,8 +179,8 @@ def test_centered_shift_reproduces_centered_hpga(
     'variant, horiz_res, vert_res',
     [
         (variant, *pair)
-        for variant in _GRADIENT_VARIANTS
-        for pair in _resolution_pairs(variant)
+        for variant in GRADIENT_VARIANTS
+        for pair in resolution_pairs(variant)
     ],
 )
 def test_centered_shift_with_horizontal_structure(
@@ -299,7 +196,7 @@ def test_centered_shift_with_horizontal_structure(
     The identity is algebraic and should not care, which is the point of
     checking.
     """
-    ds = _build_state(variant, horiz_res, vert_res, None)
+    ds = build_state(variant, horiz_res, vert_res, None)
     hpga, reference, tol = _valid_hpga(ds, horiz_res)
 
     max_diff = float(np.max(np.abs(hpga - reference)))
@@ -312,11 +209,11 @@ def test_centered_shift_with_horizontal_structure(
 
 @pytest.mark.parametrize(
     'variant, horiz_res, vert_res, tilt',
-    [(variant, *point) for variant in _VARIANTS for point in _sweep(variant)]
+    [(variant, *point) for variant in VARIANTS for point in sweep(variant)]
     + [
         (variant, *pair, None)
-        for variant in _GRADIENT_VARIANTS
-        for pair in _resolution_pairs(variant)
+        for variant in GRADIENT_VARIANTS
+        for pair in resolution_pairs(variant)
     ],
 )
 def test_state_is_valid_exactly_where_the_column_is(
@@ -336,7 +233,7 @@ def test_state_is_valid_exactly_where_the_column_is(
     ``get_pchip_layer_mean`` removed, this test fires on
     ``temperature_gradient`` while every other test in this file still passes.
     """
-    ds = _build_state(variant, horiz_res, vert_res, tilt)
+    ds = build_state(variant, horiz_res, vert_res, tilt)
 
     level = xr.DataArray(
         np.arange(ds.sizes['nVertLevels']), dims=['nVertLevels']
@@ -356,7 +253,7 @@ def test_state_is_valid_exactly_where_the_column_is(
         )
 
     # a mean of a monotone profile cannot leave the range of its own nodes
-    config = _make_config(variant)
+    config = make_config(variant)
     x = horiz_res * np.array([-0.5, 0.5])
     for field in ['temperature', 'salinity']:
         nodes = get_array_from_mid_grad(config, field, x)
@@ -368,7 +265,7 @@ def test_state_is_valid_exactly_where_the_column_is(
             assert column.max() <= nodes[icell, :].max() + 1e-10
 
 
-@pytest.mark.parametrize('variant', _VARIANTS)
+@pytest.mark.parametrize('variant', VARIANTS)
 def test_centered_shift_grows_with_tilt(variant):
     """``S`` is not identically zero and grows with tilt.
 
@@ -381,7 +278,7 @@ def test_centered_shift_grows_with_tilt(variant):
     itself declares the response a staircase rather than a power law.  Across
     the whole sweep only overall growth is required.
     """
-    config = _make_config(variant)
+    config = make_config(variant)
     section = config['horiz_press_grad']
     horiz_res = float(section.getexpression('horiz_resolutions')[0])
     vert_res = float(section.getexpression('vert_resolutions')[0])
@@ -391,7 +288,7 @@ def test_centered_shift_grows_with_tilt(variant):
 
     rms = []
     for tilt in tilts:
-        ds = _build_state(variant, horiz_res, vert_res, tilt)
+        ds = build_state(variant, horiz_res, vert_res, tilt)
         hpga, _, _ = _valid_hpga(ds, horiz_res)
         rms.append(float(np.sqrt(np.mean(hpga**2))))
 

--- a/tests/ocean/horiz_press_grad/test_finite_volume.py
+++ b/tests/ocean/horiz_press_grad/test_finite_volume.py
@@ -5,8 +5,8 @@ configurations.
 All tests are self-contained: no file I/O, no mesh generation and no Omega
 build.  Each builds the same two-column state
 :py:class:`~polaris.tasks.ocean.horiz_press_grad.init.Init` writes to
-``init.nc``, from the packaged config of a resting-state variant, and compares
-the new code against the ``HPGA`` field that step already produces.
+``init.nc``, from the packaged config of one of the task's variants, and
+compares the new code against the ``HPGA`` field that step already produces.
 """
 
 import logging
@@ -17,6 +17,9 @@ import xarray as xr
 
 from polaris.config import PolarisConfigParser
 from polaris.ocean.vertical.ztilde import Gravity
+from polaris.tasks.ocean.horiz_press_grad.column import (
+    get_array_from_mid_grad,
+)
 from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
     centered_shift,
     hpga_from_shift,
@@ -63,7 +66,7 @@ _STATE_CACHE: dict[tuple[str, float, float, float | None], xr.Dataset] = {}
 
 
 def _make_config(variant: str) -> PolarisConfigParser:
-    """Load the packaged config for one resting-state variant."""
+    """Load the packaged config for one variant of the task."""
     config = PolarisConfigParser()
     config.add_from_package('polaris.ocean', 'ocean.cfg')
     config.add_from_package(_HPG_PKG, 'horiz_press_grad.cfg')
@@ -221,6 +224,64 @@ def test_centered_shift_with_horizontal_structure(
         f'max |S-derived HPGA - Init HPGA| = {max_diff:.3e} m s-2 exceeds '
         f'{tol:.3e} m s-2'
     )
+
+
+@pytest.mark.parametrize(
+    'variant, horiz_res, vert_res, tilt',
+    [(variant, *point) for variant in _VARIANTS for point in _sweep(variant)]
+    + [
+        (variant, *pair, None)
+        for variant in _GRADIENT_VARIANTS
+        for pair in _resolution_pairs(variant)
+    ],
+)
+def test_state_is_valid_exactly_where_the_column_is(
+    variant, horiz_res, vert_res, tilt
+):
+    """Temperature and salinity are finite in every valid layer and no others.
+
+    The layer means are taken over each layer's two interfaces, and in every
+    configuration the outermost interfaces sit on the outermost profile nodes
+    up to round-off -- the column is summed upward from the sea floor, so
+    whether the top interface lands just inside or just outside its node is the
+    sign of a round-off error.  Landing outside yields a NaN there, which then
+    feeds back through the p-star iteration and corrupts the whole column.  The
+    corruption is silent: the HPGA identity above still holds on a corrupted
+    state, since both sides are computed from it, and the masked comparison
+    simply skips the NaN.  Measured with the clipping in
+    ``get_pchip_layer_mean`` removed, this test fires on
+    ``temperature_gradient`` while every other test in this file still passes.
+    """
+    ds = _build_state(variant, horiz_res, vert_res, tilt)
+
+    level = xr.DataArray(
+        np.arange(ds.sizes['nVertLevels']), dims=['nVertLevels']
+    )
+    # minLevelCell and maxLevelCell are 1-based
+    expected = np.logical_and(
+        level >= ds.minLevelCell - 1, level <= ds.maxLevelCell - 1
+    )
+
+    for field in ['temperature', 'salinity', 'SpecVol']:
+        finite = np.isfinite(ds[field].isel(Time=0))
+        assert bool((finite == expected).all()), (
+            f'{variant} at horiz_res={horiz_res} km, vert_res={vert_res} m, '
+            f'tilt={tilt}: {field} is finite in '
+            f'{int(finite.sum())} layers but the columns span '
+            f'{int(expected.sum())}'
+        )
+
+    # a mean of a monotone profile cannot leave the range of its own nodes
+    config = _make_config(variant)
+    x = horiz_res * np.array([-0.5, 0.5])
+    for field in ['temperature', 'salinity']:
+        nodes = get_array_from_mid_grad(config, field, x)
+        values = ds[field].isel(Time=0).values
+        for icell in range(ds.sizes['nCells']):
+            column = values[icell, :]
+            column = column[np.isfinite(column)]
+            assert column.min() >= nodes[icell, :].min() - 1e-10
+            assert column.max() <= nodes[icell, :].max() + 1e-10
 
 
 @pytest.mark.parametrize('variant', _VARIANTS)

--- a/tests/ocean/horiz_press_grad/test_finite_volume.py
+++ b/tests/ocean/horiz_press_grad/test_finite_volume.py
@@ -28,6 +28,7 @@ from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
 from .two_column import (
     GRADIENT_VARIANTS,
     LINEAR_VARIANT,
+    REPRESENTATIVE,
     VARIANTS,
     build_state,
     make_config,
@@ -78,7 +79,10 @@ def _valid_hpga(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize('horiz_res, vert_res, tilt', sweep(LINEAR_VARIANT))
+@pytest.mark.parametrize(
+    'horiz_res, vert_res, tilt',
+    [point[1:] for point in REPRESENTATIVE if point[0] == LINEAR_VARIANT],
+)
 def test_linear_variant_is_in_the_exact_set(horiz_res, vert_res, tilt):
     """``hydrostatic_consistency_linear`` puts the state in the exact set.
 
@@ -213,15 +217,7 @@ def test_centered_shift_with_horizontal_structure(
     )
 
 
-@pytest.mark.parametrize(
-    'variant, horiz_res, vert_res, tilt',
-    [(variant, *point) for variant in VARIANTS for point in sweep(variant)]
-    + [
-        (variant, *pair, None)
-        for variant in GRADIENT_VARIANTS
-        for pair in resolution_pairs(variant)
-    ],
-)
+@pytest.mark.parametrize('variant, horiz_res, vert_res, tilt', REPRESENTATIVE)
 def test_state_is_valid_exactly_where_the_column_is(
     variant, horiz_res, vert_res, tilt
 ):

--- a/tests/ocean/horiz_press_grad/test_finite_volume.py
+++ b/tests/ocean/horiz_press_grad/test_finite_volume.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for the ``FiniteVolume`` HPGA of the two-column ``horiz_press_grad``
+configurations.
+
+All tests are self-contained: no file I/O, no mesh generation and no Omega
+build.  Each builds the same two-column state
+:py:class:`~polaris.tasks.ocean.horiz_press_grad.init.Init` writes to
+``init.nc``, from the packaged config of a resting-state variant, and compares
+the new code against the ``HPGA`` field that step already produces.
+"""
+
+import logging
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.config import PolarisConfigParser
+from polaris.ocean.vertical.ztilde import Gravity
+from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
+    centered_shift,
+    hpga_from_shift,
+    hydrostatic_scale,
+)
+from polaris.tasks.ocean.horiz_press_grad.init import Init
+
+_HPG_PKG = 'polaris.tasks.ocean.horiz_press_grad'
+
+# The resting-state variants and their sweeps.  These are the configurations
+# whose true HPGA is identically zero, so whatever the centered scheme returns
+# there is error, and they are the only ones that sweep a tilt.
+_VARIANTS = ['hydrostatic_consistency', 'bathymetry_step']
+
+# Machine-precision tolerance, as a multiple of the hydrostatic scale rather
+# than as an absolute number (``PGradHighOrder.md`` §3.7.5).  The largest
+# discrepancy measured over the two sweeps is 0.45 * eps of that scale, so this
+# leaves a factor of ~100.  It is still far from vacuous: the closest plausible
+# mis-derivation tried -- a cell-local rather than edge-averaged specific
+# volume -- misses by 700 times this tolerance at the smallest tilt in the
+# sweep, and dropping the pressure term misses by 1e9 times it.
+_ROUNDOFF_TOL = 1.0e-14
+
+# Built states are reused across tests: 42 sweep points at ~0.25 s each.
+_STATE_CACHE: dict[tuple[str, float, float, float], xr.Dataset] = {}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(variant: str) -> PolarisConfigParser:
+    """Load the packaged config for one resting-state variant."""
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.ocean', 'ocean.cfg')
+    config.add_from_package(_HPG_PKG, 'horiz_press_grad.cfg')
+    config.add_from_package(_HPG_PKG, f'{variant}.cfg')
+    return config
+
+
+def _sweep(variant: str) -> list[tuple[float, float, float]]:
+    """The ``(horiz_res, vert_res, tilt)`` points of a variant's sweep."""
+    section = _make_config(variant)['horiz_press_grad']
+    horiz_resolutions = section.getexpression('horiz_resolutions')
+    vert_resolutions = section.getexpression('vert_resolutions')
+    tilt_values = section.getexpression('tilt_values')
+    return [
+        (float(horiz_res), float(vert_res), float(tilt))
+        for horiz_res, vert_res in zip(
+            horiz_resolutions, vert_resolutions, strict=True
+        )
+        for tilt in tilt_values
+    ]
+
+
+def _build_state(
+    variant: str, horiz_res: float, vert_res: float, tilt: float
+) -> xr.Dataset:
+    """
+    Build (or return a cached) two-column state for one sweep point.
+
+    The Polaris ``Step`` constructor is bypassed, as in
+    ``tests/ocean/vertical/test_pstar_init.py``, so that no component, work
+    directory or config file is needed.
+    """
+    key = (variant, horiz_res, vert_res, tilt)
+    if key in _STATE_CACHE:
+        return _STATE_CACHE[key]
+
+    config = _make_config(variant)
+    step = object.__new__(Init)
+    step.config = config
+    step.logger = logging.getLogger('test_finite_volume')
+    step.horiz_res = horiz_res
+    step.vert_res = vert_res
+    step.tilt_option = config.get('horiz_press_grad', 'tilt_option')
+    step.tilt = tilt
+    step.x = np.array([])
+
+    ds_mesh = xr.Dataset({'xCell': xr.DataArray(np.zeros(2), dims=['nCells'])})
+    ds = step.build_column_state(ds_mesh)
+
+    _STATE_CACHE[key] = ds
+    return ds
+
+
+def _valid_hpga(
+    ds: xr.Dataset, horiz_res: float
+) -> tuple[np.ndarray, np.ndarray, float]:
+    """
+    Return the HPGA from ``centered_shift``, the HPGA the ``Init`` step wrote,
+    and the round-off tolerance, over the layers valid in both columns.
+    """
+    dx = 1e3 * horiz_res
+    hpga = hpga_from_shift(centered_shift(ds), dx)
+    reference = ds.HPGA
+    valid = np.logical_and(np.isfinite(hpga), np.isfinite(reference))
+    assert int(valid.sum()) > 0, 'no layer is valid in both columns'
+    tol = _ROUNDOFF_TOL * (Gravity / dx) * hydrostatic_scale(ds)
+    return hpga.values[valid.values], reference.values[valid.values], tol
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'variant, horiz_res, vert_res, tilt',
+    [(variant, *point) for variant in _VARIANTS for point in _sweep(variant)],
+)
+def test_centered_shift_reproduces_centered_hpga(
+    variant, horiz_res, vert_res, tilt
+):
+    """``-(g / d_e) * S`` is the centered HPGA, at every point in the sweep.
+
+    This is the design's ``[centered-shift]`` identity: the centered scheme's
+    Montgomery-potential apparatus is nothing but the first-order conversion
+    from a height difference at fixed layer index to one at fixed pressure.
+    The whole of the decomposition ``T^p = -(g/d_e)(S + R)`` rests on it, so it
+    is checked against the answer ``Init`` already produces -- including that
+    step's convention that the mid-layer Montgomery potential is the mean of
+    the two interface values, which is what makes the identity hold.
+
+    Run at every tilt because the identity is claimed to be exact at any tilt;
+    a single-tilt check could pass by coincidence.
+    """
+    ds = _build_state(variant, horiz_res, vert_res, tilt)
+    hpga, reference, tol = _valid_hpga(ds, horiz_res)
+
+    max_diff = float(np.max(np.abs(hpga - reference)))
+    assert max_diff <= tol, (
+        f'{variant} at horiz_res={horiz_res} km, vert_res={vert_res} m, '
+        f'tilt={tilt} m/km: max |S-derived HPGA - Init HPGA| = '
+        f'{max_diff:.3e} m s-2 exceeds {tol:.3e} m s-2'
+    )
+
+
+@pytest.mark.parametrize('variant', _VARIANTS)
+def test_centered_shift_grows_with_tilt(variant):
+    """``S`` is not identically zero and grows with tilt.
+
+    Guard (a) of ``PGradHighOrder.md`` §5.2, and the check that the identity
+    above has content: a scheme that returned zero, or that had become
+    insensitive to tilt, would satisfy the identity trivially.
+
+    Strict monotonicity is asserted only up to ``tilt_fit_max``, beyond which
+    the two columns' ``maxLevelCell`` values start to differ and the config
+    itself declares the response a staircase rather than a power law.  Across
+    the whole sweep only overall growth is required.
+    """
+    config = _make_config(variant)
+    section = config['horiz_press_grad']
+    horiz_res = float(section.getexpression('horiz_resolutions')[0])
+    vert_res = float(section.getexpression('vert_resolutions')[0])
+    tilts = [float(tilt) for tilt in section.getexpression('tilt_values')]
+    tilt_fit = section.getboolean('tilt_fit')
+    tilt_fit_max = section.getfloat('tilt_fit_max')
+
+    rms = []
+    for tilt in tilts:
+        ds = _build_state(variant, horiz_res, vert_res, tilt)
+        hpga, _, _ = _valid_hpga(ds, horiz_res)
+        rms.append(float(np.sqrt(np.mean(hpga**2))))
+
+    for tilt, value in zip(tilts, rms, strict=True):
+        assert value > 0.0, (
+            f'{variant}: RMS HPGA from S is zero at tilt={tilt} m/km'
+        )
+
+    assert rms[-1] > rms[0], (
+        f'{variant}: RMS HPGA from S does not grow across the tilt sweep, '
+        f'{rms[0]:.3e} at tilt={tilts[0]} to {rms[-1]:.3e} at '
+        f'tilt={tilts[-1]} m/km'
+    )
+
+    if not tilt_fit:
+        return
+
+    fit_range = [
+        (tilt, value)
+        for tilt, value in zip(tilts, rms, strict=True)
+        if tilt <= tilt_fit_max
+    ]
+    for (tilt, value), (next_tilt, next_value) in zip(
+        fit_range[:-1], fit_range[1:], strict=True
+    ):
+        assert next_value > value, (
+            f'{variant}: RMS HPGA from S does not increase from '
+            f'tilt={tilt} ({value:.3e}) to tilt={next_tilt} '
+            f'({next_value:.3e} m s-2)'
+        )

--- a/tests/ocean/horiz_press_grad/test_finite_volume.py
+++ b/tests/ocean/horiz_press_grad/test_finite_volume.py
@@ -32,7 +32,15 @@ _HPG_PKG = 'polaris.tasks.ocean.horiz_press_grad'
 # The resting-state variants and their sweeps.  These are the configurations
 # whose true HPGA is identically zero, so whatever the centered scheme returns
 # there is error, and they are the only ones that sweep a tilt.
-_VARIANTS = ['hydrostatic_consistency', 'bathymetry_step']
+_VARIANTS = [
+    'hydrostatic_consistency',
+    'hydrostatic_consistency_linear',
+    'bathymetry_step',
+]
+
+# The one variant whose profile is linear in pressure, and so the only one in
+# the finite-volume scheme's exact set.
+_LINEAR_VARIANT = 'hydrostatic_consistency_linear'
 
 # The four gradient variants, which sweep resolution rather than tilt.  They
 # add nothing to the algebra but a good deal to the states it is checked on:
@@ -55,6 +63,13 @@ _GRADIENT_VARIANTS = [
 # specific volume -- misses by 700 times this tolerance at the smallest tilt in
 # the sweep, and dropping the pressure term misses by 1e9 times it.
 _ROUNDOFF_TOL = 1.0e-14
+
+# Tolerance for "exactly linear in pressure", relative to the magnitude of the
+# field.  The largest departure measured over the linear variant's sweep is
+# 2.3 * eps, so this leaves a factor of ~200; a genuinely curved profile like
+# hydrostatic_consistency's departs by ~3e-3 of its salinity, ten orders of
+# magnitude above this.
+_LINEARITY_TOL = 1.0e-13
 
 # Built states are reused across tests, at roughly 0.25 s each.
 _STATE_CACHE: dict[tuple[str, float, float, float | None], xr.Dataset] = {}
@@ -161,6 +176,75 @@ def _valid_hpga(
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('horiz_res, vert_res, tilt', _sweep(_LINEAR_VARIANT))
+def test_linear_variant_is_in_the_exact_set(horiz_res, vert_res, tilt):
+    """``hydrostatic_consistency_linear`` puts the state in the exact set.
+
+    Two conditions have to hold, and they are different claims:
+
+    1. In each column, the layer-mean temperature and salinity are exactly
+       linear functions of the layer-mean pressure.  This is what a linear
+       mean-preserving reconstruction can reproduce exactly, and it is what
+       makes ``PGradHighOrder.md`` §3.7.3's "linear in pressure" row apply.
+    2. The two columns give the *same* line.  This is the condition that
+       actually matters (§3.7.2, condition 1): the two columns must describe
+       one water column as a function of pressure, however differently their
+       layers are distributed.  It holds here even at large tilt, where the
+       two columns' layer means differ substantially, because the map from
+       pressure to state is universal.
+
+    Without this test the exactness measurement in a later commit could be run
+    on a configuration that cannot show exactness -- which is finding F-P1, and
+    is the case for the curved ``hydrostatic_consistency`` variant.
+    """
+    ds = _build_state(_LINEAR_VARIANT, horiz_res, vert_res, tilt)
+
+    for field in ['temperature', 'salinity']:
+        # tolerances are relative to the size of the values being differenced,
+        # not to the profile's range, since that is what sets the round-off
+        lines = []
+        ranges = []
+        magnitude = float(np.abs(ds[field]).max())
+        tol = _LINEARITY_TOL * magnitude
+
+        for icell in range(ds.sizes['nCells']):
+            pressure = ds.pressure.isel(Time=0, nCells=icell).values
+            values = ds[field].isel(Time=0, nCells=icell).values
+            valid = np.logical_and(np.isfinite(pressure), np.isfinite(values))
+            pressure = pressure[valid]
+            values = values[valid]
+            assert len(pressure) >= 3
+
+            # the line through the shallowest and deepest valid layers
+            slope = (values[-1] - values[0]) / (pressure[-1] - pressure[0])
+
+            def line(at, values=values, pressure=pressure, slope=slope):
+                return values[0] + slope * (at - pressure[0])
+
+            residual = float(np.max(np.abs(values - line(pressure))))
+            assert residual <= tol, (
+                f'{field} in column {icell} at vert_res={vert_res} m, '
+                f'tilt={tilt} m/km departs from a line in pressure by '
+                f'{residual:.3e}, more than {tol:.3e}'
+            )
+            lines.append(line)
+            ranges.append((pressure[0], pressure[-1]))
+
+        # The two columns must describe the same function of pressure.  Compare
+        # the two lines over the pressures both columns span, rather than
+        # comparing slopes and intercepts, so the check is in the units of the
+        # field and does not amplify by an extrapolation distance.
+        low = max(ranges[0][0], ranges[1][0])
+        high = min(ranges[0][1], ranges[1][1])
+        probe = np.array([low, 0.5 * (low + high), high])
+        disagreement = float(np.max(np.abs(lines[0](probe) - lines[1](probe))))
+        assert disagreement <= tol, (
+            f'{field} at vert_res={vert_res} m, tilt={tilt} m/km: the two '
+            f'columns describe functions of pressure differing by '
+            f'{disagreement:.3e}, more than {tol:.3e}'
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/ocean/horiz_press_grad/test_finite_volume.py
+++ b/tests/ocean/horiz_press_grad/test_finite_volume.py
@@ -31,17 +31,30 @@ _HPG_PKG = 'polaris.tasks.ocean.horiz_press_grad'
 # there is error, and they are the only ones that sweep a tilt.
 _VARIANTS = ['hydrostatic_consistency', 'bathymetry_step']
 
+# The four gradient variants, which sweep resolution rather than tilt.  They
+# add nothing to the algebra but a good deal to the states it is checked on:
+# temperature and salinity contrasts across the edge, pseudo-height nodes that
+# move with x, and -- in surface_pressure_gradient -- a different surface
+# pressure in the two columns, so that Delta_e q is nonzero at the top
+# interface and not only in the interior.
+_GRADIENT_VARIANTS = [
+    'temperature_gradient',
+    'salinity_gradient',
+    'ztilde_gradient',
+    'surface_pressure_gradient',
+]
+
 # Machine-precision tolerance, as a multiple of the hydrostatic scale rather
 # than as an absolute number (``PGradHighOrder.md`` §3.7.5).  The largest
-# discrepancy measured over the two sweeps is 0.45 * eps of that scale, so this
-# leaves a factor of ~100.  It is still far from vacuous: the closest plausible
-# mis-derivation tried -- a cell-local rather than edge-averaged specific
-# volume -- misses by 700 times this tolerance at the smallest tilt in the
-# sweep, and dropping the pressure term misses by 1e9 times it.
+# discrepancy measured over every state below is 0.5 * eps of that scale, so
+# this leaves a factor of ~90.  It is still far from vacuous: the closest
+# plausible mis-derivation tried -- a cell-local rather than an edge-averaged
+# specific volume -- misses by 700 times this tolerance at the smallest tilt in
+# the sweep, and dropping the pressure term misses by 1e9 times it.
 _ROUNDOFF_TOL = 1.0e-14
 
-# Built states are reused across tests: 42 sweep points at ~0.25 s each.
-_STATE_CACHE: dict[tuple[str, float, float, float], xr.Dataset] = {}
+# Built states are reused across tests, at roughly 0.25 s each.
+_STATE_CACHE: dict[tuple[str, float, float, float | None], xr.Dataset] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -73,11 +86,30 @@ def _sweep(variant: str) -> list[tuple[float, float, float]]:
     ]
 
 
+def _resolution_pairs(variant: str) -> list[tuple[float, float]]:
+    """The coarsest and finest ``(horiz_res, vert_res)`` pairs of a sweep."""
+    section = _make_config(variant)['horiz_press_grad']
+    pairs = [
+        (float(horiz_res), float(vert_res))
+        for horiz_res, vert_res in zip(
+            section.getexpression('horiz_resolutions'),
+            section.getexpression('vert_resolutions'),
+            strict=True,
+        )
+    ]
+    return [pairs[0], pairs[-1]]
+
+
 def _build_state(
-    variant: str, horiz_res: float, vert_res: float, tilt: float
+    variant: str, horiz_res: float, vert_res: float, tilt: float | None
 ) -> xr.Dataset:
     """
     Build (or return a cached) two-column state for one sweep point.
+
+    ``tilt`` is the value of the variant's ``tilt_option``, or ``None`` for the
+    gradient variants, which override no option -- exactly as
+    :py:class:`~polaris.tasks.ocean.horiz_press_grad.task.HorizPressGradTask`
+    constructs the step.
 
     The Polaris ``Step`` constructor is bypassed, as in
     ``tests/ocean/vertical/test_pstar_init.py``, so that no component, work
@@ -93,7 +125,10 @@ def _build_state(
     step.logger = logging.getLogger('test_finite_volume')
     step.horiz_res = horiz_res
     step.vert_res = vert_res
-    step.tilt_option = config.get('horiz_press_grad', 'tilt_option')
+    if tilt is None:
+        step.tilt_option = None
+    else:
+        step.tilt_option = config.get('horiz_press_grad', 'tilt_option')
     step.tilt = tilt
     step.x = np.array([])
 
@@ -153,6 +188,38 @@ def test_centered_shift_reproduces_centered_hpga(
         f'{variant} at horiz_res={horiz_res} km, vert_res={vert_res} m, '
         f'tilt={tilt} m/km: max |S-derived HPGA - Init HPGA| = '
         f'{max_diff:.3e} m s-2 exceeds {tol:.3e} m s-2'
+    )
+
+
+@pytest.mark.parametrize(
+    'variant, horiz_res, vert_res',
+    [
+        (variant, *pair)
+        for variant in _GRADIENT_VARIANTS
+        for pair in _resolution_pairs(variant)
+    ],
+)
+def test_centered_shift_with_horizontal_structure(
+    variant, horiz_res, vert_res
+):
+    """The same identity on the four gradient variants.
+
+    The resting-state configurations are horizontally uniform in temperature
+    and salinity, and their surface pressure is the same in both columns, so
+    ``Delta_e q`` vanishes at the top interface there.  These configurations
+    put horizontal structure in the state instead, and
+    ``surface_pressure_gradient`` differs in surface pressure across the edge.
+    The identity is algebraic and should not care, which is the point of
+    checking.
+    """
+    ds = _build_state(variant, horiz_res, vert_res, None)
+    hpga, reference, tol = _valid_hpga(ds, horiz_res)
+
+    max_diff = float(np.max(np.abs(hpga - reference)))
+    assert max_diff <= tol, (
+        f'{variant} at horiz_res={horiz_res} km, vert_res={vert_res} m: '
+        f'max |S-derived HPGA - Init HPGA| = {max_diff:.3e} m s-2 exceeds '
+        f'{tol:.3e} m s-2'
     )
 
 

--- a/tests/ocean/horiz_press_grad/test_finite_volume.py
+++ b/tests/ocean/horiz_press_grad/test_finite_volume.py
@@ -13,14 +13,16 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from polaris.ocean.vertical.ztilde import Gravity
+from polaris.ocean.vertical.ztilde import Gravity, RhoSw
 from polaris.tasks.ocean.horiz_press_grad.column import (
     get_array_from_mid_grad,
 )
 from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
     centered_shift,
+    centered_shift_accumulated,
     hpga_from_shift,
     hydrostatic_scale,
+    shift_increments,
 )
 
 from .two_column import (
@@ -60,6 +62,7 @@ def _valid_hpga(
     """
     Return the HPGA from ``centered_shift``, the HPGA the ``Init`` step wrote,
     and the round-off tolerance, over the layers valid in both columns.
+
     """
     dx = 1e3 * horiz_res
     hpga = hpga_from_shift(centered_shift(ds), dx)
@@ -95,6 +98,7 @@ def test_linear_variant_is_in_the_exact_set(horiz_res, vert_res, tilt):
     Without this test the exactness measurement in a later commit could be run
     on a configuration that cannot show exactness -- which is finding F-P1, and
     is the case for the curved ``hydrostatic_consistency`` variant.
+
     """
     ds = build_state(LINEAR_VARIANT, horiz_res, vert_res, tilt)
 
@@ -163,6 +167,7 @@ def test_centered_shift_reproduces_centered_hpga(
 
     Run at every tilt because the identity is claimed to be exact at any tilt;
     a single-tilt check could pass by coincidence.
+
     """
     ds = build_state(variant, horiz_res, vert_res, tilt)
     hpga, reference, tol = _valid_hpga(ds, horiz_res)
@@ -195,6 +200,7 @@ def test_centered_shift_with_horizontal_structure(
     ``surface_pressure_gradient`` differs in surface pressure across the edge.
     The identity is algebraic and should not care, which is the point of
     checking.
+
     """
     ds = build_state(variant, horiz_res, vert_res, None)
     hpga, reference, tol = _valid_hpga(ds, horiz_res)
@@ -232,6 +238,7 @@ def test_state_is_valid_exactly_where_the_column_is(
     simply skips the NaN.  Measured with the clipping in
     ``get_pchip_layer_mean`` removed, this test fires on
     ``temperature_gradient`` while every other test in this file still passes.
+
     """
     ds = build_state(variant, horiz_res, vert_res, tilt)
 
@@ -277,6 +284,7 @@ def test_centered_shift_grows_with_tilt(variant):
     the two columns' ``maxLevelCell`` values start to differ and the config
     itself declares the response a staircase rather than a power law.  Across
     the whole sweep only overall growth is required.
+
     """
     config = make_config(variant)
     section = config['horiz_press_grad']
@@ -318,4 +326,231 @@ def test_centered_shift_grows_with_tilt(variant):
             f'{variant}: RMS HPGA from S does not increase from '
             f'tilt={tilt} ({value:.3e}) to tilt={next_tilt} '
             f'({next_value:.3e} m s-2)'
+        )
+
+
+# ---------------------------------------------------------------------------
+# 9d: the cancellation-free accumulation
+# ---------------------------------------------------------------------------
+
+# A representative handful of states rather than the full sweeps: the identity
+# these check is state-independent, and the sweeps are already covered above.
+_ACCUMULATION_CASES = [
+    ('hydrostatic_consistency', 4.0, 256.0, 50.0),
+    ('hydrostatic_consistency', 4.0, 64.0, 50.0),
+    ('hydrostatic_consistency_linear', 4.0, 256.0, 0.05),
+    ('bathymetry_step', 4.0, 128.0, 200.0),
+    ('temperature_gradient', 4.0, 4.0, None),
+]
+
+
+@pytest.mark.parametrize(
+    'variant, horiz_res, vert_res, tilt', _ACCUMULATION_CASES
+)
+def test_accumulated_shift_matches_the_direct_form(
+    variant, horiz_res, vert_res, tilt
+):
+    """``[gamma-increments]`` reproduces ``[centered-shift]`` to round-off.
+
+    The two evaluate the same quantity in a different order, so §3.9's
+    reduction to the centered scheme becomes algebraic rather than bit-for-bit
+    -- the trade §3.5.1 accepts in exchange for never forming the two large
+    terms.
+    """
+    ds = build_state(variant, horiz_res, vert_res, tilt)
+    direct = centered_shift(ds)
+    accumulated = centered_shift_accumulated(ds)
+
+    valid = np.logical_and(
+        np.isfinite(direct.values), np.isfinite(accumulated.values)
+    )
+    difference = float(np.max(np.abs((direct - accumulated).values[valid])))
+    tolerance = _ROUNDOFF_TOL * hydrostatic_scale(ds)
+    assert difference <= tolerance, (
+        f'{variant} at vert_res={vert_res} m, tilt={tilt}: accumulated and '
+        f'direct forms of S differ by {difference:.3e} m, more than '
+        f'{tolerance:.3e} m'
+    )
+
+
+@pytest.mark.parametrize(
+    'variant, horiz_res, vert_res, tilt', _ACCUMULATION_CASES
+)
+def test_both_anchors_agree(variant, horiz_res, vert_res, tilt):
+    """Accumulating from the surface or from the bathymetry gives the same S.
+
+    §3.7.4 leaves the choice of end open, calling it a round-off question
+    rather than a consistency one.  This settles it by measurement for double
+    precision: the two agree to round-off, so the choice is free here.
+    """
+    ds = build_state(variant, horiz_res, vert_res, tilt)
+    from_surface = centered_shift_accumulated(ds, anchor='surface')
+    from_bathymetry = centered_shift_accumulated(ds, anchor='bathymetry')
+
+    valid = np.logical_and(
+        np.isfinite(from_surface.values), np.isfinite(from_bathymetry.values)
+    )
+    difference = float(
+        np.max(np.abs((from_surface - from_bathymetry).values[valid]))
+    )
+    tolerance = _ROUNDOFF_TOL * hydrostatic_scale(ds)
+    assert difference <= tolerance, (
+        f'{variant} at vert_res={vert_res} m, tilt={tilt}: the two anchors '
+        f'differ by {difference:.3e} m, more than {tolerance:.3e} m'
+    )
+
+
+@pytest.mark.parametrize(
+    'variant, horiz_res, vert_res, tilt', _ACCUMULATION_CASES
+)
+def test_increments_are_small_against_the_terms_they_replace(
+    variant, horiz_res, vert_res, tilt
+):
+    """Deliverable D7: how much precision the accumulation actually saves.
+
+    ``[centered-shift]`` differences ``Delta_e Z`` directly, which reaches 160
+    m
+    at 50 m/km of tilt.  The increments of ``[gamma-increments]`` are products
+    of a small factor with a bounded one, so they are far smaller, and the
+    ratio is the quantitative form of "no large-number cancellation occurs".
+
+    Measured: 1.1e-3 on ``hydrostatic_consistency`` at 256 m layers and 50
+    m/km, 2.7e-4 at 64 m, 2.0e-4 on ``bathymetry_step`` -- roughly three
+    decimal digits of headroom recovered, against the five §3.7.5 estimates are
+    consumed in
+    ``[centered-shift]``.  The gradient variants sit near 7e-2 because their
+    coordinate is flat, so ``Delta_e Z`` is only 0.18 m to begin with and there
+    is little to save; the bound below is loose enough to cover both regimes.
+
+    """
+    ds = build_state(variant, horiz_res, vert_res, tilt)
+    increments = shift_increments(ds)
+
+    largest = max(
+        float(np.abs(increments.within_layer).max()),
+        float(np.abs(increments.between_layers).max()),
+    )
+    replaced = float(np.abs(increments.delta_z_interface).max())
+    assert largest < 0.2 * replaced, (
+        f'{variant} at vert_res={vert_res} m, tilt={tilt}: largest increment '
+        f'{largest:.3e} m against max |Delta_e Z| {replaced:.3e} m'
+    )
+
+
+def _redistribution_state(equal_totals: bool) -> tuple[xr.Dataset, dict]:
+    """A synthetic state in the limit ``[centered-error]`` is written for.
+
+    Specific volume horizontally uniform within each layer, equal surface
+    pressure and equal surface height, so ``Gamma_0 = 0``.  ``equal_totals``
+    selects whether the coordinate merely *redistributes* thickness between the
+    columns (``sum_j Delta_e htilde_j = 0``) or also changes the total, which
+    is what a ``z_tilde_bot`` tilt does.
+    """
+    alpha = np.array([9.60e-4, 9.65e-4, 9.72e-4, 9.78e-4, 9.83e-4, 9.90e-4])
+    thickness_0 = np.array([200.0, 260.0, 300.0, 340.0, 380.0, 420.0])
+    if equal_totals:
+        offset = np.array([30.0, -10.0, 20.0, -25.0, -40.0, 25.0])
+    else:
+        offset = np.array([30.0, -10.0, 20.0, -25.0, -40.0, 60.0])
+    thickness_1 = thickness_0 + offset
+
+    thickness = np.stack([thickness_0, thickness_1])
+    q = np.zeros((2, len(alpha) + 1))
+    z = np.zeros((2, len(alpha) + 1))
+    for icell in range(2):
+        for level in range(len(alpha)):
+            q[icell, level + 1] = (
+                q[icell, level] + RhoSw * Gravity * thickness[icell, level]
+            )
+            z[icell, level + 1] = (
+                z[icell, level]
+                - RhoSw * alpha[level] * thickness[icell, level]
+            )
+
+    ds = xr.Dataset(
+        {
+            'GeomZInterface': xr.DataArray(
+                z[np.newaxis, ...], dims=['Time', 'nCells', 'nVertLevelsP1']
+            ),
+            'ZTildeInterface': xr.DataArray(
+                -q[np.newaxis, ...] / (RhoSw * Gravity),
+                dims=['Time', 'nCells', 'nVertLevelsP1'],
+            ),
+            'SpecVol': xr.DataArray(
+                np.broadcast_to(alpha, (1, 2, len(alpha))).copy(),
+                dims=['Time', 'nCells', 'nVertLevels'],
+            ),
+            'PseudoThickness': xr.DataArray(
+                thickness[np.newaxis, ...],
+                dims=['Time', 'nCells', 'nVertLevels'],
+            ),
+        }
+    )
+    return ds, {'alpha': alpha, 'delta_thickness': offset}
+
+
+@pytest.mark.parametrize('equal_totals', [True, False])
+def test_centered_error_reconciliation(equal_totals):
+    """Reconcile ``[gamma-increments]`` against ``[centered-error]`` (§3.5.1).
+
+    In the limit ``[centered-error]`` is written for -- specific volume
+    horizontally uniform within each layer -- summation by parts gives
+
+        S_k = rho0 sum_{j>k} (alpha_j - alpha_k) d_j
+              + C + rho0 * alpha_k * sum_j d_j
+        C   = Gamma_0 - rho0 sum_j d_j alpha_j
+
+    with ``d_j = Delta_e htilde_j``.  The constant ``C`` is identified
+    explicitly rather than fitted, and it is set by the anchor.
+
+    The sharper half, which is why the plan asks for the check *without*
+    assuming
+    ``sum_j d_j = 0``: the two expressions agree up to a k-independent constant
+    **only** when the two columns have the same total pseudo-thickness.
+    Otherwise the extra ``rho0 alpha_k sum_j d_j`` depends on k through
+    ``alpha_k`` and cannot be absorbed into an anchor.  That case is the normal
+    one here -- a ``z_tilde_bot`` tilt gives the two columns different
+    pseudo-bottom depths -- so the design's expectation holds only in the
+    redistribution limit its own text assumes.
+
+    """
+    ds, parts = _redistribution_state(equal_totals)
+    alpha = parts['alpha']
+    delta_thickness = parts['delta_thickness']
+
+    shift = centered_shift_accumulated(ds).values[0, :]
+
+    layers = len(alpha)
+    centered_error = np.array(
+        [
+            RhoSw
+            * np.sum(
+                (alpha[level + 1 :] - alpha[level])
+                * delta_thickness[level + 1 :]
+            )
+            for level in range(layers)
+        ]
+    )
+    # Gamma_0 is zero by construction: equal surface pressure and height
+    constant = -RhoSw * np.sum(delta_thickness * alpha)
+    extra = RhoSw * alpha * np.sum(delta_thickness)
+
+    # atol because the shallowest layer's value is an exact zero here, which a
+    # relative tolerance cannot express; the terms being summed are ~4e2, so
+    # 1e-12 m is about ten times their round-off
+    np.testing.assert_allclose(
+        shift, centered_error + constant + extra, rtol=1e-12, atol=1e-12
+    )
+
+    residual = shift - centered_error
+    if equal_totals:
+        assert np.allclose(np.sum(delta_thickness), 0.0, atol=1e-12)
+        # k-independent: the residual is the anchor constant and nothing else
+        np.testing.assert_allclose(residual, constant, rtol=1e-12, atol=1e-12)
+    else:
+        assert abs(np.sum(delta_thickness)) > 1.0
+        # not k-independent, and demonstrably so
+        assert np.ptp(residual) > 1.0e-3 * abs(constant)
+        np.testing.assert_allclose(
+            residual, constant + extra, rtol=1e-12, atol=1e-12
         )

--- a/tests/ocean/horiz_press_grad/test_matched_pressure.py
+++ b/tests/ocean/horiz_press_grad/test_matched_pressure.py
@@ -12,6 +12,7 @@ import pytest
 from polaris.ocean.vertical.ztilde import Gravity
 from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
     anchor_difference,
+    anchor_index,
     centered_shift,
     column_scan,
     delta_specvol_at_pressure,
@@ -191,45 +192,91 @@ def test_integrand_is_nonzero_off_the_exact_set():
 @pytest.mark.parametrize(
     'vert_res, tilt', [(256.0, 1.0), (256.0, 50.0), (64.0, 50.0)]
 )
-def test_scan_is_zero_at_every_interface_on_the_exact_set(vert_res, tilt):
-    """``D_k`` is zero to round-off at every ``k``, not only in the mean.
+def test_scan_is_flat_on_the_exact_set(vert_res, tilt):
+    """``D_k`` is *constant* down the column to round-off.
 
     Asserting it at every interface rather than in the layer mean is what
     separates the two failure modes the plan names: a residual that grows with
-    depth would point at the scan, and one that is flat would point at the
-    anchor.
+    depth points at the scan, and one that is flat points at the anchor.  This
+    asserts the first is absent -- every increment of ``[d-recurrence]`` is
+    zero to round-off, because ``[dalpha]`` is zero at every quadrature point
+    on the exact set.
 
+    It asserts flatness rather than zero.  ``D_k`` is *not* zero here, and the
+    offset is entirely the anchor: see
+    :py:func:`test_anchor_carries_the_bottom_pressure_offset` for what sets it
+    and why it is a property of the state rather than of the scheme.  Anchored
+    at the sea surface these were the same assertion, which is why this test
+    used to be able to demand zero.
     """
     ds = build_state(LINEAR_VARIANT, 4.0, vert_res, tilt)
     difference = column_scan(matched_pressure_pieces(ds))
 
-    worst = float(np.max(np.abs(difference)))
+    worst = float(np.ptp(difference))
     tolerance = _ROUNDOFF_TOL * hydrostatic_scale(ds)
     assert worst <= tolerance, (
-        f'vert_res={vert_res} m, tilt={tilt} m/km: max |D_k| = {worst:.3e} m, '
-        f'more than {tolerance:.3e} m'
+        f'vert_res={vert_res} m, tilt={tilt} m/km: D_k varies by '
+        f'{worst:.3e} m down the column, more than {tolerance:.3e} m, which '
+        'points at the scan rather than the anchor'
     )
 
 
 @pytest.mark.parametrize(
     'variant, vert_res, tilt',
     [
-        (LINEAR_VARIANT, 256.0, 50.0),
-        ('hydrostatic_consistency', 256.0, 50.0),
-        ('bathymetry_step', 256.0, 200.0),
+        (LINEAR_VARIANT, 256.0, 0.05),
+        (LINEAR_VARIANT, 128.0, 5.0),
+        ('hydrostatic_consistency', 256.0, 0.05),
     ],
 )
-def test_anchor_is_exactly_zero_without_a_surface_pressure_gradient(
-    variant, vert_res, tilt
-):
-    """With equal surface pressures the anchor is identically zero.
+def test_anchor_carries_the_bottom_pressure_offset(variant, vert_res, tilt):
+    """The sea-floor anchor is nonzero, and it is the state that makes it so.
 
-    Both short integrals of ``[anchor]`` then run over a zero-width interval
-    and the sea-surface heights are equal, so nothing is left to cancel.  This
-    is the trivial half of D10; the informative half is the next test.
+    Anchored at the sea floor (design §3.7.4) the anchor is
+
+        Delta_e Z + alphabar * Delta_e p_bot / g
+
+    at the deepest interface valid in both columns.  Both columns' floors sit
+    at the same geometric height here, so ``Delta_e Z`` is zero and the whole
+    anchor is the second term: the two columns reach *different bottom
+    pressures* at the same depth, so at a common pressure their heights
+    genuinely differ.
+
+    Why they differ, though both hold the same water and the profile is inside
+    the reconstruction's exact set: ``VertCoord`` accumulates
+    ``rho0 * alpha_k * htilde_k`` with ``alpha_k`` the exact TEOS-10 specific
+    volume *at the layer-mean state*, and alpha is nonlinear in pressure, so
+    that is not the layer average of ``alpha(p)``.  Two columns partitioned
+    differently by the tilt therefore accumulate slightly different masses.
+    This is the O(htilde^2) effect design §3.7.4 invokes to argue for the floor
+    anchor in the first place; at the floor it lands in the bottom pressure
+    instead of in the derived sea-surface height.
+
+    So the scheme is right to report this, and the assertion is against the
+    offset the state implies rather than against zero.  The residual is
+    ``alpha`` versus its edge-shared linearization over the interval, a few
+    parts in 1e3.
     """
     ds = build_state(variant, 4.0, vert_res, tilt)
-    assert anchor_difference(matched_pressure_pieces(ds)) == 0.0
+    pieces = matched_pressure_pieces(ds)
+    interface = anchor_index(pieces)
+
+    if pieces['deepest'][0] != pieces['deepest'][1]:
+        pytest.skip('prediction assumes both columns end at the same index')
+
+    delta_z = (
+        pieces['interface_height'][1, interface]
+        - pieces['interface_height'][0, interface]
+    )
+    delta_p = (
+        pieces['interface'][1, interface] - pieces['interface'][0, interface]
+    )
+    alpha = float(ds.SpecVol.isel(Time=0).values[:, interface - 1].mean())
+    predicted = delta_z + alpha * delta_p / Gravity
+
+    measured = anchor_difference(pieces)
+    assert measured != 0.0
+    np.testing.assert_allclose(measured, predicted, rtol=5.0e-3, atol=0.0)
 
 
 def test_anchor_reports_the_inverse_barometer_residual():
@@ -365,40 +412,46 @@ def test_scan_round_trips(vert_res, tilt):
 
 
 @pytest.mark.parametrize('horiz_res, vert_res, tilt', sweep(LINEAR_VARIANT))
-def test_assembled_hpga_is_zero_on_the_exact_set(horiz_res, vert_res, tilt):
-    """C2 / D4'': the assembled tendency is machine zero on the exact set.
+def test_assembled_hpga_is_the_anchor_on_the_exact_set(
+    horiz_res, vert_res, tilt
+):
+    """C2 / D4'': on the exact set the whole tendency is the anchor.
 
     Run across the whole tilt sweep at three vertical resolutions, because this
     is the measurement the entire exercise exists to make.
 
-    The tolerance is a multiple of the *hydrostatic scale*, not an absolute
-    number, and that is not pedantry here.  At the smallest tilts the residual
-    sits at 2e-14 m s-2 rather than the 2e-18 at larger ones -- not because
-    the scheme is worse there, but because the floor is round-off of the ~7e3 m
-    of column the scan works against, which is about 5 eps and independent of
-    how small the signal is.  An absolute threshold tight enough to be
-    meaningful at 50 m/km would fail at 0.05 m/km for no reason.
+    **This asserted machine zero when the scan was anchored at the sea
+    surface, and it no longer can.**  Anchored at the sea floor (design §3.7.4)
+    the anchor is not zero on a Polaris-initialized state -- see
+    :py:func:`test_anchor_carries_the_bottom_pressure_offset` -- so the
+    tendency inherits it.  What survives, and is asserted here instead, is the
+    sharper statement: the residual is the anchor *and nothing else*, to a part
+    in 1e7 across the whole sweep, so every increment of the scan is still zero
+    to round-off and the scheme's central property is intact.
 
-    The comparison that matters is against ``PressureGradCentered`` on the same
-    state, which ranges from 6.8e-10 to 2.6e-05 m s-2 across this sweep.
+    Read together with the flatness assertion on the scan, this localizes the
+    residual completely: it enters at one interface, as one number, from the
+    state rather than from the discretization.
+
+    The scheme still beats ``PressureGradCentered`` on the same state by 21x to
+    1049x over this sweep.  The floor of 15x is below the measured minimum
+    rather than at it.
     """
     ds = build_state(LINEAR_VARIANT, horiz_res, vert_res, tilt)
-    hpga = finite_volume_hpga(ds, 1.0e3 * horiz_res)
+    dx = 1.0e3 * horiz_res
+    hpga = finite_volume_hpga(ds, dx)
 
     valid = np.isfinite(hpga.values)
     worst = float(np.max(np.abs(hpga.values[valid])))
     centered = float(np.abs(ds.HPGA).max())
-    tolerance = (
-        _ROUNDOFF_TOL * hydrostatic_scale(ds) * Gravity / (1.0e3 * horiz_res)
+
+    anchor = abs(anchor_difference(matched_pressure_pieces(ds)))
+    np.testing.assert_allclose(
+        worst, Gravity * anchor / dx, rtol=1.0e-6, atol=0.0
     )
-    assert worst <= tolerance, (
-        f'vert_res={vert_res} m, tilt={tilt} m/km: max |HPGA| = {worst:.3e} '
-        f'm s-2, more than {tolerance:.3e} (centered gives {centered:.3e})'
-    )
-    assert worst < 1.0e-4 * centered, (
+    assert worst < centered / 15.0, (
         f'vert_res={vert_res} m, tilt={tilt} m/km: the scheme is only '
-        f'{centered / worst:.1f} times better than centered, so this '
-        'configuration is no longer showing exactness'
+        f'{centered / worst:.1f} times better than centered'
     )
 
 
@@ -406,10 +459,17 @@ def test_exactness_survives_differing_max_level_cell():
     """D8': the below-floor extrapolation does not break exactness.
 
     At 50 m/km the two columns of ``hydrostatic_consistency_linear`` reach
-    different ``maxLevelCell`` (13 and 14), so the deepest edge layer evaluates
-    one column's reconstruction below its own floor.  Exactness is unaffected,
+    different ``maxLevelCell``, so the deepest edge layer evaluates one
+    column's reconstruction below its own floor.  Exactness is unaffected,
     which is what design §3.5 consequence 3 predicts and what demotes A5 from
     an exactness risk to an accuracy question.
+
+    "Unaffected" is asserted as *the scan stays flat*: the extrapolation feeds
+    the integrand, and if it broke the cancellation the increments would stop
+    being zero and ``D_k`` would drift with depth.  It is deliberately not
+    asserted as a small tendency, which the sea-floor anchor's own offset
+    would dominate and which would therefore not be testing the extrapolation
+    at all.
     """
     ds = build_state(LINEAR_VARIANT, 4.0, 256.0, 50.0)
     pieces = matched_pressure_pieces(ds)
@@ -418,9 +478,8 @@ def test_exactness_survives_differing_max_level_cell():
         'the test has stopped checking what it claims to'
     )
 
-    hpga = finite_volume_hpga(ds, 4.0e3)
-    valid = np.isfinite(hpga.values)
-    assert float(np.max(np.abs(hpga.values[valid]))) < 1.0e-15
+    difference = column_scan(pieces)
+    assert float(np.ptp(difference)) <= _ROUNDOFF_TOL * hydrostatic_scale(ds)
 
 
 def test_assembled_hpga_beats_centered_off_the_exact_set():
@@ -518,26 +577,37 @@ def test_quadrature_points_comes_from_config():
     [
         ('cell_local_expansion', True),
         ('state_by_index', False),
-        ('anchor_delta_z_only', False),
+        ('anchor_delta_z_only', True),
     ],
 )
 def test_guards_on_the_exact_set(guard, must_fire):
-    """Which deliberate mistakes break exactness, and which cannot.
+    """Which deliberate mistakes break the scheme here, and which cannot.
 
-    Only one of the three does, and that is itself the finding: the scheme's
-    exactness is structural enough that most plausible errors leave it intact.
-
-    * ``cell_local_expansion`` **fires**, at 1e-5.  Design §3.5 consequence 1
-      says the shared coefficients may take *any value*; it does not say the
-      two columns may use *different* ones.  ``[dalpha]`` only collapses to a
-      coefficient times a contrast when one set multiplies both columns, so the
-      edge-shared expansion point of §3.3.1 remains load-bearing for exactness.
+    * ``cell_local_expansion`` **fires**, taking the tendency to 2.6e-5 m s-2,
+      comparable to what the centered scheme gives on the same state.  Design
+      §3.5 consequence 1 says the shared coefficients may take *any value*; it
+      does not say the two columns may use *different* ones.  ``[dalpha]`` only
+      collapses to a coefficient times a contrast when one set multiplies both
+      columns, so the edge-shared expansion point of §3.3.1 remains
+      load-bearing.
     * ``state_by_index`` cannot fire here: this variant's profile is a single
       line in pressure, so every layer's reconstruction is that same line and
       looking up the wrong layer costs nothing.
-    * ``anchor_delta_z_only`` cannot fire here either, because the two columns
-      share a surface pressure and the correction it drops is zero.  It fires
-      hard where they do not -- see the next test.
+    * ``anchor_delta_z_only`` **fires**, at 3e5 times the correct answer.  This
+      is a change: with the scan anchored at the sea surface it could not fire
+      on this variant, because both columns shared a surface pressure and the
+      correction it drops was zero.  Anchored at the sea floor, this tilt gives
+      the columns different ``maxLevelCell``, so the anchor interface is one
+      column's floor and the other's interior and the raw ``Delta_e Z`` there
+      is 28 m against a corrected anchor of 8e-5 m.  The guard is therefore
+      sharper than it was -- though note it is the *tilt* that gives it teeth:
+      over a flat floor with matching ``maxLevelCell``, ``Delta_e Z`` is
+      ~1e-13 m and dropping the correction would again cost almost nothing.
+
+    Thresholds are ratios against the correct tendency, which on the exact set
+    is now the anchor rather than machine zero, so a firing guard shows as
+    1e2--1e5 rather than the 1e6+ a zero baseline used to give.  The absolute
+    magnitudes the guards produce are unchanged.
     """
     ds = build_state(LINEAR_VARIANT, 4.0, 256.0, 50.0)
     correct = finite_volume_hpga(ds, 4.0e3)
@@ -548,22 +618,68 @@ def test_guards_on_the_exact_set(guard, must_fire):
     result = float(np.max(np.abs(perturbed.values[valid])))
 
     if must_fire:
-        assert result > 1.0e6 * baseline, (
+        assert result > 50.0 * baseline, (
             f'{guard} left the tendency at {result:.3e}, so it is not a guard'
         )
     else:
-        assert result < 1.0e3 * baseline, (
+        assert result < 2.0 * baseline, (
             f'{guard} changed the tendency to {result:.3e}, which contradicts '
             'the reason given for why it cannot'
         )
 
 
+@pytest.mark.parametrize('vert_res, tilt', [(256.0, 0.05), (256.0, 50.0)])
+def test_anchor_at_surface_guard_is_sensitive(vert_res, tilt):
+    """The retained surface anchor is a guard that actually moves the answer.
+
+    Design §3.7.4 settles the anchor at the sea floor and §3.5.1's prose still
+    says the surface, so the surface end is kept as a switch rather than
+    deleted -- but a switch nobody checks is the "guard that cannot fire" this
+    branch has already been caught by twice.
+
+    On a Polaris-initialized state the two ends differ by the whole anchor: the
+    initial condition pins the sea surface, so the surface anchor returns
+    round-off, while the floor anchor reports the offset the state's bottom
+    pressures imply.  Asserting the surface end is at round-off is what makes
+    this a sharp check rather than a loose one -- and it is also the
+    measurement behind the claim that the residual comes from the state and
+    not from the scan.
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, vert_res, tilt)
+    pieces = matched_pressure_pieces(ds)
+
+    assert anchor_index(pieces) != 0
+    assert anchor_index(pieces, guards={'anchor_at_surface'}) == 0
+
+    at_floor = anchor_difference(pieces)
+    at_surface = anchor_difference(pieces, guards={'anchor_at_surface'})
+
+    assert abs(at_surface) <= _ROUNDOFF_TOL * hydrostatic_scale(ds), (
+        f'the surface anchor is {at_surface:.3e} m, above round-off, so this '
+        'state no longer pins the sea surface and the comparison below means '
+        'something different'
+    )
+    assert abs(at_floor) > 1.0e-9, (
+        f'the two anchors agree to {at_floor:.3e} m, so the guard is not '
+        'sensitive on this configuration'
+    )
+
+
 def test_anchor_guard_fires_where_surface_pressures_differ():
     """``anchor_delta_z_only`` is a real guard, on the right configuration.
 
-    Dropping the correction to a common pressure leaves the raw sea-surface
-    height difference, which is 3.57 m rather than the 6.1e-4 m residual, and
-    the tendency comes out some thousands of times too large.
+    Dropping the correction to a common pressure leaves the raw geometric
+    height difference at the anchor interface, and the tendency comes out some
+    thousands of times wrong.
+
+    **The direction is inverted relative to a surface anchor**, which is worth
+    stating because it looks like a broken guard otherwise.  At the sea surface
+    the uncorrected difference was the raw 3.57 m sea-surface offset against a
+    6.1e-4 m residual, so the guard inflated the answer.  At the sea floor the
+    floor is flat, so the uncorrected difference is ~1e-13 m and the guard
+    *discards* the entire 6.1e-4 m signal instead.  Either way the correction
+    to a common pressure is the whole content of the anchor here; the assertion
+    is therefore that the ratio is far from one, not that it is large.
     """
     ds = build_state('surface_pressure_gradient', 4.0, 4.0, None)
     correct = finite_volume_hpga(ds, 4.0e3)
@@ -573,8 +689,8 @@ def test_anchor_guard_fires_where_surface_pressures_differ():
     ratio = float(np.max(np.abs(perturbed.values[valid]))) / float(
         np.max(np.abs(correct.values[valid]))
     )
-    assert ratio > 1.0e3, (
-        f'the anchor guard only changed things by {ratio:.1f}x'
+    assert ratio > 1.0e3 or ratio < 1.0e-3, (
+        f'the anchor guard only changed things by {ratio:.3e}x'
     )
 
 

--- a/tests/ocean/horiz_press_grad/test_matched_pressure.py
+++ b/tests/ocean/horiz_press_grad/test_matched_pressure.py
@@ -30,7 +30,13 @@ from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
 )
 from polaris.tasks.ocean.horiz_press_grad.reference import ReferenceColumn
 
-from .two_column import LINEAR_VARIANT, build_state, make_config, sweep
+from .two_column import (
+    LINEAR_VARIANT,
+    STEP_LINEAR_VARIANT,
+    build_state,
+    make_config,
+    sweep,
+)
 
 # Machine-precision tolerance as a multiple of the hydrostatic scale, matching
 # tests/ocean/horiz_press_grad/test_finite_volume.py.
@@ -485,6 +491,83 @@ def test_exactness_survives_differing_max_level_cell():
 
     difference = column_scan(pieces)
     assert float(np.ptp(difference)) <= _ROUNDOFF_TOL * hydrostatic_scale(ds)
+
+
+@pytest.mark.parametrize('tilt', [1.0, 25.0, 100.0, 200.0])
+def test_scan_stays_flat_over_a_bathymetry_step(tilt):
+    """D8' on the geometry it was most doubted in.
+
+    ``bathymetry_step_linear`` is inside the exact set *and* has a stepped sea
+    floor, so anything the scan does here is the geometry's doing and not the
+    profile's.  At 100 and 200 m/km the two columns reach different
+    ``maxLevelCell`` and the deepest edge layers evaluate one column's
+    reconstruction two and three layers below its own floor.  The scan stays
+    flat to round-off regardless, which is what design §3.5 consequence 3
+    predicts and what keeps A5 an accuracy question rather than an exactness
+    one.
+    """
+    ds = build_state(STEP_LINEAR_VARIANT, 4.0, 256.0, tilt)
+    difference = column_scan(matched_pressure_pieces(ds))
+
+    worst = float(np.ptp(difference))
+    tolerance = _ROUNDOFF_TOL * hydrostatic_scale(ds)
+    assert worst <= tolerance, (
+        f'grad={tilt} m/km: D_k varies by {worst:.3e} m down the column, more '
+        f'than {tolerance:.3e} m, so the below-floor extrapolation is '
+        'breaking the cancellation'
+    )
+
+
+@pytest.mark.parametrize('tilt', [25.0, 200.0])
+def test_step_anchor_is_not_quadrature_error(tilt):
+    """What the anchor costs over a bathymetry step, and what it is not.
+
+    On a stepped floor the anchor is a difference of large quantities: at
+    200 m/km it cancels 205.586735 m against -205.586735 m to leave 1.7e-7 m,
+    nine decimal digits.  Design §3.7.5 says of the reformulated scheme that
+    "no large quantity is formed anywhere, so nothing large has to cancel" --
+    true of the scan, whose every increment is a horizontal contrast, but not
+    of the anchor.
+
+    The residual is **not** quadrature error, and this test is what establishes
+    that: ``hat_alpha`` is linear in pressure, so every Gauss rule integrates
+    it exactly and refining cannot help.  What is left is the equation of
+    state -- the anchor integrates the edge-shared *linear* expansion of alpha
+    across the whole step, some 2e6 Pa at 200 m/km, where the neglected
+    second-order term is not small.  That attribution is a scaling argument
+    rather than a measurement, but the insensitivity asserted here rules out
+    the alternative.
+    """
+    ds = build_state(STEP_LINEAR_VARIANT, 4.0, 256.0, tilt)
+    pieces = matched_pressure_pieces(ds)
+
+    interface = anchor_index(pieces)
+    delta_z = abs(
+        pieces['interface_height'][1, interface]
+        - pieces['interface_height'][0, interface]
+    )
+    anchor = anchor_difference(pieces)
+
+    # the anchor forms and cancels a quantity of order the bathymetry step
+    assert delta_z > 1.0, (
+        f'grad={tilt} m/km: Delta_e Z at the anchor is only {delta_z:.3e} m, '
+        'so this configuration no longer exercises the cancellation'
+    )
+    assert abs(anchor) < 1.0e-5 * delta_z
+
+    # And refining the rule does not move it, because there is no quadrature
+    # error to remove.  The tolerance is scaled to the quantity being
+    # cancelled, not to the answer: changing the rule reorders a sum of terms
+    # of order Delta_e Z, so the last bits move even though the mathematics
+    # does not.  At 25 m/km that is 1.4e-14 on a 100 m cancellation, against an
+    # anchor of 2.6e-8 -- six orders below the residual being explained.
+    for order in (4, 8, 16):
+        np.testing.assert_allclose(
+            anchor_difference(pieces, order=order),
+            anchor,
+            rtol=0.0,
+            atol=1.0e-13 * delta_z,
+        )
 
 
 def test_assembled_hpga_beats_centered_off_the_exact_set():

--- a/tests/ocean/horiz_press_grad/test_matched_pressure.py
+++ b/tests/ocean/horiz_press_grad/test_matched_pressure.py
@@ -1,0 +1,166 @@
+"""
+Unit tests for the matched-pressure integrand, ``[dalpha]``.
+
+This is deliverable D9: the fixed-pressure contrast in specific volume must be
+zero **at every quadrature point** on the exact set, not merely in the layer
+mean.
+"""
+
+import numpy as np
+import pytest
+
+from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
+    delta_specvol_at_pressure,
+    layer_containing_pressure,
+    matched_pressure_pieces,
+)
+
+from .two_column import LINEAR_VARIANT, build_state, sweep
+
+# Four-point Gauss-Legendre, as the column scan will use.
+_NODES, _ = np.polynomial.legendre.leggauss(4)
+
+# Pointwise tolerance, relative to the size of the terms being differenced --
+# alpha_theta times the temperature range.  Measured worst case over the linear
+# variant's sweep is ~1e-17 of specific volume; this leaves several decades.
+_POINTWISE_TOL = 1.0e-14
+
+
+def _quadrature_points(pieces, edge_layer):
+    edges = pieces['edge_interface']
+    top, bot = edges[edge_layer], edges[edge_layer + 1]
+    return 0.5 * (top + bot) + 0.5 * (bot - top) * _NODES
+
+
+def _deepest_shared(pieces):
+    return int(min(pieces['deepest']))
+
+
+@pytest.mark.parametrize('horiz_res, vert_res, tilt', sweep(LINEAR_VARIANT))
+def test_integrand_is_pointwise_zero_on_the_exact_set(
+    horiz_res, vert_res, tilt
+):
+    """``[dalpha]`` is zero at every quadrature point of every edge layer.
+
+    This is the central property of the scheme (design §3.5).  Because the
+    integrand itself vanishes rather than its integral, exactness cannot depend
+    on the quadrature, on the coefficients, or on the two columns' interfaces
+    lining up -- and asserting it pointwise rather than in the layer mean is
+    what distinguishes "zero" from "integrates to zero by cancellation".
+    """
+    ds = build_state(LINEAR_VARIANT, horiz_res, vert_res, tilt)
+    pieces = matched_pressure_pieces(ds)
+    scale = float(np.abs(pieces['expansion'].alpha_theta).max()) * float(
+        np.nanmax(pieces['theta']) - np.nanmin(pieces['theta'])
+    )
+
+    worst = 0.0
+    for edge_layer in range(_deepest_shared(pieces) + 1):
+        pressure = _quadrature_points(pieces, edge_layer)
+        contrast = delta_specvol_at_pressure(pieces, edge_layer, pressure)
+        worst = max(worst, float(np.max(np.abs(contrast))))
+
+    assert worst <= _POINTWISE_TOL * scale, (
+        f'vert_res={vert_res} m, tilt={tilt} m/km: max |Delta_e alpha| = '
+        f'{worst:.3e} m3 kg-1, more than {_POINTWISE_TOL * scale:.3e}'
+    )
+
+
+@pytest.mark.parametrize(
+    'vert_res, tilt, expected_offset',
+    [(256.0, 50.0, 1), (64.0, 50.0, 2)],
+)
+def test_lookup_returns_a_layer_other_than_the_edge_layer(
+    vert_res, tilt, expected_offset
+):
+    """Under tilt, a column's layer containing p is not its layer ``k``.
+
+    Without this the suite cannot tell matched-pressure from matched-index: if
+    the lookup silently returned ``k`` the scheme would be a different one, and
+    that is the defect the previous formulation failed on.  The offset grows
+    with tilt and with refinement -- at 64 m and 50 m/km the two columns' layer
+    ``k`` do not overlap in pressure at all.
+
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, vert_res, tilt)
+    pieces = matched_pressure_pieces(ds)
+
+    largest = 0
+    for edge_layer in range(_deepest_shared(pieces) + 1):
+        pressure = _quadrature_points(pieces, edge_layer)
+        for icell in range(2):
+            index = layer_containing_pressure(pieces, icell, pressure)
+            largest = max(largest, int(np.max(np.abs(index - edge_layer))))
+
+    assert largest >= expected_offset, (
+        f'vert_res={vert_res} m, tilt={tilt} m/km: the lookup never departs '
+        f'from the edge layer by more than {largest}, so this configuration '
+        'cannot distinguish matched-pressure from matched-index'
+    )
+
+
+@pytest.mark.parametrize('vert_res, tilt', [(256.0, 50.0), (64.0, 1.0)])
+def test_lookup_returns_the_layer_that_brackets_the_pressure(vert_res, tilt):
+    """The layer returned actually contains the pressure, in that column."""
+    ds = build_state(LINEAR_VARIANT, 4.0, vert_res, tilt)
+    pieces = matched_pressure_pieces(ds)
+
+    for edge_layer in range(_deepest_shared(pieces) + 1):
+        pressure = _quadrature_points(pieces, edge_layer)
+        for icell in range(2):
+            index = layer_containing_pressure(pieces, icell, pressure)
+            top = pieces['interface'][icell, index]
+            bot = pieces['interface'][icell, index + 1]
+            assert np.all(top <= pressure), (
+                f'column {icell}: a returned layer starts below its pressure'
+            )
+            assert np.all(pressure <= bot), (
+                f'column {icell}: a returned layer ends above its pressure'
+            )
+
+
+def test_lookup_clamps_outside_the_column():
+    """Above the surface and below the floor, the outermost layer is used.
+
+    Exactness does not depend on this (design §3.5, consequence 3): an
+    extrapolated reconstruction still reproduces a profile it resolves.  What
+    it costs off the exact set is deliverable D8'.
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, 256.0, 50.0)
+    pieces = matched_pressure_pieces(ds)
+
+    for icell in range(2):
+        deepest = int(pieces['deepest'][icell])
+        surface = pieces['interface'][icell, 0]
+        floor = pieces['interface'][icell, deepest + 1]
+        above = layer_containing_pressure(
+            pieces, icell, np.array([surface - 1.0e5])
+        )
+        below = layer_containing_pressure(
+            pieces, icell, np.array([floor + 1.0e5])
+        )
+        assert above[0] == 0
+        assert below[0] == deepest
+
+
+def test_integrand_is_nonzero_off_the_exact_set():
+    """The pointwise test above has content.
+
+    On the curved ``hydrostatic_consistency`` profile the reconstruction cannot
+    reproduce the true profile, so the two columns describe slightly different
+    water and the contrast is genuinely nonzero -- eleven orders of magnitude
+    above the exact-set result.  Without this, the pointwise test could pass
+    for an implementation that returned zero unconditionally.
+    """
+    ds = build_state('hydrostatic_consistency', 4.0, 256.0, 50.0)
+    pieces = matched_pressure_pieces(ds)
+
+    worst = 0.0
+    for edge_layer in range(_deepest_shared(pieces) + 1):
+        pressure = _quadrature_points(pieces, edge_layer)
+        contrast = delta_specvol_at_pressure(pieces, edge_layer, pressure)
+        worst = max(worst, float(np.max(np.abs(contrast))))
+
+    assert worst > 1.0e-9, (
+        f'max |Delta_e alpha| is only {worst:.3e} on a curved profile'
+    )

--- a/tests/ocean/horiz_press_grad/test_matched_pressure.py
+++ b/tests/ocean/horiz_press_grad/test_matched_pressure.py
@@ -260,10 +260,19 @@ def test_anchor_reports_the_inverse_barometer_residual():
         f'anchor is {anchor:.3e} m, outside the range the reference-density '
         'inverse barometer explains'
     )
-    # flat with depth: the anchor offsets the whole column, the scan adds
-    # essentially nothing
-    assert float(np.ptp(difference)) < 1.0e-3 * abs(anchor), (
+    # Flat with depth: the anchor offsets the whole column and the scan adds
+    # essentially nothing on top of it.  "Essentially nothing" is ~1e-3 of the
+    # anchor, not round-off -- the two columns' p-star grids differ because
+    # their surface pressures do, so there is a genuine small contrast for the
+    # scan to integrate.  The bound is 5e-3 rather than the measured value
+    # because that value moves with the quadrature: 2.1e-3, 1.1e-3, 1.4e-3 and
+    # 9.8e-4 of the anchor at one through four points, since the integrand is
+    # piecewise linear with breakpoints at the union of the two columns'
+    # interfaces and no fixed rule resolves them.  A threshold pinned to any
+    # one of those readings tests the quadrature rather than the scan.
+    assert float(np.ptp(difference)) < 5.0e-3 * abs(anchor), (
         f'D_k varies by {float(np.ptp(difference)):.3e} m down the column, '
+        f'{float(np.ptp(difference)) / abs(anchor):.1e} of the anchor, '
         'which points at the scan rather than the anchor'
     )
 
@@ -461,6 +470,47 @@ def test_hpga_finite_volume_is_written_to_the_state():
     finite = np.isfinite(ds.HPGAFiniteVolume.values[0])
     assert bool(finite[: deepest + 1].all())
     assert not bool(finite[deepest + 1 :].any())
+
+
+def test_quadrature_points_comes_from_config():
+    """The Gauss rule is the configured one, not a default in the kernel.
+
+    ``quadrature_points`` fills in Omega's ``PressureGrad:QuadraturePoints``
+    and the Python kernel's rule from one option, because
+    ``omega_vs_polaris_rms_threshold`` only checks Omega's arithmetic if both
+    sides integrate the same way.  Two sides quadrating differently are two
+    algorithms, and their disagreement is not distinguishable from a bug in
+    either.
+
+    ``surface_pressure_gradient`` rather than the linear variant: on the exact
+    set the integrand is zero at every point, so *every* rule gives the same
+    answer and the test could not fail.
+    """
+    default = build_state('surface_pressure_gradient', 4.0, 4.0, None)
+    two = build_state(
+        'surface_pressure_gradient', 4.0, 4.0, None, quadrature_points=2
+    )
+    one = build_state(
+        'surface_pressure_gradient', 4.0, 4.0, None, quadrature_points=1
+    )
+
+    # the shipped value is 2, matching Omega's Phase 1 default
+    np.testing.assert_array_equal(
+        default.HPGAFiniteVolume.values, two.HPGAFiniteVolume.values
+    )
+
+    # and a different rule gives a different answer, so the option is read
+    # rather than ignored
+    valid = np.isfinite(two.HPGAFiniteVolume.values[0])
+    assert not np.allclose(
+        one.HPGAFiniteVolume.values[0][valid],
+        two.HPGAFiniteVolume.values[0][valid],
+        rtol=1.0e-12,
+        atol=0.0,
+    ), (
+        'one- and two-point quadrature give the same HPGAFiniteVolume, so '
+        'quadrature_points is not reaching the kernel'
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/ocean/horiz_press_grad/test_matched_pressure.py
+++ b/tests/ocean/horiz_press_grad/test_matched_pressure.py
@@ -355,25 +355,41 @@ def test_scan_round_trips(vert_res, tilt):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    'vert_res, tilt', [(256.0, 1.0), (256.0, 50.0), (64.0, 50.0)]
-)
-def test_assembled_hpga_is_zero_on_the_exact_set(vert_res, tilt):
-    """D4'': the assembled tendency is machine zero on the exact set.
+@pytest.mark.parametrize('horiz_res, vert_res, tilt', sweep(LINEAR_VARIANT))
+def test_assembled_hpga_is_zero_on_the_exact_set(horiz_res, vert_res, tilt):
+    """C2 / D4'': the assembled tendency is machine zero on the exact set.
 
-    Measured at 3.7e-18 m s-2 against ``PressureGradCentered``'s 6.9e-05 on the
-    same state -- thirteen orders.  This is the property the whole exercise is
-    for.
+    Run across the whole tilt sweep at three vertical resolutions, because this
+    is the measurement the entire exercise exists to make.
+
+    The tolerance is a multiple of the *hydrostatic scale*, not an absolute
+    number, and that is not pedantry here.  At the smallest tilts the residual
+    sits at 2e-14 m s-2 rather than the 2e-18 at larger ones -- not because
+    the scheme is worse there, but because the floor is round-off of the ~7e3 m
+    of column the scan works against, which is about 5 eps and independent of
+    how small the signal is.  An absolute threshold tight enough to be
+    meaningful at 50 m/km would fail at 0.05 m/km for no reason.
+
+    The comparison that matters is against ``PressureGradCentered`` on the same
+    state, which ranges from 6.8e-10 to 2.6e-05 m s-2 across this sweep.
     """
-    ds = build_state(LINEAR_VARIANT, 4.0, vert_res, tilt)
-    hpga = finite_volume_hpga(ds, 4.0e3)
+    ds = build_state(LINEAR_VARIANT, horiz_res, vert_res, tilt)
+    hpga = finite_volume_hpga(ds, 1.0e3 * horiz_res)
 
     valid = np.isfinite(hpga.values)
     worst = float(np.max(np.abs(hpga.values[valid])))
     centered = float(np.abs(ds.HPGA).max())
-    assert worst < 1.0e-15, (
+    tolerance = (
+        _ROUNDOFF_TOL * hydrostatic_scale(ds) * Gravity / (1.0e3 * horiz_res)
+    )
+    assert worst <= tolerance, (
         f'vert_res={vert_res} m, tilt={tilt} m/km: max |HPGA| = {worst:.3e} '
-        f'm s-2 (centered gives {centered:.3e})'
+        f'm s-2, more than {tolerance:.3e} (centered gives {centered:.3e})'
+    )
+    assert worst < 1.0e-4 * centered, (
+        f'vert_res={vert_res} m, tilt={tilt} m/km: the scheme is only '
+        f'{centered / worst:.1f} times better than centered, so this '
+        'configuration is no longer showing exactness'
     )
 
 
@@ -535,3 +551,36 @@ def test_operator_is_antisymmetric_under_swapping_the_columns():
         f'swapping the columns left {residual:.3e} against a signal of '
         f'{scale:.3e}'
     )
+
+
+@pytest.mark.parametrize('tilt', [1.0, 10.0])
+def test_second_order_off_the_exact_set(tilt):
+    """C3: the residual shrinks like h^2 under vertical refinement.
+
+    Without this, C2 could pass for a scheme that returned zero for the wrong
+    reason -- a scheme insensitive to the state would also be "exact".
+
+    Measured order on ``hydrostatic_consistency``'s curved profile is 1.55 to
+    2.02 across 256 -> 128 -> 64 m, consistent with the O(h^2) design §3.7.3
+    gives Phase 1 for a generally smooth profile.
+
+    Worth recording alongside: ``PressureGradCentered`` converges *faster* than
+    this on the same profile (1.88 to 2.93), from a much larger starting value,
+    so the finite-volume advantage narrows with refinement -- 6.5x at 256 m,
+    2.4x at 64 m.  The orders-of-magnitude win is on the exact set, not here.
+    That anomaly in the centered scheme's order is the one noted in the
+    findings document and is not yet explained.
+    """
+    errors = []
+    for vert_res in [256.0, 128.0, 64.0]:
+        ds = build_state('hydrostatic_consistency', 4.0, vert_res, tilt)
+        hpga = finite_volume_hpga(ds, 4.0e3)
+        valid = np.isfinite(hpga.values)
+        errors.append(float(np.sqrt(np.mean(hpga.values[valid] ** 2))))
+
+    for coarse, fine in zip(errors[:-1], errors[1:], strict=True):
+        order = np.log2(coarse / fine)
+        assert 1.4 < order < 2.6, (
+            f'tilt={tilt} m/km: observed order {order:.2f}, outside the range '
+            'a second-order scheme should show'
+        )

--- a/tests/ocean/horiz_press_grad/test_matched_pressure.py
+++ b/tests/ocean/horiz_press_grad/test_matched_pressure.py
@@ -6,10 +6,15 @@ zero **at every quadrature point** on the exact set, not merely in the layer
 mean.
 """
 
+import gsw
 import numpy as np
 import pytest
 
-from polaris.ocean.vertical.ztilde import Gravity
+from polaris.ocean.vertical.ztilde import (
+    Gravity,
+    RhoSw,
+    pressure_from_z_tilde,
+)
 from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
     anchor_difference,
     anchor_index,
@@ -626,6 +631,77 @@ def test_guards_on_the_exact_set(guard, must_fire):
             f'{guard} changed the tendency to {result:.3e}, which contradicts '
             'the reason given for why it cannot'
         )
+
+
+def test_the_anchor_is_the_midpoint_rules_partition_dependence():
+    """What the sea-floor anchor actually measures, pinned to an independent
+    calculation.
+
+    Both Polaris and Omega turn pressure into geometric height with a midpoint
+    rule, ``rho0 * SpecVol * PseudoThickness`` summed over layers.  Against a
+    high-order integral of the same specific volume over the same pressure
+    range, that truncates each 3500 m column by about 1.1 mm at 256 m layers.
+
+    ``Init`` holds ``bottomDepth`` at the prescribed bathymetry and solves for
+    the ``BottomPressure`` that reproduces it, so both columns' midpoint sums
+    come out at exactly 3500 m and it is the *pressures* that differ.  Under
+    tilt the two columns' interfaces fall in different places, so their
+    truncation errors differ -- and that difference is the whole anchor.
+
+    This is asserted here rather than left in the documentation because it is
+    the reason the exactness tests assert flatness instead of machine zero.  If
+    it ever stops holding, the explanation attached to those tests is wrong and
+    they should be re-derived rather than re-tuned.
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, 256.0, 0.05)
+    section = make_config(LINEAR_VARIANT)['horiz_press_grad']
+    z_nodes = section.getexpression('z_tilde_mid')
+    theta_nodes = section.getexpression('temperature_mid')
+    salt_nodes = section.getexpression('salinity_mid')
+
+    # the variant's profile is a straight line in pseudo-height, and pressure
+    # is proportional to pseudo-height, so it is a straight line in pressure
+    def _line(pressure, values):
+        z = -pressure / (RhoSw * Gravity)
+        fraction = (z - z_nodes[0]) / (z_nodes[1] - z_nodes[0])
+        return values[0] + fraction * (values[1] - values[0])
+
+    nodes, weights = np.polynomial.legendre.leggauss(10)
+    interface = pressure_from_z_tilde(ds.ZTildeInterface).isel(Time=0).values
+    deepest = ds.maxLevelCell.values.astype(int)
+    spec_vol = ds.SpecVol.isel(Time=0).values
+    thickness = ds.PseudoThickness.isel(Time=0).values
+
+    truncation = np.empty(2)
+    for icell in range(2):
+        n_valid = deepest[icell]
+        increment = (
+            RhoSw * spec_vol[icell, :n_valid] * thickness[icell, :n_valid]
+        )
+        midpoint_sum = float(np.sum(increment))
+        exact = 0.0
+        for level in range(n_valid):
+            top, bot = interface[icell, level], interface[icell, level + 1]
+            middle, half = 0.5 * (top + bot), 0.5 * (bot - top)
+            probe = middle + half * nodes
+            alpha = gsw.specvol(
+                _line(probe, salt_nodes),
+                _line(probe, theta_nodes),
+                probe / 1.0e4,
+            )
+            exact += half * float(np.sum(weights * alpha))
+        truncation[icell] = midpoint_sum - exact / Gravity
+
+    # each column is truncated by ~1.1 mm, and both midpoint sums land on the
+    # prescribed 3500 m, so the columns differ only through the truncation
+    assert -2.0e-3 < truncation[0] < -5.0e-4, (
+        f'midpoint-rule truncation is {truncation[0]:.3e} m, not the ~1.1 mm '
+        'this test was written against'
+    )
+
+    predicted = truncation[1] - truncation[0]
+    measured = anchor_difference(matched_pressure_pieces(ds))
+    np.testing.assert_allclose(-measured, predicted, rtol=1.0e-3, atol=0.0)
 
 
 @pytest.mark.parametrize('vert_res, tilt', [(256.0, 0.05), (256.0, 50.0)])

--- a/tests/ocean/horiz_press_grad/test_matched_pressure.py
+++ b/tests/ocean/horiz_press_grad/test_matched_pressure.py
@@ -12,8 +12,11 @@ import pytest
 from polaris.ocean.vertical.ztilde import Gravity
 from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
     anchor_difference,
+    centered_shift,
     column_scan,
     delta_specvol_at_pressure,
+    finite_volume_hpga,
+    hpga_from_shift,
     hydrostatic_scale,
     layer_containing_pressure,
     matched_pressure_pieces,
@@ -345,3 +348,190 @@ def test_scan_round_trips(vert_res, tilt):
 
     worst = float(np.max(np.abs(upward - difference)))
     assert worst <= _ROUNDOFF_TOL * hydrostatic_scale(ds)
+
+
+# ---------------------------------------------------------------------------
+# 9h: the assembled scheme, HPGAFiniteVolume, and the A5 rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'vert_res, tilt', [(256.0, 1.0), (256.0, 50.0), (64.0, 50.0)]
+)
+def test_assembled_hpga_is_zero_on_the_exact_set(vert_res, tilt):
+    """D4'': the assembled tendency is machine zero on the exact set.
+
+    Measured at 3.7e-18 m s-2 against ``PressureGradCentered``'s 6.9e-05 on the
+    same state -- thirteen orders.  This is the property the whole exercise is
+    for.
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, vert_res, tilt)
+    hpga = finite_volume_hpga(ds, 4.0e3)
+
+    valid = np.isfinite(hpga.values)
+    worst = float(np.max(np.abs(hpga.values[valid])))
+    centered = float(np.abs(ds.HPGA).max())
+    assert worst < 1.0e-15, (
+        f'vert_res={vert_res} m, tilt={tilt} m/km: max |HPGA| = {worst:.3e} '
+        f'm s-2 (centered gives {centered:.3e})'
+    )
+
+
+def test_exactness_survives_differing_max_level_cell():
+    """D8': the below-floor extrapolation does not break exactness.
+
+    At 50 m/km the two columns of ``hydrostatic_consistency_linear`` reach
+    different ``maxLevelCell`` (13 and 14), so the deepest edge layer evaluates
+    one column's reconstruction below its own floor.  Exactness is unaffected,
+    which is what design §3.5 consequence 3 predicts and what demotes A5 from
+    an exactness risk to an accuracy question.
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, 256.0, 50.0)
+    pieces = matched_pressure_pieces(ds)
+    assert pieces['deepest'][0] != pieces['deepest'][1], (
+        'this configuration no longer exercises differing maxLevelCell, so '
+        'the test has stopped checking what it claims to'
+    )
+
+    hpga = finite_volume_hpga(ds, 4.0e3)
+    valid = np.isfinite(hpga.values)
+    assert float(np.max(np.abs(hpga.values[valid]))) < 1.0e-15
+
+
+def test_assembled_hpga_beats_centered_off_the_exact_set():
+    """On the curved and stepped variants the scheme is a large improvement.
+
+    Not exactness -- these are outside the exact set -- but the accuracy gain
+    is what Phase 1 is for.  ``bathymetry_step`` is the one that matters most:
+    it is the two-column analogue of the bottom-layer error seen in realistic
+    global runs, and the deepest edge layer there extends up to 65% below the
+    shallower column's floor.
+    """
+    for variant, tilt in [
+        ('hydrostatic_consistency', 50.0),
+        ('bathymetry_step', 200.0),
+    ]:
+        ds = build_state(variant, 4.0, 256.0, tilt)
+        hpga = finite_volume_hpga(ds, 4.0e3)
+        valid = np.isfinite(hpga.values)
+        scheme = float(np.max(np.abs(hpga.values[valid])))
+        centered = float(np.abs(ds.HPGA).max())
+        assert scheme < 0.2 * centered, (
+            f'{variant}: finite volume gives {scheme:.3e} against centered '
+            f'{centered:.3e}'
+        )
+
+
+def test_hpga_finite_volume_is_written_to_the_state():
+    """``HPGAFiniteVolume`` lands alongside ``HPGA``, which is unchanged.
+
+    ``HPGA`` keeping its name, meaning and values is what leaves the recorded
+    baselines valid; if it moved, something in the assembly would be wrong.
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, 256.0, 50.0)
+
+    assert 'HPGAFiniteVolume' in ds
+    assert ds.HPGAFiniteVolume.dims == ('Time', 'nVertLevels')
+    np.testing.assert_array_equal(
+        ds.HPGAFiniteVolume.values, finite_volume_hpga(ds, 4.0e3).values
+    )
+    np.testing.assert_allclose(
+        ds.HPGA.values,
+        hpga_from_shift(centered_shift(ds), 4.0e3).values,
+        rtol=0.0,
+        atol=1.0e-14 * hydrostatic_scale(ds) * Gravity / 4.0e3,
+    )
+    deepest = int(ds.maxLevelCell.min()) - 1
+    finite = np.isfinite(ds.HPGAFiniteVolume.values[0])
+    assert bool(finite[: deepest + 1].all())
+    assert not bool(finite[deepest + 1 :].any())
+
+
+@pytest.mark.parametrize(
+    'guard, must_fire',
+    [
+        ('cell_local_expansion', True),
+        ('state_by_index', False),
+        ('anchor_delta_z_only', False),
+    ],
+)
+def test_guards_on_the_exact_set(guard, must_fire):
+    """Which deliberate mistakes break exactness, and which cannot.
+
+    Only one of the three does, and that is itself the finding: the scheme's
+    exactness is structural enough that most plausible errors leave it intact.
+
+    * ``cell_local_expansion`` **fires**, at 1e-5.  Design §3.5 consequence 1
+      says the shared coefficients may take *any value*; it does not say the
+      two columns may use *different* ones.  ``[dalpha]`` only collapses to a
+      coefficient times a contrast when one set multiplies both columns, so the
+      edge-shared expansion point of §3.3.1 remains load-bearing for exactness.
+    * ``state_by_index`` cannot fire here: this variant's profile is a single
+      line in pressure, so every layer's reconstruction is that same line and
+      looking up the wrong layer costs nothing.
+    * ``anchor_delta_z_only`` cannot fire here either, because the two columns
+      share a surface pressure and the correction it drops is zero.  It fires
+      hard where they do not -- see the next test.
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, 256.0, 50.0)
+    correct = finite_volume_hpga(ds, 4.0e3)
+    perturbed = finite_volume_hpga(ds, 4.0e3, guards={guard})
+
+    valid = np.isfinite(correct.values)
+    baseline = float(np.max(np.abs(correct.values[valid])))
+    result = float(np.max(np.abs(perturbed.values[valid])))
+
+    if must_fire:
+        assert result > 1.0e6 * baseline, (
+            f'{guard} left the tendency at {result:.3e}, so it is not a guard'
+        )
+    else:
+        assert result < 1.0e3 * baseline, (
+            f'{guard} changed the tendency to {result:.3e}, which contradicts '
+            'the reason given for why it cannot'
+        )
+
+
+def test_anchor_guard_fires_where_surface_pressures_differ():
+    """``anchor_delta_z_only`` is a real guard, on the right configuration.
+
+    Dropping the correction to a common pressure leaves the raw sea-surface
+    height difference, which is 3.57 m rather than the 6.1e-4 m residual, and
+    the tendency comes out some thousands of times too large.
+    """
+    ds = build_state('surface_pressure_gradient', 4.0, 4.0, None)
+    correct = finite_volume_hpga(ds, 4.0e3)
+    perturbed = finite_volume_hpga(ds, 4.0e3, guards={'anchor_delta_z_only'})
+
+    valid = np.isfinite(correct.values)
+    ratio = float(np.max(np.abs(perturbed.values[valid]))) / float(
+        np.max(np.abs(correct.values[valid]))
+    )
+    assert ratio > 1.0e3, (
+        f'the anchor guard only changed things by {ratio:.1f}x'
+    )
+
+
+def test_operator_is_antisymmetric_under_swapping_the_columns():
+    """Swapping the two columns negates the tendency, to round-off.
+
+    The edge normal reverses, so nothing else may.
+    """
+    ds = build_state('hydrostatic_consistency', 4.0, 256.0, 50.0)
+    swapped = ds.copy()
+    for name in ds.data_vars:
+        if 'nCells' in ds[name].dims:
+            swapped[name] = (
+                ds[name].isel(nCells=[1, 0]).transpose(*ds[name].dims)
+            )
+
+    forward = finite_volume_hpga(ds, 4.0e3)
+    reverse = finite_volume_hpga(swapped, 4.0e3)
+    valid = np.isfinite(forward.values) & np.isfinite(reverse.values)
+
+    residual = float(np.max(np.abs((forward.values + reverse.values)[valid])))
+    scale = float(np.max(np.abs(forward.values[valid])))
+    assert residual < 1.0e-10 * scale, (
+        f'swapping the columns left {residual:.3e} against a signal of '
+        f'{scale:.3e}'
+    )

--- a/tests/ocean/horiz_press_grad/test_matched_pressure.py
+++ b/tests/ocean/horiz_press_grad/test_matched_pressure.py
@@ -9,13 +9,23 @@ mean.
 import numpy as np
 import pytest
 
+from polaris.ocean.vertical.ztilde import Gravity
 from polaris.tasks.ocean.horiz_press_grad.finite_volume import (
+    anchor_difference,
+    column_scan,
     delta_specvol_at_pressure,
+    hydrostatic_scale,
     layer_containing_pressure,
     matched_pressure_pieces,
+    scan_increments,
 )
+from polaris.tasks.ocean.horiz_press_grad.reference import ReferenceColumn
 
-from .two_column import LINEAR_VARIANT, build_state, sweep
+from .two_column import LINEAR_VARIANT, build_state, make_config, sweep
+
+# Machine-precision tolerance as a multiple of the hydrostatic scale, matching
+# tests/ocean/horiz_press_grad/test_finite_volume.py.
+_ROUNDOFF_TOL = 1.0e-14
 
 # Four-point Gauss-Legendre, as the column scan will use.
 _NODES, _ = np.polynomial.legendre.leggauss(4)
@@ -47,6 +57,7 @@ def test_integrand_is_pointwise_zero_on_the_exact_set(
     on the quadrature, on the coefficients, or on the two columns' interfaces
     lining up -- and asserting it pointwise rather than in the layer mean is
     what distinguishes "zero" from "integrates to zero by cancellation".
+
     """
     ds = build_state(LINEAR_VARIANT, horiz_res, vert_res, tilt)
     pieces = matched_pressure_pieces(ds)
@@ -80,6 +91,7 @@ def test_lookup_returns_a_layer_other_than_the_edge_layer(
     that is the defect the previous formulation failed on.  The offset grows
     with tilt and with refinement -- at 64 m and 50 m/km the two columns' layer
     ``k`` do not overlap in pressure at all.
+
 
     """
     ds = build_state(LINEAR_VARIANT, 4.0, vert_res, tilt)
@@ -125,6 +137,7 @@ def test_lookup_clamps_outside_the_column():
     Exactness does not depend on this (design §3.5, consequence 3): an
     extrapolated reconstruction still reproduces a profile it resolves.  What
     it costs off the exact set is deliverable D8'.
+
     """
     ds = build_state(LINEAR_VARIANT, 4.0, 256.0, 50.0)
     pieces = matched_pressure_pieces(ds)
@@ -151,6 +164,7 @@ def test_integrand_is_nonzero_off_the_exact_set():
     water and the contrast is genuinely nonzero -- eleven orders of magnitude
     above the exact-set result.  Without this, the pointwise test could pass
     for an implementation that returned zero unconditionally.
+
     """
     ds = build_state('hydrostatic_consistency', 4.0, 256.0, 50.0)
     pieces = matched_pressure_pieces(ds)
@@ -164,3 +178,170 @@ def test_integrand_is_nonzero_off_the_exact_set():
     assert worst > 1.0e-9, (
         f'max |Delta_e alpha| is only {worst:.3e} on a curved profile'
     )
+
+
+# ---------------------------------------------------------------------------
+# 9g: the column scan and the anchor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'vert_res, tilt', [(256.0, 1.0), (256.0, 50.0), (64.0, 50.0)]
+)
+def test_scan_is_zero_at_every_interface_on_the_exact_set(vert_res, tilt):
+    """``D_k`` is zero to round-off at every ``k``, not only in the mean.
+
+    Asserting it at every interface rather than in the layer mean is what
+    separates the two failure modes the plan names: a residual that grows with
+    depth would point at the scan, and one that is flat would point at the
+    anchor.
+
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, vert_res, tilt)
+    difference = column_scan(matched_pressure_pieces(ds))
+
+    worst = float(np.max(np.abs(difference)))
+    tolerance = _ROUNDOFF_TOL * hydrostatic_scale(ds)
+    assert worst <= tolerance, (
+        f'vert_res={vert_res} m, tilt={tilt} m/km: max |D_k| = {worst:.3e} m, '
+        f'more than {tolerance:.3e} m'
+    )
+
+
+@pytest.mark.parametrize(
+    'variant, vert_res, tilt',
+    [
+        (LINEAR_VARIANT, 256.0, 50.0),
+        ('hydrostatic_consistency', 256.0, 50.0),
+        ('bathymetry_step', 256.0, 200.0),
+    ],
+)
+def test_anchor_is_exactly_zero_without_a_surface_pressure_gradient(
+    variant, vert_res, tilt
+):
+    """With equal surface pressures the anchor is identically zero.
+
+    Both short integrals of ``[anchor]`` then run over a zero-width interval
+    and the sea-surface heights are equal, so nothing is left to cancel.  This
+    is the trivial half of D10; the informative half is the next test.
+    """
+    ds = build_state(variant, 4.0, vert_res, tilt)
+    assert anchor_difference(matched_pressure_pieces(ds)) == 0.0
+
+
+def test_anchor_reports_the_inverse_barometer_residual():
+    """D10, and the check of condition 3 (design §3.5.1).
+
+    ``surface_pressure_gradient`` is a resting state with a surface-pressure
+    gradient, so the anchor is where condition 3 is actually tested.  It comes
+    out **nonzero**, at 6.1e-4 m, and that is correct rather than a defect:
+    Polaris initializes the sea surface from the *reference-density* inverse
+    barometer, ``-p_surf / (rho0 g)``, so the state it produces genuinely has a
+    fixed-pressure height difference of that size -- the residual of two 3.57 m
+    terms, of relative size ``(alpha - 1/rho0)/alpha``.
+
+    The design's claim that ``D_1`` is zero for a resting ocean is therefore
+    conditional on an *exact* inverse barometer, which this initialization does
+    not use.  The scheme is right to report it: the quasi-analytic reference
+    reports the same tendency (see the accuracy test below).
+
+    ``D_k`` is flat with depth here, which is the anchor signature rather than
+    a scan defect.
+    """
+    ds = build_state('surface_pressure_gradient', 4.0, 4.0, None)
+    pieces = matched_pressure_pieces(ds)
+    difference = column_scan(pieces)
+
+    anchor = anchor_difference(pieces)
+    assert 1.0e-4 < abs(anchor) < 1.0e-2, (
+        f'anchor is {anchor:.3e} m, outside the range the reference-density '
+        'inverse barometer explains'
+    )
+    # flat with depth: the anchor offsets the whole column, the scan adds
+    # essentially nothing
+    assert float(np.ptp(difference)) < 1.0e-3 * abs(anchor), (
+        f'D_k varies by {float(np.ptp(difference)):.3e} m down the column, '
+        'which points at the scan rather than the anchor'
+    )
+
+
+def test_scan_matches_the_reference_where_the_state_is_not_at_rest():
+    """The scan reproduces the quasi-analytic reference, and beats `Centered`.
+
+    On ``surface_pressure_gradient`` the true tendency is not zero, so this is
+    an accuracy check rather than an exactness one -- and it is the first
+    direct comparison of the new scheme against the reference.  Measured rms
+    against the reference: 3.9e-10 m s-2 for the scan against 8.1e-10 for
+    ``PressureGradCentered`` on the same state.
+
+    The layer mean proper is 9h's job; the interface trapezoid used here is a
+    stand-in, so treat the margin as provisional rather than as the final
+    accuracy result.
+
+    """
+    ds = build_state('surface_pressure_gradient', 4.0, 4.0, None)
+    pieces = matched_pressure_pieces(ds)
+    difference = column_scan(pieces)
+    deepest = _deepest_shared(pieces)
+
+    implied = -(Gravity / 4.0e3) * 0.5 * (difference[:-1] + difference[1:])
+    reference = ReferenceColumn(
+        make_config('surface_pressure_gradient'), x_sign=1.0
+    )
+    z_tilde = 0.5 * (
+        ds.ZTildeInterface.isel(Time=0, nCells=0).values
+        + ds.ZTildeInterface.isel(Time=0, nCells=1).values
+    )
+    expected = reference.layer_mean_hpga(z_tilde[: deepest + 2])
+    centered = ds.HPGA.isel(Time=0).values[: deepest + 1]
+
+    scan_error = float(np.sqrt(np.mean((implied - expected) ** 2)))
+    centered_error = float(np.sqrt(np.mean((centered - expected) ** 2)))
+    assert scan_error < centered_error, (
+        f'the scan is {scan_error:.3e} from the reference against '
+        f'{centered_error:.3e} for the centered scheme'
+    )
+
+
+@pytest.mark.parametrize(
+    'variant, vert_res, tilt',
+    [(LINEAR_VARIANT, 256.0, 50.0), ('hydrostatic_consistency', 64.0, 50.0)],
+)
+def test_scan_increments_are_small(variant, vert_res, tilt):
+    """§3.7.5's claim, quantified: nothing large is formed or cancelled.
+
+    Each increment is an integral of a horizontal contrast, so it should be
+    tiny against the hydrostatic scale -- the ~7e3 m of column that a scheme
+    comparing at fixed layer index has to difference and cancel.
+    """
+    ds = build_state(variant, 4.0, vert_res, tilt)
+    increments = scan_increments(matched_pressure_pieces(ds))
+
+    ratio = float(np.max(np.abs(increments))) / hydrostatic_scale(ds)
+    assert ratio < 1.0e-6, (
+        f'{variant}: largest scan increment is {ratio:.3e} of the hydrostatic '
+        'scale'
+    )
+
+
+@pytest.mark.parametrize('vert_res, tilt', [(256.0, 50.0), (64.0, 1.0)])
+def test_scan_round_trips(vert_res, tilt):
+    """Accumulating back up the column recovers the same ``D_k``.
+
+    The previous formulation had two physically distinct anchors to compare;
+    this one has only the surface, so what is testable is that the increments
+    are individually accurate enough that the direction of accumulation does
+    not matter in double precision.
+    """
+    ds = build_state(LINEAR_VARIANT, 4.0, vert_res, tilt)
+    pieces = matched_pressure_pieces(ds)
+    difference = column_scan(pieces)
+    increments = scan_increments(pieces)
+
+    upward = np.empty_like(difference)
+    upward[-1] = difference[-1]
+    for level in range(len(increments) - 1, -1, -1):
+        upward[level] = upward[level + 1] - increments[level]
+
+    worst = float(np.max(np.abs(upward - difference)))
+    assert worst <= _ROUNDOFF_TOL * hydrostatic_scale(ds)

--- a/tests/ocean/horiz_press_grad/test_reconstruction.py
+++ b/tests/ocean/horiz_press_grad/test_reconstruction.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for the mean-preserving linear reconstruction.
+
+Pure numpy/xarray: no config, no dataset, no file I/O, and no parametrization
+over the configured sweeps.
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.tasks.ocean.horiz_press_grad.reconstruction import (
+    layer_deviation,
+    linear_slope,
+    reconstruct,
+)
+
+_DIMS = ['Time', 'nCells', 'nVertLevels']
+
+# Deliberately non-uniform layer pressure thicknesses, and a uniform set as the
+# control.  The control is the point of the pair: an estimator that quietly
+# assumed uniform thickness passes on the uniform grid and fails on the other.
+_NON_UNIFORM = np.array([0.5, 3.0, 1.0, 4.0, 2.0, 0.25, 6.0]) * 1.0e6
+_UNIFORM = np.full(7, 2.0e6)
+
+
+def _column(thickness: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Interface and mid-layer pressures for one column, from thicknesses."""
+    interfaces = np.concatenate([[0.0], np.cumsum(thickness)])
+    mid = 0.5 * (interfaces[:-1] + interfaces[1:])
+    return interfaces, mid
+
+
+def _as_state(mid: np.ndarray, values: np.ndarray):
+    """Wrap a single column as a (Time, nCells, nVertLevels) pair."""
+    return (
+        xr.DataArray(values[np.newaxis, np.newaxis, :], dims=_DIMS),
+        xr.DataArray(mid[np.newaxis, np.newaxis, :], dims=_DIMS),
+    )
+
+
+@pytest.mark.parametrize(
+    'thickness, label', [(_NON_UNIFORM, 'non-uniform'), (_UNIFORM, 'uniform')]
+)
+def test_slope_is_exact_for_a_linear_profile(thickness, label):
+    """The slope of a linear profile is recovered exactly, on any grid.
+
+    For a profile linear in pressure the layer means lie exactly on the line as
+    a function of mid-layer pressure, because the mean of a linear function
+    over a layer is its value at the layer's midpoint.  So this must hold to
+    round-off on the non-uniform grid as well as the uniform one.
+    """
+    _, mid = _column(thickness)
+    intercept = 12.0
+    slope = -3.0e-7
+    values, pressure_mid = _as_state(mid, intercept + slope * mid)
+
+    recovered = linear_slope(values, pressure_mid)
+    np.testing.assert_allclose(
+        recovered.values.ravel(), slope, rtol=1e-12, err_msg=label
+    )
+
+
+def test_reconstruction_reproduces_a_linear_profile_everywhere():
+    """Not just the slope: the reconstructed profile is the original line."""
+    interfaces, mid = _column(_NON_UNIFORM)
+    intercept = 34.9
+    slope = 1.5e-8
+    values, pressure_mid = _as_state(mid, intercept + slope * mid)
+    recovered = linear_slope(values, pressure_mid)
+
+    # evaluate at each layer's own interfaces, where the shift is largest
+    for edge in [interfaces[:-1], interfaces[1:]]:
+        probe = xr.DataArray(edge[np.newaxis, np.newaxis, :], dims=_DIMS)
+        reconstructed = reconstruct(values, recovered, pressure_mid, probe)
+        np.testing.assert_allclose(
+            reconstructed.values.ravel(),
+            intercept + slope * edge,
+            rtol=1e-12,
+        )
+
+
+def test_deviation_integrates_to_zero_over_its_layer():
+    """The mean-preserving constraint, which ``[z-increment-exact]`` rests on.
+
+    Checked by exact quadrature rather than sampling: the deviation is linear
+    in pressure, so a two-point Gauss rule integrates it exactly and the result
+    is limited by round-off.
+    """
+    interfaces, mid = _column(_NON_UNIFORM)
+    values, pressure_mid = _as_state(
+        mid, np.array([22.0, 18.0, 8.0, 6.0, 4.0, 2.0, 1.0])
+    )
+    slope = linear_slope(values, pressure_mid)
+
+    offset = 1.0 / np.sqrt(3.0)
+    thickness = interfaces[1:] - interfaces[:-1]
+    integral = np.zeros(len(mid))
+    for sign in [-1.0, 1.0]:
+        probe = xr.DataArray(
+            (mid + sign * 0.5 * offset * thickness)[np.newaxis, np.newaxis, :],
+            dims=_DIMS,
+        )
+        integral += (
+            0.5
+            * thickness
+            * layer_deviation(slope, pressure_mid, probe).values.ravel()
+        )
+
+    # scale by what the layer mean itself contributes over the layer
+    scale = np.abs(values.values.ravel() * thickness)
+    np.testing.assert_allclose(integral / scale, 0.0, atol=1e-15)
+
+
+def test_reconstruction_returns_the_layer_mean_at_the_midpoint():
+    """By construction, and worth pinning: Requirement 2.4 depends on it."""
+    _, mid = _column(_NON_UNIFORM)
+    values, pressure_mid = _as_state(mid, np.linspace(20.0, 2.0, 7))
+    slope = linear_slope(values, pressure_mid)
+
+    reconstructed = reconstruct(values, slope, pressure_mid, pressure_mid)
+    np.testing.assert_array_equal(reconstructed.values, values.values)
+
+
+def test_slope_is_zero_for_a_uniform_profile():
+    """A vertically uniform profile reconstructs as a constant."""
+    _, mid = _column(_NON_UNIFORM)
+    values, pressure_mid = _as_state(mid, np.full(7, 34.7))
+
+    slope = linear_slope(values, pressure_mid)
+    np.testing.assert_array_equal(slope.values, 0.0)
+
+
+def test_reconstruction_is_second_order_on_a_quadratic_profile():
+    """Off the exact set the reconstruction is second order, not exact.
+
+    The honest limit of a linear reconstruction, and what §3.7.3 means by
+    The honest limit of a linear reconstruction, and what §3.7.3 means by
+    putting a quadratic-in-pressure profile at O(h^2) for Phase 1 rather than
+    at machine precision.  Two things are worth knowing about how it gets
+    there, both of which this test is arranged to respect:
+
+    * On a *uniform* grid the estimator is exact even for a quadratic, because
+      the ``h^2/12`` offsets in the neighbouring layer means cancel and the
+      centred difference of ``mid^2`` is exact.  So the refinement below uses a
+      self-similar non-uniform grid; a uniform one would measure round-off.
+    * On a non-uniform grid the *slope* error is only first order, but the
+      *reconstruction* error is second order, because the slope multiplies
+      ``(p - p^mid)``, which is itself O(h).  Second order in the reconstructed
+      profile is what the scheme consumes, so that is what is asserted.
+
+    """
+    curvature = 4.0e-14
+    total = 1.6e7
+    pattern = np.array([1.0, 2.5, 0.5, 1.8])
+    errors = []
+    for repeats in [4, 8, 16]:
+        thickness = np.tile(pattern, repeats)
+        thickness = thickness * (total / thickness.sum())
+        interfaces, mid = _column(thickness)
+        # exact layer mean of a quadratic: <p^2> = mid^2 + h^2/12
+        exact_mean = curvature * (mid**2 + thickness**2 / 12.0)
+        values, pressure_mid = _as_state(mid, exact_mean)
+        slope = linear_slope(values, pressure_mid)
+
+        largest = 0.0
+        for fraction in [-0.5, -0.25, 0.0, 0.25, 0.5]:
+            probe = mid + fraction * thickness
+            reconstructed = reconstruct(
+                values,
+                slope,
+                pressure_mid,
+                xr.DataArray(probe[np.newaxis, np.newaxis, :], dims=_DIMS),
+            )
+            error = reconstructed.values.ravel() - curvature * probe**2
+            # interior only; the one-sided ends are lower order by construction
+            largest = max(largest, float(np.max(np.abs(error[1:-1]))))
+        errors.append(largest)
+
+    for coarse, fine in zip(errors[:-1], errors[1:], strict=True):
+        order = np.log2(coarse / fine)
+        assert 1.8 < order < 2.2, (
+            f'observed order {order:.2f} in the reconstructed profile'
+        )
+
+
+def test_masked_layers_and_short_columns():
+    """Invalid layers stay ``NaN``; the ends of the valid column are one-sided.
+
+    With tilt or a stepped floor the two columns have different numbers of
+    valid layers, so the estimator has to find the ends of each column rather
+    than of the array.
+    """
+    _, mid = _column(_NON_UNIFORM)
+    intercept = 10.0
+    slope_value = -2.0e-7
+    profile = intercept + slope_value * mid
+
+    # column 0 valid throughout; column 1 stops two layers early
+    values = np.stack([profile, profile])
+    pressure = np.stack([mid, mid])
+    values[1, -2:] = np.nan
+    pressure[1, -2:] = np.nan
+
+    slope = linear_slope(
+        xr.DataArray(values[np.newaxis, ...], dims=_DIMS),
+        xr.DataArray(pressure[np.newaxis, ...], dims=_DIMS),
+    )
+
+    assert np.all(np.isnan(slope.values[0, 1, -2:]))
+    # still exact for the linear profile in both columns, including at the
+    # deepest valid layer of the shortened one
+    np.testing.assert_allclose(slope.values[0, 0, :], slope_value, rtol=1e-12)
+    np.testing.assert_allclose(
+        slope.values[0, 1, :-2], slope_value, rtol=1e-12
+    )
+
+
+def test_single_valid_layer_gives_a_constant():
+    """One layer has nothing to difference against."""
+    _, mid = _column(_NON_UNIFORM)
+    values = np.full(7, np.nan)
+    pressure = np.full(7, np.nan)
+    values[0] = 15.0
+    pressure[0] = mid[0]
+
+    slope = linear_slope(
+        xr.DataArray(values[np.newaxis, np.newaxis, :], dims=_DIMS),
+        xr.DataArray(pressure[np.newaxis, np.newaxis, :], dims=_DIMS),
+    )
+    assert slope.values[0, 0, 0] == 0.0
+    assert np.all(np.isnan(slope.values[0, 0, 1:]))
+
+
+def test_dimension_checks():
+    _, mid = _column(_NON_UNIFORM)
+    values, pressure_mid = _as_state(mid, np.linspace(20.0, 2.0, 7))
+    with pytest.raises(ValueError, match='same dimensions'):
+        linear_slope(values, pressure_mid.rename({'nCells': 'nOther'}))
+    with pytest.raises(ValueError, match='nVertLevels'):
+        linear_slope(
+            values.transpose('Time', 'nVertLevels', 'nCells'),
+            pressure_mid.transpose('Time', 'nVertLevels', 'nCells'),
+        )

--- a/tests/ocean/horiz_press_grad/test_scheme_axis.py
+++ b/tests/ocean/horiz_press_grad/test_scheme_axis.py
@@ -13,18 +13,25 @@ passing.
 
 import importlib.resources as imp_res
 
+import numpy as np
 import pytest
 import yaml
 from jinja2 import Template
 
 from polaris.component import Component
 from polaris.tasks.ocean.horiz_press_grad.forward import SCHEME_HPGA, SCHEMES
+from polaris.tasks.ocean.horiz_press_grad.metrics import rms
 from polaris.tasks.ocean.horiz_press_grad.resting_state_task import (
     HorizPressGradRestingStateTask,
 )
 from polaris.tasks.ocean.horiz_press_grad.task import HorizPressGradTask
 
-from .two_column import GRADIENT_VARIANTS, VARIANTS, make_config
+from .two_column import (
+    GRADIENT_VARIANTS,
+    VARIANTS,
+    build_state,
+    make_config,
+)
 
 _HPG_PKG = 'polaris.tasks.ocean.horiz_press_grad'
 
@@ -108,3 +115,50 @@ def test_forward_yaml_renders_what_omega_expects(scheme):
     # Phase 1 defaults apply; the Phase 2 values are rejected with an error
     assert 'HorzOrder' not in block
     assert 'VerticalReconstruction' not in block
+
+
+# The sweep point where each resting-state variant's advantage is smallest,
+# found by scanning the full sweeps offline.  Gating at the worst point is what
+# makes resting_state_improvement_min meaningful; gating at a typical one would
+# pass while the variant regressed somewhere else in its sweep.
+_WORST_IMPROVEMENT = {
+    'hydrostatic_consistency': (4.0, 128.0, 50.0, 2.58),
+    'hydrostatic_consistency_linear': (4.0, 64.0, 50.0, 7.71),
+    'bathymetry_step': (4.0, 256.0, 200.0, 1169.54),
+    'bathymetry_step_linear': (4.0, 256.0, 200.0, 58828.46),
+}
+
+
+@pytest.mark.parametrize('variant', sorted(_WORST_IMPROVEMENT))
+def test_improvement_gate_is_below_what_the_kernel_delivers(variant):
+    """``resting_state_improvement_min`` is set from measurement, with margin.
+
+    The configured gates were taken from these numbers rather than guessed, so
+    this test is what stops the two drifting apart: if the kernel changes, the
+    measured ratio moves and either this assertion or the recorded one fails,
+    rather than the gate silently becoming vacuous or unreachable.
+
+    It also pins the *shape* of the result, which is the interesting part.  The
+    advantage spans four orders of magnitude across the four variants, smallest
+    where the profile is curved and the coordinate is tilted and largest where
+    the profile is resolved and the sea floor steps -- so a single shared gate
+    would be either vacuous on one end or wrong on the other.
+    """
+    horiz_res, vert_res, tilt, expected = _WORST_IMPROVEMENT[variant]
+    ds = build_state(variant, horiz_res, vert_res, tilt)
+    n_valid = int(ds.maxLevelCell.min())
+
+    centered = rms(ds.HPGA.isel(Time=0).values[:n_valid])
+    finite_volume = rms(ds.HPGAFiniteVolume.isel(Time=0).values[:n_valid])
+    measured = centered / finite_volume
+
+    np.testing.assert_allclose(measured, expected, rtol=0.02, atol=0.0)
+
+    configured = make_config(variant)['horiz_press_grad'].getfloat(
+        'resting_state_improvement_min'
+    )
+    assert configured < measured, (
+        f'{variant}: the configured improvement gate {configured:g} is at or '
+        f'above the {measured:.2f}x the kernel actually delivers at its worst '
+        'sweep point, so the gate cannot pass'
+    )

--- a/tests/ocean/horiz_press_grad/test_scheme_axis.py
+++ b/tests/ocean/horiz_press_grad/test_scheme_axis.py
@@ -1,0 +1,110 @@
+"""
+The pressure-gradient scheme axis: that each variant builds one forward step
+per scheme over one shared init step, that the ``forward.yaml`` template
+renders what Omega expects, and that each scheme is paired with the right
+Polaris-side field.
+
+These are cheap structural checks, but they cover the wiring that no numerical
+test can reach: the numerical tests build states directly and never construct a
+task, so a scheme axis that silently collapsed to one scheme, or paired
+``finite_volume`` with the centered ``HPGA``, would leave every one of them
+passing.
+"""
+
+import importlib.resources as imp_res
+
+import pytest
+import yaml
+from jinja2 import Template
+
+from polaris.component import Component
+from polaris.tasks.ocean.horiz_press_grad.forward import SCHEME_HPGA, SCHEMES
+from polaris.tasks.ocean.horiz_press_grad.resting_state_task import (
+    HorizPressGradRestingStateTask,
+)
+from polaris.tasks.ocean.horiz_press_grad.task import HorizPressGradTask
+
+from .two_column import GRADIENT_VARIANTS, VARIANTS, make_config
+
+_HPG_PKG = 'polaris.tasks.ocean.horiz_press_grad'
+
+
+def _task(name):
+    """Build one variant's task against a throwaway component.
+
+    Deliberately not via ``polaris.tasks.get_components()``: that builds every
+    component in the repository, and the e3sm/init tests clear the shared
+    component objects those tasks are registered on, so a later call from
+    inside the test suite raises.  Constructing the one task under test needs
+    none of that and cannot be perturbed by it.
+    """
+    component = Component(name='ocean')
+    if name in VARIANTS:
+        return HorizPressGradRestingStateTask(component=component, name=name)
+    return HorizPressGradTask(component=component, name=name)
+
+
+def test_schemes_and_their_polaris_fields_line_up():
+    """Every scheme maps to an Omega name and to a Polaris counterpart.
+
+    The pairing in ``SCHEME_HPGA`` is what stops the analysis comparing Omega's
+    finite-volume output against the centered ``HPGA``, which would measure the
+    difference between two schemes and report it as an implementation
+    disagreement.
+    """
+    assert set(SCHEMES) == set(SCHEME_HPGA)
+    assert SCHEMES['centered'] == 'Centered'
+    assert SCHEMES['finite_volume'] == 'FiniteVolume'
+    assert SCHEME_HPGA['centered'] == 'HPGA'
+    assert SCHEME_HPGA['finite_volume'] == 'HPGAFiniteVolume'
+
+
+@pytest.mark.parametrize('variant', GRADIENT_VARIANTS + VARIANTS)
+def test_one_forward_step_per_scheme_over_a_shared_init(variant):
+    """The scheme axis multiplies forward steps and not init steps.
+
+    Init is scheme-independent -- it writes both schemes' Polaris-side HPGA
+    from the same state -- so sharing it is what lets the analysis compare the
+    two schemes at an identical initial condition rather than at two states
+    that merely ought to match.
+    """
+    task = _task(variant)
+    schemes = make_config(variant)['horiz_press_grad'].getexpression(
+        'pressure_grad_types'
+    )
+    assert len(schemes) > 1, 'the shipped config should exercise both schemes'
+
+    names = list(task.steps)
+    init_steps = [name for name in names if name.startswith('init')]
+    forward_steps = [name for name in names if name.startswith('forward')]
+
+    assert len(forward_steps) == len(schemes) * len(init_steps)
+    for scheme in schemes:
+        matching = [
+            name for name in forward_steps if name.endswith(f'_{scheme}')
+        ]
+        assert len(matching) == len(init_steps)
+
+
+@pytest.mark.parametrize('scheme', sorted(SCHEMES))
+def test_forward_yaml_renders_what_omega_expects(scheme):
+    """The template produces a valid ``PressureGrad`` block.
+
+    ``PressureGradType`` must come out a string: an unrecognized value is fatal
+    on the Omega side rather than falling back to ``Centered``, which is the
+    behaviour that stops a typo here producing centered answers that read as a
+    pass.
+    """
+    text = imp_res.files(_HPG_PKG).joinpath('forward.yaml').read_text()
+    rendered = Template(text).render(
+        pressure_grad_type=SCHEMES[scheme], quadrature_points=2
+    )
+    block = yaml.safe_load(rendered)['Omega']['PressureGrad']
+
+    assert block['PressureGradType'] == SCHEMES[scheme]
+    assert isinstance(block['PressureGradType'], str)
+    assert block['QuadraturePoints'] == 2
+    # HorzOrder and VerticalReconstruction are deliberately absent, so Omega's
+    # Phase 1 defaults apply; the Phase 2 values are rejected with an error
+    assert 'HorzOrder' not in block
+    assert 'VerticalReconstruction' not in block

--- a/tests/ocean/horiz_press_grad/two_column.py
+++ b/tests/ocean/horiz_press_grad/two_column.py
@@ -56,7 +56,9 @@ GRADIENT_VARIANTS = [
 ]
 
 # Built states are reused across tests, at roughly 0.25 s each.
-_STATE_CACHE: dict[tuple[str, float, float, float | None], xr.Dataset] = {}
+_STATE_CACHE: dict[
+    tuple[str, float, float, float | None, int | None], xr.Dataset
+] = {}
 
 
 # A representative subset of the sweeps, for tests whose point is not "at every
@@ -118,7 +120,11 @@ def resolution_pairs(variant: str) -> list[tuple[float, float]]:
 
 
 def build_state(
-    variant: str, horiz_res: float, vert_res: float, tilt: float | None
+    variant: str,
+    horiz_res: float,
+    vert_res: float,
+    tilt: float | None,
+    quadrature_points: int | None = None,
 ) -> xr.Dataset:
     """
     Build (or return a cached) two-column state for one sweep point.
@@ -128,15 +134,24 @@ def build_state(
     :py:class:`~polaris.tasks.ocean.horiz_press_grad.task.HorizPressGradTask`
     constructs the step.
 
+    ``quadrature_points`` overrides the config option of that name, which is
+    what sets the Gauss-Legendre rule ``HPGAFiniteVolume`` is built with.  It
+    exists so that a test can confirm the option is read rather than a default
+    being used; leave it ``None`` to take the variant's configured value.
+
     The Polaris ``Step`` constructor is bypassed, as in
     ``tests/ocean/vertical/test_pstar_init.py``, so that no component, work
     directory or config file is needed.
     """
-    key = (variant, horiz_res, vert_res, tilt)
+    key = (variant, horiz_res, vert_res, tilt, quadrature_points)
     if key in _STATE_CACHE:
         return _STATE_CACHE[key]
 
     config = make_config(variant)
+    if quadrature_points is not None:
+        config.set(
+            'horiz_press_grad', 'quadrature_points', str(quadrature_points)
+        )
     step = object.__new__(Init)
     step.config = config
     step.logger = logging.getLogger('test_finite_volume')

--- a/tests/ocean/horiz_press_grad/two_column.py
+++ b/tests/ocean/horiz_press_grad/two_column.py
@@ -17,6 +17,7 @@ from polaris.config import PolarisConfigParser
 from polaris.tasks.ocean.horiz_press_grad.init import Init
 
 __all__ = [
+    'REPRESENTATIVE',
     'VARIANTS',
     'LINEAR_VARIANT',
     'GRADIENT_VARIANTS',
@@ -56,6 +57,26 @@ GRADIENT_VARIANTS = [
 
 # Built states are reused across tests, at roughly 0.25 s each.
 _STATE_CACHE: dict[tuple[str, float, float, float | None], xr.Dataset] = {}
+
+
+# A representative subset of the sweeps, for tests whose point is not "at every
+# tilt".  The full sweeps are kept only for the S identity, which is the
+# cheapest test and the one whose whole claim is that it holds everywhere.
+# Trimming this rather than the number of test functions is what keeps the
+# collected count reasonable: the functions are few, the parametrization was
+# what grew.
+REPRESENTATIVE = [
+    ('hydrostatic_consistency', 4.0, 256.0, 0.05),
+    ('hydrostatic_consistency', 4.0, 64.0, 50.0),
+    ('hydrostatic_consistency_linear', 4.0, 256.0, 0.05),
+    ('hydrostatic_consistency_linear', 4.0, 256.0, 50.0),
+    ('hydrostatic_consistency_linear', 4.0, 64.0, 50.0),
+    ('bathymetry_step', 4.0, 256.0, 1.0),
+    ('bathymetry_step', 4.0, 128.0, 200.0),
+    ('temperature_gradient', 4.0, 4.0, None),
+    ('surface_pressure_gradient', 4.0, 4.0, None),
+    ('ztilde_gradient', 0.5, 0.5, None),
+]
 
 
 def make_config(variant: str) -> PolarisConfigParser:

--- a/tests/ocean/horiz_press_grad/two_column.py
+++ b/tests/ocean/horiz_press_grad/two_column.py
@@ -20,6 +20,7 @@ __all__ = [
     'REPRESENTATIVE',
     'VARIANTS',
     'LINEAR_VARIANT',
+    'STEP_LINEAR_VARIANT',
     'GRADIENT_VARIANTS',
     'make_config',
     'sweep',
@@ -36,11 +37,18 @@ VARIANTS = [
     'hydrostatic_consistency',
     'hydrostatic_consistency_linear',
     'bathymetry_step',
+    'bathymetry_step_linear',
 ]
 
-# The one variant whose profile is linear in pressure, and so the only one in
-# the finite-volume scheme's exact set.
+# The variant whose profile is linear in pressure and whose coordinate is
+# tilted -- the exact set, exercised against a tilted coordinate.
 LINEAR_VARIANT = 'hydrostatic_consistency_linear'
+
+# The same profile against a stepped sea floor instead.  Also in the exact set,
+# and the only configuration in the family that is both exact and in the
+# geometry that drives the global bottom-layer error, which is what makes it
+# the one that isolates what a bathymetry step costs the scheme.
+STEP_LINEAR_VARIANT = 'bathymetry_step_linear'
 
 # The four gradient variants, which sweep resolution rather than tilt.  They
 # add nothing to the algebra but a good deal to the states it is checked on:
@@ -75,6 +83,8 @@ REPRESENTATIVE = [
     ('hydrostatic_consistency_linear', 4.0, 64.0, 50.0),
     ('bathymetry_step', 4.0, 256.0, 1.0),
     ('bathymetry_step', 4.0, 128.0, 200.0),
+    ('bathymetry_step_linear', 4.0, 256.0, 25.0),
+    ('bathymetry_step_linear', 4.0, 256.0, 200.0),
     ('temperature_gradient', 4.0, 4.0, None),
     ('surface_pressure_gradient', 4.0, 4.0, None),
     ('ztilde_gradient', 0.5, 0.5, None),

--- a/tests/ocean/horiz_press_grad/two_column.py
+++ b/tests/ocean/horiz_press_grad/two_column.py
@@ -1,0 +1,135 @@
+"""
+Shared fixtures for the two-column ``horiz_press_grad`` tests.
+
+Builds the same state
+:py:class:`~polaris.tasks.ocean.horiz_press_grad.init.Init` writes to
+``init.nc``, from the packaged config of one of the task's variants, with no
+mesh generation and no file I/O.  Several test modules need these states, so
+they live here rather than in whichever module wanted them first.
+"""
+
+import logging
+
+import numpy as np
+import xarray as xr
+
+from polaris.config import PolarisConfigParser
+from polaris.tasks.ocean.horiz_press_grad.init import Init
+
+__all__ = [
+    'VARIANTS',
+    'LINEAR_VARIANT',
+    'GRADIENT_VARIANTS',
+    'make_config',
+    'sweep',
+    'resolution_pairs',
+    'build_state',
+]
+
+_HPG_PKG = 'polaris.tasks.ocean.horiz_press_grad'
+
+# The resting-state variants and their sweeps.  These are the configurations
+# whose true HPGA is identically zero, so whatever the centered scheme returns
+# there is error, and they are the only ones that sweep a tilt.
+VARIANTS = [
+    'hydrostatic_consistency',
+    'hydrostatic_consistency_linear',
+    'bathymetry_step',
+]
+
+# The one variant whose profile is linear in pressure, and so the only one in
+# the finite-volume scheme's exact set.
+LINEAR_VARIANT = 'hydrostatic_consistency_linear'
+
+# The four gradient variants, which sweep resolution rather than tilt.  They
+# add nothing to the algebra but a good deal to the states it is checked on:
+# temperature and salinity contrasts across the edge, pseudo-height nodes that
+# move with x, and -- in surface_pressure_gradient -- a different surface
+# pressure in the two columns, so that Delta_e q is nonzero at the top
+# interface and not only in the interior.
+GRADIENT_VARIANTS = [
+    'temperature_gradient',
+    'salinity_gradient',
+    'ztilde_gradient',
+    'surface_pressure_gradient',
+]
+
+# Built states are reused across tests, at roughly 0.25 s each.
+_STATE_CACHE: dict[tuple[str, float, float, float | None], xr.Dataset] = {}
+
+
+def make_config(variant: str) -> PolarisConfigParser:
+    """Load the packaged config for one variant of the task."""
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.ocean', 'ocean.cfg')
+    config.add_from_package(_HPG_PKG, 'horiz_press_grad.cfg')
+    config.add_from_package(_HPG_PKG, f'{variant}.cfg')
+    return config
+
+
+def sweep(variant: str) -> list[tuple[float, float, float]]:
+    """The ``(horiz_res, vert_res, tilt)`` points of a variant's sweep."""
+    section = make_config(variant)['horiz_press_grad']
+    horiz_resolutions = section.getexpression('horiz_resolutions')
+    vert_resolutions = section.getexpression('vert_resolutions')
+    tilt_values = section.getexpression('tilt_values')
+    return [
+        (float(horiz_res), float(vert_res), float(tilt))
+        for horiz_res, vert_res in zip(
+            horiz_resolutions, vert_resolutions, strict=True
+        )
+        for tilt in tilt_values
+    ]
+
+
+def resolution_pairs(variant: str) -> list[tuple[float, float]]:
+    """The coarsest and finest ``(horiz_res, vert_res)`` pairs of a sweep."""
+    section = make_config(variant)['horiz_press_grad']
+    pairs = [
+        (float(horiz_res), float(vert_res))
+        for horiz_res, vert_res in zip(
+            section.getexpression('horiz_resolutions'),
+            section.getexpression('vert_resolutions'),
+            strict=True,
+        )
+    ]
+    return [pairs[0], pairs[-1]]
+
+
+def build_state(
+    variant: str, horiz_res: float, vert_res: float, tilt: float | None
+) -> xr.Dataset:
+    """
+    Build (or return a cached) two-column state for one sweep point.
+
+    ``tilt`` is the value of the variant's ``tilt_option``, or ``None`` for the
+    gradient variants, which override no option -- exactly as
+    :py:class:`~polaris.tasks.ocean.horiz_press_grad.task.HorizPressGradTask`
+    constructs the step.
+
+    The Polaris ``Step`` constructor is bypassed, as in
+    ``tests/ocean/vertical/test_pstar_init.py``, so that no component, work
+    directory or config file is needed.
+    """
+    key = (variant, horiz_res, vert_res, tilt)
+    if key in _STATE_CACHE:
+        return _STATE_CACHE[key]
+
+    config = make_config(variant)
+    step = object.__new__(Init)
+    step.config = config
+    step.logger = logging.getLogger('test_finite_volume')
+    step.horiz_res = horiz_res
+    step.vert_res = vert_res
+    if tilt is None:
+        step.tilt_option = None
+    else:
+        step.tilt_option = config.get('horiz_press_grad', 'tilt_option')
+    step.tilt = tilt
+    step.x = np.array([])
+
+    ds_mesh = xr.Dataset({'xCell': xr.DataArray(np.zeros(2), dims=['nCells'])})
+    ds = step.build_column_state(ds_mesh)
+
+    _STATE_CACHE[key] = ds
+    return ds

--- a/tests/ocean/vertical/test_pstar_init.py
+++ b/tests/ocean/vertical/test_pstar_init.py
@@ -313,8 +313,8 @@ def test_surface_pressure_sets_ztilde_surface_correctly():
     This is the invariant that the reference solution relies on: it computes
     z_tilde_surf = -surface_pressure / (RhoSw * Gravity) and expects the
     z-tilde grid to start there.  If the surface is stuck at zero the tracer
-    interpolation in init_tracers (which uses ZTildeMid) and the reference
-    solution will be offset from each other.
+    initialization in init_tracers (which is built on the z-tilde grid) and the
+    reference solution will be offset from each other.
     """
     target_depth = 500.0
     ssp = RhoSw * Gravity * 1.0  # ~1 m water-column equivalent


### PR DESCRIPTION
**Draft.** Phase 1 only — the tests run the existing `Centered` scheme and establish a baseline. Scheme comparison waits on Omega's `FiniteVolume` option.

**Depends on** #674 (anchoring the geometric column at the prescribed sea surface). This branch sits on top of it and adds nothing under `polaris/ocean/vertical/`.

## What this adds

- Two variants of `ocean/column/horiz_press_grad` that are **exact resting states**: conservative temperature and absolute salinity are horizontally uniform functions of pseudo-height, so specific volume is a function of pressure alone, isobars are level, and the true HPGA is identically zero. Whatever the model returns is error, and no reference solution is involved.
  - `hydrostatic_consistency` — tilts the p-star coordinate; sweeps `z_tilde_bot_grad` over ~3 decades.
  - `bathymetry_step` — steps the sea floor; sweeps `geom_z_bot_grad`.
- `RestingAnalysis`, a reference-free analysis step that measures absolute RMS HPGA, fits the exponent `q` in `|HPGA| ~ tilt^q`, and gates on sensitivity, Omega-vs-Polaris consistency, and bathymetry fidelity.
- `metrics.py`, a dependency-light leaf module holding helpers previously private to `analysis.py` (pure refactor).
- A new design doc, plus user- and developer-guide sections.

These implement the discrete hydrostatic consistency test called for in the Omega higher-order pressure-gradient design (`PGradHighOrder.md` §2.3, §3.7, §5.2).

## Bug fix included: the reference comparison discarded the bottom layer

- `analysis.py` dropped the deepest layer valid in both columns from the Omega-vs-reference RMS. That was a limitation of the *previous* five-column finite-difference reference, whose stencil could not be formed where a neighbour's collocation point fell below its own bathymetry. The reference is now a single analytic column at the edge, valid to the seafloor, so the exclusion no longer has a basis.
- The `omega_vs_python` comparison in the same function already included that layer, so the two comparisons had been disagreeing about which layers count. They now agree.

**Answer-changing for one existing variant.** Three of the four are unaffected. `ztilde_gradient` is the only one with a tilted coordinate, so its two columns clip the bottom layer at different thicknesses; that cell carries `-1.55e-09` m/s² at 0.5 km against an interior RMS of `6.8e-12` and converges at roughly first order, pulling the fitted slope from 2.003 to 1.119. This is a real first-order error in the bottom partial cell that the exclusion was hiding, not a regression — it is what the higher-order scheme exists to fix. `ztilde_gradient.cfg` takes its own convergence band `[0.9, 1.4]`; no RMS threshold needed changing.

## Results

All six variants pass. Omega agrees with the Polaris-side kernel to **8.7e-15** (threshold 1e-10).

- **The centered scheme's tilt exponent is q = 1.000** (1.000, 1.000, 0.989, 1.000 across resolution groups) — specific volume is effectively piecewise constant in pressure. This is the calibration the higher-order scheme has to beat.
- Sensitivity gate (1e-6 m/s², the order of the global bottom-layer error) passes by ~20×: max RMS 2.59e-05 (`hydrostatic_consistency`), 2.26e-05 (`bathymetry_step`).

<img width="2916" height="2319" alt="image" src="https://github.com/user-attachments/assets/9bee5fef-17df-4266-ab2c-a59b663cbca1" />

<img width="2916" height="2319" alt="image" src="https://github.com/user-attachments/assets/3c96494a-0fa9-4264-91c7-5d090b95c610" />

- `bathymetry_step` is a staircase rather than a power law, as expected — its signal is set by where `maxLevelCell` changes — so it does not fit an exponent.

Existing variants, fitted slope / RMS at 0.5 km: `salinity_gradient` 1.799 / 2.60e-07, `surface_pressure_gradient` 2.013 / 1.13e-11, `temperature_gradient` 1.625 / 2.77e-07, `ztilde_gradient` 1.119 / 4.95e-11.

## What this tells us about realistic global testing

Compared against the `EC30to60E2r2` uniform-T/S resting state used to chase Omega's spurious bottom-layer kinetic energy.

- **A sea-floor step does not tilt interior coordinate surfaces in a p-star column.** Both columns share one reference grid, so moving the sea floor changes only where it is clipped; every interior interface sits at an identical pressure. The entire `bathymetry_step` signal is in the bottom partial cell, with the interior at round-off.
- **`bathymetry_step` reproduces the global bottom-layer error.** Splitting the global error into depth-mean and deviation — only the baroclinic part can survive free-surface adjustment — the two-column test matches the global baroclinic bottom-layer error to **within 20–35%** across the p25–p75 bathymetric-slope range where most of the mesh sits. It over-predicts steeply sloped edges by 3–10×, presumably because an isolated two-column step is harsher than a real slope where neighbouring cells share the descent.
- **Interior coordinate tilt is not the global mechanism.** The global IC's interior coordinate is level to 2–18 Pa cross-edge; the smallest tilt in the `hydrostatic_consistency` sweep is 1.74e3 Pa, 100–1000× more. Scaling the measured q = 1 line to the global tilt puts it ~6000× below the observed global interior error. That variant remains the design's §5.2 test and the source of the q = 1 calibration, but a good result there would **not** predict a global improvement.
- **Scale of the target.** In the global bottom layer the truncation error is 1.28× (median) and 1.55× (p99) the pressure gradient the model actually carries. A useful scheme has to bring that well below 1×, which is a factor of 5–10 at realistic slopes, not a factor of 2.

Not established: whether fixing the resting-state error fixes the global bottom-layer KE. That link is still an inference, and only a global run with the new scheme settles it.

## Notes for review

- The two new variants are deliberately **not** in `omega_pr` or `omega_nightly` — thresholds should be settled in phase 2 first.
- `resting_state_max_rms` ships as `none` on purpose: the centered scheme fails any meaningful value, and the threshold for a hydrostatically consistent scheme should be set from measurement rather than guessed.
- Both variants set `partial_cell_type = None`, which is required: snapping moves the sea floor, and the sea floor is the quantity `bathymetry_step` sweeps. Despite the name this does **not** mean "no partial cells" — `_compute_ref_pseudo_thickness` clips the deepest layer at the pseudo-bottom depth unconditionally, so partial bottom cells are always produced. `partial_cell_type` controls only whether the sea floor is *moved* before that clipping: `partial` enforces a `min_pc_fraction` floor, and `full` is the setting that actually removes partial cells. Measured in the run, bottom cells span 0.002 to 1.00 of a full layer.
- `ztilde_gradient`'s new convergence band is the one pass criterion this PR moves, and it is marked in the cfg as set from the phase-1 run.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
