### PR TITLE
Restore the `[job]` scheduler options 

### DIFF
--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "polaris",
-    "mache_version": "3.10.0",
+    "mache_version": "3.11.0",
     "description": "Deploy polaris environment"
   },
   "arguments": [

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -3,7 +3,7 @@
 bootstrap_python = 3.14
 python = 3.14
 geometric_features = 1.6.3
-mache = 3.10.0
+mache = 3.11.0
 mpas_tools = 2.0.0
 otps = 2021.10
 parallelio = 2.6.9

--- a/docs/users_guide/machines/aurora.md
+++ b/docs/users_guide/machines/aurora.md
@@ -49,13 +49,6 @@ spack = /lus/flare/projects/E3SM_Dec/soft/polaris/aurora/spack
 # whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
 # pnetcdf as E3SM (spack modules are used otherwise)
 use_e3sm_hdf5_netcdf = True
-
-
-# Config options related to creating a job script
-[job]
-
-# the filesystems used for the job
-filesystems = home:flare
 ```
 
 Additionally, some relevant config options come from the
@@ -69,16 +62,19 @@ Additionally, some relevant config options come from the
 system = pbs
 
 # whether to use mpirun or srun to run a task
-parallel_executable = mpirun
+parallel_executable = mpiexec --label
 
-# cores per node on the machine (with hyperthreading)
-cores_per_node = 208
+# cores per node on the machine (for the oneapi-ifx compiler)
+cores_per_node = 102
 
 # account for running diagnostics jobs
 account = E3SM_Dec
 
-# queues (default is the first)
-queues = prod, debug
+# available queues (default is chosen based on the job size)
+queues = capacity, prod, debug
+
+# the filesystems used for batch jobs
+filesystems = home:flare
 
 # Config options related to spack environments
 [spack]

--- a/docs/users_guide/machines/chrysalis.md
+++ b/docs/users_guide/machines/chrysalis.md
@@ -57,13 +57,13 @@ Additionally, some relevant config options come from the
 system = slurm
 
 # whether to use mpirun or srun to run a task
-parallel_executable = srun
+parallel_executable = srun --mpi=pmi2 -l
 
 # cores per node on the machine
-cores_per_node = 128
+cores_per_node = 64
 
-# available partition(s) (default is the first)
-partitions = debug, compute, high
+# available partition(s) (default is chosen based on the job size)
+partitions = compute, debug
 ```
 
 ## Loading and running Polaris on Chrysalis

--- a/docs/users_guide/machines/frontier.md
+++ b/docs/users_guide/machines/frontier.md
@@ -90,16 +90,19 @@ Additionally, some relevant config options come from the
 system = slurm
 
 # whether to use mpirun or srun to run a task
-parallel_executable = srun
+parallel_executable = srun -l -K --threads-per-core=1
 
 # cores per node on the machine
-cores_per_node = 64
+cores_per_node = 56
 
 # account for running diagnostics jobs
 account = cli115
 
-# available partition(s) (default is the first)
-partitions = batch
+# available partition(s) (default is chosen based on the job size)
+partitions = batch, extended
+
+# available quality of service (default is chosen based on the job size)
+qos = normal, debug
 
 
 # Config options related to spack environments

--- a/docs/users_guide/machines/index.md
+++ b/docs/users_guide/machines/index.md
@@ -162,12 +162,31 @@ The values you can choose from are the `partitions`, `qos`, `queues` and
 each machine's page below.  Mache also knows the node limits and the maximum
 wall-clock time of each target.
 
+Machines hang the same concept off different axes, so if your intent is
+machine independent -- "use the debug target" -- name it once with
+`scheduler_target` and let mache work out which axis this machine uses:
+
+```cfg
+[job]
+
+wall_time = 00:20:00
+scheduler_target = debug
+```
+
+That selects the `debug` partition on Chrysalis, the `debug` QOS on Frontier
+and Perlmutter, and the `debug` queue on Aurora.  `partition`, `qos` and
+`queue` win on the axis they name, so you can set a broad `scheduler_target`
+and still pin one axis.
+
 A request is honored only if the machine can satisfy it.  If the target does
 not exist on that machine, if it does not allow the number of nodes the job
 needs, or if its maximum wall-clock time is shorter than `wall_time`, Polaris
 falls back to the machine default and prints a warning saying which of those
-was the problem.  For example, asking for `qos = debug` on Perlmutter with
-`wall_time = 02:00:00` gives:
+was the problem.  A request on an axis the machine does not use at all -- a
+`qos` on a machine that defines none, say -- is not a denied request; it is
+simply ignored, so setting all of `partition`, `qos` and `queue` for
+portability is harmless.  For example, asking for `qos = debug` on Perlmutter
+with `wall_time = 02:00:00` gives:
 
 ```none
 Warning: the "debug" qos allows a maximum wall clock of 00:30:00 but 02:00:00 was requested

--- a/docs/users_guide/machines/index.md
+++ b/docs/users_guide/machines/index.md
@@ -80,13 +80,19 @@ system = slurm
 parallel_executable = srun
 
 # cores per node on the machine
-cores_per_node = 36
+cores_per_node = 128
 
 # account for running diagnostics jobs
 account = e3sm
 
-# quality of service (default is the first)
-qos = regular, interactive
+# available partition(s) (default is chosen based on the job size)
+partitions = regular, debug
+
+# available quality of service (default is chosen based on the job size)
+qos = regular, debug, premium
+
+# available constraint(s) (default is the first)
+constraints = cpu
 ```
 
 The `parallel` section defined properties of the machine, to do with parallel
@@ -128,6 +134,49 @@ qstat # show all jobs
 qstat -u $USER # show only your jobs
 qcancel <jobid> # cancel a job
 ```
+
+(scheduler-targets)=
+
+## Requesting a partition, QOS or queue
+
+By default, Polaris lets mache choose which scheduler target to submit to
+based on how many nodes the job needs.  If you want a specific one, set it in
+the `job` section of your user config file:
+
+```cfg
+[job]
+
+# wall-clock time
+wall_time = 00:20:00
+
+# on a Slurm machine
+partition = debug
+qos = debug
+
+# on a PBS machine
+queue = debug
+```
+
+The values you can choose from are the `partitions`, `qos`, `queues` and
+`constraints` lists in the machine's `parallel` section, which are shown on
+each machine's page below.  Mache also knows the node limits and the maximum
+wall-clock time of each target.
+
+A request is honored only if the machine can satisfy it.  If the target does
+not exist on that machine, if it does not allow the number of nodes the job
+needs, or if its maximum wall-clock time is shorter than `wall_time`, Polaris
+falls back to the machine default and prints a warning saying which of those
+was the problem.  For example, asking for `qos = debug` on Perlmutter with
+`wall_time = 02:00:00` gives:
+
+```none
+Warning: the "debug" qos allows a maximum wall clock of 00:30:00 but 02:00:00 was requested
+```
+
+Even without a request, `wall_time` is capped at the maximum the selected
+target allows, so a job never asks for more time than the scheduler would
+accept.  The partition, QOS, queue and constraint that were actually used are
+recorded in the `provenance` file in the work directory.
 
 (supported-machines)=
 

--- a/docs/users_guide/machines/perlmutter.md
+++ b/docs/users_guide/machines/perlmutter.md
@@ -97,10 +97,10 @@ Additionally, some relevant config options come from the
 system = slurm
 
 # whether to use mpirun or srun to run a task
-parallel_executable = srun
+parallel_executable = srun --label
 
-# cores per node on the machine
-cores_per_node = 256
+# cores per node on the machine (without hyperthreading)
+cores_per_node = 128
 
 # account for running diagnostics jobs
 account = e3sm
@@ -108,8 +108,8 @@ account = e3sm
 # available constraint(s) (default is the first)
 constraints = cpu
 
-# quality of service (default is the first)
-qos = regular, premium, debug
+# available quality of service (default is chosen based on the job size)
+qos = regular, debug, premium
 
 # Config options related to spack environments
 [spack]
@@ -189,10 +189,10 @@ Additionally, some relevant config options come from the
 system = slurm
 
 # whether to use mpirun or srun to run a task
-parallel_executable = srun
+parallel_executable = srun --label
 
-# cores per node on the machine (with hyperthreading)
-cores_per_node = 128
+# cores per node on the machine (without hyperthreading)
+cores_per_node = 64
 
 # gpus per node on the machine
 gpus_per_node = 4
@@ -203,7 +203,7 @@ account = e3sm
 # available constraint(s) (default is the first)
 constraints = gpu
 
-# quality of service (default is the first)
+# available quality of service (default is chosen based on the job size)
 qos = regular, debug, premium
 
 # Config options related to spack environments

--- a/polaris/default.cfg
+++ b/polaris/default.cfg
@@ -56,8 +56,17 @@ wall_time = 1:00:00
 # machine cannot satisfy -- because the target does not exist there, because it
 # does not allow the requested node count, or because its wall-clock limit is
 # shorter than wall_time above -- falls back to the machine default and prints
-# a warning saying why.  Leaving an option at <<<default>>> makes no request at
-# all, in which case mache chooses a target based on the size of the job.
+# a warning saying why.  A request on an axis the machine does not use at all
+# (a qos on a machine with no qos, say) is simply ignored.  Leaving an option
+# at <<<default>>> makes no request at all, in which case mache chooses a
+# target based on the size of the job.
+
+# A target named without saying whether it is a partition, a QOS or a queue,
+# for when the intent is machine independent ("use the debug target").  Mache
+# maps it onto whichever axis the machine lists it under: the debug partition
+# on Chrysalis, the debug QOS on Frontier and Perlmutter, the debug queue on
+# Aurora.  The options below win on the axis they name.
+scheduler_target = <<<default>>>
 
 # The job partition to use (Slurm machines), by default chosen by mache from
 # the partitions available on the machine

--- a/polaris/default.cfg
+++ b/polaris/default.cfg
@@ -52,20 +52,27 @@ job_name = <<<default>>>
 # wall-clock time
 wall_time = 1:00:00
 
-# The job partition to use, by default, taken from the first partition (if any)
-# provided for the machine by mache
+# The options below request a specific scheduler target.  A request that the
+# machine cannot satisfy -- because the target does not exist there, because it
+# does not allow the requested node count, or because its wall-clock limit is
+# shorter than wall_time above -- falls back to the machine default and prints
+# a warning saying why.  Leaving an option at <<<default>>> makes no request at
+# all, in which case mache chooses a target based on the size of the job.
+
+# The job partition to use (Slurm machines), by default chosen by mache from
+# the partitions available on the machine
 partition = <<<default>>>
 
-# The job quality of service (QOS) to use, by default, taken from the first
-# qos (if any) provided for the machine by mache
+# The job quality of service (QOS) to use (Slurm machines), by default chosen
+# by mache from the QOS available on the machine
 qos = <<<default>>>
 
-# The job constraint to use, by default, taken from the first constraint (if
-# any) provided for the  machine by mache
+# The job constraint to use, by default the first constraint (if any) provided
+# for the machine by mache
 constraint = <<<default>>>
 
-# The job queue to use, by default, taken from the first queue (if any)
-# provided for the machine by mache
+# The job queue to use (PBS machines), by default chosen by mache from the
+# queues available on the machine
 queue = <<<default>>>
 
 

--- a/polaris/job/__init__.py
+++ b/polaris/job/__init__.py
@@ -148,6 +148,11 @@ mache.parallel.pbs.PbsOptions, None}
     requested_queue = _get_job_option(config, 'queue')
     requested_constraint = _get_job_option(config, 'constraint')
 
+    # a target named without saying which axis it is on.  mache maps it onto
+    # whichever of the machine's partitions, qos or queues lists it, so the
+    # options above win on the axis they name.
+    requested_target = _get_job_option(config, 'scheduler_target')
+
     options: SlurmOptions | PbsOptions
     if system == 'slurm':
         options = SlurmSystem.resolve_slurm_options(
@@ -158,6 +163,7 @@ mache.parallel.pbs.PbsOptions, None}
             qos=requested_qos,
             constraint=requested_constraint,
             desired_wall_time=desired_wall_time,
+            scheduler_target=requested_target,
         )
         template_name = 'job_script.slurm.template'
         render_kwargs.update(
@@ -175,6 +181,7 @@ mache.parallel.pbs.PbsOptions, None}
             queue=requested_queue,
             constraint=requested_constraint,
             desired_wall_time=desired_wall_time,
+            scheduler_target=requested_target,
         )
         template_name = 'job_script.pbs.template'
         render_kwargs.update(

--- a/polaris/job/__init__.py
+++ b/polaris/job/__init__.py
@@ -4,8 +4,8 @@ import os as os
 import numpy as np
 from jinja2 import Template as Template
 from mache.parallel import get_parallel_system
-from mache.parallel.pbs import PbsSystem
-from mache.parallel.slurm import SlurmSystem
+from mache.parallel.pbs import PbsOptions, PbsSystem
+from mache.parallel.slurm import SlurmOptions, SlurmSystem
 
 
 def write_job_script(
@@ -65,6 +65,14 @@ def write_job_script(
     run_command : str, optional
         The command(s) to run in the job script. If not provided, defaults to
         'polaris serial {{suite}}'.
+
+    Returns
+    -------
+    options : {mache.parallel.slurm.SlurmOptions, \
+mache.parallel.pbs.PbsOptions, None}
+        The scheduler options that were rendered into the job script, or
+        ``None`` if no job script was written because the machine does not
+        use a supported job scheduler
     """
     if config.combined is None:
         config.combine()
@@ -132,53 +140,58 @@ def write_job_script(
 
     desired_wall_time = config.get('job', 'wall_time')
 
+    # a specific scheduler target the user has asked for, if any.  mache
+    # treats placeholders such as '<<<default>>>' as "no request", so they
+    # are passed through unmodified.
+    requested_partition = _get_job_option(config, 'partition')
+    requested_qos = _get_job_option(config, 'qos')
+    requested_queue = _get_job_option(config, 'queue')
+    requested_constraint = _get_job_option(config, 'constraint')
+
+    options: SlurmOptions | PbsOptions
     if system == 'slurm':
-        (
-            partition,
-            qos,
-            constraint,
-            gpus_per_node,
-            max_wallclock,
-            nodes,
-        ) = SlurmSystem.get_slurm_options(
+        options = SlurmSystem.resolve_slurm_options(
             config=config.combined,
             nodes=nodes,
             min_nodes_allowed=min_nodes_allowed,
+            partition=requested_partition,
+            qos=requested_qos,
+            constraint=requested_constraint,
+            desired_wall_time=desired_wall_time,
         )
-        wall_time = _cap_wall_time(desired_wall_time, max_wallclock)
         template_name = 'job_script.slurm.template'
         render_kwargs.update(
-            partition=partition,
-            qos=qos,
-            constraint=constraint,
-            gpus_per_node=gpus_per_node,
-            wall_time=wall_time,
+            partition=options.partition,
+            qos=options.qos,
+            constraint=options.constraint,
+            gpus_per_node=options.gpus_per_node,
+            wall_time=options.wall_time,
         )
     elif system == 'pbs':
-        (
-            queue,
-            constraint,
-            gpus_per_node,
-            max_wallclock,
-            filesystems,
-            nodes,
-        ) = PbsSystem.get_pbs_options(
+        options = PbsSystem.resolve_pbs_options(
             config=config.combined,
             nodes=nodes,
             min_nodes_allowed=min_nodes_allowed,
+            queue=requested_queue,
+            constraint=requested_constraint,
+            desired_wall_time=desired_wall_time,
         )
-        wall_time = _cap_wall_time(desired_wall_time, max_wallclock)
         template_name = 'job_script.pbs.template'
         render_kwargs.update(
-            queue=queue,
-            constraint=constraint,
-            gpus_per_node=gpus_per_node,
-            wall_time=wall_time,
-            filesystems=filesystems,
+            queue=options.queue,
+            constraint=options.constraint,
+            gpus_per_node=options.gpus_per_node,
+            wall_time=options.wall_time,
+            filesystems=options.filesystems,
         )
     else:
         # Do not write a job script for other systems
-        return
+        return None
+
+    nodes = options.effective_nodes
+
+    if not options.honored:
+        print(f'Warning: {options.reason}')
 
     job_name = config.get('job', 'job_name')
     if job_name == '<<<default>>>':
@@ -213,6 +226,18 @@ def write_job_script(
     with open(script_filename, 'w') as handle:
         handle.write(text)
 
+    return options
+
+
+def _get_job_option(config, option):
+    """Get a requested ``[job]`` option, or None if it is unset or empty."""
+    if not config.has_option('job', option):
+        return None
+    value = config.get('job', option).strip()
+    if value == '':
+        return None
+    return value
+
 
 def _get_min_nodes_allowed(
     cores_per_node,
@@ -240,30 +265,3 @@ def _get_min_nodes_allowed(
     if len(minima) == 0:
         return None
     return max(minima)
-
-
-def _wallclock_to_seconds(wallclock):
-    """Convert HH:MM:SS wall-clock string to total seconds, or None."""
-    parts = wallclock.split(':')
-    if len(parts) != 3:
-        return None
-    try:
-        return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
-    except ValueError:
-        return None
-
-
-def _cap_wall_time(desired, max_wallclock):
-    """Return desired wall time, capped at max_wallclock if it is smaller.
-
-    Defaults to desired if max_wallclock is empty or cannot be parsed.
-    """
-    if not max_wallclock:
-        return desired
-    desired_secs = _wallclock_to_seconds(desired)
-    max_secs = _wallclock_to_seconds(max_wallclock)
-    if desired_secs is None or max_secs is None:
-        return desired
-    if desired_secs <= max_secs:
-        return desired
-    return max_wallclock

--- a/polaris/provenance.py
+++ b/polaris/provenance.py
@@ -6,7 +6,14 @@ import sys
 from polaris.build.omega import detect_omega_build_type
 
 
-def write(work_dir, tasks, config=None, machine=None, baseline_dir=None):
+def write(
+    work_dir,
+    tasks,
+    config=None,
+    machine=None,
+    baseline_dir=None,
+    job_options=None,
+):
     """
     Write a file with provenance, such as the git version, conda packages,
     command, and tasks, to the work directory.
@@ -32,6 +39,12 @@ def write(work_dir, tasks, config=None, machine=None, baseline_dir=None):
 
     baseline_dir : str, optional
         The path to the baseline work directory, if any
+
+    job_options : {mache.parallel.slurm.SlurmOptions, \
+mache.parallel.pbs.PbsOptions}, optional
+        The scheduler options that were written to the job script, as
+        returned by :py:func:`polaris.job.write_job_script()`.  If not
+        provided, no scheduler metadata is recorded.
     """
     polaris_git_version = None
     if os.path.exists('.git'):
@@ -85,7 +98,7 @@ def write(work_dir, tasks, config=None, machine=None, baseline_dir=None):
 
     # Add readily parsable, PR-friendly metadata discovered at setup time
     _write_meta(provenance_file, 'machine', machine)
-    _write_scheduler_metadata(provenance_file, config)
+    _write_scheduler_metadata(provenance_file, job_options)
     _write_meta(provenance_file, 'compiler', _get_compiler(config))
     _write_meta(provenance_file, 'work directory', work_dir)
     _write_meta(provenance_file, 'build directory', _get_build_dir(config))
@@ -179,76 +192,6 @@ def _is_executable_file(path):
     )
 
 
-def _get_system(config):
-    if config is None:
-        return None
-    if config.has_option('parallel', 'system'):
-        return config.get('parallel', 'system')
-    return None
-
-
-def _resolve_scheduler_fields(config, system):
-    """Resolve partition/qos/constraint (slurm) or just constraint (pbs)."""
-    partition = None
-    qos = None
-    constraint = None
-
-    if config is None:
-        return partition, qos, constraint
-
-    if system == 'pbs':
-        # PBS: only constraint is relevant for our purposes
-        cons_val = (
-            config.get('job', 'constraint')
-            if config.has_option('job', 'constraint')
-            else None
-        )
-        if cons_val and cons_val != '<<<default>>>':
-            constraint = cons_val
-        elif config.has_option('parallel', 'constraints'):
-            cons_list = config.getlist('parallel', 'constraints')
-            if cons_list:
-                constraint = cons_list[0]
-        return partition, qos, constraint
-
-    # Default to slurm-like resolution
-    part_val = (
-        config.get('job', 'partition')
-        if config.has_option('job', 'partition')
-        else None
-    )
-    if part_val and part_val != '<<<default>>>':
-        partition = part_val
-    elif config.has_option('parallel', 'partitions'):
-        parts = config.getlist('parallel', 'partitions')
-        if parts:
-            partition = parts[0]
-
-    qos_val = (
-        config.get('job', 'qos') if config.has_option('job', 'qos') else None
-    )
-    if qos_val and qos_val != '<<<default>>>':
-        qos = qos_val
-    elif config.has_option('parallel', 'qos'):
-        qos_list = config.getlist('parallel', 'qos')
-        if qos_list:
-            qos = qos_list[0]
-
-    cons_val = (
-        config.get('job', 'constraint')
-        if config.has_option('job', 'constraint')
-        else None
-    )
-    if cons_val and cons_val != '<<<default>>>':
-        constraint = cons_val
-    elif config.has_option('parallel', 'constraints'):
-        cons_list = config.getlist('parallel', 'constraints')
-        if cons_list:
-            constraint = cons_list[0]
-
-    return partition, qos, constraint
-
-
 def _get_compiler(config):
     if config is None:
         return None
@@ -314,11 +257,14 @@ def _write_meta(provenance_file, label, value):
     provenance_file.write(f'{label}: {value}\n\n')
 
 
-def _write_scheduler_metadata(provenance_file, config):
-    """Write partition/qos/constraint metadata when available."""
-    system = _get_system(config)
-    partition, qos, constraint = _resolve_scheduler_fields(config, system)
-    _write_meta(provenance_file, 'partition', partition)
-    _write_meta(provenance_file, 'qos', qos)
-    _write_meta(provenance_file, 'constraint', constraint)
-    # No return value; this function only writes metadata lines
+def _write_scheduler_metadata(provenance_file, job_options):
+    """Write the scheduler options that the job script actually used.
+
+    Slurm machines have a partition and a QOS, PBS machines have a queue,
+    and either may have a constraint, so only the fields that the resolved
+    options actually carry are written.
+    """
+    if job_options is None:
+        return
+    for label in ('partition', 'qos', 'queue', 'constraint'):
+        _write_meta(provenance_file, label, getattr(job_options, label, None))

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -271,7 +271,7 @@ def setup_tasks(
         print(f'minimum gpus: {max_of_min_gpus}')
 
     if machine is not None:
-        write_job_script(
+        job_options = write_job_script(
             config=basic_config,
             machine=machine,
             target_cores=max_cores,
@@ -281,6 +281,19 @@ def setup_tasks(
             work_dir=work_dir,
             suite=suite_name,
         )
+
+        if job_options is not None:
+            # Rewrite provenance (it was written earlier so that it exists
+            # even if setup fails) now that we know which scheduler options
+            # the suite's job script ended up using.
+            provenance.write(
+                work_dir,
+                tasks,
+                config=basic_config,
+                machine=machine,
+                baseline_dir=baseline_dir,
+                job_options=job_options,
+            )
 
     return tasks
 

--- a/tests/test_job_script.py
+++ b/tests/test_job_script.py
@@ -135,6 +135,67 @@ def test_queue_request_exceeds_wall_clock(tmp_path, capsys):
     assert '01:00:00' in capsys.readouterr().out
 
 
+def test_scheduler_target_maps_to_a_partition(tmp_path, capsys):
+    """A target is used as a partition on a machine that lists it there."""
+    text, options = get_job_script(
+        tmp_path, 'chrysalis', nodes=2, scheduler_target='debug'
+    )
+    assert '#SBATCH --partition=debug' in text
+    assert options.partition == 'debug'
+    assert options.honored
+    assert capsys.readouterr().out == ''
+
+
+def test_scheduler_target_maps_to_a_qos(tmp_path, capsys):
+    """The same target is used as a QOS on a machine that lists it there."""
+    text, options = get_job_script(
+        tmp_path,
+        'pm-cpu',
+        nodes=2,
+        scheduler_target='debug',
+        wall_time='00:20:00',
+    )
+    assert '#SBATCH --qos=debug' in text
+    assert options.honored
+    assert capsys.readouterr().out == ''
+
+
+def test_scheduler_target_maps_to_a_queue(tmp_path, capsys):
+    """The same target is used as a queue on a PBS machine."""
+    text, options = get_job_script(
+        tmp_path,
+        'aurora',
+        nodes=2,
+        scheduler_target='debug',
+        wall_time='00:30:00',
+    )
+    assert '#PBS -q debug' in text
+    assert options.queue == 'debug'
+    assert options.honored
+    assert capsys.readouterr().out == ''
+
+
+def test_named_axis_wins_over_scheduler_target(tmp_path):
+    """An explicit request wins on the axis it names."""
+    text, options = get_job_script(
+        tmp_path, 'pm-cpu', nodes=2, scheduler_target='debug', qos='regular'
+    )
+    assert '#SBATCH --qos=regular' in text
+    assert options.honored
+
+
+def test_scheduler_target_unavailable(tmp_path, capsys):
+    """A target on no axis at all falls back with a warning."""
+    text, options = get_job_script(
+        tmp_path, 'pm-cpu', nodes=2, scheduler_target='nonexistent'
+    )
+    assert '#SBATCH --qos=regular' in text
+    assert not options.honored
+    warning = capsys.readouterr().out
+    assert 'not an available scheduler target' in warning
+    assert 'qos: regular, debug, premium' in warning
+
+
 def test_constraint_request_honored(tmp_path, capsys):
     """A constraint the machine supports is passed through."""
     text, options = get_job_script(
@@ -158,14 +219,27 @@ def test_constraint_request_unavailable(tmp_path, capsys):
 
 
 def test_constraint_request_on_machine_without_constraints(tmp_path, capsys):
-    """A constraint request on a machine that defines none falls back."""
+    """A constraint request on a machine that defines none is ignored."""
     text, options = get_job_script(
         tmp_path, 'chrysalis', nodes=2, constraint='anything'
     )
     assert '--constraint' not in text
     assert options.constraint == ''
-    assert not options.honored
-    assert 'defines no constraints' in capsys.readouterr().out
+    # the machine has no notion of a constraint, so there was no choice to
+    # deny
+    assert options.honored
+    assert capsys.readouterr().out == ''
+
+
+def test_request_on_an_axis_the_machine_does_not_use(tmp_path, capsys):
+    """A QOS request on a machine that defines no QOS is ignored."""
+    text, options = get_job_script(
+        tmp_path, 'chrysalis', nodes=2, partition='debug', qos='debug'
+    )
+    assert '#SBATCH --partition=debug' in text
+    assert '--qos' not in text
+    assert options.honored
+    assert capsys.readouterr().out == ''
 
 
 def test_single_node_writes_no_script(tmp_path):
@@ -208,7 +282,9 @@ def test_provenance_without_a_job_script(tmp_path):
         assert label not in recorded
 
 
-@pytest.mark.parametrize('option', ['partition', 'qos', 'constraint'])
+@pytest.mark.parametrize(
+    'option', ['partition', 'qos', 'constraint', 'scheduler_target']
+)
 def test_empty_option_is_not_a_request(tmp_path, option):
     """An empty ``[job]`` option is treated as no request at all."""
     text, options = get_job_script(tmp_path, 'pm-cpu', nodes=2, **{option: ''})

--- a/tests/test_job_script.py
+++ b/tests/test_job_script.py
@@ -1,0 +1,216 @@
+import os
+
+import pytest
+
+from polaris import provenance
+from polaris.config import PolarisConfigParser
+from polaris.job import write_job_script
+
+
+def get_config(machine=None, **job_options):
+    """Build a config for ``machine`` with the given ``[job]`` options set."""
+    config = PolarisConfigParser()
+    config.add_from_package('polaris', 'default.cfg')
+    if machine is not None:
+        config.add_from_package('mache.machines', f'{machine}.cfg')
+    for option, value in job_options.items():
+        config.set('job', option, value)
+    return config
+
+
+def get_job_script(tmp_path, machine, nodes, **job_options):
+    """Write a job script for ``machine`` and return its text and options."""
+    config = get_config(machine, **job_options)
+    options = write_job_script(
+        config=config,
+        machine=machine,
+        work_dir=str(tmp_path),
+        nodes=nodes,
+    )
+    script = os.path.join(str(tmp_path), 'job_script.sh')
+    if not os.path.exists(script):
+        return None, options
+    with open(script) as handle:
+        text = handle.read()
+    return text, options
+
+
+def test_qos_request_honored(tmp_path):
+    """A QOS the machine supports is passed through to the job script."""
+    text, options = get_job_script(
+        tmp_path, 'pm-cpu', nodes=2, qos='debug', wall_time='00:20:00'
+    )
+    assert '#SBATCH --qos=debug' in text
+    assert '#SBATCH --time=00:20:00' in text
+    assert options.honored
+    assert options.reason is None
+
+
+def test_qos_request_exceeds_wall_clock(tmp_path, capsys):
+    """A QOS that cannot fit the requested wall time falls back."""
+    text, options = get_job_script(
+        tmp_path, 'pm-cpu', nodes=2, qos='debug', wall_time='02:00:00'
+    )
+    assert '#SBATCH --qos=regular' in text
+    assert '#SBATCH --time=02:00:00' in text
+    assert not options.honored
+    warning = capsys.readouterr().out
+    assert 'Warning:' in warning
+    assert '00:30:00' in warning
+    assert '02:00:00' in warning
+
+
+def test_qos_request_unavailable(tmp_path, capsys):
+    """A QOS the machine does not have falls back with a warning."""
+    text, options = get_job_script(
+        tmp_path, 'pm-cpu', nodes=2, qos='nonexistent'
+    )
+    assert '#SBATCH --qos=regular' in text
+    assert not options.honored
+    warning = capsys.readouterr().out
+    assert 'not an available qos' in warning
+    assert 'regular, debug, premium' in warning
+
+
+def test_default_sentinel_is_not_a_request(tmp_path, capsys):
+    """The shipped ``<<<default>>>`` values mean "let mache choose"."""
+    text, options = get_job_script(tmp_path, 'pm-cpu', nodes=2)
+    assert '<<<' not in text
+    assert '#SBATCH --qos=regular' in text
+    assert '#SBATCH --constraint=cpu' in text
+    assert '#SBATCH --job-name=polaris' in text
+    assert options.honored
+    assert capsys.readouterr().out == ''
+
+
+def test_partition_request_honored(tmp_path):
+    """A partition the machine supports is passed through."""
+    text, options = get_job_script(
+        tmp_path, 'chrysalis', nodes=2, partition='debug'
+    )
+    assert '#SBATCH --partition=debug' in text
+    assert options.honored
+
+
+def test_frontier_qos_request_honored(tmp_path):
+    """Frontier's debug QOS is honored within its wall-clock limit."""
+    text, options = get_job_script(
+        tmp_path, 'frontier', nodes=8, qos='debug', wall_time='01:00:00'
+    )
+    assert '#SBATCH --partition=batch' in text
+    assert '#SBATCH --qos=debug' in text
+    assert '#SBATCH --time=01:00:00' in text
+    assert options.honored
+
+
+def test_wall_time_capped_by_job_size(tmp_path):
+    """A wall time longer than the job-size bin allows is capped."""
+    text, options = get_job_script(
+        tmp_path, 'frontier', nodes=8, wall_time='04:00:00'
+    )
+    assert '#SBATCH --time=02:00:00' in text
+    assert options.max_wallclock == '02:00:00'
+    # capping is not a request that was denied
+    assert options.honored
+
+
+def test_queue_request_honored(tmp_path):
+    """A PBS queue the machine supports is passed through."""
+    text, options = get_job_script(
+        tmp_path, 'aurora', nodes=2, queue='debug', wall_time='00:30:00'
+    )
+    assert '#PBS -q debug' in text
+    assert '#PBS -l walltime=00:30:00' in text
+    assert '#PBS -l filesystems=home:flare' in text
+    assert options.honored
+
+
+def test_queue_request_exceeds_wall_clock(tmp_path, capsys):
+    """A PBS queue that cannot fit the requested wall time falls back."""
+    text, options = get_job_script(
+        tmp_path, 'aurora', nodes=2, queue='debug', wall_time='02:00:00'
+    )
+    assert '#PBS -q capacity' in text
+    assert not options.honored
+    assert '01:00:00' in capsys.readouterr().out
+
+
+def test_constraint_request_honored(tmp_path, capsys):
+    """A constraint the machine supports is passed through."""
+    text, options = get_job_script(
+        tmp_path, 'pm-gpu', nodes=2, constraint='gpu'
+    )
+    assert '#SBATCH --constraint=gpu' in text
+    assert options.honored
+    assert capsys.readouterr().out == ''
+
+
+def test_constraint_request_unavailable(tmp_path, capsys):
+    """A constraint the machine does not have falls back with a warning."""
+    text, options = get_job_script(
+        tmp_path, 'pm-gpu', nodes=2, constraint='cpu'
+    )
+    assert '#SBATCH --constraint=gpu' in text
+    assert not options.honored
+    warning = capsys.readouterr().out
+    assert 'not an available constraint' in warning
+    assert 'available: gpu' in warning
+
+
+def test_constraint_request_on_machine_without_constraints(tmp_path, capsys):
+    """A constraint request on a machine that defines none falls back."""
+    text, options = get_job_script(
+        tmp_path, 'chrysalis', nodes=2, constraint='anything'
+    )
+    assert '--constraint' not in text
+    assert options.constraint == ''
+    assert not options.honored
+    assert 'defines no constraints' in capsys.readouterr().out
+
+
+def test_single_node_writes_no_script(tmp_path):
+    """No job script is written for machines without a job scheduler."""
+    config = get_config()
+    config.set('parallel', 'system', 'single_node')
+    options = write_job_script(
+        config=config,
+        machine=None,
+        work_dir=str(tmp_path),
+        nodes=1,
+    )
+    assert options is None
+    assert not os.path.exists(os.path.join(str(tmp_path), 'job_script.sh'))
+
+
+def test_provenance_agrees_with_job_script(tmp_path):
+    """Provenance records the options the job script actually used."""
+    text, options = get_job_script(
+        tmp_path, 'pm-cpu', nodes=2, qos='debug', wall_time='02:00:00'
+    )
+    # the request was not honored, so provenance must not report it
+    assert '#SBATCH --qos=regular' in text
+    provenance.write(str(tmp_path), tasks={}, job_options=options)
+    with open(os.path.join(str(tmp_path), 'provenance')) as handle:
+        recorded = handle.read()
+    assert 'qos: regular' in recorded
+    assert 'constraint: cpu' in recorded
+    # pm-cpu has no partitions and is not a PBS machine
+    assert 'partition:' not in recorded
+    assert 'queue:' not in recorded
+
+
+def test_provenance_without_a_job_script(tmp_path):
+    """No scheduler metadata is recorded when no job script was written."""
+    provenance.write(str(tmp_path), tasks={}, job_options=None)
+    with open(os.path.join(str(tmp_path), 'provenance')) as handle:
+        recorded = handle.read()
+    for label in ('partition:', 'qos:', 'queue:', 'constraint:'):
+        assert label not in recorded
+
+
+@pytest.mark.parametrize('option', ['partition', 'qos', 'constraint'])
+def test_empty_option_is_not_a_request(tmp_path, option):
+    """An empty ``[job]`` option is treated as no request at all."""
+    text, options = get_job_script(tmp_path, 'pm-cpu', nodes=2, **{option: ''})
+    assert '<<<' not in text
+    assert options.honored


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

## What was broken

Polaris has documented four scheduler options in the `[job]` section of `polaris/default.cfg` -- `partition`, `qos`, `constraint` and `queue` -- but since Polaris moved to `mache.parallel` in #474 they have silently done nothing. `write_job_script()` never read them; the scheduler target came entirely from mache's availability lists. Setting `[job] qos = debug` on Frontier produced a job script asking for the `normal` QOS, with no warning that the request had been dropped.

Worse, the `provenance` file was written from a separate, older implementation that *did* honor those options, so it could report `partition: debug` while the job script sitting next to it said `--partition=batch`.

Wall times were also only loosely constrained: the job script asked for whatever `[job] wall_time` said, even when the selected partition or QOS would reject it at submission.

## What this fixes

- The `[job] partition`, `qos`, `constraint` and `queue` options work again. They are passed to mache, which owns the machine metadata and decides whether the request can be honored.
- A request that cannot be satisfied now says why instead of being silently ignored, and it distinguishes the three ways it can fail: the target does not exist on this machine, it does not allow the number of nodes the job needs, or its wall-clock limit is shorter than the requested wall time. For example: `Warning: the "debug" qos allows a maximum wall clock of 00:30:00 but 02:00:00 was requested`.
- `wall_time` is capped against the selected target's real limit, including Frontier's job-size-dependent limits, so a job never asks for more time than the scheduler would accept.
- The `provenance` file records the partition, QOS, queue and constraint that were actually written to the job script, so it can no longer disagree with it. The queue is now recorded on PBS machines, which it never was before.
- `docs/users_guide/machines/index.md` explains how to request a target and what happens when the request cannot be honored. The mache config quoted on each machine page has been refreshed -- those excerpts had drifted, and Aurora still documented a `[job] filesystems` option that nothing has read for some time.

Leaving an option at its shipped `<<<default>>>` value means "no request", and mache treats it that way, so default behavior is unchanged apart from the wall-time capping.

## Requirements

This needs mache 3.11.0, which adds the API for requesting a specific scheduler target and gives Frontier partition and QOS metadata to ask for: E3SM-Project/mache#464. `deploy/pins.cfg` is bumped accordingly, so this cannot land until mache 3.11.0 is on conda-forge.

The suite-level `.cfg` work on `increase-job-duration` / `pr-suites-to-debug-queues` builds on this rather than being part of it. Suites are Polaris's business -- mache has no concept of them -- but that branch currently carries framework workarounds for the missing mache API which should be dropped rather than merged once it rebases on this.

## Testing

Run in the deployed pixi environment on a laptop:

- `pytest tests/test_job_script.py` -- 18 passed. This is new coverage; there was none for job-script generation before. The tests build configs from `polaris/default.cfg` plus a real `mache.machines` config rather than a fixture, so they check against mache's actual metadata for pm-cpu, pm-gpu, chrysalis, frontier and aurora. They cover honored partition, QOS, queue and constraint requests; each of the three failure modes and the warning text for each; wall-time capping by Frontier's job-size bin; that `<<<default>>>` never leaks into a rendered script; that a `single_node` config writes no script; and that provenance reports what the script actually used.
- `pytest tests/` -- 276 passed, no regressions.
- `pre-commit run --files <changed files>` -- all hooks pass.

Still to do, and the case that started all of this: a real `polaris setup` on Frontier with `[job] qos = debug`, confirming the generated `job_script.sh` carries the debug QOS, and that a request exceeding its wall-clock limit falls back with a warning. That cannot be checked from a laptop.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
