### PR TITLE
Add Omega support for the `seamount` tests

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -462,6 +462,9 @@
    init.Init.setup
    init.Init.run
 
+   init_utils.compute_target_density
+   init_utils.compute_tracers
+
    viz.Viz
    viz.Viz.run
 ```

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -648,10 +648,12 @@
    compute_specvol
    convert_tracer_pair
    convert_tracers
+   ct_from_potential_density
 
    constant.compute_constant_density
    linear.compute_linear_density
    teos10.compute_specvol
+   teos10.ct_from_potential_density
 ```
 
 

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -465,6 +465,8 @@
    init_utils.compute_target_density
    init_utils.compute_tracers
 
+   short.Short
+
    viz.Viz
    viz.Viz.run
 ```

--- a/docs/developers_guide/ocean/tasks/seamount.md
+++ b/docs/developers_guide/ocean/tasks/seamount.md
@@ -129,6 +129,8 @@ the Omega `History` stream alongside `State`.
 ## default
 
 The {py:class}`polaris.tasks.ocean.seamount.default.Default`
-test runs the `init` step, a short `forward` step, and the `viz` step.  It is
-added once per tree, so four times.
+test runs the `init` step, a 6 day `forward` step, and the `viz` step.  It is
+added once per tree, so four times.  Unlike most tasks, `viz` runs by
+default here: the forward run is long enough that it is not worth making the
+user re-run the task just to get the plots.
 

--- a/docs/developers_guide/ocean/tasks/seamount.md
+++ b/docs/developers_guide/ocean/tasks/seamount.md
@@ -93,10 +93,10 @@ The class {py:class}`polaris.tasks.ocean.seamount.forward.Forward`
 defines a step for running the ocean from the initial condition produced in
 the `init` step. Namelist and streams files are updated in
 {py:meth}`polaris.tasks.ocean.seamount.forward.Forward.dynamic_model_config()`
-with time steps determined algorithmically based on config options.  Omega has
-no split-explicit time integrator, so it takes its step from `omega_dt_per_km`
-and its integrator from `omega_time_integrator` rather than the MPAS-Ocean
-`dt_per_km` and `time_integrator`.  The
+with time steps determined algorithmically based on config options.  Both
+models take the same step from `dt_per_km` and the same integrator from
+`time_integrator`; the only model-dependent part is translating the
+integrator name to Omega's (`RK4` becomes `RungeKutta4`).  The
 number of cells is approximated from config options in
 {py:meth}`polaris.tasks.ocean.seamount.forward.Forward.compute_cell_count()`
 so that this can be used to constrain the number of MPI tasks that Polaris

--- a/docs/developers_guide/ocean/tasks/seamount.md
+++ b/docs/developers_guide/ocean/tasks/seamount.md
@@ -2,9 +2,10 @@
 
 # seamount
 
-The seamount task group is comprised of one `default` task in each of two task
-trees, `planar/seamount/sigma` and `planar/seamount/zstar`, one per vertical
-coordinate for the initial condition.
+The seamount task group is comprised of one `default` task in each of four
+task trees, `planar/seamount/{linear,nonlinear}/{sigma,zstar}`, combining the
+equation of state with the vertical coordinate used for the initial
+condition.  This follows the `planar/overflow/{eos}/{coord}` pattern.
 
 ## framework
 
@@ -12,6 +13,17 @@ The shared config options for `seamount` tests  are described in
 {ref}`ocean-seamount` in the User's Guide.  `coord_type`, and for z-star
 `partial_cell_type`, live in per-coordinate `seamount_sigma.cfg` and
 `seamount_zstar.cfg` overrides layered on top of the shared `seamount.cfg`.
+The equation of state is layered on the same way: `seamount_linear.cfg`
+carries the `eos_linear_*` options, which mean nothing to the nonlinear
+trees and so are added only for the linear ones.  `add_seamount_tasks()`
+also picks up `linear.cfg` or `teos10.cfg` from `polaris.ocean.eos` per
+tree; the nonlinear trees need nothing beyond that.
+
+Neither equation of state needs new plumbing.  `update_namelist_eos()`
+already maps `teos-10` to `jm` for MPAS-Ocean and passes it through to
+Omega, and the geometric-to-pseudo-height conversion described below
+dispatches on `eos_type` through
+{py:func}`polaris.ocean.eos.compute_specvol()`.
 
 Additionally, the tests share a `forward.yaml` file with a few common model
 config options related to time management, time integration, Laplacian
@@ -35,6 +47,11 @@ geometric round trip, that sigma layers stay proportional to column depth, and
 that interior interfaces sit at genuinely different pressures from column to
 column, with a flat-bottom negative control for the last of these.
 
+`tests/ocean/seamount/test_tracers.py` covers the initial condition: that
+both equation-of-state branches reproduce the same Beckmann and Haidvogel
+profile, and the negative control that in-situ density under TEOS-10 really
+does depart from it with depth.
+
 ### init
 
 The class {py:class}`polaris.tasks.ocean.seamount.init.Init`
@@ -44,9 +61,31 @@ First, a mesh appropriate for the resolution is generated using
 {py:func}`mpas_tools.planar_hex.make_planar_hex_mesh()`. The bottom topography
 is defined along with a vertical grid with 32 layers by default.  Next, the
 ocean state is generated with a vertical temperature stratification,
-back-computed from the target Beckmann and Haidvogel density by inverting the
-full linear equation of state, salinity term included, so that the density the
-model sees matches the profile the test intends.
+back-computed from the target Beckmann and Haidvogel density so that the
+density the model sees matches the profile the test intends.
+
+The profile and the back-solve live in
+{py:mod}`polaris.tasks.ocean.seamount.init_utils`, a leaf module free of
+`mpas_tools` and of the step framework so the unit tests can import it.
+{py:func}`polaris.tasks.ocean.seamount.init_utils.compute_tracers()` branches
+on `eos_type`: the linear equation of state is inverted algebraically with
+the salinity term included, and TEOS-10 is inverted with
+{py:func}`polaris.ocean.eos.ct_from_potential_density()`, which reads the
+profile as a potential density referenced to the surface.  See
+{ref}`ocean-seamount-init` in the User's Guide for why the surface reference
+is the only workable one and what it buys.
+
+The step leaves its tracers in the convention implied by `eos_type` and does
+nothing model-specific: in the `nonlinear` trees, the framework converts them
+to potential temperature and practical salinity at the nominal lon/lat when
+the model is MPAS-Ocean (see {ref}`dev-ocean-framework-init-state`), computing
+the pressure that conversion needs from the layer thicknesses since a
+geometric vertical coordinate carries none.
+
+Note that the tracers carry the `Time` dimension that `layerThickness` and
+the rest of the state have.  TEOS-10 requires its inputs to be aligned; the
+linear equation of state did not, which is why the seamount got away without
+it for a while.
 
 ### forward
 
@@ -91,5 +130,5 @@ the Omega `History` stream alongside `State`.
 
 The {py:class}`polaris.tasks.ocean.seamount.default.Default`
 test runs the `init` step, a short `forward` step, and the `viz` step.  It is
-added once per coordinate tree.
+added once per tree, so four times.
 

--- a/docs/developers_guide/ocean/tasks/seamount.md
+++ b/docs/developers_guide/ocean/tasks/seamount.md
@@ -2,10 +2,11 @@
 
 # seamount
 
-The seamount task group is comprised of one `default` task in each of four
-task trees, `planar/seamount/{linear,nonlinear}/{sigma,zstar}`, combining the
-equation of state with the vertical coordinate used for the initial
-condition.  This follows the `planar/overflow/{eos}/{coord}` pattern.
+The seamount task group is comprised of a `default` task and a `short` task
+in each of four task trees,
+`planar/seamount/{linear,nonlinear}/{sigma,zstar}`, combining the equation of
+state with the vertical coordinate used for the initial condition.  This
+follows the `planar/overflow/{eos}/{coord}` pattern.
 
 ## framework
 
@@ -103,8 +104,9 @@ so that this can be used to constrain the number of MPI tasks that Polaris
 tasks have as their target and minimum (if the resources are not explicitly
 prescribed).  For MPAS-Ocean, PIO namelist options are modified and a
 graph partition is generated as part of `runtime_setup()`.  Next, the ocean
-model is run. The duration is set by `run_duration` in the config section
-corresponding to the task (`seamount_default`). Finally,
+model is run. The duration is set by `run_duration`, in hours, in the config
+section corresponding to the task (`seamount_default` or `seamount_short`,
+selected by the `task_name` passed to the step). Finally,
 the variables `kineticEnergyCell` and `normalVelocity` in the
 `output.nc` file are visualized in the `viz` directory.
 
@@ -133,4 +135,24 @@ test runs the `init` step, a 6 day `forward` step, and the `viz` step.  It is
 added once per tree, so four times.  Unlike most tasks, `viz` runs by
 default here: the forward run is long enough that it is not worth making the
 user re-run the task just to get the plots.
+
+
+(dev-ocean-seamount-short)=
+
+## short
+
+The {py:class}`polaris.tasks.ocean.seamount.short.Short` test is the same
+task with a 1 hour `forward` step, and it too is added once per tree.  It
+exists as a regression test rather than a measurement: an hour is far too
+short for the spurious circulation to develop.  `viz` is opt-in here, as
+usual, because re-running the task to get the plots is cheap.
+
+The two tasks differ only in their config section, `seamount_default` versus
+`seamount_short`, which is what {py:class}`Forward` looks up from its
+`task_name`.
+
+Two of the four short tasks are in the `mpaso_pr` and `omega_pr` suites,
+`linear/zstar` and `nonlinear/sigma`, which covers both equations of state
+and both coordinates in two runs.  Nothing from the seamount is in the
+nightly suites yet; the `default` tasks are 6 day runs.
 

--- a/docs/developers_guide/ocean/tasks/seamount.md
+++ b/docs/developers_guide/ocean/tasks/seamount.md
@@ -2,16 +2,38 @@
 
 # seamount
 
-The seamount task group is currently comprised of one `default` task.
+The seamount task group is comprised of one `default` task in each of two task
+trees, `planar/seamount/sigma` and `planar/seamount/zstar`, one per vertical
+coordinate for the initial condition.
+
 ## framework
 
 The shared config options for `seamount` tests  are described in
-{ref}`ocean-seamount` in the User's Guide.
+{ref}`ocean-seamount` in the User's Guide.  `coord_type`, and for z-star
+`partial_cell_type`, live in per-coordinate `seamount_sigma.cfg` and
+`seamount_zstar.cfg` overrides layered on top of the shared `seamount.cfg`.
 
 Additionally, the tests share a `forward.yaml` file with a few common model
-config options related to time management, time integration, and Laplacian
-viscosity, as well as defining `mesh`, `input`, `restart`, and `output`
-streams.
+config options related to time management, time integration, Laplacian
+viscosity, bottom drag and vertical mixing, as well as defining `mesh`,
+`input`, `restart`, and `output` streams.  It is split into a shared `ocean:`
+section and model-specific `mpas-ocean:` and `Omega:` sections.
+
+### support for both ocean models
+
+Both coordinates are geometric, so one `init` step serves either model.  When
+`model = omega`, `Ocean.write_vert_coord_dataset()` and
+`Ocean.write_model_dataset()` convert `restingThickness` and `layerThickness`
+into `RefPseudoThickness` and `PseudoThickness` by integrating gauge pressure
+down each column through the configured equation of state.  No p-star-specific
+initialization is involved and no reference pseudo-grid is needed, so the
+seamount does not use
+{py:class}`polaris.ocean.vertical.pstar_init.PStarInitStep`.
+
+`tests/ocean/seamount/test_sigma_to_pseudo.py` covers that conversion: the
+geometric round trip, that sigma layers stay proportional to column depth, and
+that interior interfaces sit at genuinely different pressures from column to
+column, with a flat-bottom negative control for the last of these.
 
 ### init
 
@@ -20,8 +42,11 @@ defines a step for setting up the initial state for each test case.
 
 First, a mesh appropriate for the resolution is generated using
 {py:func}`mpas_tools.planar_hex.make_planar_hex_mesh()`. The bottom topography
-is defined along with a vertical grid with 10 layers by default.  Next, the
-ocean state is generated with a vertical temperature stratification.
+is defined along with a vertical grid with 32 layers by default.  Next, the
+ocean state is generated with a vertical temperature stratification,
+back-computed from the target Beckmann and Haidvogel density by inverting the
+full linear equation of state, salinity term included, so that the density the
+model sees matches the profile the test intends.
 
 ### forward
 
@@ -29,7 +54,10 @@ The class {py:class}`polaris.tasks.ocean.seamount.forward.Forward`
 defines a step for running the ocean from the initial condition produced in
 the `init` step. Namelist and streams files are updated in
 {py:meth}`polaris.tasks.ocean.seamount.forward.Forward.dynamic_model_config()`
-with time steps determined algorithmically based on config options.  The
+with time steps determined algorithmically based on config options.  Omega has
+no split-explicit time integrator, so it takes its step from `omega_dt_per_km`
+and its integrator from `omega_time_integrator` rather than the MPAS-Ocean
+`dt_per_km` and `time_integrator`.  The
 number of cells is approximated from config options in
 {py:meth}`polaris.tasks.ocean.seamount.forward.Forward.compute_cell_count()`
 so that this can be used to constrain the number of MPI tasks that Polaris
@@ -47,8 +75,14 @@ the variables `kineticEnergyCell` and `normalVelocity` in the
 The {py:class}`polaris.tasks.ocean.seamount.viz.Viz` plots the maximum velocity
 as a function of time; a horizontal cross-section of the normal velocity;
 and a vertical cross-section of the kinetic energy. The vertical cross-section
-is also convenient to see the vertical coordinate (sigma versus z-level) and
+is also convenient to see the vertical coordinate (sigma versus z-star) and
 the bottom topography.
+
+The transect needs a geometric layer thickness, and `layerThickness` is the
+right field for both models.  Omega writes `PseudoThickness` rather than a
+geometric thickness, but `Ocean.open_model_dataset()` converts it on read,
+as `RhoSw * SpecVol * PseudoThickness`.  That is why `SpecVol` has to be in
+the Omega `History` stream alongside `State`.
 
 
 (dev-ocean-seamount-default)=
@@ -56,5 +90,6 @@ the bottom topography.
 ## default
 
 The {py:class}`polaris.tasks.ocean.seamount.default.Default`
-test runs the `init` step, a short `forward` step, and the `viz` step.
+test runs the `init` step, a short `forward` step, and the `viz` step.  It is
+added once per coordinate tree.
 

--- a/docs/users_guide/ocean/tasks/seamount.md
+++ b/docs/users_guide/ocean/tasks/seamount.md
@@ -8,7 +8,41 @@ This case tests the error due to pressure gradients in tilted layers.
 
 ## supported models
 
-These tasks support only MPAS-Ocean.
+These tasks support both MPAS-Ocean and Omega.
+
+The vertical coordinate is built in geometric height in either case, and is
+converted to the pseudo-height (`RefPseudoThickness`) that Omega's p-star
+dynamics read when `model = omega`.  Both models therefore start from the same
+geometric layer positions, which is what makes the two comparable.  The
+conversion integrates gauge pressure down each column through the configured
+equation of state, so it needs no p-star-specific initialization and no
+reference pseudo-grid.
+
+Because Omega's linear equation of state has no reference temperature or
+salinity, `eos_linear_Tref` and `eos_linear_Sref` must both be zero; the
+Beckmann and Haidvogel reference state is folded into `eos_linear_rhoref`
+instead.
+
+Omega has no split-explicit time integrator, so it is limited by the
+barotropic gravity wave and needs a shorter time step than MPAS-Ocean.  The
+two are configured separately, through `dt_per_km` and `omega_dt_per_km`.
+
+(ocean-seamount-variants)=
+
+## coordinate variants
+
+Each task exists in two trees, one per vertical coordinate for the initial
+condition:
+
+- `planar/seamount/sigma` — the terrain-following coordinate, and the main
+  target.  Every layer is tilted relative to the isobars by construction, so
+  the pressure gradient error is exercised throughout the water column.
+- `planar/seamount/zstar` — the control.  Layers are nearly level, so the
+  spurious velocity should be much smaller.  Partial bottom cells are used
+  here: z-star cuts the reference grid at the seafloor, and without snapping
+  the seamount flanks produce bottom cells only centimetres thick.  Set
+  `partial_cell_type = full` for the limiting case in which the layers are
+  exactly level and the pressure gradient vanishes to machine precision.
 
 (ocean-seamount-default)=
 
@@ -45,7 +79,23 @@ which is set by the ``resolution`` config option. The domain is
 
 ### vertical grid
 
-The default setting is a sigma (terrain-following) vertical coordinate. One may also test z-level coordinates (`coord_type = z-level`) with full cells (`partial_cell_type = full`) or partial bottom cells (`partial_cell_type = None`). Here `None` means no alteration, so it uses original bottom depth. 
+The coordinate is set by the task tree, `sigma` or `zstar`, as described in
+{ref}`ocean-seamount-variants`. `coord_type` therefore lives in
+`seamount_sigma.cfg` / `seamount_zstar.cfg` rather than in the shared config
+below. One may also test `coord_type = z-level`.
+
+The 32 levels divide the 5000 m bottom depth into exact 156.25 m layers. That
+is a multiple of 16, which Omega prefers, and it sits in the range the
+literature uses for this case (20 in Beckmann and Haidvogel, 20-30 in
+Shchepetkin and McWilliams). It also keeps the z-star tree usable: with the
+10 levels this task used previously, the 500 m summit column would have had a
+single level.
+
+`partial_cell_type = None` means no alteration, so the original bottom depth
+is used; `partial` snaps the bottom cell to at least `min_pc_fraction` of a
+full cell, and `full` snaps it to a whole cell. The z-star tree overrides the
+default below to `partial`, because without snapping the seamount flanks
+produce bottom cells only centimetres thick.
 
 ```cfg
 # Options related to the vertical grid
