### PR TITLE
Add weight gen to mesh step and fix recon variable names

### DIFF
--- a/docs/developers_guide/ocean/utils/add_reconstruction_weights.md
+++ b/docs/developers_guide/ocean/utils/add_reconstruction_weights.md
@@ -11,43 +11,26 @@ The weights are computed using the least-squares method described in
 using a two-ring edge stencil (see Figure 5 of that paper).
 
 The script auto-detects whether the input file uses MPAS-Ocean or Omega
-naming conventions and writes output in the same convention.  Only the
-small mesh/grid variables are loaded; large state/tracer fields are
-skipped, making it safe to run on production meshes.
+naming conventions and writes output in the same convention.
+`compute_reconstruction_weights()` internally selects only the small
+mesh/grid variables needed for the calculation, so large state/tracer
+fields are never loaded, making it safe to run on production meshes.
 
 ## Usage
 
 ```bash
 ./utils/omega/add_reconstruction_weights.py \
     -i <input_mesh.nc> \
-    -o <output_mesh.nc> \
-    [-w <num_workers>] \
-    [-c <chunk_size>]
+    -o <output_mesh.nc>
 ```
 
 | Flag | Description |
 |------|-------------|
 | `-i` / `--input_file`  | Input mesh file (MPAS-Ocean or Omega format) |
 | `-o` / `--output_file` | Output file (copy of input with weights appended) |
-| `-w` / `--num_workers` | Number of dask worker processes (enables parallel mode) |
-| `-c` / `--chunk_size`  | Cells per dask chunk (default: 1000) |
 
-Passing either `-w` or `-c` enables dask parallelism. If `-c` is given
-without `-w`, the worker count is inferred from mache (requires running
-on a recognised machine).
-
-## Parallel performance
-
-The script uses a local multiprocessing dask scheduler and can exploit
-all cores on a single node. Based on timing tests on Chrysalis with the
-EC30to60 mesh (~1.8 M cells, 32 workers):
-
-| `num_workers` | `chunk_size` | wall time |
-|:---:|---:|---:|
-| 32 | 7000 | ~5m 57s |
-| 32 | 3700 | ~4m 42s |
-| 32 | 1850 | ~4m 16s |
-
-**Fewer workers with more, smaller chunks per worker tends to be faster
-than filling each worker with one large chunk.**  Start with a chunk size
-that gives several chunks per worker and tune from there.
+For production-sized meshes (e.g. `6to18km`) the script should be run on a
+compute node. Since the mesh connectivity information needed to compute the
+weights fits into memory, the reconstruction weights are computed serially
+using numpy/xarray, as recommended by
+[Dask best practices](https://docs.dask.org/en/stable/array-best-practices.html#use-numpy).

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -29,6 +29,73 @@ _RECONSTRUCTION_FIELD_NAMES: dict[ReconstructionType, dict[str, str]] = {
     },
 }
 
+# variables read by build_reconstruction_weights() for each location
+_RECONSTRUCTION_INPUT_VARS: dict[ReconstructionType, tuple[str, ...]] = {
+    'cell': (
+        'xCell',
+        'yCell',
+        'zCell',
+        'xEdge',
+        'yEdge',
+        'zEdge',
+        'verticesOnCell',
+        'edgesOnVertex',
+        'cellsOnEdge',
+    ),
+    'vertex': (
+        'xVertex',
+        'yVertex',
+        'zVertex',
+        'xEdge',
+        'yEdge',
+        'zEdge',
+        'edgesOnVertex',
+        'verticesOnEdge',
+        'cellsOnEdge',
+    ),
+}
+
+
+def select_reconstruction_vars(
+    ds: xr.Dataset, location: ReconstructionType = 'cell'
+) -> xr.Dataset:
+    """
+    Trim an MPAS mesh dataset down to just the variables needed to compute
+    vector-reconstruction weights and stencils at the given location.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        MPAS mesh dataset
+
+    location: str ["cell", "vertex"]
+        Point location where the reconstruction occurs
+
+    Returns
+    -------
+    ds: xr.Dataset
+        A minimal dataset containing only the variables (and global attrs)
+        needed for reconstruction at the given location
+    """
+    if location not in _RECONSTRUCTION_INPUT_VARS:
+        raise ValueError(
+            f"Invalid location: {location}. Must be 'cell' or 'vertex'."
+        )
+
+    var_names = [
+        name for name in _RECONSTRUCTION_INPUT_VARS[location] if name in ds
+    ]
+    subset = ds[var_names]
+
+    # maxEdges2 is otherwise only attached to the legacy coeffs_reconstruct
+    # fields (not selected above), so it must be reinstated by hand
+    if location == 'cell' and 'maxEdges2' not in subset.sizes:
+        subset = subset.assign_coords(
+            maxEdges2=np.arange(ds.sizes['maxEdges2'])
+        )
+
+    return subset
+
 
 def fix_out_of_bounds_indices(ds: xr.Dataset) -> xr.Dataset:
     """
@@ -721,6 +788,10 @@ def compute_reconstruction_weights(
             f"Warning: overwriting existing '{names['weights']}' field "
             'in the mesh dataset.'
         )
+
+    # trim ds down to the variables needed for reconstruction, then load
+    # eagerly since the subset is small
+    ds = select_reconstruction_vars(ds, location).load()
 
     # For stencil creation to work all indices in the connectivity arrays must
     # [0, dim_size], where 0 is the invalid index sentinel

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -10,7 +10,6 @@ import dask
 import numpy as np
 import xarray as xr
 from dask.diagnostics import ProgressBar
-from scipy import linalg
 
 from polaris.mesh.vector import compute_edge_normal_vec
 
@@ -427,12 +426,12 @@ def rotate_local_to_cartesian(
     stencil_dim = _stencil_dim(weights)
 
     return xr.apply_ufunc(
-        lambda U, w: np.einsum('lg,le->ge', U, w),
+        lambda U, w: np.einsum('...lg,...le->...ge', U, w),
         rotation_matrix,
         weights,
         input_core_dims=[['d1', 'd2'], ['R3', stencil_dim]],
         output_core_dims=[['R3', stencil_dim]],
-        vectorize=True,
+        vectorize=False,
         dask='parallelized',
         output_dtypes=[weights.dtype],
         dask_gufunc_kwargs={
@@ -461,11 +460,11 @@ def solve_psuedo_inverse(M: xr.DataArray) -> xr.DataArray:
     stencil_dim = _stencil_dim(M)
 
     return xr.apply_ufunc(
-        linalg.pinv,
+        np.linalg.pinv,
         M,
         input_core_dims=[[stencil_dim, 'SIX']],
         output_core_dims=[['SIX', stencil_dim]],
-        vectorize=True,
+        vectorize=False,
         dask='parallelized',
         output_dtypes=[M.dtype],
         dask_gufunc_kwargs={

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -20,12 +20,12 @@ ReconstructionType = Literal['cell', 'vertex']
 _RECONSTRUCTION_FIELD_NAMES: dict[ReconstructionType, dict[str, str]] = {
     'cell': {
         'stencil': 'reconstructStencilCell',
-        'n_edges': 'nCellReconstructEdges',
+        'n_edges': 'nEdgesReconstructOnCell',
         'weights': 'reconstructWeightsCell',
     },
     'vertex': {
         'stencil': 'reconstructStencilVertex',
-        'n_edges': 'nVertexReconstructEdges',
+        'n_edges': 'nEdgesReconstructOnVertex',
         'weights': 'reconstructWeightsVertex',
     },
 }

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -1,3 +1,4 @@
+import time
 from typing import Literal
 
 import numpy as np
@@ -732,6 +733,8 @@ def compute_reconstruction_weights(
         and coefficient fields for the requested reconstruction point location.
     """
 
