### PR TITLE
Shared configs and framework fixes

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -125,6 +125,7 @@ seaice/api
    Component.add_step
    Component.remove_step
    Component.add_config
+   Component.get_or_create_shared_config
    Component.get_or_create_shared_step
    Component.set_parallel_system
    Component.get_available_resources

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -60,6 +60,16 @@ is already registered at that path.  The `setup` callback runs only when the
 config is actually created, so it must not be relied on for anything a later
 caller needs.
 
+Being called once per consumer is the thing to keep in mind generally.  Prefer
+wiring a dependency inside the step's own constructor, as `RemapWoa23Step` and
+`RemapJra55Step` do, since `get_or_create_shared_step()` passes constructor
+arguments only when it really creates the step, so the wiring happens exactly
+once.  Where that is not possible — a chain whose links are only known to the
+helper, say — {py:meth}`polaris.Step.add_dependency()` may simply be called
+again: adding the same step under the same name is a no-op.  Adding a
+*different* step under a name already in use is still an error, which is what
+its `name` argument exists to resolve.
+
 See the [design document on shared steps](../../design_docs/shared_steps.md)
 for more details about the motivation and implementation.
 

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -39,6 +39,27 @@ shared_step = component.get_or_create_shared_step(
 )
 ```
 
+The shared config those steps use needs the same treatment, which is what
+{py:meth}`polaris.Component.get_or_create_shared_config()` is for:
+
+```python
+
+config = component.get_or_create_shared_config(
+    filepath=os.path.join(component.name, subdir, "init.cfg"),
+    setup=lambda config: config.add_from_package("my.package", "init.cfg"),
+)
+```
+
+A `get_*_steps()` helper is called once per consumer, so building its config
+unconditionally is a bug even though it looks harmless.  The second caller gets
+a *different* config object at the same path, while the shared steps — created
+on the first call — go on using the first one.  Options set on what the second
+caller was handed then reach nothing, and passing it to
+{py:meth}`polaris.Task.set_shared_config()` raises, because a different config
+is already registered at that path.  The `setup` callback runs only when the
+config is actually created, so it must not be relied on for anything a later
+caller needs.
+
 See the [design document on shared steps](../../design_docs/shared_steps.md)
 for more details about the motivation and implementation.
 

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -44,9 +44,17 @@ The shared config those steps use needs the same treatment, which is what
 
 ```python
 