@@ -55,16 +105,16 @@ The default setting is a sigma (terrain-following) vertical coordinate. One may 
 bottom_depth = 5000.0
 
 # Number of vertical levels
-vert_levels = 10
+vert_levels = 32
 
 # The type of vertical grid
 grid_type = uniform
 
-# The type of vertical coordinate (e.g. z-level, z-star)
-coord_type = sigma
-
 # Whether to use "partial" or "full", or "None" to not alter the topography
 partial_cell_type = None
+
+# The minimum fraction of a layer for partial cells
+min_pc_fraction = 0.1
 ```
 
 ### initial conditions
@@ -72,12 +122,38 @@ partial_cell_type = None
 Salinity is constant throughout the domain at the value given by the config
 option ``constant_salinity`` (35 PSU by default).  The initial density 
 is based on the formulas given in [Beckmann and Haidvogel (1993)](https://journals.ametsoc.org/view/journals/phoc/23/8/1520-0485_1993_023_1736_nsofaa_2_0_co_2.xml) equations 15-16.
-The initial temperature is back-computed from this density with an assumed linear equation of state using 
-`seamount_density_Tref` and `seamount_density_alpha`.
+The initial temperature is back-computed from this density by inverting the
+linear equation of state that Polaris and both ocean models apply,
+`rho = rhoref - alpha * (T - Tref) + beta * (S - Sref)`, using the
+`eos_linear_*` options in the `ocean` section. The salinity term matters:
+dropping it would leave the model's density offset from the Beckmann and
+Haidvogel profile by `beta * S`, which is harmless in MPAS-Ocean but not in
+Omega, where the geometric-to-pseudo-height mapping depends on the absolute
+density.
 
 ### forcing
 
 N/A
+
+### vertical mixing and bottom drag
+
+All vertical mixing is off. The exact solution is a resting ocean, so the
+only thing that would trigger convection is a spurious pressure gradient —
+the quantity being measured — and convection is a known source of
+MPAS-Ocean/Omega divergence, since Omega uses a single coefficient for both
+convective diffusivity and viscosity. cvmix stays enabled with its
+coefficients zeroed rather than disabled, because `config_use_cvmix = false`
+falls back on MPAS-Ocean's constant vertical viscosity and diffusivity, which
+are not zero.
+
+Bottom drag is implicit and constant in both models, at
+`bottom_drag_coeff = 1.0e-3`. That is an order of magnitude below the value
+comparable idealized planar cases use. The implicit drag damping timescale is
+`h_bot / (Cd * |u|)`, and the bottom layer over the seamount summit is only
+about 16 m thick, so at `1.0e-2` a 5 cm/s spurious velocity would damp in
+under half a day against a 6 day run — capping a bad pressure gradient while
+leaving a good one untouched, and compressing the dynamic range this test
+exists to measure.
 
 ### time step and run duration
 
@@ -101,11 +177,28 @@ The following config section is specific to this test case:
 # Options related to the seamount case
 [seamount]
 
-# Timestep per km horizontal resolution (s)
+# Timestep per km horizontal resolution (s) for MPAS-Ocean, whose
+# split-explicit integrator resolves the barotropic mode separately
 dt_per_km = 10.
 
-# Barotropic timestep per km horizontal resolution (s)
+# Barotropic timestep per km horizontal resolution (s), MPAS-Ocean only
 btr_dt_per_km = 2.5
+
+# Timestep per km horizontal resolution (s) for Omega, which has no
+# split-explicit integrator and so is limited by the barotropic gravity wave
+omega_dt_per_km = 2.5
+
+# Time integrator for MPAS-Ocean
+time_integrator = split_explicit_ab2
+
+# Time integrator for Omega
+omega_time_integrator = RK4
+
+# Horizontal tracer advection order, shared by both models
+horiz_adv_order = 3
+
+# Constant bottom drag coefficient
+bottom_drag_coeff = 1.0e-3
 
 # The width of the domain in the across-slope dimension (km)
 ly = 320
@@ -141,15 +234,6 @@ seamount_density_depth_linear = 4500.0
 # Density reference depth for exponential vertical stratification (m)
 seamount_density_depth_exp = 500.0
 
-# Density reference for eos to initialize temperature (kg m^{-3})
-seamount_density_ref = 1028.0
-
-# Reference temperature for eos to initialize temperature (C)
-seamount_density_Tref = 5.0
-
-# Linear thermal expansion coefficient to initialize temperature (kg m^{-3} C^{-1})
-seamount_density_alpha = 0.2
-
 # Height of sea mount, H_0 (m)
 seamount_height = 4500.0
 
@@ -158,9 +242,41 @@ seamount_width = 40.0e3
 
 # Salinity of the water in the entire domain (PSU)
 constant_salinity = 35.0
+```
 
-# Coriolis parameter for entire domain (s^{-1})
-coriolis_parameter = -1.0e-4
+The Coriolis parameter is set in the shared `coriolis` section:
+
+```cfg
+# config options for Coriolis
+[coriolis]
+
+# type of Coriolis: zero, constant, beta_plane, spherical, or rotated_sphere
+type = constant
+
+# the constant Coriolis parameter
+constant_f = -1.0e-4
+```
+
+The linear equation of state used to back-compute temperature from the target
+density is configured in the `ocean` section. `eos_linear_Tref` must be zero,
+because Omega's linear equation of state has no reference temperature; the
+Beckmann and Haidvogel reference state (1028 kg m^{-3} at T = 5 C, S = 35 PSU)
+is folded into `eos_linear_rhoref` instead, as
+`1028.0 + 0.2 * 5.0 - 0.8 * 35.0 = 1001.0`. `eos_linear_beta` and
+`eos_linear_Sref` come from `polaris.ocean.eos`'s `linear.cfg`.
+
+```cfg
+# Options related the ocean component
+[ocean]
+
+# Equation of state reference density when T and S are the reference values
+eos_linear_rhoref = 1001.
+
+# Equation of state -drho/dT
+eos_linear_alpha = 0.2
+
+# Equation of state reference temperature
+eos_linear_Tref = 0.
 ```
 
 ### cores

--- a/docs/users_guide/ocean/tasks/seamount.md
+++ b/docs/users_guide/ocean/tasks/seamount.md
@@ -23,9 +23,11 @@ salinity, `eos_linear_Tref` and `eos_linear_Sref` must both be zero; the
 Beckmann and Haidvogel reference state is folded into `eos_linear_rhoref`
 instead.
 
-Omega has no split-explicit time integrator, so it is limited by the
-barotropic gravity wave and needs a shorter time step than MPAS-Ocean.  The
-two are configured separately, through `dt_per_km` and `omega_dt_per_km`.
+Omega has no split time stepper, so it is limited by the barotropic gravity
+wave.  Rather than let the two models use different integrators, MPAS-Ocean
+gives up its split-explicit scheme and both run RK4 at the same `dt_per_km`
+until Omega gains a split time stepper.  `btr_dt_per_km` therefore has no
+effect unless `time_integrator` is set back to a split-explicit scheme.
 
 (ocean-seamount-variants)=
 
@@ -188,14 +190,20 @@ N/A
 
 ### vertical mixing and bottom drag
 
-All vertical mixing is off. The exact solution is a resting ocean, so the
-only thing that would trigger convection is a spurious pressure gradient —
-the quantity being measured — and convection is a known source of
+All vertical mixing is off in both models. The exact solution is a resting
+ocean, so the only thing that would trigger convection is a spurious pressure
+gradient — the quantity being measured — and convection is a known source of
 MPAS-Ocean/Omega divergence, since Omega uses a single coefficient for both
-convective diffusivity and viscosity. cvmix stays enabled with its
-coefficients zeroed rather than disabled, because `config_use_cvmix = false`
-falls back on MPAS-Ocean's constant vertical viscosity and diffusivity, which
-are not zero.
+convective diffusivity and viscosity. Convection and shear mixing are
+switched off explicitly and the background diffusivity and viscosity are
+zeroed, because Omega defaults them on; MPAS-Ocean additionally sets
+`config_use_cvmix = false`, which leaves its vertical viscosity and
+diffusivity at zero.
+
+Only the coefficients are zeroed. The implicit vertical mixing solve itself
+stays on in both models, because that is what applies the implicit bottom
+drag; Omega aborts if the vertical mixing tendency is disabled while the
+bottom drag is implicit.
 
 Bottom drag is implicit and constant in both models, at
 `bottom_drag_coeff = 1.0e-3`. That is an order of magnitude below the value
@@ -228,22 +236,15 @@ The following config section is specific to this test case:
 # Options related to the seamount case
 [seamount]
 
-# Timestep per km horizontal resolution (s) for MPAS-Ocean, whose
-# split-explicit integrator resolves the barotropic mode separately
-dt_per_km = 10.
+# Timestep per km horizontal resolution (s), shared by both models
+dt_per_km = 4.0
 
-# Barotropic timestep per km horizontal resolution (s), MPAS-Ocean only
+# Barotropic timestep per km horizontal resolution (s), MPAS-Ocean only, and
+# unused unless time_integrator is a split-explicit scheme
 btr_dt_per_km = 2.5
 
-# Timestep per km horizontal resolution (s) for Omega, which has no
-# split-explicit integrator and so is limited by the barotropic gravity wave
-omega_dt_per_km = 2.5
-
-# Time integrator for MPAS-Ocean
-time_integrator = split_explicit_ab2
-
-# Time integrator for Omega
-omega_time_integrator = RK4
+# Time integrator, shared by both models
+time_integrator = RK4
 
 # Horizontal tracer advection order, shared by both models
 horiz_adv_order = 3

--- a/docs/users_guide/ocean/tasks/seamount.md
+++ b/docs/users_guide/ocean/tasks/seamount.md
@@ -77,7 +77,7 @@ compared directly.
 
 The test case begins with a zero velocity field and is unforced, so the exact solution is to remain motionless. 
 The seamount rises from a flat sea floor in the center of the domain. 