+    start_time = time.perf_counter()
+
     names = _RECONSTRUCTION_FIELD_NAMES[location]
 
     if names['weights'] in ds:
@@ -765,6 +768,12 @@ def compute_reconstruction_weights(
         'edge-normal values on the reconstruction stencil',
         units='unitless',
     )
+
+    elapsed = time.perf_counter() - start_time
+
+    print('\n')
+    print(f'Computed reconstruction weights in {elapsed:.2f} s')
+    print('\n')
 
     return xr.Dataset(
         {

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -1,15 +1,7 @@
-"""
-NOTE: Intermediate connectivity arrays are computed using the lightweight
-synchronous dask scheduler to avoid the overhead of spinning up a process
-pool for small integer topology data.
-"""
-
 from typing import Literal
 
-import dask
 import numpy as np
 import xarray as xr
-from dask.diagnostics import ProgressBar
 
 from polaris.mesh.vector import compute_edge_normal_vec
 
@@ -199,8 +191,6 @@ def construct_edgesOnVerticesOnCell(ds: xr.Dataset) -> xr.DataArray:
 
     maxEdges2 = ds.sizes['maxEdges2']
 
-    ds['verticesOnCell'] = ds.verticesOnCell.compute(scheduler='sync')
-
     conn = ds.edgesOnVertex[ds.verticesOnCell - 1]
     conn = conn.where(ds.verticesOnCell != 0, 0)
 
@@ -211,12 +201,8 @@ def construct_edgesOnVerticesOnCell(ds: xr.Dataset) -> xr.DataArray:
         input_core_dims=[['maxEdges', 'vertexDegree']],
         output_core_dims=[['maxEdges2']],
         vectorize=True,
-        dask='parallelized',
         output_dtypes=[conn.dtype],
-        dask_gufunc_kwargs={
-            'output_sizes': {'maxEdges2': maxEdges2},
-        },
-    ).compute(scheduler='sync')
+    )
 
 
 def construct_edgesOnVerticesOnVertex(ds: xr.Dataset) -> xr.DataArray:
@@ -242,8 +228,6 @@ def construct_edgesOnVerticesOnVertex(ds: xr.Dataset) -> xr.DataArray:
     max_neighbors = 2 * vertex_degree
     nine = 3 * vertex_degree
 
-    ds['edgesOnVertex'] = ds.edgesOnVertex.compute(scheduler='sync')
-
     # one-ring of neighboring vertices (including the vertex itself),
     conn = ds.verticesOnEdge[ds.edgesOnVertex - 1]
     conn = conn.where(ds.edgesOnVertex != 0, 0)
@@ -255,11 +239,7 @@ def construct_edgesOnVerticesOnVertex(ds: xr.Dataset) -> xr.DataArray:
         input_core_dims=[['vertexDegree', 'TWO']],
         output_core_dims=[['maxVertexNeighbors']],
         vectorize=True,
-        dask='parallelized',
         output_dtypes=[conn.dtype],
-        dask_gufunc_kwargs={
-            'output_sizes': {'maxVertexNeighbors': max_neighbors},
-        },
     )
 
     # union of edgesOnVertex over the two-ring edge stencil for target vertex
@@ -272,12 +252,8 @@ def construct_edgesOnVerticesOnVertex(ds: xr.Dataset) -> xr.DataArray:
         input_core_dims=[['maxVertexNeighbors', 'vertexDegree']],
         output_core_dims=[['NINE']],
         vectorize=True,
-        dask='parallelized',
         output_dtypes=[conn.dtype],