+filepath = os.path.join(component.name, subdir, "init.cfg")
+
+
+def create():
+    config = PolarisConfigParser(filepath=filepath)
+    config.add_from_package("my.package", "init.cfg")
+    return config
+
+
 config = component.get_or_create_shared_config(
-    filepath=os.path.join(component.name, subdir, "init.cfg"),
-    setup=lambda config: config.add_from_package("my.package", "init.cfg"),
+    filepath=filepath, create=create
 )
 ```
 
@@ -56,9 +64,15 @@ a *different* config object at the same path, while the shared steps — created
 on the first call — go on using the first one.  Options set on what the second
 caller was handed then reach nothing, and passing it to
 {py:meth}`polaris.Task.set_shared_config()` raises, because a different config
-is already registered at that path.  The `setup` callback runs only when the
-config is actually created, so it must not be relied on for anything a later
-caller needs.
+is already registered at that path.
+
+The `create` callback runs only when the config does not already exist, so it
+must not be relied on for anything a later caller needs.  Because it returns
+the config rather than filling one in, an existing config builder — such as
+{py:func}`polaris.mesh.spherical.unified.get_unified_mesh_config()` — can be
+passed straight through.  It must return a config whose `filepath` matches, or
+the config would be registered under a path it does not know about; that is
+checked.
 
 Being called once per consumer is the thing to keep in mind generally.  Prefer
 wiring a dependency inside the step's own constructor, as `RemapWoa23Step` and

--- a/docs/developers_guide/organization/tasks.md
+++ b/docs/developers_guide/organization/tasks.md
@@ -382,7 +382,18 @@ outside of the `cosine_bell` work directory so it could be used by any task
 that needs a quasi-uniform (`qu`) or subdivided icosahedral (`icos`) mesh of
 the given resolution.  A path within the task for a symlink is provided using
 the `symlink` argument to make it easier for users and developers to find the
-shared step.  Here's what the work directory structure will look like for the
+shared step.
+
+A symlink that would land in the directory already holding the step is dropped
+rather than created, since it would sit beside what it points to and only add a
+second name for it — `cull_mask` next to `mask`.  This matters because a
+`get_*_steps()` helper suggests one symlink name per step, chosen for consumers
+whose tasks live elsewhere in the tree; a task that lives in the steps' own
+directory can pass those names straight through without having to filter them.
+A symlink to a step nested *deeper* under the task is kept: surfacing it under a
+descriptive name is what symlinks are for.
+
+Here's what the work directory structure will look like for the
 `ocean/spherical/icos/cosine_bell` task:
 
  * ocean

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -213,10 +213,10 @@ class Component:
             )
         self.configs[config.filepath] = config
 
-    def get_or_create_shared_config(self, filepath, setup=None):
+    def get_or_create_shared_config(self, filepath, create=None):
         """
-        Get a shared config from the component if it exists, otherwise create,
-        set up and add it.
+        Get a shared config from the component if it exists, otherwise build
+        and add it.
 
         The companion to :py:meth:`get_or_create_shared_step`, and needed for
         the same reason.  A ``get_*_steps()`` helper is called once per
@@ -232,10 +232,14 @@ class Component:
             The path of the config file relative to the base work directory,
             which is what identifies a shared config
 
-        setup : callable, optional
-            Called with the new config to add packages and set options.  It is
-            not called when the config already exists, so it must not be relied
-            on for anything a later caller needs.
+        create : callable, optional
+            Called with no arguments to build the config, and only when it does
+            not already exist -- so it must not be relied on for anything a
+            later caller needs.  It must return a
+            :py:class:`polaris.config.PolarisConfigParser` whose ``filepath``
+            is ``filepath``.  A config builder that returns a new parser, as
+            several in Polaris do, can be passed directly.  The default builds
+            an empty parser.
 
         Returns
         -------
@@ -244,9 +248,16 @@ class Component:
         """
         if filepath in self.configs:
             return self.configs[filepath]
-        config = PolarisConfigParser(filepath=filepath)
-        if setup is not None:
-            setup(config)
+        if create is None:
+            config = PolarisConfigParser(filepath=filepath)
+        else:
+            config = create()
+            if config.filepath != filepath:
+                raise ValueError(
+                    f'The config built for {filepath} has filepath '
+                    f'{config.filepath}; it would be registered under a path '
+                    f'it does not know about.'
+                )
         self.add_config(config)
         return config
 

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -367,6 +367,7 @@ class Component:
             pkg_file = imp_res.files(package).joinpath(filename)
             with pkg_file.open('r') as data_file:
                 self.cached_files = json.load(data_file)
-        except FileNotFoundError:
-            # no cached files for this core
+        except (FileNotFoundError, ModuleNotFoundError, TypeError):
+            # the component has no package of its own or no cached files in
+            # it, so there is nothing to read
             pass

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -213,6 +213,43 @@ class Component:
             )
         self.configs[config.filepath] = config
 
+    def get_or_create_shared_config(self, filepath, setup=None):
+        """
+        Get a shared config from the component if it exists, otherwise create,
+        set up and add it.
+
+        The companion to :py:meth:`get_or_create_shared_step`, and needed for
+        the same reason.  A ``get_*_steps()`` helper is called once per
+        consumer, so building its config unconditionally hands the second
+        caller a config that the shared steps -- created on the first call --
+        are not using.  Options set on it reach nothing, and passing it to
+        :py:meth:`polaris.Task.set_shared_config` raises, because a different
+        config is already registered at that path.
+
+        Parameters
+        ----------
+        filepath : str
+            The path of the config file relative to the base work directory,
+            which is what identifies a shared config
+
+        setup : callable, optional
+            Called with the new config to add packages and set options.  It is
+            not called when the config already exists, so it must not be relied
+            on for anything a later caller needs.
+
+        Returns
+        -------
+        config : polaris.config.PolarisConfigParser
+            The shared config parser
+        """
+        if filepath in self.configs:
+            return self.configs[filepath]
+        config = PolarisConfigParser(filepath=filepath)
+        if setup is not None:
+            setup(config)
+        self.add_config(config)
+        return config
+
     def configure(self, config, tasks):
         """
         Configure the component

--- a/polaris/mesh/base/add.py
+++ b/polaris/mesh/base/add.py
@@ -116,12 +116,15 @@ def _get_base_mesh_config(
     config_filename,
 ):
     filepath = os.path.join(component.name, subdir, config_filename)
-    if filepath in component.configs:
-        return component.configs[filepath]
 
-    config = PolarisConfigParser(filepath=filepath)
-    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
-    config.set('spherical_mesh', 'prefix', MESH_NAME_PREFIXES[prefix])
-    config.set('spherical_mesh', 'min_cell_width', f'{min_res:g}')
-    config.set('spherical_mesh', 'max_cell_width', f'{max_res:g}')
-    return config
+    def create():
+        config = PolarisConfigParser(filepath=filepath)
+        config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+        config.set('spherical_mesh', 'prefix', MESH_NAME_PREFIXES[prefix])
+        config.set('spherical_mesh', 'min_cell_width', f'{min_res:g}')
+        config.set('spherical_mesh', 'max_cell_width', f'{max_res:g}')
+        return config
+
+    return component.get_or_create_shared_config(
+        filepath=filepath, create=create
+    )

--- a/polaris/ocean/vertical/grid_1d/__init__.py
+++ b/polaris/ocean/vertical/grid_1d/__init__.py
@@ -11,6 +11,12 @@ from polaris.ocean.vertical.grid_1d.tanh_dz import (
     create_tanh_dz_grid as create_tanh_dz_grid,
 )
 
+# The 1D reference vertical coordinate variables added by ``add_1d_grid``.
+# Kept here as the single source of truth so that consumers that need to
+# route or exclude these variables (e.g. dropping them from Omega output)
+# stay in sync with what ``add_1d_grid`` actually writes.
+REF_COORD_VARS = ['refTopDepth', 'refZMid', 'refBottomDepth', 'refInterfaces']
+
 
 def generate_1d_grid(config):
     """

--- a/polaris/ocean/vertical/pstar_init.py
+++ b/polaris/ocean/vertical/pstar_init.py
@@ -10,7 +10,7 @@ import numpy as np
 import xarray as xr
 
 from polaris.ocean.eos import compute_specvol
-from polaris.ocean.vertical.grid_1d import generate_1d_grid
+from polaris.ocean.vertical.grid_1d import add_1d_grid, generate_1d_grid
 from polaris.ocean.vertical.pstar import init_pstar_vertical_coord
 from polaris.ocean.vertical.ztilde import (
     Gravity,
@@ -418,6 +418,26 @@ class PStarInitStep(Step, ABC):
 
         ds.PseudoThickness.attrs['long_name'] = 'pseudo-layer thickness'
         ds.PseudoThickness.attrs['units'] = 'm'
+
+        # Add the 1D reference vertical coordinate (refBottomDepth, refZMid,
+        # refTopDepth, refInterfaces).  The p-star reference grid is the same
+        # 1D grid used to build the coordinate, so this is iteration
+        # independent and belongs in the one-time output assembly.
+        # MPAS-Ocean requires refBottomDepth as an input; Omega does not use
+        # these fields.
+        add_1d_grid(config, ds)
+        ds.refTopDepth.attrs['long_name'] = 'reference depth of layer top'
+        ds.refTopDepth.attrs['units'] = 'm'
+        ds.refZMid.attrs['long_name'] = 'reference depth of layer midpoint'
+        ds.refZMid.attrs['units'] = 'm'
+        ds.refBottomDepth.attrs['long_name'] = (
+            'reference depth of layer bottom'
+        )
+        ds.refBottomDepth.attrs['units'] = 'm'
+        ds.refInterfaces.attrs['long_name'] = (
+            'reference depth of layer interfaces'
+        )
+        ds.refInterfaces.attrs['units'] = 'm'
 
         return ds
 

--- a/polaris/remap/mapping_file_step.py
+++ b/polaris/remap/mapping_file_step.py
@@ -66,8 +66,16 @@ class MappingFileStep(Step):
             ntasks=ntasks,
             min_tasks=min_tasks,
         )
+        # use_tmp=False because pyremap would otherwise put the SCRIP and
+        # MOAB .h5m files in a temporary directory under /tmp, which is
+        # node-local on many HPC machines.  The MPI tasks running the mapping
+        # tool are typically spread over several nodes, so the files must be
+        # in the step's work directory on a shared filesystem.
         self.remapper = Remapper(
-            ntasks=ntasks, map_filename=map_filename, method=method
+            ntasks=ntasks,
+            map_filename=map_filename,
+            method=method,
+            use_tmp=False,
         )
 
     def run(self):

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -589,6 +589,17 @@ class Step:
         step : polaris.Step
             The step that is a dependency
 
+        Adding the same dependency again under the same name does nothing, so
+        that a ``get_*_steps()`` helper which wires a dependency outside a step
+        constructor is safe to call once per consumer, as shared steps are.
+        Adding a *different* step under a name already in use is still an
+        error, which is what the ``name`` argument exists to resolve.
+
+        Parameters
+        ----------
+        step : polaris.Step
+            The step that is a dependency
+
         name : str, optional
             The name of the step used to access it in the ``dependencies``
             dictionary.  By default, it is ``step.name`` but another name may
@@ -597,8 +608,13 @@ class Step:
         if name is None:
             name = step.name
         if name in self.dependencies:
+            if self.dependencies[name] is step:
+                # already wired; returning rather than falling through matters
+                # because neither add_output_file() nor add_input_file()
+                # de-duplicates
+                return
             raise ValueError(
-                'Adding a dependency that is already in dependencies.'
+                f'A different dependency has already been added as {name!r}.'
             )
         self.dependencies[name] = step
         step.is_dependency = True

--- a/polaris/task.py
+++ b/polaris/task.py
@@ -153,7 +153,16 @@ class Task:
         symlink : str, optional
             A location for a symlink to the step, relative to the test case's
             work directory. This is typically used for a shared step that lives
-            outside of the test case
+            outside of the test case.
+
+            A symlink that would land in the directory that already holds the
+            step is dropped, since it would sit beside what it points to and
+            only add a second name for it.  A ``get_*_steps()`` helper suggests
+            one symlink name per step for consumers whose tasks live elsewhere
+            in the tree, and a task that lives in the steps' own directory can
+            pass those through without having to filter them.  A symlink to a
+            step nested deeper under the task is kept: surfacing it under a
+            descriptive name is what symlinks are for.
 
         run_by_default : bool, optional
             Whether to add this step to the list of steps to run when the
@@ -187,10 +196,22 @@ class Task:
 
         self.steps[step.name] = step
         step.tasks[self.subdir] = self
-        if symlink:
+        if symlink and not self._symlink_is_beside_step(symlink, step):
             self.step_symlinks[step.name] = symlink
         if run_by_default:
             self.steps_to_run.append(step.name)
+
+    def _symlink_is_beside_step(self, symlink, step):
+        """
+        Whether a symlink would land in the directory that already holds the
+        step, making it a second name for something already in view.
+
+        Compared on the full path within the base work directory, since a step
+        may belong to another component and two components can have the same
+        subdirectory layout.
+        """
+        link_path = os.path.normpath(os.path.join(self.path, symlink))
+        return os.path.dirname(link_path) == os.path.dirname(step.path)
 
     def remove_step(self, step):
         """

--- a/polaris/tasks/e3sm/init/topo/combine/steps.py
+++ b/polaris/tasks/e3sm/init/topo/combine/steps.py
@@ -1,5 +1,6 @@
 import os
 
+from polaris.config import PolarisConfigParser
 from polaris.e3sm.init.topo import format_lat_lon_resolution_name
 from polaris.step import Step
 from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
@@ -130,7 +131,8 @@ def _get_target_topo_steps(component, target_grid, resolution, include_viz):
     config_filename = 'combine_topo.cfg'
     filepath = os.path.join(component.name, subdir, config_filename)
 
-    def setup(config):
+    def create():
+        config = PolarisConfigParser(filepath=filepath)
         config.add_from_package(
             'polaris.tasks.e3sm.init.topo.combine', 'combine.cfg'
         )
@@ -141,9 +143,10 @@ def _get_target_topo_steps(component, target_grid, resolution, include_viz):
             )
         else:
             config.set('combine_topo', 'resolution_latlon', f'{resolution}')
+        return config
 
     config = component.get_or_create_shared_config(
-        filepath=filepath, setup=setup
+        filepath=filepath, create=create
     )
 
     steps: dict[str, Step] = {}

--- a/polaris/tasks/e3sm/init/topo/combine/steps.py
+++ b/polaris/tasks/e3sm/init/topo/combine/steps.py
@@ -1,6 +1,5 @@
 import os
 
-from polaris.config import PolarisConfigParser
 from polaris.e3sm.init.topo import format_lat_lon_resolution_name
 from polaris.step import Step
 from polaris.tasks.e3sm.init.topo.combine.step import CombineStep
@@ -130,15 +129,22 @@ def _get_target_topo_steps(component, target_grid, resolution, include_viz):
 
     config_filename = 'combine_topo.cfg'
     filepath = os.path.join(component.name, subdir, config_filename)
-    config = PolarisConfigParser(filepath=filepath)
-    config.add_from_package(
-        'polaris.tasks.e3sm.init.topo.combine', 'combine.cfg'
+
+    def setup(config):
+        config.add_from_package(
+            'polaris.tasks.e3sm.init.topo.combine', 'combine.cfg'
+        )
+        config.set('combine_topo', 'target_grid', target_grid)
+        if target_grid == 'cubed_sphere':
+            config.set(
+                'combine_topo', 'resolution_cubedsphere', f'{resolution}'
+            )
+        else:
+            config.set('combine_topo', 'resolution_latlon', f'{resolution}')
+
+    config = component.get_or_create_shared_config(
+        filepath=filepath, setup=setup
     )
-    config.set('combine_topo', 'target_grid', target_grid)
-    if target_grid == 'cubed_sphere':
-        config.set('combine_topo', 'resolution_cubedsphere', f'{resolution}')
-    else:
-        config.set('combine_topo', 'resolution_latlon', f'{resolution}')
 
     steps: dict[str, Step] = {}
     combine_step = component.get_or_create_shared_step(

--- a/polaris/tasks/e3sm/init/topo/cull/steps.py
+++ b/polaris/tasks/e3sm/init/topo/cull/steps.py
@@ -89,30 +89,33 @@ def get_cull_topo_steps(mesh_name, include_viz=False):
 
 
 def _get_cull_topo_config(filepath, base_mesh_step, mesh_name):
-    component = e3sm_init
-    if filepath in component.configs:
-        return component.configs[filepath]
-
-    config = PolarisConfigParser(filepath=filepath)
-    config.add_from_package('polaris.tasks.e3sm.init.topo.cull', 'cull.cfg')
-    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
-
-    if mesh_name in UNIFIED_MESH_NAMES:
-        # unified-mesh config options (e.g. per-mesh overrides of the
-        # dcEdge diagnostic thresholds)
+    def create():
+        config = PolarisConfigParser(filepath=filepath)
         config.add_from_package(
-            'polaris.mesh.spherical.unified', 'unified_mesh.cfg'
+            'polaris.tasks.e3sm.init.topo.cull', 'cull.cfg'
         )
-        config.add_from_package(
-            'polaris.mesh.spherical.unified', f'{mesh_name}.cfg'
-        )
+        config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
 
-    convention = base_mesh_step.config.get(
-        'spherical_mesh', 'antarctic_boundary_convention'
+        if mesh_name in UNIFIED_MESH_NAMES:
+            # unified-mesh config options (e.g. per-mesh overrides of the
+            # dcEdge diagnostic thresholds)
+            config.add_from_package(
+                'polaris.mesh.spherical.unified', 'unified_mesh.cfg'
+            )
+            config.add_from_package(
+                'polaris.mesh.spherical.unified', f'{mesh_name}.cfg'
+            )
+
+        convention = base_mesh_step.config.get(
+            'spherical_mesh', 'antarctic_boundary_convention'
+        )
+        config.set(
+            'spherical_mesh',
+            'antarctic_boundary_convention',
+            convention,
+        )
+        return config
+
+    return e3sm_init.get_or_create_shared_config(
+        filepath=filepath, create=create
     )
-    config.set(
-        'spherical_mesh',
-        'antarctic_boundary_convention',
-        convention,
-    )
-    return config

--- a/polaris/tasks/e3sm/init/topo/remap/steps.py
+++ b/polaris/tasks/e3sm/init/topo/remap/steps.py
@@ -143,24 +143,27 @@ def get_remap_topo_steps(mesh_name, smoothing=False, include_viz=False):
 
 
 def _get_remap_topo_config(filepath, base_mesh_step, low_res):
-    component = e3sm_init
-    if filepath in component.configs:
-        return component.configs[filepath]
-
-    config = PolarisConfigParser(filepath=filepath)
-    config.add_from_package('polaris.tasks.e3sm.init.topo.remap', 'remap.cfg')
-    if low_res:
+    def create():
+        config = PolarisConfigParser(filepath=filepath)
         config.add_from_package(
-            'polaris.tasks.e3sm.init.topo.remap', 'remap_low_res.cfg'
+            'polaris.tasks.e3sm.init.topo.remap', 'remap.cfg'
         )
-    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+        if low_res:
+            config.add_from_package(
+                'polaris.tasks.e3sm.init.topo.remap', 'remap_low_res.cfg'
+            )
+        config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
 
-    convention = base_mesh_step.config.get(
-        'spherical_mesh', 'antarctic_boundary_convention'
+        convention = base_mesh_step.config.get(
+            'spherical_mesh', 'antarctic_boundary_convention'
+        )
+        config.set(
+            'spherical_mesh',
+            'antarctic_boundary_convention',
+            convention,
+        )
+        return config
+
+    return e3sm_init.get_or_create_shared_config(
+        filepath=filepath, create=create
     )
-    config.set(
-        'spherical_mesh',
-        'antarctic_boundary_convention',
-        convention,
-    )
-    return config

--- a/polaris/tasks/mesh/spherical/unified/base_mesh/steps.py
+++ b/polaris/tasks/mesh/spherical/unified/base_mesh/steps.py
@@ -27,20 +27,25 @@ def get_unified_base_mesh_config(mesh_name, filepath=None):
     config : polaris.config.PolarisConfigParser
         The shared config options for the named unified base mesh.
     """
+
+    def create():
+        config = get_unified_mesh_config(
+            mesh_name=mesh_name, filepath=filepath
+        )
+        config.add_from_package(
+            'polaris.tasks.mesh.spherical.unified.base_mesh', 'base_mesh.cfg'
+        )
+
+        min_cell_width, max_cell_width = _get_mesh_cell_width_bounds(config)
+        config.set('spherical_mesh', 'prefix', 'UN')
+        config.set('spherical_mesh', 'min_cell_width', f'{min_cell_width:g}')
+        config.set('spherical_mesh', 'max_cell_width', f'{max_cell_width:g}')
+        return config
+
     component = _get_mesh_component()
-    if filepath in component.configs:
-        return component.configs[filepath]
-
-    config = get_unified_mesh_config(mesh_name=mesh_name, filepath=filepath)
-    config.add_from_package(
-        'polaris.tasks.mesh.spherical.unified.base_mesh', 'base_mesh.cfg'
+    return component.get_or_create_shared_config(
+        filepath=filepath, create=create
     )
-
-    min_cell_width, max_cell_width = _get_mesh_cell_width_bounds(config)
-    config.set('spherical_mesh', 'prefix', 'UN')
-    config.set('spherical_mesh', 'min_cell_width', f'{min_cell_width:g}')
-    config.set('spherical_mesh', 'max_cell_width', f'{max_cell_width:g}')
-    return config
 
 
 def get_unified_base_mesh_steps(mesh_name, include_viz=False):

--- a/polaris/tasks/mesh/spherical/unified/coastline/steps.py
+++ b/polaris/tasks/mesh/spherical/unified/coastline/steps.py
@@ -154,16 +154,18 @@ def get_unified_mesh_coastline_steps(
 
 
 def _get_lat_lon_coastline_config(filepath, config_filename):
-    component = _get_mesh_component()
-    if filepath in component.configs:
-        return component.configs[filepath]
+    def create():
+        config = PolarisConfigParser(filepath=filepath)
+        config.add_from_package(
+            'polaris.tasks.mesh.spherical.unified.coastline',
+            config_filename,
+        )
+        return config
 
-    config = PolarisConfigParser(filepath=filepath)
-    config.add_from_package(
-        'polaris.tasks.mesh.spherical.unified.coastline',
-        config_filename,
+    component = _get_mesh_component()
+    return component.get_or_create_shared_config(
+        filepath=filepath, create=create
     )
-    return config
 
 
 def _get_mesh_component():

--- a/polaris/tasks/mesh/spherical/unified/river/steps.py
+++ b/polaris/tasks/mesh/spherical/unified/river/steps.py
@@ -127,10 +127,12 @@ def get_unified_mesh_river_steps(
 
 def _get_mesh_river_config(mesh_name, filepath):
     component = _get_mesh_component()
-    if filepath in component.configs:
-        return component.configs[filepath]
-
-    return get_unified_mesh_config(mesh_name=mesh_name, filepath=filepath)
+    return component.get_or_create_shared_config(
+        filepath=filepath,
+        create=lambda: get_unified_mesh_config(
+            mesh_name=mesh_name, filepath=filepath
+        ),
+    )
 
 
 def _get_mesh_component():

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/steps.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/steps.py
@@ -116,10 +116,12 @@ def get_unified_mesh_sizing_field_steps(
 
 def _get_lat_lon_sizing_field_config(mesh_name, filepath):
     component = _get_mesh_component()
-    if filepath in component.configs:
-        return component.configs[filepath]
-
-    return get_sizing_field_config(mesh_name=mesh_name, filepath=filepath)
+    return component.get_or_create_shared_config(
+        filepath=filepath,
+        create=lambda: get_sizing_field_config(
+            mesh_name=mesh_name, filepath=filepath
+        ),
+    )
 
 
 def _get_mesh_component():

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -21,6 +21,7 @@ from polaris.ocean.vertical.diagnostics import (
     geom_thickness_from_ds,
     pseudothickness_from_ds,
 )
+from polaris.ocean.vertical.grid_1d import REF_COORD_VARS
 from polaris.ocean.vertical.ztilde import (
     geom_height_from_pseudo_height,
     get_iter_count_for_eos,
@@ -524,6 +525,14 @@ class Ocean(Component):
         ds = self.remove_horiz_mesh_vars(ds)
         if self.model == 'omega':
             ds = self.remove_vert_coord_vars(ds)
+
+            # Omega uses RefPseudoThickness, not the 1D reference depth
+            # coordinate, so drop those fields (added by the p-star init for
+            # MPAS-Ocean) from the Omega initial state.
+            drop = [v for v in REF_COORD_VARS if v in ds]
+            if drop:
+                ds = ds.drop_vars(drop)
+
             # Omega requires a surface pressure in its initial state but
             # MPAS-Ocean does not, so only add it for Omega.  This is the one
             # place the vertical_grid:surface_pressure config option is read

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -302,8 +302,12 @@ def plot_global_lat_lon_field(
 
     figsize = (8, 4.5)
     fig = plt.figure(figsize=figsize)
+    # Reserve room for the inset colorbar and its tick labels on the right.
+    # The margins have to be explicit because we no longer save with
+    # bbox_inches='tight' (see the comment on savefig below).
+    fig.subplots_adjust(left=0.08, right=0.86, top=0.90, bottom=0.10)
     if title is not None:
-        fig.suptitle(title, y=0.935)
+        fig.suptitle(title, y=0.96)
 
     subplots = [111]
     ref_projection = cartopy.crs.PlateCarree()
@@ -357,7 +361,12 @@ def plot_global_lat_lon_field(
         cbar.set_ticks(ticks)
         cbar.set_ticklabels([f'{tick}' for tick in ticks])
 
-    plt.savefig(out_filename, bbox_inches='tight', pad_inches=0.2)
+    # bbox_inches='tight' on a fixed-aspect GeoAxes can shrink the map axes so
+    # only part of the domain is drawn, clipping Antarctica off the bottom.
+    # Use the explicit margins set above instead.  This is the same failure
+    # mode fixed for plot_global_mpas_field in "Fix half-globe clipping in
+    # plot_global_mpas_field", which was never propagated here.
+    fig.savefig(out_filename)
 
     plt.close()
 

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -213,6 +213,12 @@ def plot_global_mpas_field(
         cbar.set_ticks(ticks)
         cbar.set_ticklabels([f'{tick}' for tick in ticks])
 
+    # cartopy's Gridliner draws its tick labels itself and constrained_layout
+    # does not measure them, so the labels that stick out furthest (the
+    # 30-degree ones on Robinson, which sit left of the 60-degree ones) get
+    # clipped at the figure edge.  Reserve the margin explicitly.
+    fig.get_layout_engine().set(rect=(0.04, 0.0, 0.96, 1.0))
+
     # Let constrained_layout manage the margins; combining it with
     # bbox_inches='tight' on a fixed-aspect GeoAxes with an attached colorbar
     # can collapse the map axes so only part of the globe is drawn.

--- a/tests/e3sm/init/topo/test_unified_tasks.py
+++ b/tests/e3sm/init/topo/test_unified_tasks.py
@@ -1,3 +1,5 @@
+import os
+
 from polaris.component import Component
 from polaris.tasks.e3sm.init import e3sm_init
 from polaris.tasks.e3sm.init.topo.cull import (
@@ -112,8 +114,19 @@ def test_remap_topo_task_uses_factory_symlink_keys():
     )
 
     assert list(task.steps) == [step.name for step in steps.values()]
+    # the factory's suggested names are used as-is, except for the steps that
+    # live in the task's own directory, whose symlinks would sit beside them
+    suggested = {step.name: symlink for symlink, step in steps.items()}
+    beside = {
+        name
+        for name, step in task.steps.items()
+        if os.path.dirname(step.subdir) == task.subdir
+    }
+    assert beside
     assert task.step_symlinks == {
-        step.name: symlink for symlink, step in steps.items()
+        name: symlink
+        for name, symlink in suggested.items()
+        if name not in beside
     }
 
 
@@ -132,8 +145,19 @@ def test_cull_topo_task_uses_factory_symlink_keys():
     )
 
     assert list(task.steps) == [step.name for step in steps.values()]
+    # the factory's suggested names are used as-is, except for the steps that
+    # live in the task's own directory, whose symlinks would sit beside them
+    suggested = {step.name: symlink for symlink, step in steps.items()}
+    beside = {
+        name
+        for name, step in task.steps.items()
+        if os.path.dirname(step.subdir) == task.subdir
+    }
+    assert beside
     assert task.step_symlinks == {
-        step.name: symlink for symlink, step in steps.items()
+        name: symlink
+        for name, symlink in suggested.items()
+        if name not in beside
     }
 
 

--- a/tests/ocean/test_mesh_init_split.py
+++ b/tests/ocean/test_mesh_init_split.py
@@ -61,6 +61,16 @@ def _make_state_ds(surface_pressure=None):
     return xr.Dataset(data_vars=data_vars)
 
 
+def _make_ref_coord_ds():
+    """A minimal initial state plus the four 1D reference coordinate vars."""
+    ds = _make_state_ds()
+    ds['refTopDepth'] = ('nVertLevels', [0.0])
+    ds['refZMid'] = ('nVertLevels', [-5.0])
+    ds['refBottomDepth'] = ('nVertLevels', [10.0])
+    ds['refInterfaces'] = ('nVertLevelsP1', [0.0, 10.0])
+    return ds
+
+
 def test_write_initial_state_dataset_omega_drops_horiz_mesh_vars(tmp_path):
     component = Ocean()
     component.model = 'omega'
@@ -221,6 +231,44 @@ def test_write_initial_state_dataset_mpas_ocean_omits_surface_pressure(
     ds_out = xr.open_dataset(filename)
     assert 'surfacePressure' not in ds_out
     assert 'SurfacePressure' not in ds_out
+
+
+def test_write_initial_state_dataset_omega_drops_ref_coord_vars(tmp_path):
+    component = Ocean()
+    component.model = 'omega'
+    component._read_var_map()
+
+    config = _make_surface_pressure_config('omega')
+
+    ds = _make_ref_coord_ds()
+
+    filename = tmp_path / 'initial_state.nc'
+    component.write_initial_state_dataset(ds, str(filename), config)
+
+    ds_out = xr.open_dataset(filename)
+    assert 'Temperature' in ds_out
+    for var in ('refTopDepth', 'refZMid', 'refBottomDepth', 'refInterfaces'):
+        assert var not in ds_out
+
+
+def test_write_initial_state_dataset_mpas_ocean_keeps_ref_coord_vars(
+    tmp_path,
+):
+    component = Ocean()
+    component.model = 'mpas-ocean'
+    component._read_var_map()
+
+    config = _make_surface_pressure_config('mpas-ocean')
+
+    ds = _make_ref_coord_ds()
+
+    filename = tmp_path / 'initial_state.nc'
+    component.write_initial_state_dataset(ds, str(filename), config)
+
+    ds_out = xr.open_dataset(filename)
+    assert 'temperature' in ds_out
+    for var in ('refTopDepth', 'refZMid', 'refBottomDepth', 'refInterfaces'):
+        assert var in ds_out
 
 
 def _make_tracer_config(

--- a/tests/ocean/vertical/test_grid_1d.py
+++ b/tests/ocean/vertical/test_grid_1d.py
@@ -1,0 +1,22 @@
+from configparser import ConfigParser
+
+import xarray as xr
+
+from polaris.ocean.vertical.grid_1d import REF_COORD_VARS, add_1d_grid
+
+
+def _make_config(vert_levels=4, bottom_depth=100.0):
+    config = ConfigParser()
+    config.add_section('vertical_grid')
+    config.set('vertical_grid', 'grid_type', 'uniform')
+    config.set('vertical_grid', 'vert_levels', str(vert_levels))
+    config.set('vertical_grid', 'bottom_depth', str(bottom_depth))
+    return config
+
+
+def test_ref_coord_vars_matches_add_1d_grid():
+    """REF_COORD_VARS must stay in sync with what add_1d_grid writes."""
+    config = _make_config()
+    ds = xr.Dataset()
+    add_1d_grid(config, ds)
+    assert set(REF_COORD_VARS) == set(ds.data_vars)

--- a/tests/ocean/vertical/test_pstar_init.py
+++ b/tests/ocean/vertical/test_pstar_init.py
@@ -199,9 +199,16 @@ def test_minimal_subclass_returns_complete_dataset():
         'maxLevelCell',
         'RefPseudoThickness',
         'vertCoordMovementWeights',
+        'refTopDepth',
+        'refZMid',
+        'refBottomDepth',
+        'refInterfaces',
     ]
     for var in required:
         assert var in ds, f'{var!r} missing from output dataset'
+
+    # refInterfaces spans layer interfaces (one more than layer midpoints)
+    assert ds.sizes['nVertLevelsP1'] == ds.sizes['nVertLevels'] + 1
 
 
 def test_constant_density_converges_cleanly(caplog):

--- a/tests/remap/test_mapping_file_step.py
+++ b/tests/remap/test_mapping_file_step.py
@@ -1,0 +1,38 @@
+from polaris.remap import MappingFileStep
+
+
+class _FakeComponent:
+    name = 'fake'
+
+
+def _make_step(**kwargs):
+    return MappingFileStep(
+        component=_FakeComponent(),
+        name='map',
+        subdir='map',
+        **kwargs,
+    )
+
+
+def test_remapper_does_not_use_tmp():
+    """
+    /tmp is node-local on many HPC machines, so the SCRIP and .h5m files
+    must go in the step's work directory instead.
+    """
+    step = _make_step()
+    assert step.remapper.use_tmp is False
+
+
+def test_remapper_method_is_passed_through():
+    step = _make_step(method='conserve')
+    assert step.remapper.method == 'conserve'
+
+
+def test_remapper_defaults_to_bilinear():
+    step = _make_step()
+    assert step.remapper.method == 'bilinear'
+
+
+def test_remapper_ntasks_is_passed_through():
+    step = _make_step(ntasks=128, min_tasks=16)
+    assert step.remapper.ntasks == 128

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,0 +1,64 @@
+from polaris import Component
+from polaris.tasks.e3sm.init import e3sm_init
+from polaris.tasks.e3sm.init.topo.combine import get_lat_lon_topo_steps
+
+FILEPATH = 'component/some/where/thing.cfg'
+
+
+def test_get_or_create_shared_config_creates_and_registers():
+    component = Component(name='component')
+    config = component.get_or_create_shared_config(filepath=FILEPATH)
+    assert config.filepath == FILEPATH
+    # registered right away, which is what lets a second caller find it
+    assert component.configs[FILEPATH] is config
+
+
+def test_get_or_create_shared_config_returns_the_same_config():
+    component = Component(name='component')
+    first = component.get_or_create_shared_config(filepath=FILEPATH)
+    second = component.get_or_create_shared_config(filepath=FILEPATH)
+    assert second is first
+
+
+def test_get_or_create_shared_config_sets_up_only_once():
+    """
+    The setup callback must not run again for an existing config, or a second
+    caller would re-add its packages on top of options the first caller's
+    steps may already have been given.
+    """
+    component = Component(name='component')
+    calls = []
+
+    def setup(config):
+        calls.append(config)
+        config.set('section', 'option', 'value')
+
+    first = component.get_or_create_shared_config(
+        filepath=FILEPATH, setup=setup
+    )
+    first.set('section', 'option', 'changed')
+    second = component.get_or_create_shared_config(
+        filepath=FILEPATH, setup=setup
+    )
+    assert len(calls) == 1
+    assert second.get('section', 'option') == 'changed'
+
+
+def test_shared_topo_steps_hand_back_the_config_their_steps_use():
+    """
+    A get_*_steps() helper is called once per consumer.  Building its config
+    unconditionally handed the second caller a config that the shared steps --
+    created on the first call -- were not using, so options set on it reached
+    nothing, and registering it raised.
+    """
+    first_steps, first_config = get_lat_lon_topo_steps(
+        component=e3sm_init, resolution=0.25
+    )
+    second_steps, second_config = get_lat_lon_topo_steps(
+        component=e3sm_init, resolution=0.25
+    )
+    assert second_config is first_config
+    for name, step in first_steps.items():
+        assert second_steps[name] is step, name
+    # and re-registering what was handed back is a no-op rather than an error
+    e3sm_init.add_config(second_config)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,4 +1,7 @@
+import pytest
+
 from polaris import Component
+from polaris.config import PolarisConfigParser
 from polaris.tasks.e3sm.init import e3sm_init
 from polaris.tasks.e3sm.init.topo.combine import get_lat_lon_topo_steps
 
@@ -20,28 +23,46 @@ def test_get_or_create_shared_config_returns_the_same_config():
     assert second is first
 
 
-def test_get_or_create_shared_config_sets_up_only_once():
+def test_get_or_create_shared_config_builds_only_once():
     """
-    The setup callback must not run again for an existing config, or a second
-    caller would re-add its packages on top of options the first caller's
-    steps may already have been given.
+    The create callback must not run again for an existing config, or a second
+    caller would rebuild on top of options the first caller's steps may already
+    have been given.
     """
     component = Component(name='component')
     calls = []
 
-    def setup(config):
-        calls.append(config)
+    def create():
+        config = PolarisConfigParser(filepath=FILEPATH)
         config.set('section', 'option', 'value')
+        calls.append(config)
+        return config
 
     first = component.get_or_create_shared_config(
-        filepath=FILEPATH, setup=setup
+        filepath=FILEPATH, create=create
     )
     first.set('section', 'option', 'changed')
     second = component.get_or_create_shared_config(
-        filepath=FILEPATH, setup=setup
+        filepath=FILEPATH, create=create
     )
     assert len(calls) == 1
+    assert second is first
     assert second.get('section', 'option') == 'changed'
+
+
+def test_get_or_create_shared_config_rejects_a_mismatched_filepath():
+    """
+    A builder that ignores the filepath would register a config under a path it
+    does not know about, which is the same silent mismatch this method exists
+    to prevent.
+    """
+    component = Component(name='component')
+    with pytest.raises(ValueError, match='filepath'):
+        component.get_or_create_shared_config(
+            filepath=FILEPATH,
+            create=lambda: PolarisConfigParser(filepath='somewhere/else.cfg'),
+        )
+    assert FILEPATH not in component.configs
 
 
 def test_shared_topo_steps_hand_back_the_config_their_steps_use():

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,0 +1,56 @@
+import pytest
+
+from polaris import Component, Step
+
+
+def _step(component, name):
+    return Step(component=component, name=name, subdir=name)
+
+
+def test_add_dependency_wires_the_files_that_carry_it():
+    component = Component(name='component')
+    step = _step(component, 'consumer')
+    dependency = _step(component, 'producer')
+    step.add_dependency(dependency)
+
+    assert step.dependencies['producer'] is dependency
+    assert dependency.is_dependency
+    assert 'step_after_run.pickle' in dependency.outputs
+    assert len(step.input_data) == 1
+
+
+def test_add_dependency_is_idempotent_for_the_same_step():
+    """
+    A get_*_steps() helper that wires a dependency outside a step constructor
+    is called once per consumer, since the steps themselves are shared.  Asking
+    for the same wiring again has to be a no-op rather than an error -- and a
+    no-op all the way down, since neither add_output_file() nor
+    add_input_file() de-duplicates.
+    """
+    component = Component(name='component')
+    step = _step(component, 'consumer')
+    dependency = _step(component, 'producer')
+
+    step.add_dependency(dependency)
+    step.add_dependency(dependency)
+
+    assert step.dependencies == {'producer': dependency}
+    assert dependency.outputs.count('step_after_run.pickle') == 1
+    assert len(step.input_data) == 1
+
+
+def test_add_dependency_still_rejects_a_different_step():
+    """
+    The error worth keeping is the name collision the ``name`` argument exists
+    to resolve, not the repeat request.
+    """
+    component = Component(name='component')
+    step = _step(component, 'consumer')
+    first = _step(component, 'producer')
+    second = _step(component, 'other')
+
+    step.add_dependency(first)
+    with pytest.raises(ValueError, match='different dependency'):
+        step.add_dependency(second, name='producer')
+
+    assert step.dependencies['producer'] is first

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,81 @@
+from polaris import Component, Step, Task
+
+
+def _component():
+    return Component(name='ocean')
+
+
+def _task(component, subdir):
+    return Task(component=component, name=subdir.split('/')[-1], subdir=subdir)
+
+
+def _step(component, subdir):
+    return Step(component=component, name=subdir.split('/')[-1], subdir=subdir)
+
+
+def test_add_step_keeps_a_symlink_to_a_step_elsewhere():
+    """
+    The ordinary case: a task gathers shared steps that live higher up the
+    tree, and the symlinks are the only thing that puts them in one place.
+    """
+    component = _component()
+    task = _task(component, 'mesh/task')
+    step = _step(component, 'shared/init')
+    task.add_step(step, symlink='init')
+
+    assert task.step_symlinks == {'init': 'init'}
+
+
+def test_add_step_drops_a_symlink_beside_the_step():
+    """
+    A ``get_*_steps()`` helper suggests one symlink name per step, which suits
+    a consumer whose task is elsewhere.  A task that lives in the steps' own
+    directory can pass those through, and the symlink would land next to what
+    it points to -- ``cull_mask`` beside ``mask`` -- which only adds a second
+    name for something already in view.
+    """
+    component = _component()
+    task = _task(component, 'icos480km/topo/cull')
+    step = _step(component, 'icos480km/topo/cull/mask')
+    task.add_step(step, symlink='cull_mask')
+
+    assert task.step_symlinks == {}
+    # the step itself is added as usual
+    assert task.steps['mask'] is step
+    assert 'mask' in task.steps_to_run
+
+
+def test_add_step_keeps_a_symlink_to_a_step_nested_deeper():
+    """
+    Surfacing a step from further down under a descriptive name is what
+    symlinks are for, so only the side-by-side case is dropped.
+    """
+    component = _component()
+    task = _task(component, 'icos480km/topo/remap')
+    step = _step(component, 'icos480km/topo/remap/unsmoothed/viz')
+    task.add_step(step, symlink='viz_remapped_unsmoothed_topo')
+
+    assert task.step_symlinks == {'viz': 'viz_remapped_unsmoothed_topo'}
+
+
+def test_add_step_compares_across_components():
+    """
+    Two components can have the same subdirectory layout, so a step from
+    another component that happens to share the task's subdirectory is still
+    somewhere else on disk and still needs its symlink.
+    """
+    task = _task(_component(), 'topo/cull')
+    step = _step(Component(name='mesh'), 'topo/cull/mask')
+    task.add_step(step, symlink='cull_mask')
+
+    assert task.step_symlinks == {'mask': 'cull_mask'}
+
+
+def test_add_step_drops_a_symlink_naming_the_step_itself():
+    # the degenerate case of the same thing: the link would point to itself
+    component = _component()
+    task = _task(component, 'topo/cull')
+    step = _step(component, 'topo/cull/mask')
+    task.add_step(step, symlink='mask')
+
+    assert task.step_symlinks == {}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This branch collects framework fixes that were developed while working on realistic global ocean initialization but that stand on their own. No new tasks are added and no existing task's results change, apart from the plotting and p-star output fixes noted below.

## Shared config options

Polaris lets several tasks share a single step (via `Component.get_or_create_shared_step()`) and a single set of config options. The helpers that build shared steps are called once per consumer, but the code that built the *config* for those steps ran unconditionally on every call. The second caller therefore got a brand-new config object at a path where a different config was already registered: options set on it reached nothing, and handing it to `Task.set_shared_config()` raised an error. Several places worked around this with an ad-hoc "is it already in `component.configs`?" check, and others simply didn't.

- Add `Component.get_or_create_shared_config()`, the config-level companion to the existing `get_or_create_shared_step()`; it returns the registered config if one exists and otherwise calls a `create` callback to build it.
- The callback returns the config rather than filling one in, so existing config builders can be passed straight through; it is checked to return a config whose `filepath` matches the path it is registered under.
- Route every shared config in the repo through the new helper (base mesh, combined/culled/remapped topography, and the unified-mesh base mesh, coastline, river and sizing-field steps), replacing the hand-rolled lookups.
- `Step.add_dependency()` now treats adding the *same* step under the same name as a no-op, so a `get_*_steps()` helper that wires dependencies outside a step constructor is safe to call once per consumer. Adding a *different* step under a name already in use is still an error, and the error message says so.
- Document both in the developers' guide (`organization/steps.md`) and the API listing.

## 1D reference vertical coordinate in p-star initial conditions

- `PStarInitStep` now writes the 1D reference vertical coordinate (`refTopDepth`, `refZMid`, `refBottomDepth`, `refInterfaces`) to its output, since MPAS-Ocean requires `refBottomDepth` as an input.
- Omega does not use those fields, so they are dropped when writing an Omega initial state, alongside the other MPAS-Ocean-only vertical coordinate variables.
- The variable list lives in one place, `polaris.ocean.vertical.grid_1d.REF_COORD_VARS`, so the writer and the Omega filter cannot drift apart.

## Other fixes

- `MappingFileStep` no longer lets pyremap write its SCRIP and MOAB files under `/tmp`. That directory is node-local on many HPC machines, while the MPI tasks building a mapping file are typically spread over several nodes, so the files have to be in the step's work directory on a shared filesystem.
- `plot_global_lat_lon_field()` no longer saves with `bbox_inches='tight'`, which could shrink the fixed-aspect map axes so that only part of the domain was drawn (Antarctica was being clipped off the bottom). It uses explicit margins instead — the same fix already applied to `plot_global_mpas_field()`, which had never been propagated here.
- `plot_global_mpas_field()` reserves a margin for cartopy's gridline labels, which `constrained_layout` does not measure and which were being clipped at the figure edge.

## Testing

- New unit tests cover the shared-config helper and its `filepath` check, the repeated-dependency no-op, the 1D reference coordinate in p-star output and its removal for Omega, and the `MappingFileStep` temporary-file setting.
- The full unit test suite passes (273 tests).
- The plotting changes are best checked by eye on any task that produces global plots.


<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