-In a pure z-level vertical coordinate without partial bottom cells (`partial_cell_type = full`), the pressure gradient will remain zero and induce no flow to machine precision. When any layer tilting is added, including from partial bottom cells, some flow is introduced by the pressure gradient error. This is fundamentally because the pressure must be extrapolated vertically at cell centers to the mid-depth of the edge. The default setting is the sigma coordinate. These are the images produced in the `viz` folder.
+In a pure z-level vertical coordinate without partial bottom cells (`partial_cell_type = full`), the pressure gradient will remain zero and induce no flow to machine precision. When any layer tilting is added, including from partial bottom cells, some flow is introduced by the pressure gradient error. This is fundamentally because the pressure must be extrapolated vertically at cell centers to the mid-depth of the edge. The default setting is the sigma coordinate. These are the images produced in the `viz` folder, which runs by default in this task because the 6 day forward run is too long to want to repeat just to get the plots.
 
 ```{image} images/seamount_velocity_max_t.png
 :align: center

--- a/docs/users_guide/ocean/tasks/seamount.md
+++ b/docs/users_guide/ocean/tasks/seamount.md
@@ -29,20 +29,43 @@ two are configured separately, through `dt_per_km` and `omega_dt_per_km`.
 
 (ocean-seamount-variants)=
 
-## coordinate variants
+## variants
 
-Each task exists in two trees, one per vertical coordinate for the initial
-condition:
+Each task exists in four trees, combining the equation of state with the
+vertical coordinate used for the initial condition:
+`planar/seamount/{linear,nonlinear}/{sigma,zstar}`.
 
-- `planar/seamount/sigma` — the terrain-following coordinate, and the main
-  target.  Every layer is tilted relative to the isobars by construction, so
-  the pressure gradient error is exercised throughout the water column.
-- `planar/seamount/zstar` — the control.  Layers are nearly level, so the
-  spurious velocity should be much smaller.  Partial bottom cells are used
-  here: z-star cuts the reference grid at the seafloor, and without snapping
-  the seamount flanks produce bottom cells only centimetres thick.  Set
+The coordinate chooses how much the layers tilt:
+
+- `sigma` — the terrain-following coordinate, and the main target.  Every
+  layer is tilted relative to the isobars by construction, so the pressure
+  gradient error is exercised throughout the water column.
+- `zstar` — the control.  Layers are nearly level, so the spurious velocity
+  should be much smaller.  Partial bottom cells are used here: z-star cuts
+  the reference grid at the seafloor, and without snapping the seamount
+  flanks produce bottom cells only centimetres thick.  Set
   `partial_cell_type = full` for the limiting case in which the layers are
   exactly level and the pressure gradient vanishes to machine precision.
+
+The equation of state chooses whether density depends on pressure:
+
+- `linear` — `rho = rhoref - alpha * (T - Tref) + beta * (S - Sref)`, with
+  no pressure dependence at all.
+- `nonlinear` — TEOS-10 for Omega and Jackett-McDougall (`jm`) for
+  MPAS-Ocean, the closest nonlinear equation of state it has.  The thermal
+  expansion coefficient then varies along a tilted layer, which the linear
+  trees cannot represent.
+
+The two equations of state are given the same buoyancy stratification, as
+described under {ref}`ocean-seamount-init`, so a difference in spurious
+velocity between the `linear` and `nonlinear` trees is attributable to the
+equation of state and not to a different `N^2`.
+
+One caveat on cross-model comparison: TEOS-10 and Jackett-McDougall are
+genuinely different functions, not two implementations of one, so the two
+models are only expected to agree qualitatively in the `nonlinear` trees.
+In the `linear` trees they solve the same equation of state and can be
+compared directly.
 
 (ocean-seamount-default)=
 
@@ -84,6 +107,9 @@ The coordinate is set by the task tree, `sigma` or `zstar`, as described in
 `seamount_sigma.cfg` / `seamount_zstar.cfg` rather than in the shared config
 below. One may also test `coord_type = z-level`.
 
+All of these are geometric coordinates, so all of them reach Omega through
+the same pseudo-height conversion, under either equation of state.
+
 The 32 levels divide the 5000 m bottom depth into exact 156.25 m layers. That
 is a multiple of 16, which Omega prefers, and it sits in the range the
 literature uses for this case (20 in Beckmann and Haidvogel, 20-30 in
@@ -117,19 +143,44 @@ partial_cell_type = None
 min_pc_fraction = 0.1
 ```
 
+(ocean-seamount-init)=
+
 ### initial conditions
 
 Salinity is constant throughout the domain at the value given by the config