-        dask_gufunc_kwargs={
-            'output_sizes': {'NINE': nine},
-        },
-    ).compute(scheduler='sync')
+    )
 
 
 def construct_rotation_matrix(
@@ -318,14 +294,12 @@ def construct_rotation_matrix(
     # directly from the coordinate arrays, rather than hard-coding it
     point_dim = x_hat.dims[0]
     n_points = x_hat.sizes[point_dim]
-    # preserve existing chunking along point_dim. If None; use a single chunk
-    point_chunks = ds.chunksizes.get(point_dim, -1)
 
     # return identity matrix for planar meshes
     if ds.attrs['on_a_sphere'] == 'NO':
         return xr.DataArray(
             np.ones((n_points, 3, 3)), dims=(point_dim, 'd1', 'd2')
-        ).chunk({point_dim: point_chunks, 'd1': -1, 'd2': -1})
+        )
 
     c_y = np.sqrt(y_hat**2 + z_hat**2)
     s_y = x_hat
@@ -348,9 +322,7 @@ def construct_rotation_matrix(
     U_y[:, 2, 0] = s_y
     U_y[:, 2, 2] = c_y
 
-    return xr.DataArray(
-        np.matmul(U_y, U_x), dims=(point_dim, 'd1', 'd2')
-    ).chunk({point_dim: point_chunks, 'd1': -1, 'd2': -1})
+    return xr.DataArray(np.matmul(U_y, U_x), dims=(point_dim, 'd1', 'd2'))
 
 
 def project_edge_normal_to_tangent_plane(
@@ -374,7 +346,6 @@ def project_edge_normal_to_tangent_plane(
     """
 
     stencil_dim = _stencil_dim(stencil)
-    stencil_size = stencil.sizes[stencil_dim]
 
     # get the edge normal vector for the edges in the stencil
     edge_normal_vector = normal_vector.isel(nEdges=stencil - 1)
@@ -386,11 +357,7 @@ def project_edge_normal_to_tangent_plane(
         input_core_dims=[['d1', 'd2'], [stencil_dim, 'R3']],
         output_core_dims=[[stencil_dim, 'R3']],
         vectorize=True,
-        dask='parallelized',
         output_dtypes=[edge_normal_vector.dtype],
-        dask_gufunc_kwargs={
-            'output_sizes': {stencil_dim: stencil_size, 'R3': 3},
-        },
     )
 
 
@@ -499,20 +466,13 @@ def rotate_local_to_cartesian(
         input_core_dims=[['d1', 'd2'], ['R3', stencil_dim]],
         output_core_dims=[['R3', stencil_dim]],
         vectorize=False,
-        dask='parallelized',
         output_dtypes=[weights.dtype],
-        dask_gufunc_kwargs={
-            'output_sizes': {'R3': 3, stencil_dim: weights.sizes[stencil_dim]},
-        },
     )
 
 
 def solve_psuedo_inverse(M: xr.DataArray) -> xr.DataArray:
     """
-    Solve the batched pseudo-inverse of a matrix M using scipy.linalg.pinv
-
-    Will parallelize over the reconstruction-point dimension if M is a
-    dask array and chunked along said dimension.
+    Solve the batched pseudo-inverse of a matrix M using numpy.linalg.pinv
 
     Parameters
     ----------
@@ -532,11 +492,7 @@ def solve_psuedo_inverse(M: xr.DataArray) -> xr.DataArray:
         input_core_dims=[[stencil_dim, 'SIX']],
         output_core_dims=[['SIX', stencil_dim]],
         vectorize=False,
-        dask='parallelized',
         output_dtypes=[M.dtype],
-        dask_gufunc_kwargs={
-            'output_sizes': {'SIX': 6, stencil_dim: M.sizes[stencil_dim]},
-        },
     )
 
 
@@ -576,10 +532,10 @@ def build_reconstruction_weights(
 
     # compute the normal vector for each edge in Cartesian coordinates
     cartesian_normal_vector = compute_edge_normal_vec(ds)
-    # build the edge coord vec (nEdges, R3), w/ single chunk along the R3 dim
+    # build the edge coord vec (nEdges, R3)
     cartesian_edge_coords = xr.concat(
         [ds.xEdge, ds.yEdge, ds.zEdge], dim='R3'
-    ).T.chunk({'R3': -1})
+    ).T
 
     # project the normal vector onto the tangent plane at the cell center
     local_normal_vector = project_edge_normal_to_tangent_plane(
@@ -597,11 +553,6 @@ def build_reconstruction_weights(
     matrix = xr.concat(
         [local_normal_vector.isel(R3=[0, 1])] * 3, dim='R3'
     ).rename({'R3': 'SIX'})
-
-    # We just want to parallelize over the reconstruction point dimension
-    # so we set a single chunk along all other dimensions
-    stencil_dim = _stencil_dim(stencil)
-    matrix = matrix.chunk({'SIX': -1, stencil_dim: -1})
 
     matrix.loc[{'SIX': [2, 3]}] *= local_edge_coords.isel(R3=0)
     matrix.loc[{'SIX': [4, 5]}] *= local_edge_coords.isel(R3=1)
@@ -814,9 +765,6 @@ def compute_reconstruction_weights(
         'edge-normal values on the reconstruction stencil',
         units='unitless',
     )
-
-    with ProgressBar():
-        stencil, n_edges, weights = dask.compute(stencil, n_edges, weights)
 
     return xr.Dataset(
         {

--- a/polaris/mesh/spherical/__init__.py
+++ b/polaris/mesh/spherical/__init__.py
@@ -15,6 +15,7 @@ from mpas_tools.viz.paraview_extractor import extract_vtk
 
 from polaris import Step
 from polaris.constants import get_constant
+from polaris.mesh.reconstruct import compute_reconstruction_weights
 from polaris.mesh.spherical.quality import check_cell_polygon_quality
 from polaris.model_step import make_graph_file
 
@@ -94,6 +95,7 @@ class SphericalBaseStep(Step):
             'jigsaw_mesh_filename',
             'mpas_mesh_filename',
             'cell_width_filename',
+            'reconstruction_weights_filename',
         ]:
             filename = config.get('spherical_mesh', option)
             self.add_output_file(filename=filename)
@@ -133,6 +135,13 @@ class SphericalBaseStep(Step):
         write_netcdf(ds_mesh, mpas_mesh_filename)
 
         self._check_cell_polygon_quality(ds_mesh=ds_mesh)
+
+        logger.info('Compute vector-reconstruction weights at cell centers')
+        reconstruction_weights_filename = section.get(
+            'reconstruction_weights_filename'
+        )
+        ds_weights = compute_reconstruction_weights(ds_mesh, location='cell')
+        write_netcdf(ds_weights, reconstruction_weights_filename)
 
         if section.getboolean('add_mesh_density'):
             logger.info('Add meshDensity into the mesh file')

--- a/polaris/mesh/spherical/__init__.py
+++ b/polaris/mesh/spherical/__init__.py
@@ -91,13 +91,16 @@ class SphericalBaseStep(Step):
         Add output files
         """
         config = self.config
+        section = config['spherical_mesh']
         for option in [
             'jigsaw_mesh_filename',
             'mpas_mesh_filename',
             'cell_width_filename',
-            'reconstruction_weights_filename',
         ]:
-            filename = config.get('spherical_mesh', option)
+            filename = section.get(option)
+            self.add_output_file(filename=filename)
+        if section.getboolean('generate_reconstruction_weights'):
+            filename = section.get('reconstruction_weights_filename')
             self.add_output_file(filename=filename)
         self.add_output_file(filename='graph.info')
 
@@ -136,12 +139,18 @@ class SphericalBaseStep(Step):
 
         self._check_cell_polygon_quality(ds_mesh=ds_mesh)
 
-        logger.info('Compute vector-reconstruction weights at cell centers')
-        reconstruction_weights_filename = section.get(
-            'reconstruction_weights_filename'
-        )
-        ds_weights = compute_reconstruction_weights(ds_mesh, location='cell')
-        write_netcdf(ds_weights, reconstruction_weights_filename)
+        if section.getboolean('generate_reconstruction_weights'):
+            logger.info('\n')
+            logger.info(
+                'Compute vector-reconstruction weights at cell centers'
+            )
+            reconstruction_weights_filename = section.get(
+                'reconstruction_weights_filename'
+            )
+            ds_weights = compute_reconstruction_weights(
+                ds_mesh, location='cell'
+            )
+            write_netcdf(ds_weights, reconstruction_weights_filename)
 
         if section.getboolean('add_mesh_density'):
             logger.info('Add meshDensity into the mesh file')

--- a/polaris/mesh/spherical/spherical.cfg
+++ b/polaris/mesh/spherical/spherical.cfg
@@ -12,6 +12,7 @@ jigsaw_jcfg_filename = opts.jig
 jigsaw_hfun_filename = spac.msh
 triangles_filename = mesh_triangles.nc
 mpas_mesh_filename = base_mesh.nc
+reconstruction_weights_filename = reconstruction_weights.nc
 
 # options related to mesh name and resolution
 # the prefix (e.g. Icos, QU, SO, RRS)

--- a/polaris/mesh/spherical/spherical.cfg
+++ b/polaris/mesh/spherical/spherical.cfg
@@ -14,6 +14,13 @@ triangles_filename = mesh_triangles.nc
 mpas_mesh_filename = base_mesh.nc
 reconstruction_weights_filename = reconstruction_weights.nc
 
+# whether to compute vector-reconstruction weights and stencils at cell
+# centers for the base mesh. Needed by Omega, not by MPAS-Ocean. Meshes
+# that get culled afterward (e.g. unified meshes) can skip this, since
+# culling invalidates cell indices and the weights must be recomputed on
+# the culled mesh anyway.
+generate_reconstruction_weights = True
+
 # options related to mesh name and resolution
 # the prefix (e.g. Icos, QU, SO, RRS)
 prefix = PREFIX

--- a/polaris/mesh/spherical/unified/configs.py
+++ b/polaris/mesh/spherical/unified/configs.py
@@ -56,8 +56,8 @@ def get_unified_mesh_config(mesh_name, filepath=None):
     config_filename = _get_mesh_config_filename(mesh_name)
     family_name = _get_mesh_family_name(config_filename)
     config = PolarisConfigParser(filepath=filepath)
-    config.add_from_package(PACKAGE, DEFAULT_CONFIG_FILENAME)
     config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+    config.add_from_package(PACKAGE, DEFAULT_CONFIG_FILENAME)
     config.add_from_package(RIVER_CONFIG_PACKAGE, RIVER_CONFIG_FILENAME)
     config.add_from_package(
         SIZING_FIELD_CONFIG_PACKAGE, SIZING_FIELD_CONFIG_FILENAME

--- a/polaris/mesh/spherical/unified/unified_mesh.cfg
+++ b/polaris/mesh/spherical/unified/unified_mesh.cfg
@@ -1,3 +1,9 @@
 [unified_mesh]
 # Mesh family used to specialize shared unified-mesh behavior
 mesh_family = default
+
+[spherical_mesh]
+# the base mesh is mostly land, which gets culled away before the
+# reconstruction weights would ever be used; skip computing them here and
+# let the culling step compute weights on the much smaller culled mesh
+generate_reconstruction_weights = False

--- a/polaris/mesh/vector.py
+++ b/polaris/mesh/vector.py
@@ -17,7 +17,7 @@ def compute_edge_normal_vec(ds: xr.Dataset) -> xr.DataArray:
         Normal vector for each edge in the mesh
     """
 
-    periodic = ds.attrs['is_periodic'].lower() == 'yes'
+    periodic = ds.attrs.get('is_periodic', 'NO') == 'YES'
     if periodic:
         period = np.array([ds.attrs['x_period'], ds.attrs['y_period'], 0.0])
     else:

--- a/polaris/mesh/vector.py
+++ b/polaris/mesh/vector.py
@@ -25,15 +25,8 @@ def compute_edge_normal_vec(ds: xr.Dataset) -> xr.DataArray:
         # formulas below are correct for non-periodic meshes as well
         period = np.array([0.0, 0.0, 0.0])
 
-    # concatenating along a new R3 dim leaves it chunked into one chunk
-    # per input array; force it back to a single chunk so it can be used
-    # as a core dimension in apply_ufunc(dask='parallelized', ...) calls
-    vec_cell = xr.concat([ds.xCell, ds.yCell, ds.zCell], dim='R3').T.chunk(
-        {'R3': -1}
-    )
-    vec_edge = xr.concat([ds.xEdge, ds.yEdge, ds.zEdge], dim='R3').T.chunk(
-        {'R3': -1}
-    )
+    vec_cell = xr.concat([ds.xCell, ds.yCell, ds.zCell], dim='R3').T
+    vec_edge = xr.concat([ds.xEdge, ds.yEdge, ds.zEdge], dim='R3').T
 
     cell_1 = ds.cellsOnEdge.isel(TWO=0) - 1
     cell_2 = ds.cellsOnEdge.isel(TWO=1) - 1

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -47,13 +47,13 @@ variables:
   kiteAreasOnVertex: KiteAreasOnVertex
   weightsOnEdge: WeightsOnEdge
 
-  # # variables used for LSTSQ vector reconstruction
-  reconstructStencilCell: ReconstructStencilCell
-  reconstructStencilVertex: ReconstructStencilVertex
-  nCellReconstructEdges: NCellReconstructEdges
-  nVertexReconstructEdges: NVertexReconstructEdges
-  reconstructWeightsCell: ReconstructWeightsCell
-  reconstructWeightsVertex: ReconstructWeightsVertex
+  # variables used for LSTSQ vector reconstruction
+  reconstructStencilCell: ReconStencilCell
+  reconstructStencilVertex: ReconStencilVertex
+  nEdgesReconstructOnCell: NEdgesReconOnCell
+  nEdgesReconstructOnVertex: NEdgesReconOnVertex
+  reconstructWeightsCell: ReconWeightsCell
+  reconstructWeightsVertex: ReconWeightsVertex
 
   # Coriolis
   fCell: FCell

--- a/polaris/ocean/model/variables.yaml
+++ b/polaris/ocean/model/variables.yaml
@@ -56,6 +56,11 @@ mpas-ocean:
     - layerThickness
 
 Omega:
+  horiz_mesh_variables:
+    # cell-centered vector-reconstruction fields; not used by MPAS-Ocean
+    - ReconStencilCell
+    - NEdgesReconOnCell
+    - ReconWeightsCell
   vert_coord_variables:
     # [MinLayerCell, MaxLayerCell, BottomGeomDepth,
     # VertCoordMovementWeights, RefPseudoThickness]

--- a/polaris/tasks/e3sm/init/topo/cull/cull.py
+++ b/polaris/tasks/e3sm/init/topo/cull/cull.py
@@ -9,6 +9,7 @@ from mpas_tools.mesh.cull import map_culled_to_base
 from pyremap import MpasCellMeshDescriptor
 
 from polaris import Step
+from polaris.mesh.reconstruct import compute_reconstruction_weights
 from polaris.model_step import make_graph_file
 
 CULL_PREFIXES = ['ocean', 'ocean_no_cavities', 'land']
@@ -74,6 +75,9 @@ class CullMeshStep(Step):
                 self.add_output_file(filename=f'culled_{prefix}_mesh.scrip.nc')
             if prefix.startswith('ocean'):
                 self.add_output_file(filename=f'culled_{prefix}_graph.info')
+                self.add_output_file(
+                    filename=f'culled_{prefix}_reconstruction_weights.nc'
+                )
 
     def setup(self):
         """
@@ -128,7 +132,8 @@ class CullMeshStep(Step):
     def _cull_mesh(self, prefix):
         """
         Cull and sort the mesh to the region specified by the prefix. For
-        ocean regions, also produce a graph file for the culled mesh.
+        ocean regions, also produce a graph file and vector-reconstruction
+        weights for the culled mesh.
         """
         logger = self.logger
 
@@ -174,6 +179,17 @@ class CullMeshStep(Step):
             make_graph_file(
                 mesh_filename=out_filename,
                 graph_filename=f'culled_{prefix}_graph.info',
+            )
+
+            logger.info(
+                f'Compute vector-reconstruction weights at cell centers '
+                f'for culled {prefix} mesh'
+            )
+            ds_weights = compute_reconstruction_weights(
+                ds_culled_mesh, location='cell'
+            )
+            write_netcdf(
+                ds_weights, f'culled_{prefix}_reconstruction_weights.nc'
             )
 
     def _create_scrip_file(self, mesh_filename, prefix):

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -53,6 +53,11 @@ class Ocean(Component):
     vert_coord_vars : list of str
         Variables that belong in the vertical coordinate file (Omega only)
         rather than the initial condition file
+
+    omega_only_horiz_mesh_vars : list of str
+        Horizontal mesh variables that are specific to Omega (currently
+        just the cell-centered vector-reconstruction fields), read from
+        the ``Omega`` section of variables.yaml
     """
 
     def __init__(self):
@@ -66,6 +71,7 @@ class Ocean(Component):
         self.horiz_mesh_vars: Union[None, list[str]] = None
         self.vert_coord_vars: Union[None, list[str]] = None
         self.state_vars: Union[None, list[str]] = None
+        self.omega_only_horiz_mesh_vars: Union[None, list[str]] = None
 
     def configure(self, config, tasks):
         """
@@ -290,7 +296,10 @@ class Ocean(Component):
         if self.model == 'omega' and self.mpaso_to_omega_var_map is None:
             self._read_var_map()
         assert self.horiz_mesh_vars is not None
-        if self.model == 'omega':
+
+        is_spherical = ds.attrs.get('on_a_sphere', 'NO') == 'YES'
+
+        if self.model == 'omega' and is_spherical:
             recon_filename = 'reconstruction_weights.nc'
             if not os.path.exists(recon_filename):
                 raise FileNotFoundError(
@@ -303,7 +312,16 @@ class Ocean(Component):
             ds_recon = open_dataset(recon_filename)
             ds = ds.merge(ds_recon)
         ds = self.map_to_native_model_vars(ds)
-        native_vars = self.map_var_list_to_native_model(self.horiz_mesh_vars)
+        horiz_mesh_vars = self.horiz_mesh_vars
+        if self.model == 'omega' and not is_spherical:
+            # planar meshes never have reconstruction weights and don't
+            # need them (least-squares vector reconstruction is only used
+            # on spherical meshes)
+            omega_only = self.omega_only_horiz_mesh_vars or []
+            horiz_mesh_vars = [
+                var for var in horiz_mesh_vars if var not in omega_only
+            ]
+        native_vars = self.map_var_list_to_native_model(horiz_mesh_vars)
         self._check_vars_present(ds, native_vars, 'write_horiz_mesh_dataset')
         write_netcdf(ds=ds, fileName=filename)
 
@@ -925,6 +943,9 @@ class Ocean(Component):
         if model_key:
             extra = nested_dict.get(model_key, {}).get(
                 'horiz_mesh_variables', []
+            )
+            self.omega_only_horiz_mesh_vars = (
+                list(extra) if model_key == 'Omega' else []
             )
             self.horiz_mesh_vars.extend(extra)
             extra = nested_dict.get(model_key, {}).get(

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -267,6 +267,12 @@ class Ocean(Component):
         Write a horizontal mesh dataset, validating that all expected mesh
         variables are present.
 
+        For Omega, the vector-reconstruction stencil and weight fields
+        (produced alongside the base mesh by
+        ``polaris.mesh.spherical.SphericalBaseStep``) are merged in from
+        ``reconstruction_weights.nc`` in the current working directory, since
+        MPAS-Ocean does not support least-squares vector reconstruction.
+
         Parameters
         ----------
         ds : xarray.Dataset
@@ -284,6 +290,18 @@ class Ocean(Component):
         if self.model == 'omega' and self.mpaso_to_omega_var_map is None:
             self._read_var_map()
         assert self.horiz_mesh_vars is not None
+        if self.model == 'omega':
+            recon_filename = 'reconstruction_weights.nc'
+            if not os.path.exists(recon_filename):
+                raise FileNotFoundError(
+                    f'{recon_filename} not found but is required to write '
+                    'the horizontal mesh dataset for Omega. Make sure the '
+                    'base mesh step ran with vector-reconstruction weight '
+                    'generation enabled and that it is added as an input '
+                    'file to this step.'
+                )
+            ds_recon = open_dataset(recon_filename)
+            ds = ds.merge(ds_recon)
         ds = self.map_to_native_model_vars(ds)
         native_vars = self.map_var_list_to_native_model(self.horiz_mesh_vars)
         self._check_vars_present(ds, native_vars, 'write_horiz_mesh_dataset')
@@ -895,7 +913,9 @@ class Ocean(Component):
         text = imp_res.files(package).joinpath(filename).read_text()
         yaml_data = YAML(typ='rt')
         nested_dict = yaml_data.load(text)
-        self.horiz_mesh_vars = nested_dict['ocean']['horiz_mesh_variables']
+        self.horiz_mesh_vars = list(
+            nested_dict['ocean']['horiz_mesh_variables']
+        )
         self.vert_coord_vars = list(
             nested_dict['ocean']['vert_coord_variables']
         )
@@ -903,6 +923,10 @@ class Ocean(Component):
         model_section_map = {'mpas-ocean': 'mpas-ocean', 'omega': 'Omega'}
         model_key = model_section_map.get(self.model or '')
         if model_key:
+            extra = nested_dict.get(model_key, {}).get(
+                'horiz_mesh_variables', []
+            )
+            self.horiz_mesh_vars.extend(extra)
             extra = nested_dict.get(model_key, {}).get(
                 'vert_coord_variables', []
             )

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -273,11 +273,18 @@ class Ocean(Component):
         Write a horizontal mesh dataset, validating that all expected mesh
         variables are present.
 
-        For Omega, the vector-reconstruction stencil and weight fields
-        (produced alongside the base mesh by
-        ``polaris.mesh.spherical.SphericalBaseStep``) are merged in from
-        ``reconstruction_weights.nc`` in the current working directory, since
-        MPAS-Ocean does not support least-squares vector reconstruction.
+        For Omega on spherical meshes, the vector-reconstruction stencil
+        and weight fields are merged in from ``reconstruction_weights.nc``
+        in the current working directory, since MPAS-Ocean does not
+        support least-squares vector reconstruction. This file must be
+        added as an input to the step, pointing at whichever mesh ``ds``
+        was built from: the base mesh's ``reconstruction_weights.nc``
+        (from ``polaris.mesh.spherical.SphericalBaseStep``) or, for
+        culled meshes, a culled mesh's
+        ``culled_{prefix}_reconstruction_weights.nc`` (from
+        ``polaris.tasks.e3sm.init.topo.cull.CullMeshStep``). Planar
+        meshes (``on_a_sphere == 'NO'``) never compute or require these
+        fields.
 
         Parameters
         ----------
@@ -305,9 +312,10 @@ class Ocean(Component):
                 raise FileNotFoundError(
                     f'{recon_filename} not found but is required to write '
                     'the horizontal mesh dataset for Omega. Make sure the '
-                    'base mesh step ran with vector-reconstruction weight '
-                    'generation enabled and that it is added as an input '
-                    'file to this step.'
+                    'base mesh (or culled mesh) step ran with '
+                    'vector-reconstruction weight generation enabled and '
+                    'that its weights file is added as an input to this '
+                    'step, renamed to reconstruction_weights.nc.'
                 )
             ds_recon = open_dataset(recon_filename)
             ds = ds.merge(ds_recon)

--- a/polaris/tasks/ocean/cosine_bell/init.py
+++ b/polaris/tasks/ocean/cosine_bell/init.py
@@ -39,6 +39,11 @@ class Init(OceanIOStep):
             work_dir_target=f'{base_mesh.path}/base_mesh.nc',
         )
 
+        self.add_input_file(
+            filename='reconstruction_weights.nc',
+            work_dir_target=f'{base_mesh.path}/reconstruction_weights.nc',
+        )
+
     def setup(self):
         super().setup()
         self.add_output_files_for_ocean_model_input(

--- a/polaris/tasks/ocean/external_gravity_wave/init.py
+++ b/polaris/tasks/ocean/external_gravity_wave/init.py
@@ -43,6 +43,11 @@ class Init(OceanIOStep):
             work_dir_target=f'{base_mesh.path}/graph.info',
         )
 
+        self.add_input_file(
+            filename='reconstruction_weights.nc',
+            work_dir_target=f'{base_mesh.path}/reconstruction_weights.nc',
+        )
+
     def setup(self):
         super().setup()
         self.add_output_files_for_ocean_model_input(

--- a/polaris/tasks/ocean/geostrophic/init.py
+++ b/polaris/tasks/ocean/geostrophic/init.py
@@ -44,6 +44,11 @@ class Init(OceanIOStep):
             work_dir_target=f'{base_mesh.path}/graph.info',
         )
 
+        self.add_input_file(
+            filename='reconstruction_weights.nc',
+            work_dir_target=f'{base_mesh.path}/reconstruction_weights.nc',
+        )
+
     def setup(self):
         super().setup()
         self.add_output_files_for_ocean_model_input(

--- a/polaris/tasks/ocean/realistic_global/__init__.py
+++ b/polaris/tasks/ocean/realistic_global/__init__.py
@@ -18,8 +18,8 @@ def add_realistic_global_tasks(component):
     component.add_task(Woa23(component=component))
 
     mesh_dict = {
-        'QU.240km': dict(mpaso_id=151209, omega_id=260720, ncells=7153),
-        'EC30to60E2r2': dict(mpaso_id=200908, omega_id=260720, ncells=236853),
+        'QU.240km': dict(mpaso_id=151209, omega_id=260807, ncells=7153),
+        'EC30to60E2r2': dict(mpaso_id=200908, omega_id=260807, ncells=236853),
     }
     for mesh_name, mesh_info in mesh_dict.items():
         subdir = f'spherical/realistic_global/{mesh_name}'

--- a/polaris/tasks/ocean/sphere_transport/init.py
+++ b/polaris/tasks/ocean/sphere_transport/init.py
@@ -1,9 +1,8 @@
 import numpy as np
 import xarray as xr
-from mpas_tools.io import open_dataset, write_netcdf
+from mpas_tools.io import open_dataset
 
 from polaris.constants import get_constant
-from polaris.mesh.reconstruct import add_reconstruction_weights_to_dataset
 from polaris.ocean.coriolis import add_coriolis_to_dataset
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical import init_vertical_coord
@@ -62,6 +61,11 @@ class Init(OceanIOStep):
             work_dir_target=f'{base_mesh.path}/graph.info',
         )
 
+        self.add_input_file(
+            filename='reconstruction_weights.nc',
+            work_dir_target=f'{base_mesh.path}/reconstruction_weights.nc',
+        )
+
     def setup(self):
         super().setup()
         self.add_output_files_for_ocean_model_input(
@@ -92,8 +96,6 @@ class Init(OceanIOStep):
         lonEdge = ds_mesh.lonEdge
 
         ds_mesh = add_coriolis_to_dataset(config, ds_mesh)
-        ds_mesh = add_reconstruction_weights_to_dataset(ds_mesh)
-        write_netcdf(ds_mesh, 'base_mesh_with_weights.nc')
         self.write_horiz_mesh_dataset(ds_mesh, 'culled_mesh.nc', config)
 
         ds = ds_mesh.copy()

--- a/utils/omega/add_reconstruction_weights.py
+++ b/utils/omega/add_reconstruction_weights.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import contextlib
 import os
 import shutil
 import subprocess
@@ -11,27 +10,10 @@ from contextlib import contextmanager
 from importlib import resources
 from typing import Iterator, Literal
 
-import dask
 import xarray as xr
-from mache import MachineInfo
-from mache.discover import discover_machine
-from mache.parallel import get_parallel_system
 from ruamel.yaml import YAML
 
 from polaris.mesh.reconstruct import compute_reconstruction_weights
-
-DEFAULT_CHUNK_SIZE = 1_000
-
-# Dimensions found only on large, multi-level/time-resolved/tracer
-# fields (e.g. layerThickness(nCells, nVertLevels)) that are never
-# needed to compute reconstruction weights. Filtering on these (rather
-# than enumerating every small mesh variable) keeps everything the
-# algorithm needs while skipping a production mesh's bulk. Names use
-# the MPAS-Ocean convention, since filtering always runs after
-# converting to that convention.
-_LARGE_STATE_DIMS = frozenset(
-    {'Time', 'nVertLevels', 'nVertLevelsP1', 'nTracers'}
-)
 
 
 class MeshConverter:
@@ -79,39 +61,6 @@ class MeshConverter:
         return 'omega' if is_omega else 'mpaso'
 
 
-def _select_grid_vars(ds: xr.Dataset) -> list[str]:
-    """Names of the mesh/grid variables, i.e. every variable except
-    those with a large state/time/tracer dimension (see
-    ``_LARGE_STATE_DIMS``). ``ds`` is expected to already be in
-    MPAS-Ocean naming convention.
-    """
-    return [
-        name
-        for name, da in ds.data_vars.items()
-        if not (set(da.dims) & _LARGE_STATE_DIMS)
-    ]
-
-
-def _default_num_workers() -> int:
-    """Default dask worker count from mache's parallel system info.
-
-    Using mache rather than reading SLURM environment variables
-    ourselves keeps this in sync with each machine's known core count
-    and correctly falls back to a login-node core count outside of a
-    job allocation.
-    """
-    machine = discover_machine(quiet=True)
-    if machine is None:
-        raise ValueError(
-            'Unable to discover the current machine from its host '
-            'name; mache does not support this machine. Pass '
-            '--num_workers explicitly instead.'
-        )
-    machine_info = MachineInfo(machine=machine, quiet=True)
-    system = get_parallel_system(machine_info.config)
-    return system.cores
-
-
 @contextmanager
 def _timed(step: str) -> Iterator[None]:
     """Print how long the wrapped block of code took to run, labeled
@@ -140,36 +89,11 @@ def parse_args():
         type=str,
         help='Path to the output dataset file.',
     )
-    parser.add_argument(
-        '-w',
-        '--num_workers',
-        required=False,
-        type=int,
-        default=None,
-        help='Number of local dask worker processes to use. Providing '
-        'this (with or without --chunk_size) enables dask, attaching '
-        'to the resources available on the local node. If omitted, but '
-        '--chunk_size is provided, this is taken from mache instead '
-        '(requires running on a machine mache recognizes).',
-    )
-    parser.add_argument(
-        '-c',
-        '--chunk_size',
-        required=False,
-        type=int,
-        default=None,
-        help='Number of cells per dask chunk. Providing this (with or '
-        f'without --num_workers) enables dask. Defaults to '
-        f'{DEFAULT_CHUNK_SIZE} if dask is enabled via --num_workers '
-        'but --chunk_size is not given.',
-    )
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
-
-    use_dask = args.num_workers is not None or args.chunk_size is not None
 
     converter = MeshConverter()
 
@@ -177,11 +101,6 @@ def main():
     input_format = converter.detect_format(ds)
 
     ds_mpas = ds if input_format == 'mpaso' else converter.omega_to_mpas(ds)
-
-    # Only the small grid variables feed the reconstruction calculation.
-    # Restricting to those *before* loading/chunking anything means a
-    # production mesh's large state/tracer fields are never read.
-    mesh_ds = ds_mpas[_select_grid_vars(ds_mpas)]
 
     # Done reading -- close the input file before copying it below.
     ds.close()
@@ -195,36 +114,8 @@ def main():
     with _timed('copy input -> output'):
         shutil.copyfile(args.input_file, args.output_file)
 
-    if use_dask:
-        chunk_size = args.chunk_size or DEFAULT_CHUNK_SIZE
-        num_workers = args.num_workers or _default_num_workers()
-        dask_config: dict[str, str | int] = {
-            'scheduler': 'processes',
-            'multiprocessing.context': 'spawn',
-        }
-        if num_workers is not None:
-            dask_config['num_workers'] = num_workers
-
-        print(
-            f'dask config: scheduler={dask_config["scheduler"]!r}, '
-            f'num_workers={dask_config.get("num_workers", "(dask default)")}, '
-            f'multiprocessing.context='
-            f'{dask_config["multiprocessing.context"]!r}, '
-            f'chunk_size={chunk_size}'
-        )
-
-        dask_ctx = dask.config.set(**dask_config)
-
-        with _timed('dask setup + load/chunk'):
-            # Read meshg variable subset into memory before chunking.
-            mesh_ds = mesh_ds.load()
-            mesh_ds = mesh_ds.chunk({'nCells': chunk_size})
-    else:
-        dask_ctx = contextlib.nullcontext()
-
-    with _timed('compute_reconstruction_weights total'):
-        with dask_ctx:
-            weights_ds = compute_reconstruction_weights(mesh_ds)
+    # don't need _timed context manager b/c func prints its own timing info
+    weights_ds = compute_reconstruction_weights(ds_mpas)
 
     # Match the naming convention of the input file.
     if input_format == 'omega':

--- a/utils/omega/ctest/omega_ctest.py
+++ b/utils/omega/ctest/omega_ctest.py
@@ -128,9 +128,9 @@ def download_meshes(config):
     base_url = 'https://web.lcrc.anl.gov/public/e3sm/polaris/'
 
     files = [
-        'ocean.QU.240km.omega_vars.260518.nc',
+        'ocean.QU.240km.omega_vars.260807.nc',
         'PlanarPeriodic48x48.omega_vars.260518.nc',
-        'cosine_bell_icos480.omega_vars.260518.nc',
+        'cosine_bell_icos480.omega_vars.260807.nc',
     ]
 
     database_path = 'ocean/omega_ctest'


### PR DESCRIPTION
In #649 reconstruction weights were only added for visualization purposes, not generated during mesh creation. E3SM-Project/Omega#480 expects the reconstruction weights to present in spherical meshes. This PR add the weight generation to the `run` method of `SphericalBaseStep` and the `run` method of the`CullMeshStep`. Because the connectivity information changes in the  `CullMeshStep`, reconstruction weight must be re-computed after culling. Special attention has been paid to skip weight generation for the base mesh of unified meshes, because the land component can make use of the reconstruction weights. Given the high resolution of the land (relative to ocean) in unified meshes, computing the reconstruction weights for base mesh would results in *a lot* of extra computation. 

MPAS-Ocean cannot make use the these least square reconstruction coefficients. This PR introduces the conditional merging of the reconstruction weight variables into the Horizontal Mesh in the `Ocean` component **if** the model is Omega. Additionally, only spherical reconstruction weight have been validated for Omega so there is an additional check that the mesh being written is spherical (i.e. not planar). This later check can be removed once the planar reconstruction weight have been validated. 

Dropped the dask/multiprocessing parallelism from vector-reconstruction weight computation in favor of plain serial numpy/xarray: for meshes that fit in memory on a single compute node, dask chunking overhead outweighed any benefit, and testing showed serial numpy running 2-5x faster than the chunked/vectorized dask path. Also removed `xr.apply_ufunc`'s `vectorize=True` usage, since it falls back to a slow Python-level loop rather than true vectorized numpy broadcasting, and simplified `add_reconstruction_weights.py` accordingly, dropping the `-w`/`--num_workers` and `-c`/`--chunk_size` CLI options.

Also, as @philipwjones pointed out in E3SM-Project/Omega#480 the `nCellsReconstructEdges`/`nVertexReconstructVertex` variable names do not conform with MPAS standards. Those have been renamed to `nEdgesReconstructCell` and `nEdgesReconstructVertex`. 

Additionally the Omega variables have `Reconstruct` shortened to `Recon` to follow the standard in Omega. So: 
- `NCellsReconstructEdges` -> `NEdgesReconOnCell` (both shortening and fix order)
- `ReconstructWeightCell` -> `ReconWeightsCell`
- `ReconstructStencilCell` -> `ReconStencilCell`
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