-option ``constant_salinity`` (35 PSU by default).  The initial density 
+option ``constant_salinity`` (35 by default), read as practical salinity in
+the `linear` trees and as absolute salinity in the `nonlinear` ones.  The
+initial density
 is based on the formulas given in [Beckmann and Haidvogel (1993)](https://journals.ametsoc.org/view/journals/phoc/23/8/1520-0485_1993_023_1736_nsofaa_2_0_co_2.xml) equations 15-16.
-The initial temperature is back-computed from this density by inverting the
-linear equation of state that Polaris and both ocean models apply,
-`rho = rhoref - alpha * (T - Tref) + beta * (S - Sref)`, using the
-`eos_linear_*` options in the `ocean` section. The salinity term matters:
-dropping it would leave the model's density offset from the Beckmann and
-Haidvogel profile by `beta * S`, which is harmless in MPAS-Ocean but not in
-Omega, where the geometric-to-pseudo-height mapping depends on the absolute
-density.
+Temperature is then back-computed from that density, so the profile rather
+than the temperature is what the two equations of state have in common.
+
+In the `linear` trees the inversion is algebraic: the equation of state that
+Polaris and both ocean models apply,
+`rho = rhoref - alpha * (T - Tref) + beta * (S - Sref)`, is solved for `T`
+using the `eos_linear_*` options in the `ocean` section. The salinity term
+matters: dropping it would leave the model's density offset from the
+Beckmann and Haidvogel profile by `beta * S`, which is harmless in
+MPAS-Ocean but not in Omega, where the geometric-to-pseudo-height mapping
+depends on the absolute density.
+
+In the `nonlinear` trees the profile is read as a **potential density
+referenced to the surface**, and conservative temperature comes from
+`gsw.CT_from_rho` at zero reference pressure.  It cannot be read as in-situ
+density: TEOS-10 in-situ density at 5000 m is near 1050 kg m^{-3} from
+compression alone, well outside the 1025-1028 kg m^{-3} range the profile
+spans, so no temperature would reproduce it below about 1000 m.  Referencing
+to the surface also means the `linear` and `nonlinear` trees share a
+buoyancy stratification exactly while their in-situ densities differ by more
+than 20 kg m^{-3} at depth — which is the point, since that difference is
+what a nonlinear equation of state contributes to the pressure gradient
+error.
+
+Omega receives conservative temperature and absolute salinity directly.  For
+MPAS-Ocean the `nonlinear` tracers are converted to potential temperature and
+practical salinity at a nominal lon/lat location (config options
+`ocean:nominal_lon` and `ocean:nominal_lat`, both defaulting to 0 degrees)
+since the planar mesh has no geographic location.
 
 ### forcing
 
@@ -240,9 +291,15 @@ seamount_height = 4500.0
 # Width parameter of sea mount, e-folding length (m)
 seamount_width = 40.0e3
 
-# Salinity of the water in the entire domain (PSU)
+# Salinity of the water in the entire domain, read as practical salinity
+# (PSU) for the linear trees and as absolute salinity (g kg^-1) for the
+# nonlinear ones
 constant_salinity = 35.0
 ```
+
+The `nonlinear` trees add no config options of their own; they take their
+equation of state from `polaris.ocean.eos`'s `teos10.cfg` and the nominal
+location for the salinity conversion from the shared `ocean` section.
 
 The Coriolis parameter is set in the shared `coriolis` section:
 
@@ -257,13 +314,15 @@ type = constant
 constant_f = -1.0e-4
 ```
 
-The linear equation of state used to back-compute temperature from the target
-density is configured in the `ocean` section. `eos_linear_Tref` must be zero,
-because Omega's linear equation of state has no reference temperature; the
-Beckmann and Haidvogel reference state (1028 kg m^{-3} at T = 5 C, S = 35 PSU)
-is folded into `eos_linear_rhoref` instead, as
+The `linear` trees configure their equation of state in `ocean`, through
+`seamount_linear.cfg`. `eos_linear_Tref` must be zero, because Omega's
+linear equation of state has no reference temperature; the Beckmann and
+Haidvogel reference state (1028 kg m^{-3} at T = 5 C, S = 35 PSU) is folded
+into `eos_linear_rhoref` instead, as
 `1028.0 + 0.2 * 5.0 - 0.8 * 35.0 = 1001.0`. `eos_linear_beta` and
-`eos_linear_Sref` come from `polaris.ocean.eos`'s `linear.cfg`.
+`eos_linear_Sref` come from `polaris.ocean.eos`'s `linear.cfg`. These
+options have no meaning in the `nonlinear` trees, which is why they live in
+a per-variant config rather than the shared one.
 
 ```cfg
 # Options related the ocean component
@@ -278,6 +337,10 @@ eos_linear_alpha = 0.2
 # Equation of state reference temperature
 eos_linear_Tref = 0.
 ```
+
+The `nonlinear` trees instead pick up `polaris.ocean.eos`'s `teos10.cfg`,
+which sets `eos_type = teos-10` and nothing else; Polaris maps that to `jm`
+for MPAS-Ocean.
 
 ### cores
 

--- a/docs/users_guide/ocean/tasks/seamount.md
+++ b/docs/users_guide/ocean/tasks/seamount.md
@@ -98,9 +98,18 @@ In a pure z-level vertical coordinate without partial bottom cells (`partial_cel
 ### mesh
 
 The domain is planar and periodic on the zonal and the
-meridional boundaries. The 6.7 km resolution is tested by default, 
+meridional boundaries. The 6.4 km resolution is tested by default,
 which is set by the ``resolution`` config option. The domain is
-320 km by 320 km, as given by the config options ``lx`` and ``ly``.
+320 km by 320 km, as given by the config options ``lx`` and ``ly``,
+which at 6.4 km is exactly 50 cells across; the hexagonal mesh is 58 cells
+in the other direction, for 321.5 km.
+
+Neither the domain size nor the resolution is prescribed by Beckmann and
+Haidvogel — only the seamount shape and the stratification are. The
+quantity that determines how hard this case is on a tilted coordinate is
+the discrete steepness of the seamount, `max |dh| / (h1 + h2)` between
+adjacent cells, which for a Gaussian seamount is about
+`1.5 * resolution / seamount_width`, or 0.21 here.
 
 ### vertical grid
 
@@ -258,8 +267,8 @@ ly = 320
 # The length of the domain in the along-slope dimension (km)
 lx = 320
 
-# Distance from two cell centers (km)
-resolution = 6.7
+# Distance between two cell centers (km)
+resolution = 6.4
 
 # Bottom depth at bottom of seamount
 max_bottom_depth = ${vertical_grid:bottom_depth}

--- a/docs/users_guide/ocean/tasks/seamount.md
+++ b/docs/users_guide/ocean/tasks/seamount.md
@@ -221,8 +221,8 @@ The time step for forward integration is automatically computed based on the gri
 ```cfg
 [seamount_default]
 
-# Run duration (days)
-run_duration = 6.
+# Run duration (hours)
+run_duration = 144.
 
 # Output interval (hours)
 output_interval = 1.
@@ -347,4 +347,49 @@ for MPAS-Ocean.
 
 The number of cores is determined by `goal_cells_per_core` and
 `max_cells_per_core` in the `ocean` section of the config file.
+
+(ocean-seamount-short)=
+
+## short task
+
+### description
+
+The `short` task is the `default` task run for 1 hour instead of 6 days.  It
+exists for regression testing: an hour is far too short for the spurious
+circulation to develop, so it says nothing about the pressure gradient error,
+but it is long enough to catch a change in the answer cheaply.  It is
+otherwise identical to the `default` task — same mesh, vertical grid, initial
+condition, time step and physics — and it exists in all four trees.
+
+The `viz` step is present but does not run by default here, since re-running
+the task to get the plots costs almost nothing.
+
+Two of the four are in the `mpaso_pr` and `omega_pr` suites:
+`planar/seamount/linear/zstar/short` and
+`planar/seamount/nonlinear/sigma/short`.  That pair covers both equations of
+state and both vertical coordinates in two runs rather than four.
+
+### time step and run duration
+
+The time step is computed from the gridcell size exactly as in the `default`
+task.  Only the duration and output interval differ:
+
+```cfg
+[seamount_short]
+
+# Run duration (hours)
+run_duration = 1.
+
+# Output interval (hours)
+output_interval = 0.5
+```
+
+The output interval is half the run duration so that the time series the
+`viz` step plots has more than a single point in it.
+
+### config options
+
+The short task adds no config options beyond the `[seamount_short]` section
+above; everything else comes from the shared options listed under
+{ref}`ocean-seamount-default`.
 

--- a/polaris/ocean/eos/__init__.py
+++ b/polaris/ocean/eos/__init__.py
@@ -10,6 +10,9 @@ from .teos10 import TRACER_CONVENTIONS as TRACER_CONVENTIONS
 from .teos10 import compute_specvol as compute_teos10_specvol
 from .teos10 import convert_tracer_pair as convert_tracer_pair
 from .teos10 import convert_tracers as convert_tracers
+from .teos10 import (
+    ct_from_potential_density as ct_from_potential_density,
+)
 
 
 def compute_density(

--- a/polaris/ocean/eos/teos10.py
+++ b/polaris/ocean/eos/teos10.py
@@ -92,6 +92,75 @@ def compute_specvol(
     return specvol
 
 
+def ct_from_potential_density(
+    sigma_0: xr.DataArray | float,
+    sa: xr.DataArray | float,
+) -> xr.DataArray | float:
+    """
+    Compute the conservative temperature that gives a target potential
+    density referenced to the surface.
+
+    This is the TEOS-10 counterpart of back-solving a linear equation of
+    state for temperature: it lets a test case specify its stratification as
+    a density profile rather than a temperature profile.  Because the
+    reference pressure is zero, the inversion is exact and needs no
+    iteration on pressure.
+
+    Only the cold branch of ``gsw.CT_from_rho`` is physical for seawater
+    above its density maximum, which is where all oceanographically relevant
+    states lie, so the second root is not returned.
+
+    Parameters
+    ----------
+    sigma_0 : float or xarray.DataArray
+        The target potential density referenced to the surface (kg m-3).
+        Note that this is the full density, not the ``sigma`` anomaly, so
+        values are near 1027 rather than near 27.
+
+    sa : float or xarray.DataArray
+        Absolute Salinity (g kg-1) at the same points as ``sigma_0``.
+
+    Returns
+    -------
+    float or xarray.DataArray
+        Conservative Temperature (degC), with the dims and coords of
+        ``sigma_0`` if it is a ``DataArray``.
+
+    Raises
+    ------
+    ValueError
+        If any target density is unattainable at the given salinity, which
+        ``gsw`` reports as a NaN root.  Letting that NaN through would
+        otherwise propagate silently into an initial condition.
+    """
+    sigma_0_np = _to_numpy(sigma_0)
+    sa_np = _to_numpy(sa)
+
+    ct_np, _ = gsw.CT_from_rho(sigma_0_np, sa_np, 0.0)
+
+    invalid = np.isnan(ct_np) & np.isfinite(sigma_0_np)
+    if np.any(invalid):
+        bad = np.asarray(sigma_0_np)[invalid]
+        raise ValueError(
+            f'{invalid.sum()} of the target potential densities are not '
+            'attainable at the given absolute salinity; they range from '
+            f'{bad.min()} to {bad.max()} kg m-3.'
+        )
+
+    if not isinstance(sigma_0, xr.DataArray):
+        return float(ct_np)
+
+    ct = xr.DataArray(
+        ct_np,
+        dims=sigma_0.dims,
+        coords=sigma_0.coords,
+        name='ct',
+    )
+    ct.attrs['long_name'] = 'conservative temperature'
+    ct.attrs['units'] = 'degC'
+    return ct
+
+
 def convert_tracers(
     ds: xr.Dataset,
     source: str,

--- a/polaris/suites/ocean/mpaso_pr.txt
+++ b/polaris/suites/ocean/mpaso_pr.txt
@@ -1,3 +1,8 @@
+ocean/column/ekman
+ocean/column/vmix_stable
+ocean/column/vmix_unstable
+ocean/column/ideal_age
+ocean/column/inertial
 ocean/planar/baroclinic_channel/10km/threads
 ocean/planar/baroclinic_channel/10km/decomp
 ocean/planar/baroclinic_channel/10km/restart
@@ -13,10 +18,7 @@ ocean/planar/overflow/linear/zstar/smoke_test_horiz_adv_order_2
 ocean/planar/overflow/linear/zstar/smoke_test_horiz_adv_order_3
 ocean/planar/overflow/linear/zstar/smoke_test_horiz_adv_order_4
 ocean/planar/overflow/nonlinear/pstar/smoke_test_horiz_adv_order_4_del4
-ocean/column/ekman
-ocean/column/vmix_stable
-ocean/column/vmix_unstable
-ocean/column/ideal_age
-ocean/column/inertial
+ocean/planar/seamount/linear/zstar/short
+ocean/planar/seamount/nonlinear/sigma/short
 ocean/spherical/icos/cosine_bell/decomp
 ocean/spherical/icos/cosine_bell/restart

--- a/polaris/suites/ocean/omega_pr.txt
+++ b/polaris/suites/ocean/omega_pr.txt
@@ -11,6 +11,8 @@ ocean/planar/overflow/linear/zstar/smoke_test_horiz_adv_order_2_del4
 ocean/planar/overflow/linear/zstar/smoke_test_horiz_adv_order_3
 ocean/planar/overflow/linear/zstar/smoke_test_horiz_adv_order_4
 ocean/planar/overflow/nonlinear/pstar/smoke_test_horiz_adv_order_4_del4
+ocean/planar/seamount/linear/zstar/short
+ocean/planar/seamount/nonlinear/sigma/short
 ocean/spherical/icos/cosine_bell/decomp
 ocean/spherical/icos/cosine_bell/restart
 

--- a/polaris/tasks/ocean/seamount/__init__.py
+++ b/polaris/tasks/ocean/seamount/__init__.py
@@ -3,6 +3,7 @@ import os
 from polaris.config import PolarisConfigParser as PolarisConfigParser
 from polaris.tasks.ocean.seamount.default import Default as Default
 from polaris.tasks.ocean.seamount.init import Init as Init
+from polaris.tasks.ocean.seamount.short import Short as Short
 
 
 def add_seamount_tasks(component):
@@ -57,3 +58,7 @@ def _add_seamount_variant_tasks(component, eos_type, coord_type):
     default = Default(component=component, indir=taskdir, init=init_step)
     default.set_shared_config(config, link=config_filename)
     component.add_task(default)
+
+    short = Short(component=component, indir=taskdir, init=init_step)
+    short.set_shared_config(config, link=config_filename)
+    component.add_task(short)

--- a/polaris/tasks/ocean/seamount/__init__.py
+++ b/polaris/tasks/ocean/seamount/__init__.py
@@ -9,30 +9,44 @@ def add_seamount_tasks(component):
     """
     Add tasks following the seamount test case
 
-    Variants differ in the vertical coordinate used for the initial
-    condition: ``sigma`` (terrain-following) or ``zstar``.  Both are
-    geometric coordinates, so both are supported by MPAS-Ocean and by
-    Omega, which reads them as pseudo-thickness.
+    Variants combine the equation of state (linear or nonlinear) with the
+    vertical coordinate used for the initial condition, ``sigma``
+    (terrain-following) or ``zstar``.  Both coordinates are geometric, so
+    both are supported by MPAS-Ocean and by Omega, which reads them as
+    pseudo-thickness.
 
     component : polaris.ocean.Ocean
         the ocean component that the task will be added to
     """
-    for coord_type in ['sigma', 'zstar']:
-        _add_seamount_variant_tasks(component, coord_type)
+    for eos_type in ['linear', 'nonlinear']:
+        for coord_type in ['sigma', 'zstar']:
+            _add_seamount_variant_tasks(component, eos_type, coord_type)
 
 
-def _add_seamount_variant_tasks(component, coord_type):
+def _add_seamount_variant_tasks(component, eos_type, coord_type):
     """
-    Add the seamount tasks for one vertical coordinate for the initial
-    condition (``'sigma'`` or ``'zstar'``).
+    Add the seamount tasks for one combination of equation of state
+    (``'linear'`` or ``'nonlinear'``) and vertical coordinate for the
+    initial condition (``'sigma'`` or ``'zstar'``).
     """
-    taskdir = f'planar/seamount/{coord_type}'
+    taskdir = f'planar/seamount/{eos_type}/{coord_type}'
     config_filename = 'seamount.cfg'
     config = PolarisConfigParser(
         filepath=os.path.join(component.name, taskdir, config_filename)
     )
-    config.add_from_package('polaris.ocean.eos', 'linear.cfg')
+    if eos_type == 'linear':
+        eos_cfg = 'linear.cfg'
+    else:
+        eos_cfg = 'teos10.cfg'
+    config.add_from_package('polaris.ocean.eos', eos_cfg)
     config.add_from_package('polaris.tasks.ocean.seamount', config_filename)
+    if eos_type == 'linear':
+        # the linear equation of state needs coefficients that reproduce the
+        # Beckmann and Haidvogel profile; the nonlinear trees take everything
+        # they need from teos10.cfg
+        config.add_from_package(
+            'polaris.tasks.ocean.seamount', 'seamount_linear.cfg'
+        )
     config.add_from_package(
         'polaris.tasks.ocean.seamount', f'seamount_{coord_type}.cfg'
     )

--- a/polaris/tasks/ocean/seamount/__init__.py
+++ b/polaris/tasks/ocean/seamount/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from polaris.config import PolarisConfigParser as PolarisConfigParser
 from polaris.tasks.ocean.seamount.default import Default as Default
 from polaris.tasks.ocean.seamount.init import Init as Init
@@ -5,20 +7,39 @@ from polaris.tasks.ocean.seamount.init import Init as Init
 
 def add_seamount_tasks(component):
     """
-    Add a task following the seamount test case
+    Add tasks following the seamount test case
+
+    Variants differ in the vertical coordinate used for the initial
+    condition: ``sigma`` (terrain-following) or ``zstar``.  Both are
+    geometric coordinates, so both are supported by MPAS-Ocean and by
+    Omega, which reads them as pseudo-thickness.
 
     component : polaris.ocean.Ocean
         the ocean component that the task will be added to
     """
-    indir = 'planar/seamount'
+    for coord_type in ['sigma', 'zstar']:
+        _add_seamount_variant_tasks(component, coord_type)
+
+
+def _add_seamount_variant_tasks(component, coord_type):
+    """
+    Add the seamount tasks for one vertical coordinate for the initial
+    condition (``'sigma'`` or ``'zstar'``).
+    """
+    taskdir = f'planar/seamount/{coord_type}'
     config_filename = 'seamount.cfg'
-    config = PolarisConfigParser(filepath=f'{indir}/{config_filename}')
+    config = PolarisConfigParser(
+        filepath=os.path.join(component.name, taskdir, config_filename)
+    )
     config.add_from_package('polaris.ocean.eos', 'linear.cfg')
     config.add_from_package('polaris.tasks.ocean.seamount', config_filename)
+    config.add_from_package(
+        'polaris.tasks.ocean.seamount', f'seamount_{coord_type}.cfg'
+    )
 
-    init_step = Init(component=component, name='init', indir=indir)
+    init_step = Init(component=component, name='init', indir=taskdir)
     init_step.set_shared_config(config, link=config_filename)
 
-    default = Default(component=component, indir=indir, init=init_step)
+    default = Default(component=component, indir=taskdir, init=init_step)
     default.set_shared_config(config, link=config_filename)
     component.add_task(default)

--- a/polaris/tasks/ocean/seamount/default/__init__.py
+++ b/polaris/tasks/ocean/seamount/default/__init__.py
@@ -5,8 +5,8 @@ from polaris.tasks.ocean.seamount.viz import Viz as Viz
 
 class Default(Task):
     """
-    The default seamount test case simply creates the mesh and
-    initial condition, then performs a short forward run on 4 cores.
+    The default seamount test case creates the mesh and initial condition,
+    then performs a 6 day forward run and plots the results.
     """
 
     def __init__(self, component, indir, init):
@@ -37,6 +37,6 @@ class Default(Task):
             indir=self.subdir,
         )
         self.add_step(forward_step)
-        self.add_step(
-            Viz(component=component, indir=self.subdir), run_by_default=False
-        )
+        # the forward run is 6 days long, so it is worth always producing the
+        # plots rather than making the user re-run the task to get them
+        self.add_step(Viz(component=component, indir=self.subdir))

--- a/polaris/tasks/ocean/seamount/forward.py
+++ b/polaris/tasks/ocean/seamount/forward.py
@@ -112,16 +112,31 @@ class Forward(OceanModelStep):
         super().dynamic_model_config(at_setup=at_setup)
 
         config = self.config
-        resolution = config.getfloat('seamount', 'resolution')
-        dt_per_km = config.getfloat('seamount', 'dt_per_km')
-        btr_dt_per_km = config.getfloat('seamount', 'btr_dt_per_km')
+        section = config['seamount']
+        model = config.get('ocean', 'model')
+        resolution = section.getfloat('resolution')
+
+        # MPAS-Ocean resolves the barotropic mode with a sub-step, so it can
+        # take a much longer baroclinic step than Omega, which has no
+        # split-explicit integrator
+        if model == 'omega':
+            dt_per_km = section.getfloat('omega_dt_per_km')
+            time_integrator = _omega_time_integrator(
+                section.get('omega_time_integrator')
+            )
+        else:
+            dt_per_km = section.getfloat('dt_per_km')
+            time_integrator = section.get('time_integrator')
+
+        btr_dt_per_km = section.getfloat('btr_dt_per_km')
         dt_str = get_time_interval_string(seconds=dt_per_km * resolution)
         btr_dt_str = get_time_interval_string(
             seconds=btr_dt_per_km * resolution
         )
-        section = config[f'seamount_{self.task_name}']
-        run_duration = section.getfloat('run_duration')
-        output_interval = section.getfloat('output_interval')
+
+        task_section = config[f'seamount_{self.task_name}']
+        run_duration = task_section.getfloat('run_duration')
+        output_interval = task_section.getfloat('output_interval')
         run_duration_str = get_time_interval_string(
             seconds=run_duration * 86400.0
         )
@@ -132,8 +147,15 @@ class Forward(OceanModelStep):
         replacements = dict(
             dt=dt_str,
             btr_dt=btr_dt_str,
+            time_integrator=time_integrator,
             run_duration=run_duration_str,
             output_interval=output_interval_str,
+            # Omega's History stream takes an integer frequency, so express
+            # the interval in seconds to avoid truncating a fractional hour
+            output_freq=f'{round(output_interval * 3600.0)}',
+            output_freq_units='seconds',
+            horiz_adv_order=section.getint('horiz_adv_order'),
+            bottom_drag_coeff=section.getfloat('bottom_drag_coeff'),
             nu=self.nu,
         )
         self.add_yaml_file(
@@ -159,3 +181,14 @@ class Forward(OceanModelStep):
         nx, ny = compute_planar_hex_nx_ny(lx, ly, resolution)
         cell_count = nx * ny
         return cell_count
+
+
+def _omega_time_integrator(time_integrator):
+    """
+    Map an MPAS-Ocean time-integrator name to its Omega equivalent, leaving
+    names that are already Omega's alone.
+    """
+    time_integrator_map = dict([('RK4', 'RungeKutta4')])
+    if time_integrator in time_integrator_map:
+        return time_integrator_map[time_integrator]
+    return time_integrator

--- a/polaris/tasks/ocean/seamount/forward.py
+++ b/polaris/tasks/ocean/seamount/forward.py
@@ -116,17 +116,13 @@ class Forward(OceanModelStep):
         model = config.get('ocean', 'model')
         resolution = section.getfloat('resolution')
 
-        # MPAS-Ocean resolves the barotropic mode with a sub-step, so it can
-        # take a much longer baroclinic step than Omega, which has no
-        # split-explicit integrator
+        # Both models take the same time step with the same integrator:
+        # Omega has no split time stepper, so MPAS-Ocean gives up its
+        # split-explicit one to stay comparable
+        dt_per_km = section.getfloat('dt_per_km')
+        time_integrator = section.get('time_integrator')
         if model == 'omega':
-            dt_per_km = section.getfloat('omega_dt_per_km')
-            time_integrator = _omega_time_integrator(
-                section.get('omega_time_integrator')
-            )
-        else:
-            dt_per_km = section.getfloat('dt_per_km')
-            time_integrator = section.get('time_integrator')
+            time_integrator = _omega_time_integrator(time_integrator)
 
         btr_dt_per_km = section.getfloat('btr_dt_per_km')
         dt_str = get_time_interval_string(seconds=dt_per_km * resolution)

--- a/polaris/tasks/ocean/seamount/forward.py
+++ b/polaris/tasks/ocean/seamount/forward.py
@@ -134,7 +134,7 @@ class Forward(OceanModelStep):
         run_duration = task_section.getfloat('run_duration')
         output_interval = task_section.getfloat('output_interval')
         run_duration_str = get_time_interval_string(
-            seconds=run_duration * 86400.0
+            seconds=run_duration * 3600.0
         )
         output_interval_str = get_time_interval_string(
             seconds=output_interval * 3600.0

--- a/polaris/tasks/ocean/seamount/forward.yaml
+++ b/polaris/tasks/ocean/seamount/forward.yaml
@@ -1,21 +1,47 @@
-mpas-ocean:
+ocean:
   time_management:
     config_stop_time: none
     config_run_duration: {{ run_duration }}
   time_integration:
     config_dt: {{ dt }}
-    config_time_integrator: split_explicit_ab2
-  io:
-    config_write_output_on_startup: false
+    config_time_integrator: {{ time_integrator }}
   hmix_del2:
     config_use_mom_del2: true
     config_mom_del2: {{ nu }}
   bottom_drag:
+    config_bottom_drag_mode: implicit
     config_implicit_bottom_drag_type: constant
-    config_implicit_constant_bottom_drag_coeff: 0.01
+    config_implicit_constant_bottom_drag_coeff: {{ bottom_drag_coeff }}
+  # bottom drag must also be enabled for Omega via this debug flag (mapped
+  # to BottomDragTendency/Enable); false is already the MPAS-Ocean default
+  debug:
+    config_disable_vel_explicit_bottom_drag: false
+  # The exact solution is a resting ocean, so all vertical mixing is off.
+  # Convection in particular is a known source of MPAS-Ocean/Omega
+  # divergence (Omega uses a single coefficient for both convective
+  # diffusivity and viscosity), and it would only ever be triggered here by
+  # a spurious pressure gradient — the thing being measured.  Omega defaults
+  # background and shear mixing on, so they are switched off explicitly
+  # rather than left to the model default.
   cvmix:
+    config_use_cvmix_convection: false
+    config_use_cvmix_shear: false
+    config_cvmix_background_diffusion: 0.0
+    config_cvmix_background_viscosity: 0.0
+  # pinned so the two models use the same advection rather than their
+  # differing defaults (3 for MPAS-Ocean, 2 for Omega)
+  advection:
+    config_horiz_tracer_adv_order: {{ horiz_adv_order }}
+
+mpas-ocean:
+  io:
+    config_write_output_on_startup: false
+  # cvmix stays enabled with all of its coefficients zeroed above, rather
+  # than disabled, because turning it off falls back on MPAS-Ocean's
+  # constant vertical viscosity and diffusivity, which are not zero
+  cvmix:
+    config_use_cvmix: true
     config_cvmix_background_scheme: none
-    config_use_cvmix_convection: true
   split_explicit_ts:
     config_btr_dt: {{ btr_dt }}
   streams:
@@ -33,3 +59,69 @@ mpas-ocean:
       - kineticEnergyCell
       - layerThickness
       - daysSinceStartOfSim
+
+Omega:
+  Tendencies:
+    SSHTendencyEnable: false
+  Tracers:
+    Base: [Temperature, Salinity]
+  IOStreams:
+    InitialState:
+      Mode: read
+      Precision: double
+      Freq: 1
+      FreqUnits: OnStartup
+      UseStartEnd: false
+      Contents:
+        - State
+        - Base
+        - Tracers
+    RestartRead:
+      UsePointerFile: true
+      PointerFilename: ocn.pointer
+      Mode: read
+      Precision: double
+      Freq: 1
+      FreqUnits: OnStartup
+      UseStartEnd: true
+      StartTime: 0001-01-01_00:00:01
+      EndTime: 99999-12-31_00:00:00
+      Contents:
+        - Restart
+    RestartWrite:
+      UsePointerFile: true
+      PointerFilename: ocn.pointer
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Mode: write
+      IfExists: replace
+      Precision: double
+      Freq: 10
+      FreqUnits: day
+      UseStartEnd: false
+      Contents:
+        - Restart
+    History:
+      UsePointerFile: false
+      Filename: output.nc
+      FileFreq: 9999
+      FileFreqUnits: years
+      Mode: write
+      IfExists: append
+      Precision: double
+      Freq: {{ output_freq }}
+      FreqUnits: {{ output_freq_units }}
+      UseStartEnd: false
+      # SpecVol is required, not optional: Polaris converts Omega's
+      # PseudoThickness to a geometric layerThickness on read as
+      # RhoSw * SpecVol * PseudoThickness.  GeomZMid and GeomZInterface are
+      # written so the vertical coordinate can be checked directly against
+      # the initial condition.
+      Contents:
+        - Tracers
+        - State
+        - KineticEnergyCell
+        - SpecVol
+        - BottomGeomDepth
+        - SshCell
+        - GeomZMid
+        - GeomZInterface

--- a/polaris/tasks/ocean/seamount/forward.yaml
+++ b/polaris/tasks/ocean/seamount/forward.yaml
@@ -22,7 +22,11 @@ ocean:
   # diffusivity and viscosity), and it would only ever be triggered here by
   # a spurious pressure gradient — the thing being measured.  Omega defaults
   # background and shear mixing on, so they are switched off explicitly
-  # rather than left to the model default.
+  # rather than left to the model default.  Only the coefficients are
+  # zeroed: the implicit vertical mixing solve itself has to stay on in
+  # both models because that is what applies the implicit bottom drag
+  # above (Omega aborts outright if VelVertMixTendencyEnable is false while
+  # the bottom drag is implicit).
   cvmix:
     config_use_cvmix_convection: false
     config_use_cvmix_shear: false
@@ -36,12 +40,10 @@ ocean:
 mpas-ocean:
   io:
     config_write_output_on_startup: false
-  # cvmix stays enabled with all of its coefficients zeroed above, rather
-  # than disabled, because turning it off falls back on MPAS-Ocean's
-  # constant vertical viscosity and diffusivity, which are not zero
   cvmix:
-    config_use_cvmix: true
-    config_cvmix_background_scheme: none
+    config_use_cvmix: false
+  # unused with RK4; only takes effect if time_integrator is set back to a
+  # split-explicit scheme
   split_explicit_ts:
     config_btr_dt: {{ btr_dt }}
   streams:

--- a/polaris/tasks/ocean/seamount/init.py
+++ b/polaris/tasks/ocean/seamount/init.py
@@ -90,8 +90,10 @@ class Init(OceanIOStep):
             'seamount_density_depth_exp'
         )
         eos_linear_rhoref = self.config.getfloat('ocean', 'eos_linear_rhoref')
-        eos_linear_tref = self.config.getfloat('ocean', 'eos_linear_tref')
+        eos_linear_tref = self.config.getfloat('ocean', 'eos_linear_Tref')
+        eos_linear_sref = self.config.getfloat('ocean', 'eos_linear_Sref')
         eos_linear_alpha = self.config.getfloat('ocean', 'eos_linear_alpha')
+        eos_linear_beta = self.config.getfloat('ocean', 'eos_linear_beta')
         seamount_height = section.getfloat('seamount_height')
         seamount_width = section.getfloat('seamount_width')
         constant_salinity = section.getfloat('constant_salinity')
@@ -132,15 +134,25 @@ class Init(OceanIOStep):
                 * np.exp(z_mid / seamount_density_depth_exp)
             )
 
-        # Back-solve linear EOS for temperature, with S=S_ref
-        # T = T_ref - (rho - rho_ref)/alpha
+        salinity = constant_salinity * xr.ones_like(densityCell)
+
+        # Back-solve the linear EOS that both Polaris and the ocean model
+        # apply, rho = rho_ref - alpha * (T - T_ref) + beta * (S - S_ref),
+        # for the temperature that reproduces the target density.  The
+        # salinity term matters: dropping it leaves the model's density
+        # offset from the Beckmann and Haidvogel profile by beta * S.
         temperature = (
             eos_linear_tref
-            - (densityCell - eos_linear_rhoref) / eos_linear_alpha
+            + (
+                eos_linear_rhoref
+                + eos_linear_beta * (salinity - eos_linear_sref)
+                - densityCell
+            )
+            / eos_linear_alpha
         )
 
         ds['temperature'] = temperature
-        ds['salinity'] = constant_salinity * xr.ones_like(temperature)
+        ds['salinity'] = salinity
         ds['normalVelocity'] = (
             (
                 'Time',

--- a/polaris/tasks/ocean/seamount/init.py
+++ b/polaris/tasks/ocean/seamount/init.py
@@ -7,6 +7,7 @@ from polaris.mesh.planar import compute_planar_hex_nx_ny
 from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
+from polaris.tasks.ocean.seamount.init_utils import compute_tracers
 
 
 class Init(OceanIOStep):
@@ -68,35 +69,8 @@ class Init(OceanIOStep):
         # from overflow. Delete when not needed.
         max_bottom_depth = section.getfloat('max_bottom_depth')
 
-        seamount_stratification_type = section.get(
-            'seamount_stratification_type'
-        )
-        seamount_density_coef_linear = section.getfloat(
-            'seamount_density_coef_linear'
-        )
-        seamount_density_coef_exp = section.getfloat(
-            'seamount_density_coef_exp'
-        )
-        seamount_density_gradient_linear = section.getfloat(
-            'seamount_density_gradient_linear'
-        )
-        seamount_density_gradient_exp = section.getfloat(
-            'seamount_density_gradient_exp'
-        )
-        seamount_density_depth_linear = section.getfloat(
-            'seamount_density_depth_linear'
-        )
-        seamount_density_depth_exp = section.getfloat(
-            'seamount_density_depth_exp'
-        )
-        eos_linear_rhoref = self.config.getfloat('ocean', 'eos_linear_rhoref')
-        eos_linear_tref = self.config.getfloat('ocean', 'eos_linear_Tref')
-        eos_linear_sref = self.config.getfloat('ocean', 'eos_linear_Sref')
-        eos_linear_alpha = self.config.getfloat('ocean', 'eos_linear_alpha')
-        eos_linear_beta = self.config.getfloat('ocean', 'eos_linear_beta')
         seamount_height = section.getfloat('seamount_height')
         seamount_width = section.getfloat('seamount_width')
-        constant_salinity = section.getfloat('constant_salinity')
 
         ds = ds_mesh.copy()
 
@@ -115,41 +89,13 @@ class Init(OceanIOStep):
         ds['ssh'] = xr.zeros_like(ds.xCell)
 
         init_vertical_coord(config, ds)
-        z_mid = ds.zMid.squeeze('Time')
 
-        # Set stratification using temperature.
-        # See Beckmann and Haidvogel 1993 eqn 15-16.
-        if seamount_stratification_type == 'linear':
-            densityCell = (
-                seamount_density_coef_linear
-                - seamount_density_gradient_linear
-                * z_mid
-                / seamount_density_depth_linear
-            )
-
-        elif seamount_stratification_type == 'exponential':
-            densityCell = (
-                seamount_density_coef_exp
-                - seamount_density_gradient_exp
-                * np.exp(z_mid / seamount_density_depth_exp)
-            )
-
-        salinity = constant_salinity * xr.ones_like(densityCell)
-
-        # Back-solve the linear EOS that both Polaris and the ocean model
-        # apply, rho = rho_ref - alpha * (T - T_ref) + beta * (S - S_ref),
-        # for the temperature that reproduces the target density.  The
-        # salinity term matters: dropping it leaves the model's density
-        # offset from the Beckmann and Haidvogel profile by beta * S.
-        temperature = (
-            eos_linear_tref
-            + (
-                eos_linear_rhoref
-                + eos_linear_beta * (salinity - eos_linear_sref)
-                - densityCell
-            )
-            / eos_linear_alpha
-        )
+        # Set the Beckmann and Haidvogel 1993 eqn 15-16 stratification,
+        # carried entirely by temperature since salinity is constant.  The
+        # tracers keep the Time dimension that zMid carries, matching
+        # layerThickness and the other state variables; TEOS-10 requires
+        # its inputs to be aligned, and the linear EOS did not.
+        temperature, salinity = compute_tracers(config, ds.zMid)
 
         ds['temperature'] = temperature
         ds['salinity'] = salinity
@@ -166,4 +112,7 @@ class Init(OceanIOStep):
         ds.attrs['dc'] = dc
 
         self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
+        # the tracers are in the convention implied by eos_type, so
+        # write_initial_state_dataset() converts them to the model's
+        # convention on its own
         self.write_initial_state_dataset(ds, 'init.nc', config)

--- a/polaris/tasks/ocean/seamount/init_utils.py
+++ b/polaris/tasks/ocean/seamount/init_utils.py
@@ -1,0 +1,140 @@
+"""
+Shared helpers for the seamount init step: the Beckmann and Haidvogel
+density profile and the tracers that reproduce it under either equation of
+state.
+
+Kept free of ``mpas_tools`` and of the step framework so the unit tests can
+import it directly.
+"""
+
+import numpy as np
+import xarray as xr
+
+from polaris.config import PolarisConfigParser
+from polaris.ocean.eos import ct_from_potential_density
+
+
+def compute_target_density(
+    config: PolarisConfigParser, z_mid: xr.DataArray
+) -> xr.DataArray:
+    """
+    Compute the target Beckmann and Haidvogel stratification, either the
+    linear profile of their eqn 15 or the exponential profile of their
+    eqn 16.
+
+    The profile is a potential density referenced to the surface.  Under the
+    linear equation of state, which has no pressure dependence, that is the
+    same thing as the density; under a nonlinear equation of state it is
+    not, and reading it as in-situ density would be unphysical -- TEOS-10
+    in-situ density at 5000 m is near 1050 kg m-3 from compression alone,
+    well outside the range this profile spans.
+
+    Parameters
+    ----------
+    config : polaris.config.PolarisConfigParser
+        Configuration with the ``[seamount]`` stratification options.
+
+    z_mid : xarray.DataArray
+        The geometric height (m, negative down) of the layer midpoints.
+
+    Returns
+    -------
+    xarray.DataArray
+        The target potential density (kg m-3) at the layer midpoints.
+    """
+    section = config['seamount']
+    stratification_type = section.get('seamount_stratification_type')
+
+    if stratification_type == 'linear':
+        coef = section.getfloat('seamount_density_coef_linear')
+        gradient = section.getfloat('seamount_density_gradient_linear')
+        depth = section.getfloat('seamount_density_depth_linear')
+        density = coef - gradient * z_mid / depth
+    elif stratification_type == 'exponential':
+        coef = section.getfloat('seamount_density_coef_exp')
+        gradient = section.getfloat('seamount_density_gradient_exp')
+        depth = section.getfloat('seamount_density_depth_exp')
+        density = coef - gradient * np.exp(z_mid / depth)
+    else:
+        raise ValueError(
+            f'Unsupported seamount_stratification_type: {stratification_type}'
+        )
+
+    density.attrs['long_name'] = 'target potential density'
+    density.attrs['units'] = 'kg m-3'
+    return density
+
+
+def compute_tracers(
+    config: PolarisConfigParser, z_mid: xr.DataArray
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """
+    Compute the temperature and salinity that reproduce the Beckmann and
+    Haidvogel stratification under the configured equation of state.
+
+    Salinity is constant, so all of the stratification is carried by
+    temperature.  For ``eos_type = linear`` the linear equation of state is
+    inverted algebraically; for ``eos_type = teos-10`` the tracers are
+    conservative temperature and absolute salinity, and the inversion is
+    through :py:func:`polaris.ocean.eos.ct_from_potential_density`.
+
+    Both branches reproduce the same potential density, so the two
+    equations of state give the same buoyancy stratification and differ
+    only in how density depends on pressure.
+
+    Parameters
+    ----------
+    config : polaris.config.PolarisConfigParser
+        Configuration with the ``[seamount]`` and ``[ocean]`` equation of
+        state options.
+
+    z_mid : xarray.DataArray
+        The geometric height (m, negative down) of the layer midpoints.
+
+    Returns
+    -------
+    temperature : xarray.DataArray
+        Potential temperature for a linear equation of state, conservative
+        temperature for TEOS-10 (degC).
+
+    salinity : xarray.DataArray
+        Practical salinity for a linear equation of state, absolute
+        salinity for TEOS-10.
+    """
+    density = compute_target_density(config, z_mid)
+
+    constant_salinity = config.getfloat('seamount', 'constant_salinity')
+    salinity = constant_salinity * xr.ones_like(density)
+
+    eos_type = config.get('ocean', 'eos_type').strip()
+
+    if eos_type == 'linear':
+        section = config['ocean']
+        rhoref = section.getfloat('eos_linear_rhoref')
+        tref = section.getfloat('eos_linear_Tref')
+        sref = section.getfloat('eos_linear_Sref')
+        alpha = section.getfloat('eos_linear_alpha')
+        beta = section.getfloat('eos_linear_beta')
+
+        # Back-solve the linear EOS that both Polaris and the ocean model
+        # apply, rho = rho_ref - alpha * (T - T_ref) + beta * (S - S_ref),
+        # for the temperature that reproduces the target density.  The
+        # salinity term matters: dropping it leaves the model's density
+        # offset from the Beckmann and Haidvogel profile by beta * S.
+        temperature = (
+            tref + (rhoref + beta * (salinity - sref) - density) / alpha
+        )
+        temperature.attrs['long_name'] = 'potential temperature'
+        salinity.attrs['long_name'] = 'practical salinity'
+        salinity.attrs['units'] = 'PSU'
+    elif eos_type == 'teos-10':
+        temperature = ct_from_potential_density(density, salinity)
+        salinity.attrs['long_name'] = 'absolute salinity'
+        salinity.attrs['units'] = 'g kg-1'
+    else:
+        raise ValueError(
+            f'The seamount task does not support eos_type: {eos_type}'
+        )
+
+    temperature.attrs['units'] = 'degC'
+    return temperature, salinity

--- a/polaris/tasks/ocean/seamount/seamount.cfg
+++ b/polaris/tasks/ocean/seamount/seamount.cfg
@@ -37,12 +37,13 @@ constant_f = -1.0e-4
 # unsplit, so the step is limited by the barotropic gravity wave.  On the
 # uniform hex mesh the C-grid divergence-gradient operator has a largest
 # eigenvalue of 6 / dcEdge^2, so the fastest external mode is
-# omega_max = sqrt(g * H) * sqrt(6) / dcEdge = 0.081 1/s for H = 5000 m and
-# dcEdge = 6.7 km.  Against RK4's imaginary-axis limit of 2*sqrt(2) that
-# caps dt near 35 s, or 5.2 s/km.  The value here is 77% of that cap, which
-# leaves margin for the nonlinear terms, and none of the other constraints
-# come close -- del4 viscosity allows 1300 s, del2 2e4 s, and advection
-# 5e5 s.  In Omega, both 2.5 s/km and this value have been run for the full
+# omega_max = sqrt(g * H) * sqrt(6) / dcEdge = 0.085 1/s for H = 5000 m and
+# dcEdge = 6.4 km.  Against RK4's imaginary-axis limit of 2*sqrt(2) that
+# caps dt near 33 s, or 5.2 s/km.  The cap in s/km is the same at any
+# resolution, since the gravity wave frequency goes like 1 / dcEdge.  The
+# value here is 77% of that cap, which leaves margin for the nonlinear
+# terms, and none of the other constraints come close -- del4 viscosity
+# allows 1100 s, del2 2e4 s, and advection 5e5 s.  In Omega, both 2.5 s/km and this value have been run for the full
 # 6 days in both coordinate trees; sigma and z-star are stable at 4.0 s/km,
 # with max |u| of 1.8 cm/s and 0.1 cm/s respectively.
 dt_per_km = 4.0
@@ -75,8 +76,15 @@ ly = 320
 # The length of the domain in the along-slope dimension (km)
 lx = 320
 
-# Distance from two cell centers (km)
-resolution = 6.7
+# Distance between two cell centers (km).  320 km divides into exactly 50
+# cells at 6.4 km, so the domain really is lx by ly; at the 6.7 km this case
+# used previously it was 321.6 km across, since the mesh is built from
+# nx * resolution rather than from lx.  What the pressure gradient error
+# actually responds to is the discrete steepness of the seamount,
+# max |dh| / (h1 + h2) between adjacent cells, which is about
+# 1.5 * resolution / seamount_width and so barely moves: 0.22 at 6.7 km,
+# 0.21 at 6.4 km.
+resolution = 6.4
 
 # Bottom depth at bottom of seamount
 max_bottom_depth = ${vertical_grid:bottom_depth}

--- a/polaris/tasks/ocean/seamount/seamount.cfg
+++ b/polaris/tasks/ocean/seamount/seamount.cfg
@@ -116,8 +116,19 @@ constant_salinity = 35.0
 
 [seamount_default]
 
-# Run duration (days)
-run_duration = 6.
+# Run duration (hours)
+run_duration = 144.
 
 # Output interval (hours)
 output_interval = 1.
+
+# Options for the short seamount task, a regression test rather than a
+# measurement of the pressure gradient error
+[seamount_short]
+
+# Run duration (hours)
+run_duration = 1.
+
+# Output interval (hours).  Half the run duration, so the time series the viz
+# step plots has more than a single point in it.
+output_interval = 0.5

--- a/polaris/tasks/ocean/seamount/seamount.cfg
+++ b/polaris/tasks/ocean/seamount/seamount.cfg
@@ -10,11 +10,11 @@ vert_levels = 10
 # The type of vertical grid
 grid_type = uniform
 
-# The type of vertical coordinate (e.g. z-level, z-star)
-coord_type = sigma
-
 # Whether to use "partial" or "full", or "None" to not alter the topography
 partial_cell_type = None
+
+# The minimum fraction of a layer for partial cells
+min_pc_fraction = 0.1
 
 # config options for Coriolis
 [coriolis]

--- a/polaris/tasks/ocean/seamount/seamount.cfg
+++ b/polaris/tasks/ocean/seamount/seamount.cfg
@@ -33,32 +33,29 @@ constant_f = -1.0e-4
 # Options related to the seamount case
 [seamount]
 
-# Timestep per km horizontal resolution (s) for MPAS-Ocean, whose
-# split-explicit integrator resolves the barotropic mode separately
-dt_per_km = 10.
-
-# Barotropic timestep per km horizontal resolution (s), MPAS-Ocean only
-btr_dt_per_km = 2.5
-
-# Timestep per km horizontal resolution (s) for Omega, which has no
-# split-explicit integrator and so is limited by the barotropic gravity
-# wave.  On the uniform hex mesh the C-grid divergence-gradient operator has
-# a largest eigenvalue of 6 / dcEdge^2, so the fastest external mode is
+# Timestep per km horizontal resolution (s), shared by both models.  RK4 is
+# unsplit, so the step is limited by the barotropic gravity wave.  On the
+# uniform hex mesh the C-grid divergence-gradient operator has a largest
+# eigenvalue of 6 / dcEdge^2, so the fastest external mode is
 # omega_max = sqrt(g * H) * sqrt(6) / dcEdge = 0.081 1/s for H = 5000 m and
 # dcEdge = 6.7 km.  Against RK4's imaginary-axis limit of 2*sqrt(2) that
 # caps dt near 35 s, or 5.2 s/km.  The value here is 77% of that cap, which
 # leaves margin for the nonlinear terms, and none of the other constraints
 # come close -- del4 viscosity allows 1300 s, del2 2e4 s, and advection
-# 5e5 s.  Both 2.5 s/km and this value have been run for the full 6 days in
-# both coordinate trees; sigma and z-star are stable at 4.0 s/km, with max
-# |u| of 1.8 cm/s and 0.1 cm/s respectively.
-omega_dt_per_km = 4.0
+# 5e5 s.  In Omega, both 2.5 s/km and this value have been run for the full
+# 6 days in both coordinate trees; sigma and z-star are stable at 4.0 s/km,
+# with max |u| of 1.8 cm/s and 0.1 cm/s respectively.
+dt_per_km = 4.0
 
-# Time integrator for MPAS-Ocean
-time_integrator = split_explicit_ab2
+# Barotropic timestep per km horizontal resolution (s), MPAS-Ocean only.  It
+# is unused with RK4 and only takes effect if time_integrator is set back to
+# a split-explicit scheme.
+btr_dt_per_km = 2.5
 
-# Time integrator for Omega
-omega_time_integrator = RK4
+# Time integrator, shared by both models.  Omega has no split time stepper
+# yet, so MPAS-Ocean uses RK4 as well rather than its split-explicit
+# integrator, which is what makes the two runs comparable.
+time_integrator = RK4
 
 # Horizontal tracer advection order, shared by both models
 horiz_adv_order = 3

--- a/polaris/tasks/ocean/seamount/seamount.cfg
+++ b/polaris/tasks/ocean/seamount/seamount.cfg
@@ -29,11 +29,38 @@ constant_f = -1.0e-4
 # Options related to the seamount case
 [seamount]
 
-# Timestep per km horizontal resolution (s)
+# Timestep per km horizontal resolution (s) for MPAS-Ocean, whose
+# split-explicit integrator resolves the barotropic mode separately
 dt_per_km = 10.
 
-# Barotropic timestep per km horizontal resolution (s)
+# Barotropic timestep per km horizontal resolution (s), MPAS-Ocean only
 btr_dt_per_km = 2.5
+
+# Timestep per km horizontal resolution (s) for Omega, which has no
+# split-explicit integrator and so is limited by the barotropic gravity
+# wave.  On the uniform hex mesh the C-grid divergence-gradient operator has
+# a largest eigenvalue of 6 / dcEdge^2, so the fastest external mode is
+# omega_max = sqrt(g * H) * sqrt(6) / dcEdge = 0.081 1/s for H = 5000 m and
+# dcEdge = 6.7 km.  Against RK4's imaginary-axis limit of 2*sqrt(2) that
+# caps dt near 35 s, or 5.2 s/km.  The value here is 77% of that cap, which
+# leaves margin for the nonlinear terms, and none of the other constraints
+# come close -- del4 viscosity allows 1300 s, del2 2e4 s, and advection
+# 5e5 s.  Both 2.5 s/km and this value have been run for the full 6 days in
+# both coordinate trees; sigma and z-star are stable at 4.0 s/km, with max
+# |u| of 1.8 cm/s and 0.1 cm/s respectively.
+omega_dt_per_km = 4.0
+
+# Time integrator for MPAS-Ocean
+time_integrator = split_explicit_ab2
+
+# Time integrator for Omega
+omega_time_integrator = RK4
+
+# Horizontal tracer advection order, shared by both models
+horiz_adv_order = 3
+
+# Constant bottom drag coefficient
+bottom_drag_coeff = 0.01
 
 # The width of the domain in the across-slope dimension (km)
 ly = 320

--- a/polaris/tasks/ocean/seamount/seamount.cfg
+++ b/polaris/tasks/ocean/seamount/seamount.cfg
@@ -4,8 +4,12 @@
 # Depth of the bottom of the ocean (m)
 bottom_depth = 5000.0
 
-# Number of vertical levels
-vert_levels = 10
+# Number of vertical levels.  A multiple of 16, which Omega prefers, that
+# divides the 5000 m bottom depth into exact 156.25 m layers and sits in the
+# range the literature uses for this case (20 in Beckmann and Haidvogel,
+# 20-30 in Shchepetkin and McWilliams).  It also keeps the z-star variant
+# usable: at 10 levels the 500 m summit column would have a single level.
+vert_levels = 32
 
 # The type of vertical grid
 grid_type = uniform
@@ -59,8 +63,14 @@ omega_time_integrator = RK4
 # Horizontal tracer advection order, shared by both models
 horiz_adv_order = 3
 
-# Constant bottom drag coefficient
-bottom_drag_coeff = 0.01
+# Constant bottom drag coefficient.  Deliberately an order of magnitude
+# below the 1e-2 that comparable idealized planar cases use.  The implicit
+# drag damping timescale is h_bot / (Cd * |u|), and the bottom layer over
+# the seamount summit is only ~16 m thick, so at 1e-2 a 5 cm/s spurious
+# velocity damps in under half a day against a 6 day run.  That would cap a
+# bad pressure gradient while leaving a good one untouched, compressing the
+# dynamic range this test exists to measure.
+bottom_drag_coeff = 1.0e-3
 
 # The width of the domain in the across-slope dimension (km)
 ly = 320

--- a/polaris/tasks/ocean/seamount/seamount.cfg
+++ b/polaris/tasks/ocean/seamount/seamount.cfg
@@ -112,7 +112,9 @@ seamount_height = 4500.0
 # Width parameter of sea mount, e-folding length (m)
 seamount_width = 40.0e3
 
-# Salinity of the water in the entire domain (PSU)
+# Salinity of the water in the entire domain, read as practical salinity
+# (PSU) for the linear trees and as absolute salinity (g kg^-1) for the
+# nonlinear ones
 constant_salinity = 35.0
 
 [seamount_default]
@@ -122,20 +124,3 @@ run_duration = 6.
 
 # Output interval (hours)
 output_interval = 1.
-
-# Options related the ocean component
-[ocean]
-
-# Equation of state reference density when T and S are the reference values.
-# Omega's linear EOS has no reference temperature or salinity, so the
-# Beckmann and Haidvogel reference state (1028 kg m^-3 at T = 5 C, S = 35 PSU)
-# is folded into rhoref at Tref = Sref = 0:
-# 1028.0 + 0.2 * 5.0 - 0.8 * 35.0 = 1001.0
-eos_linear_rhoref = 1001.
-
-# Equation of state -drho/dT
-eos_linear_alpha = 0.2
-
-# Equation of state reference temperature.  Must be zero: nonzero Tref and
-# Sref are rejected for Omega, which has no equivalent config options.
-eos_linear_Tref = 0.

--- a/polaris/tasks/ocean/seamount/seamount.cfg
+++ b/polaris/tasks/ocean/seamount/seamount.cfg
@@ -89,11 +89,16 @@ output_interval = 1.
 # Options related the ocean component
 [ocean]
 
-# Equation of state reference density when T and S are the reference values
-eos_linear_rhoref = 1028.
+# Equation of state reference density when T and S are the reference values.
+# Omega's linear EOS has no reference temperature or salinity, so the
+# Beckmann and Haidvogel reference state (1028 kg m^-3 at T = 5 C, S = 35 PSU)
+# is folded into rhoref at Tref = Sref = 0:
+# 1028.0 + 0.2 * 5.0 - 0.8 * 35.0 = 1001.0
+eos_linear_rhoref = 1001.
 
 # Equation of state -drho/dT
 eos_linear_alpha = 0.2
 
-# Equation of state reference temperature
-eos_linear_Tref = 5.
+# Equation of state reference temperature.  Must be zero: nonzero Tref and
+# Sref are rejected for Omega, which has no equivalent config options.
+eos_linear_Tref = 0.

--- a/polaris/tasks/ocean/seamount/seamount_linear.cfg
+++ b/polaris/tasks/ocean/seamount/seamount_linear.cfg
@@ -1,0 +1,22 @@
+# Overrides for the seamount task trees that use the linear equation of
+# state.  The Beckmann and Haidvogel profile is reproduced by back-solving
+# this EOS for temperature, so the coefficients here set the temperature
+# range the initial condition spans.  They have no meaning for the nonlinear
+# trees, which is why they live here rather than in the shared config.
+
+# Options related the ocean component
+[ocean]
+
+# Equation of state reference density when T and S are the reference values.
+# Omega's linear EOS has no reference temperature or salinity, so the
+# Beckmann and Haidvogel reference state (1028 kg m^-3 at T = 5 C, S = 35 PSU)
+# is folded into rhoref at Tref = Sref = 0:
+# 1028.0 + 0.2 * 5.0 - 0.8 * 35.0 = 1001.0
+eos_linear_rhoref = 1001.
+
+# Equation of state -drho/dT
+eos_linear_alpha = 0.2
+
+# Equation of state reference temperature.  Must be zero: nonzero Tref and
+# Sref are rejected for Omega, which has no equivalent config options.
+eos_linear_Tref = 0.

--- a/polaris/tasks/ocean/seamount/seamount_sigma.cfg
+++ b/polaris/tasks/ocean/seamount/seamount_sigma.cfg
@@ -1,0 +1,8 @@
+# Overrides for the seamount task tree that uses the sigma
+# (terrain-following) vertical coordinate
+
+# Options related to the vertical grid
+[vertical_grid]
+
+# The type of vertical coordinate
+coord_type = sigma

--- a/polaris/tasks/ocean/seamount/seamount_zstar.cfg
+++ b/polaris/tasks/ocean/seamount/seamount_zstar.cfg
@@ -1,0 +1,17 @@
+# Overrides for the seamount task tree that uses the z-star vertical
+# coordinate.  This tree is the control for the sigma tree: the flatter the
+# layers, the smaller the spurious pressure-gradient velocity should be.
+# Set partial_cell_type = full for the limiting case in which the layers are
+# exactly level and the pressure gradient vanishes to machine precision.
+
+# Options related to the vertical grid
+[vertical_grid]
+
+# The type of vertical coordinate
+coord_type = z-star
+
+# Partial bottom cells, snapped to at least min_pc_fraction of a full cell.
+# Unlike sigma, z-star cuts the reference grid at the seafloor, so without
+# snapping the seamount flanks produce arbitrarily thin bottom cells and a
+# correspondingly punishing time-step limit.
+partial_cell_type = partial

--- a/polaris/tasks/ocean/seamount/short/__init__.py
+++ b/polaris/tasks/ocean/seamount/short/__init__.py
@@ -1,0 +1,46 @@
+from polaris import Task as Task
+from polaris.tasks.ocean.seamount.forward import Forward as Forward
+from polaris.tasks.ocean.seamount.viz import Viz as Viz
+
+
+class Short(Task):
+    """
+    The short seamount test case creates the mesh and initial condition, then
+    performs a 1 hour forward run.  It is too short to say anything about the
+    pressure gradient error but long enough to catch a regression, so it is
+    the variant that belongs in the pull request suites.
+    """
+
+    def __init__(self, component, indir, init):
+        """
+        Create the test case
+
+        Parameters
+        ----------
+        component : polaris.ocean.Ocean
+            The ocean component that this task belongs to
+
+        indir : str
+            The directory the task is in, to which ``name`` will be appended
+
+        init : polaris.tasks.ocean.seamount.init.Init
+            A shared step for creating the initial state
+        """
+        task_name = 'short'
+        super().__init__(component=component, name=task_name, indir=indir)
+
+        self.add_step(init, symlink='init')
+
+        forward_step = Forward(
+            component=component,
+            init=init,
+            task_name=task_name,
+            name='forward',
+            indir=self.subdir,
+        )
+        self.add_step(forward_step)
+        # unlike the default task, the forward run here is cheap to repeat, so
+        # the plots are opt-in as they are elsewhere in Polaris
+        self.add_step(
+            Viz(component=component, indir=self.subdir), run_by_default=False
+        )

--- a/tests/ocean/eos/test_ct_from_potential_density.py
+++ b/tests/ocean/eos/test_ct_from_potential_density.py
@@ -1,0 +1,62 @@
+import gsw
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_allclose
+
+from polaris.ocean.eos import ct_from_potential_density
+
+
+def test_round_trip_scalar():
+    sigma_0 = 1026.5
+    ct = ct_from_potential_density(sigma_0, 35.0)
+
+    assert isinstance(ct, float)
+    assert_allclose(gsw.rho(35.0, ct, 0.0), sigma_0)
+
+
+def test_round_trip_data_array():
+    # a Beckmann and Haidvogel exponential profile over a 5000 m column
+    z_mid = xr.DataArray(
+        -np.linspace(78.125, 4921.875, 32), dims=('nVertLevels',)
+    )
+    sigma_0 = 1028.0 - 3.0 * np.exp(z_mid / 500.0)
+
+    ct = ct_from_potential_density(sigma_0, 35.0)
+
+    assert isinstance(ct, xr.DataArray)
+    assert ct.dims == sigma_0.dims
+    assert ct.attrs['units'] == 'degC'
+    # the inversion is exact, not iterative, so this should close to
+    # round-off rather than to a solver tolerance
+    assert_allclose(gsw.rho(35.0, ct.values, 0.0), sigma_0.values, atol=1e-11)
+
+
+def test_salinity_varies_with_density():
+    sigma_0 = xr.DataArray(np.array([1025.0, 1027.0]), dims=('nCells',))
+    sa = xr.DataArray(np.array([34.0, 35.5]), dims=('nCells',))
+
+    ct = ct_from_potential_density(sigma_0, sa)
+
+    assert isinstance(ct, xr.DataArray)
+    assert_allclose(
+        gsw.rho(sa.values, ct.values, 0.0), sigma_0.values, atol=1e-11
+    )
+
+
+def test_unattainable_density_raises():
+    # far denser than seawater at this salinity can be at the surface
+    with pytest.raises(ValueError, match='not.*attainable'):
+        ct_from_potential_density(1100.0, 35.0)
+
+
+def test_nan_input_is_not_reported_as_unattainable():
+    # below-bottom cells carry NaN and must pass through rather than
+    # tripping the unattainable-density check
+    sigma_0 = xr.DataArray(np.array([1026.5, np.nan]), dims=('nCells',))
+
+    ct = ct_from_potential_density(sigma_0, 35.0)
+
+    assert isinstance(ct, xr.DataArray)
+    assert np.isfinite(ct.values[0])
+    assert np.isnan(ct.values[1])

--- a/tests/ocean/seamount/test_sigma_to_pseudo.py
+++ b/tests/ocean/seamount/test_sigma_to_pseudo.py
@@ -1,0 +1,194 @@
+"""
+Unit tests for the seamount vertical coordinate as Omega sees it.
+
+The seamount builds a geometric coordinate (sigma or z-star) and relies on
+Polaris converting it to pseudo-height for Omega, rather than on any
+p-star-specific initialization.  These tests exercise that path directly:
+build the coordinate on a seamount-like set of columns, convert it with
+``pseudothickness_from_ds()``, and check the two properties the test case
+depends on.
+
+All tests are self-contained: no file I/O, no full Polaris step framework.
+"""
+
+from configparser import ConfigParser
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.ocean.eos import compute_linear_density
+from polaris.ocean.vertical import init_vertical_coord
+from polaris.ocean.vertical.diagnostics import pseudothickness_from_ds
+from polaris.ocean.vertical.ztilde import Gravity, RhoSw
+
+# Beckmann and Haidvogel exponential stratification, as configured for the
+# seamount, together with the linear EOS parameters it is inverted through
+DENSITY_COEF = 1028.0
+DENSITY_GRADIENT = 3.0
+DENSITY_DEPTH = 500.0
+EOS_RHOREF = 1001.0
+EOS_ALPHA = 0.2
+EOS_BETA = 0.8
+SALINITY = 35.0
+
+MAX_BOTTOM_DEPTH = 5000.0
+SEAMOUNT_HEIGHT = 4500.0
+SEAMOUNT_WIDTH = 40.0e3
+VERT_LEVELS = 32
+
+
+def _make_config(coord_type, partial_cell_type='None'):
+    config = ConfigParser()
+    config.add_section('vertical_grid')
+    config.set('vertical_grid', 'grid_type', 'uniform')
+    config.set('vertical_grid', 'vert_levels', str(VERT_LEVELS))
+    config.set('vertical_grid', 'bottom_depth', str(MAX_BOTTOM_DEPTH))
+    config.set('vertical_grid', 'coord_type', coord_type)
+    config.set('vertical_grid', 'partial_cell_type', partial_cell_type)
+    config.set('vertical_grid', 'min_pc_fraction', '0.1')
+    config.set('vertical_grid', 'min_vert_levels', '1')
+    config.set('vertical_grid', 'min_layer_thickness', '0.0')
+    config.set('vertical_grid', 'pseudothickness_iter_count', '10')
+
+    config.add_section('ocean')
+    config.set('ocean', 'eos_type', 'linear')
+    config.set('ocean', 'eos_linear_rhoref', str(EOS_RHOREF))
+    config.set('ocean', 'eos_linear_alpha', str(EOS_ALPHA))
+    config.set('ocean', 'eos_linear_beta', str(EOS_BETA))
+    config.set('ocean', 'eos_linear_Tref', '0.0')
+    config.set('ocean', 'eos_linear_Sref', '0.0')
+    return config
+
+
+def _bottom_depth(flat):
+    """Seamount bathymetry, or a flat floor for the negative control."""
+    radius = np.linspace(0.0, 160.0e3, 24)
+    if flat:
+        return MAX_BOTTOM_DEPTH * np.ones_like(radius)
+    return MAX_BOTTOM_DEPTH - SEAMOUNT_HEIGHT * np.exp(
+        -(radius**2) / SEAMOUNT_WIDTH**2
+    )
+
+
+def _make_ds(config, flat=False):
+    """Build the geometric coordinate and the seamount tracer profile."""
+    ds = xr.Dataset()
+    ds['bottomDepth'] = xr.DataArray(_bottom_depth(flat), dims=['nCells'])
+    ds['ssh'] = xr.zeros_like(ds.bottomDepth)
+    init_vertical_coord(config, ds)
+
+    density = DENSITY_COEF - DENSITY_GRADIENT * np.exp(
+        ds.zMid.squeeze('Time') / DENSITY_DEPTH
+    )
+    ds['salinity'] = SALINITY * xr.ones_like(density)
+    ds['temperature'] = (
+        EOS_RHOREF + EOS_BETA * ds.salinity - density
+    ) / EOS_ALPHA
+    return ds
+
+
+def _pseudo_interface_pressure(ds, config):
+    """
+    Convert the geometric coordinate to pseudo-thickness the way Polaris
+    does when writing an Omega initial condition, then integrate gauge
+    pressure down the column.
+    """
+    pseudo_thickness, _ = pseudothickness_from_ds(
+        ds, config=config, src_var_name='restingThickness', surf_pressure=0.0
+    )
+    assert pseudo_thickness is not None
+    h_tilde = np.nan_to_num(pseudo_thickness.values)
+    if h_tilde.ndim == 3:
+        h_tilde = h_tilde[0]
+    zeros = np.zeros((h_tilde.shape[0], 1))
+    return (
+        RhoSw
+        * Gravity
+        * np.cumsum(np.concatenate([zeros, h_tilde], axis=1), axis=1)
+    )
+
+
+def test_temperature_reproduces_target_density():
+    """
+    The back-solve through the full linear EOS, including the salinity
+    term, must reproduce the Beckmann and Haidvogel density profile.
+    """
+    config = _make_config('sigma')
+    ds = _make_ds(config)
+
+    density = compute_linear_density(config, ds.temperature, ds.salinity)
+    target = DENSITY_COEF - DENSITY_GRADIENT * np.exp(
+        ds.zMid.squeeze('Time') / DENSITY_DEPTH
+    )
+    assert np.nanmax(np.abs(density - target).values) < 1.0e-10
+
+
+@pytest.mark.parametrize(
+    'coord_type,partial_cell_type',
+    [('sigma', 'None'), ('z-star', 'partial')],
+)
+def test_geometric_round_trip(coord_type, partial_cell_type):
+    """
+    Converting the geometric coordinate to pseudo-thickness and back must
+    recover the geometric column thickness.  This is the property Omega
+    relies on when it anchors the column at BottomGeomDepth.
+    """
+    config = _make_config(coord_type, partial_cell_type)
+    ds = _make_ds(config)
+
+    pseudo_thickness, spec_vol = pseudothickness_from_ds(
+        ds, config=config, src_var_name='restingThickness', surf_pressure=0.0
+    )
+    assert pseudo_thickness is not None and spec_vol is not None
+
+    geom = (spec_vol * pseudo_thickness * RhoSw).fillna(0.0)
+    column = geom.sum(dim='nVertLevels')
+    assert np.max(np.abs(column - ds.bottomDepth).values) < 1.0e-8
+
+
+def test_sigma_layers_are_proportional_to_column_depth():
+    """
+    Sigma must be exactly terrain-following in geometric height: every
+    column devotes the same fraction of its depth to each layer.
+    """
+    config = _make_config('sigma')
+    ds = _make_ds(config)
+
+    thickness = ds.restingThickness.squeeze('Time').values
+    fraction = thickness / ds.bottomDepth.values[:, None]
+    spread = fraction.max(axis=0) - fraction.min(axis=0)
+    assert np.max(spread) < 1.0e-12
+
+
+def test_sigma_interior_interfaces_tilt():
+    """
+    Interior interfaces must sit at genuinely different pressures from one
+    column to the next.  A coordinate that clipped a shared reference grid
+    at the seafloor instead of stretching to it would put every interior
+    interface at the same pressure, leaving the whole pressure-gradient
+    signal in the bottom cell.
+    """
+    config = _make_config('sigma')
+    ds = _make_ds(config)
+
+    pressure = _pseudo_interface_pressure(ds, config)
+    interior = pressure[:, 1:-1]
+    relative_rms = np.std(interior, axis=0) / np.mean(interior, axis=0)
+    assert np.min(relative_rms) > 1.0e-3
+
+
+def test_flat_bottom_interfaces_do_not_tilt():
+    """
+    The negative control for :py:func:`test_sigma_interior_interfaces_tilt`.
+    With a flat floor there is nothing for sigma to follow, so the same
+    measurement must come back at round-off.  Without this, a tilt check
+    that could never fail would look like it was protecting something.
+    """
+    config = _make_config('sigma')
+    ds = _make_ds(config, flat=True)
+
+    pressure = _pseudo_interface_pressure(ds, config)
+    interior = pressure[:, 1:-1]
+    relative_rms = np.std(interior, axis=0) / np.mean(interior, axis=0)
+    assert np.max(relative_rms) < 1.0e-12

--- a/tests/ocean/seamount/test_tracers.py
+++ b/tests/ocean/seamount/test_tracers.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for the seamount initial condition under both equations of state.
+
+The seamount specifies its stratification as a Beckmann and Haidvogel
+density profile rather than as a temperature profile, so each equation of
+state has to be inverted for the tracers that reproduce it.  These tests
+check that both inversions land on the same potential density -- which is
+what makes the linear and nonlinear trees comparable -- and that the
+nonlinear tree really does gain a pressure dependence the linear one cannot
+have.
+
+All tests are self-contained: no file I/O, no full Polaris step framework.
+"""
+
+from configparser import ConfigParser
+
+import gsw
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_allclose
+
+from polaris.ocean.eos import compute_density
+from polaris.tasks.ocean.seamount.init_utils import (
+    compute_target_density,
+    compute_tracers,
+)
+
+# Beckmann and Haidvogel exponential stratification, as configured for the
+# seamount, together with the linear EOS parameters it is inverted through
+DENSITY_COEF = 1028.0
+DENSITY_GRADIENT = 3.0
+DENSITY_DEPTH = 500.0
+EOS_RHOREF = 1001.0
+EOS_ALPHA = 0.2
+EOS_BETA = 0.8
+SALINITY = 35.0
+
+MAX_BOTTOM_DEPTH = 5000.0
+SUMMIT_DEPTH = 531.45
+VERT_LEVELS = 32
+
+
+def _make_config(eos_type, stratification='exponential'):
+    config = ConfigParser()
+
+    config.add_section('seamount')
+    config.set('seamount', 'seamount_stratification_type', stratification)
+    config.set('seamount', 'seamount_density_coef_exp', str(DENSITY_COEF))
+    config.set(
+        'seamount', 'seamount_density_gradient_exp', str(DENSITY_GRADIENT)
+    )
+    config.set('seamount', 'seamount_density_depth_exp', str(DENSITY_DEPTH))
+    config.set('seamount', 'seamount_density_coef_linear', '1024.0')
+    config.set('seamount', 'seamount_density_gradient_linear', '0.1')
+    config.set('seamount', 'seamount_density_depth_linear', '4500.0')
+    config.set('seamount', 'constant_salinity', str(SALINITY))
+
+    config.add_section('ocean')
+    config.set('ocean', 'eos_type', eos_type)
+    config.set('ocean', 'eos_linear_rhoref', str(EOS_RHOREF))
+    config.set('ocean', 'eos_linear_alpha', str(EOS_ALPHA))
+    config.set('ocean', 'eos_linear_beta', str(EOS_BETA))
+    config.set('ocean', 'eos_linear_Tref', '0.0')
+    config.set('ocean', 'eos_linear_Sref', '0.0')
+    return config
+
+
+def _sigma_z_mid():
+    """
+    Sigma layer midpoints for a pair of columns spanning the seamount's
+    depth range: the deep flank and the summit.
+    """
+    depths = np.array([MAX_BOTTOM_DEPTH, SUMMIT_DEPTH])
+    frac = (np.arange(VERT_LEVELS) + 0.5) / VERT_LEVELS
+    z_mid = -depths[:, np.newaxis] * frac[np.newaxis, :]
+    return xr.DataArray(z_mid, dims=('nCells', 'nVertLevels'))
+
+
+def test_target_density_matches_beckmann_haidvogel():
+    config = _make_config('linear')
+    z_mid = _sigma_z_mid()
+
+    density = compute_target_density(config, z_mid)
+
+    expected = DENSITY_COEF - DENSITY_GRADIENT * np.exp(
+        z_mid.values / DENSITY_DEPTH
+    )
+    assert_allclose(density.values, expected)
+    # the profile the seamount actually configures
+    assert_allclose(density.values.min(), 1025.0494, atol=1e-4)
+    assert_allclose(density.values.max(), 1027.9998, atol=1e-4)
+
+
+def test_linear_back_solve_reproduces_target():
+    config = _make_config('linear')
+    z_mid = _sigma_z_mid()
+
+    density = compute_target_density(config, z_mid)
+    temperature, salinity = compute_tracers(config, z_mid)
+
+    # the linear EOS has no pressure dependence, so density is exactly the
+    # target with no reference pressure to choose
+    modeled = compute_density(config, temperature, salinity)
+    assert isinstance(modeled, xr.DataArray)
+    assert_allclose(modeled.values, density.values, atol=1e-12)
+    assert_allclose(salinity.values, SALINITY)
+
+
+def test_nonlinear_reproduces_target_as_potential_density():
+    config = _make_config('teos-10')
+    z_mid = _sigma_z_mid()
+
+    density = compute_target_density(config, z_mid)
+    ct, sa = compute_tracers(config, z_mid)
+
+    # at zero reference pressure the TEOS-10 tracers reproduce the same
+    # Beckmann and Haidvogel profile the linear back-solve does
+    sigma_0 = compute_density(config, ct, sa, pressure=0.0)
+    assert isinstance(sigma_0, xr.DataArray)
+    assert_allclose(sigma_0.values, density.values, atol=1e-11)
+    assert sa.attrs['units'] == 'g kg-1'
+
+
+def test_both_equations_of_state_share_a_stratification():
+    """
+    The property that makes the two trees comparable: a difference in
+    spurious velocity between them is due to the equation of state, not to
+    a different N^2.
+    """
+    z_mid = _sigma_z_mid()
+
+    t_lin, s_lin = compute_tracers(_make_config('linear'), z_mid)
+    ct, sa = compute_tracers(_make_config('teos-10'), z_mid)
+
+    rho_lin = compute_density(_make_config('linear'), t_lin, s_lin)
+    assert isinstance(rho_lin, xr.DataArray)
+    sigma_0 = gsw.rho(sa.values, ct.values, 0.0)
+
+    assert_allclose(sigma_0, rho_lin.values, atol=1e-11)
+    # the temperature fields are close but not identical, since the two
+    # equations of state reach the same density by different routes
+    assert np.abs(ct.values - t_lin.values).max() > 1.0
+
+
+def test_nonlinear_gains_a_pressure_dependence():
+    """
+    The negative control: if in-situ density under TEOS-10 did not depart
+    from the surface-referenced profile, the nonlinear tree would be
+    measuring nothing the linear tree does not already measure.
+    """
+    config = _make_config('teos-10')
+    z_mid = _sigma_z_mid()
+
+    ct, sa = compute_tracers(config, z_mid)
+
+    pressure = -z_mid * 1026.0 * 9.80665
+    rho_in_situ = compute_density(config, ct, sa, pressure=pressure)
+    sigma_0 = compute_density(config, ct, sa, pressure=0.0)
+    assert isinstance(rho_in_situ, xr.DataArray)
+    assert isinstance(sigma_0, xr.DataArray)
+
+    departure = (rho_in_situ - sigma_0).values
+    # compression dominates and is monotonic with depth; at 5000 m it is
+    # far larger than the 3 kg m-3 the whole profile spans
+    assert departure.min() >= 0.0
+    assert departure.max() > 20.0
+    deep_column = departure[0, :]
+    assert np.all(np.diff(deep_column) > 0.0)
+
+
+def test_linear_stratification_branch():
+    config = _make_config('linear', stratification='linear')
+    z_mid = _sigma_z_mid()
+
+    density = compute_target_density(config, z_mid)
+
+    expected = 1024.0 - 0.1 * z_mid.values / 4500.0
+    assert_allclose(density.values, expected)
+
+
+def test_unsupported_stratification_raises():
+    config = _make_config('linear', stratification='quadratic')
+    with pytest.raises(ValueError, match='seamount_stratification_type'):
+        compute_target_density(config, _sigma_z_mid())
+
+
+def test_unsupported_eos_raises():
+    config = _make_config('constant')
+    with pytest.raises(ValueError, match='eos_type'):
+        compute_tracers(config, _sigma_z_mid())


### PR DESCRIPTION
The `seamount` task measures the spurious velocity produced by the pressure gradient error in tilted layers. This PR makes it run under Omega as well as MPAS-Ocean, splits it into a tree per equation of state and per vertical coordinate following `overflow`, and revisits the physics and numerics it inherited from Compass so that the signal it measures is not suppressed and the two models are comparable.

## Task trees

- Paths change from `planar/seamount/{sigma,zstar}` to `planar/seamount/{linear,nonlinear}/{sigma,zstar}`, following the `planar/overflow/{eos}/{coord}` pattern. No suite referenced the seamount before this PR.
- `sigma` is the main target (every layer tilted by construction); `zstar` is the control, where layers are nearly level and the spurious velocity should be much smaller.
- `linear` has no pressure dependence; `nonlinear` uses TEOS-10 for Omega and Jackett-McDougall for MPAS-Ocean. The two are different functions, not two implementations of one, so the models are only expected to agree qualitatively in the nonlinear trees.
- `coord_type`/`partial_cell_type` move to `seamount_{sigma,zstar}.cfg` and the `eos_linear_*` options to `seamount_linear.cfg`, layered over the shared `seamount.cfg` along with `linear.cfg` or `teos10.cfg` from `polaris.ocean.eos`.
- The z-star tree needs partial cells: at 32 levels, sampling the seamount profile gives a 7 cm minimum bottom cell with `partial_cell_type = None` against 15.6 m with `partial` and `min_pc_fraction = 0.1`.

## Omega support

- Both coordinates are geometric, so one `init` step serves both models: the framework converts `restingThickness`/`layerThickness` to `RefPseudoThickness`/`PseudoThickness` by integrating gauge pressure down each column. No p-star-specific init and no reference pseudo-grid, so `PStarInitStep` is not used.
- `forward.yaml` splits into shared `ocean:`, `mpas-ocean:` and `Omega:` sections; `forward.py` configures either model.
- Omega has no split time stepper, so MPAS-Ocean gives up its split-explicit scheme and both run RK4 at the same `dt_per_km = 4.0`, against a barotropic-gravity-wave stability cap of 5.2 s/km. `btr_dt_per_km` is kept but inert unless `time_integrator` is set back to a split-explicit scheme.
- Bottom drag stays implicit and constant in both models, which the recent Omega implicit bottom drag support makes possible. Horizontal tracer advection order is pinned so the models do not use their differing defaults (3 vs. 2).
- `SpecVol` is required in the Omega `History` stream, since Polaris reads back a geometric `layerThickness` as `RhoSw * SpecVol * PseudoThickness`.

## Initial condition

- **Linear EOS fix**: the back-solve dropped the `beta * (S - S_ref)` term that `compute_linear_density()` and both models actually apply, leaving the model's density 28 kg m^-3 above the intended Beckmann and Haidvogel profile — harmless in MPAS-Ocean, not in Omega, where the pseudo-height mapping depends on absolute density. It now inverts the full linear EOS.
- `eos_linear_Tref = 5` is rejected outright for Omega, whose linear EOS has no reference temperature or salinity, so the reference state is folded into `rhoref` at `Tref = Sref = 0` (`1028.0 + 0.2 * 5.0 - 0.8 * 35.0 = 1001.0`). This cancels exactly against the fix above: temperature, salinity and velocity are unchanged to machine precision and only the density diagnostic moves, onto the intended profile.
- **Nonlinear EOS**: the profile cannot be read as in-situ density, since TEOS-10 at 5000 m is near 1050 kg m^-3 from compression alone against the 1025-1028 kg m^-3 the profile spans. It is read as potential density referenced to the surface and inverted with a new `ct_from_potential_density()` in `polaris/ocean/eos/teos10.py` — exact and non-iterative at `p = 0`, cold branch only, raising rather than returning NaN for an unattainable density.
- Surface referencing makes the linear and nonlinear trees share a buoyancy stratification exactly (`sigma_0` agrees to 2.3e-13 kg m^-3 on the 32-level grid) while in-situ densities differ by more than 20 kg m^-3 at depth, so a difference in spurious velocity between the trees is attributable to the EOS rather than a different `N^2`.
- The profile and tracer construction move to a new `init_utils.py`, a leaf module free of `mpas_tools` and the step framework so the unit tests can import it. The step leaves tracers in the convention `eos_type` implies; `write_initial_state_dataset()` converts CT/SA to PT/practical salinity for MPAS-Ocean, computing pressure from layer thicknesses since a geometric coordinate carries none.
- Tracers now carry the `Time` dimension the rest of the state already had, which TEOS-10 requires for alignment and the linear EOS did not.
- No new EOS or vertical-coordinate plumbing was needed: `update_namelist_eos()` already maps `teos-10` to `jm`, and the pseudo-height conversion already dispatches on `eos_type`.

## Physics and resolution

- **Bottom drag `1e-2` → `1e-3`**: the damping timescale is `h_bot / (Cd * |u|)` and the sigma bottom layer over the summit is only ~16 m thick, so at `1e-2` a 5 cm/s spurious velocity damps in 0.4 days against a 6 day run — capping a bad pressure gradient while leaving a good one untouched. Comparable Compass cases use `1e-2`, but none measures a quantity drag suppresses.
- **Vertical levels 10 → 32**: a multiple of 16 (Omega's preference) dividing 5000 m into exact 156.25 m layers, in the range the literature uses (20 in Beckmann and Haidvogel, 20-30 in Shchepetkin and McWilliams). It also rescues z-star, where the 500 m summit column had a single level at 10 levels.
- **Resolution 6.7 → 6.4 km**: 6.7 km came from Compass, not from Beckmann and Haidvogel, and does not divide the domain — since the mesh is built from `nx * resolution`, the domain was really 321.6 km across, not the advertised 320 km. Discrete seamount steepness, which is what the pressure gradient error responds to, barely moves (0.22 → 0.21). Costs 8% more cells and a 4% shorter time step.
- **All vertical mixing off in both models**: the exact solution is a resting ocean, so convection would only ever be triggered by the spurious pressure gradient being measured, and it is a known source of MPAS-Ocean/Omega divergence. MPAS-Ocean now sets `config_use_cvmix = false` to match Omega. The implicit vertical mixing solve itself stays on in both, since that is what applies the implicit bottom drag.

## Short task and suites

- A `short` task is added in each tree: same mesh, initial condition, time step and physics, run for 1 hour. Too short to develop the spurious circulation, but enough to catch a change in the answer cheaply.
- `linear/zstar/short` and `nonlinear/sigma/short` are added to `mpaso_pr` and `omega_pr`, covering both equations of state and both coordinates in two runs. Nothing is in the nightly suites yet, since the `default` tasks are 6 day runs.
- `run_duration` is now in hours rather than days, matching `output_interval`; the default task is unchanged at 144 hours.
- `viz` now runs by default in `default` (a 6 day run is not worth repeating for plots) and stays opt-in in `short`.

## Tests

Three new self-contained unit test modules (no file I/O, no step framework), 19 tests:

- `tests/ocean/eos/test_ct_from_potential_density.py` — round trips through `gsw.rho` at `p = 0`, the unattainable-density error, NaN pass-through.
- `tests/ocean/seamount/test_sigma_to_pseudo.py` — geometric round trip for sigma and z-star with partial cells, sigma layers proportional to column depth, and interior interfaces at genuinely different pressures from column to column (the property a clipped reference grid would destroy), with a flat-bottom negative control so the tilt assertion can fail.
- `tests/ocean/seamount/test_tracers.py` — both EOS branches reproduce the same profile to 1e-11 kg m^-3; negative control that TEOS-10 in-situ density departs from it by more than 20 kg m^-3 at 5000 m against the 3 kg m^-3 the profile spans; the linear back-solve against `compute_linear_density()`; both unsupported-option errors.

## Answer changes

MPAS-Ocean answers change from the vertical refinement, the resolution change, the lower bottom drag, RK4 in place of split-explicit, and disabling cvmix. `init.nc` and `vert_coord.nc` for both linear trees match the `test_20260730` baseline exactly (23 and 5 variables), with only the added `Time` dimension differing.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
