### PR TITLE
Fix Chrysalis compiler names in many places

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@ Checklist
 * [ ] User's Guide has been updated
 * [ ] Developer's Guide has been updated
 * [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
+* [ ] `docs/developers_guide/supported_machines.yaml` has been updated if machines, compilers or MPI libraries were added, removed or renamed
 * [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
 * [ ] `Testing` comment in the PR documents testing used to verify the changes
 * [ ] New tests have been added to a test suite

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,23 @@ These instructions apply to the whole repository unless a deeper
 - Prefer starting from the existing template instead of creating task
   documentation pages from scratch.
 
+## Supported machines
+
+- `docs/developers_guide/supported_machines.yaml` is the source of the
+  supported machine table in the Developer's Guide. Update it whenever
+  machines are added or removed, or compilers and MPI libraries are
+  added, removed, or renamed.
+- Keep it consistent with the machine config files in
+  `polaris/machines/`: the `mpi_<compiler>` options under `[deploy]`
+  define the valid compiler and MPI combinations, and the
+  `<compiler>_<mpi>_target` options under `[build]` define the
+  `mpas_target` values (use `null` for Omega-only combinations).
+- When a compiler is added or renamed, update every place it appears:
+  the machine config file in `polaris/machines/`,
+  `supported_machines.yaml`, the machine pages in both the User's and
+  Developer's Guides, and any `load_polaris_*.sh` examples in the
+  documentation and tutorials.
+
 ## Contracts
 
 - Treat `deploy.py` and `deploy/cli_spec.json` as contract files shared

--- a/docs/developers_guide/docs.md
+++ b/docs/developers_guide/docs.md
@@ -21,6 +21,12 @@ For examples, see:
 - {ref}`dev-ocean` in the Developer's Guide
 - {ref}`dev-ocean-baroclinic-channel` tasks in the Developer's Guide
 
+Similarly, each time a machine is added or removed, or a compiler or MPI
+library is added, removed or renamed, the pull request making the change must
+also update `docs/developers_guide/supported_machines.yaml`, from which the
+table of supported machines in the Developer's Guide is generated.  See
+{ref}`dev-supported-machines-yaml`.
+
 Documentation for each component in the User's guide should include a label
 with the name of the component:
 

--- a/docs/developers_guide/machines/chrysalis.md
+++ b/docs/developers_guide/machines/chrysalis.md
@@ -2,13 +2,13 @@
 
 # Chrysalis
 
-## oneapi-ifx
+## intel
 
 This is the default polaris compiler on Chrysalis.  If the environment has
 been set up properly (see {ref}`dev-conda-env`), you should be able to source:
 
 ```bash
-source load_polaris_chrysalis_oneapi-ifx_openmpi.sh
+source load_polaris_chrysalis_intel_openmpi.sh
 ```
 
 You cannot build standalone MPAS components with this compiler at this time.
@@ -27,12 +27,12 @@ Then, you can build the MPAS model with
 make [DEBUG=true] [OPENMP=true] [ALBANY=true] gfortran
 ```
 
-## intel
+## intel-classic
 
 If the environment has been set up properly, you should be able to source:
 
 ```bash
-source load_polaris_chrysalis_intel_openmpi.sh
+source load_polaris_chrysalis_intel-classic_openmpi.sh
 ```
 
 Then, you can build the MPAS model with
@@ -40,4 +40,3 @@ Then, you can build the MPAS model with
 ```bash
 make [DEBUG=true] [OPENMP=true] ifort
 ```
-

--- a/docs/developers_guide/machines/index.md
+++ b/docs/developers_guide/machines/index.md
@@ -20,7 +20,7 @@ Omega or an MPAS component and work with polaris.  Just source the script that
 should appear in the base of your polaris branch, e.g.:
 
 ```bash
-source load_polaris_chrysalis_oneapi-ifx_openmpi.sh
+source load_polaris_chrysalis_intel_openmpi.sh
 ```
 
 After loading this environment, you can set up tasks or suites, and

--- a/docs/developers_guide/machines/index.md
+++ b/docs/developers_guide/machines/index.md
@@ -46,7 +46,9 @@ perlmutter
 
 The following table lists all supported machine, model, and compiler
 combinations. The MPAS make target is only applicable for MPAS-Ocean and
-MPAS-Seaice builds.
+MPAS-Seaice builds.  It is generated from
+`docs/developers_guide/supported_machines.yaml` (see
+{ref}`dev-supported-machines-yaml`).
 
 ```{jinja} supported_machines
 | Machine | Model | Compiler | MPI | MPAS Make Target |
@@ -61,6 +63,50 @@ MPAS-Seaice builds.
 :::{note}
 MPAS components currently do not support Aurora in standalone builds.
 :::
+
+(dev-supported-machines-yaml)=
+
+### Keeping `supported_machines.yaml` Up to Date
+
+The table above is rendered at documentation build time from
+`docs/developers_guide/supported_machines.yaml`, so it is only as accurate as
+that file.  Keeping it current is a required part of any change that alters
+which machine, model, compiler, and MPI combinations Polaris supports:
+
+* **A machine is added or dropped** — add or remove the corresponding
+  `machines` entry (see {ref}`dev-adding-new-machines`).
+* **A compiler or MPI library is added or dropped** — add or remove the
+  corresponding `models` entries for that machine.
+* **A compiler is renamed** — HPC centers periodically rename their compiler
+  modules.  For example, on Chrysalis `oneapi-ifx` was renamed to `intel` and
+  the former `intel` was renamed to `intel-classic`.
+
+Each entry under `models` has these fields:
+
+| Field | Description |
+| --- | --- |
+| `model` | `Omega` or `MPAS` (MPAS-Ocean and MPAS-Seaice) |
+| `compiler` | the compiler name, as it appears in the load script |
+| `mpi` | the MPI library, as it appears in the load script |
+| `mpas_target` | the MPAS make target, or `null` for Omega |
+
+Keep these entries consistent with the machine's config file in
+`polaris/machines/`.  There, the `mpi_<compiler>` options in the `[deploy]`
+section determine which compiler and MPI combinations are valid, and the
+`<compiler>_<mpi>_target` options in the `[build]` section determine the
+`mpas_target` values.  A combination with no `<compiler>_<mpi>_target` option
+can only be used to build Omega, so it should use `mpas_target: null`.
+
+Renames and additions also need to be propagated to the rest of the
+documentation, since `supported_machines.yaml` is not the only place compilers
+appear:
+
+* the machine's page in the `toctree` above, which lists the load script and
+  MPAS make target for each compiler
+* the machine's page in the {ref}`machines` section of the User's Guide, which
+  duplicates the `[deploy]` section of the machine's config file
+* any `load_polaris_*.sh` examples elsewhere in the documentation, including
+  the tutorials
 
 (dev-other-machines)=
 

--- a/docs/developers_guide/supported_machines.yaml
+++ b/docs/developers_guide/supported_machines.yaml
@@ -14,7 +14,7 @@ machines:
   - name: chrysalis
     models:
       - model: MPAS
-        compiler: intel
+        compiler: intel-classic
         mpi: openmpi
         mpas_target: ifort
       - model: MPAS
@@ -22,7 +22,7 @@ machines:
         mpi: openmpi
         mpas_target: gfortran
       - model: Omega
-        compiler: oneapi-ifx
+        compiler: intel
         mpi: openmpi
         mpas_target: null
       - model: Omega
@@ -30,7 +30,7 @@ machines:
         mpi: openmpi
         mpas_target: null
       - model: Omega
-        compiler: intel
+        compiler: intel-classic
         mpi: openmpi
         mpas_target: null
 

--- a/docs/developers_guide/supported_machines.yaml
+++ b/docs/developers_guide/supported_machines.yaml
@@ -30,7 +30,7 @@ machines:
         mpi: openmpi
         mpas_target: null
       - model: Omega
-        compiler: intel-classic
+        compiler: null
         mpi: openmpi
         mpas_target: null
 

--- a/docs/developers_guide/updating_spack/adding_new_machines.md
+++ b/docs/developers_guide/updating_spack/adding_new_machines.md
@@ -1,3 +1,5 @@
+(dev-adding-new-machines)=
+
 # Adding a New Machine
 
 Support for a new HPC machine in Polaris requires coordinated updates
@@ -46,6 +48,25 @@ After updating `mache`, you'll need to:
    * If new versions of external tools are required, update the
      [`spack_for_mache_<version>`](testing/updating_spack_fork.md) branch of the
      [E3SM Spack fork](https://github.com/E3SM-Project/spack)
+
+3. **Add the machine to Polaris**
+
+   * Add a config file for the machine in `polaris/machines/`, with the
+     `[deploy]` options describing the supported compilers and their MPI
+     libraries and, for machines that support standalone MPAS builds, the
+     `[build]` make targets
+
+4. **Document the machine**
+
+   * Add a page for the machine to `docs/developers_guide/machines/` and one
+     to `docs/users_guide/machines/`, and add both to the `toctree` in the
+     corresponding `index.md`
+   * Add the machine to `docs/developers_guide/supported_machines.yaml`, with
+     one entry per supported model, compiler, and MPI combination.  This file
+     is the source of the supported machine table in the Developer's Guide and
+     must be updated whenever machines are added or removed, or compilers and
+     MPI libraries are added, removed, or renamed.  See
+     {ref}`dev-supported-machines-yaml`.
 
 ---
 

--- a/docs/developers_guide/updating_spack/testing/running_test_suites.md
+++ b/docs/developers_guide/updating_spack/testing/running_test_suites.md
@@ -10,7 +10,7 @@ the new environment.
 ## MPAS-Ocean: Running the `pr` Suite
 
 For each machine, compiler, and MPI combination (for example, on Chrysalis
-with Intel and OpenMPI):
+with `intel-classic` and OpenMPI):
 
 1. **Start a Clean Environment**
 
@@ -19,11 +19,11 @@ with Intel and OpenMPI):
 2. **Source the Load Script**
 
    ```bash
-   source load_polaris_chrysalis_intel_openmpi.sh
+   source load_polaris_chrysalis_intel-classic_openmpi.sh
    ```
 
-   *(Replace `chrysalis`, `intel`, and `openmpi` with your machine, compiler,
-   and MPI as appropriate. See {ref}`dev-supported-machines`.)*
+   *(Replace `chrysalis`, `intel-classic`, and `openmpi` with your machine,
+   compiler, and MPI as appropriate. See {ref}`dev-supported-machines`.)*
 
 3. **Set Up (and Auto-Build) the Suite**
 
@@ -32,7 +32,7 @@ with Intel and OpenMPI):
 
    ```bash
    polaris suite -c ocean -t pr --clean_build --model mpas-ocean\
-       -w /path/to/polaris_scratch/mpaso_pr_intel_openmpi
+       -w /path/to/polaris_scratch/mpaso_pr_intel-classic_openmpi
    ```
 
    Notes:
@@ -48,7 +48,7 @@ with Intel and OpenMPI):
 4. **Run the Suite**
 
    ```bash
-   cd /path/to/polaris_scratch/mpaso_pr_intel_openmpi
+   cd /path/to/polaris_scratch/mpaso_pr_intel-classic_openmpi
    sbatch job_script_pr.sh
    ```
 
@@ -64,7 +64,7 @@ with Intel and OpenMPI):
 ## Omega: Running CTests and `omega_pr` Suite
 
 For each machine, compiler, and MPI combination (for example, on Chrysalis
-with `oneapi-ifx` and OpenMPI):
+with `intel` and OpenMPI):
 
 1. **Start a Clean Environment**
 
@@ -73,7 +73,7 @@ with `oneapi-ifx` and OpenMPI):
 2. **Source the Load Script**
 
    ```bash
-   source load_polaris_chrysalis_oneapi-ifx_openmpi.sh
+   source load_polaris_chrysalis_intel_openmpi.sh
    ```
 
    *(Replace as appropriate for your configuration.)*
@@ -100,7 +100,7 @@ with `oneapi-ifx` and OpenMPI):
 
     ```bash
     polaris suite -c ocean -t omega_pr --model omega \
-          -w /path/to/polaris_scratch/omega_pr_oneapi_openmpi \
+          -w /path/to/polaris_scratch/omega_pr_intel_openmpi \
           -p /path/to/polaris_branch/build_omega/build_<machine>_<compiler>
     ```
 
@@ -116,7 +116,7 @@ with `oneapi-ifx` and OpenMPI):
 6. **Run the Suite**
 
    ```bash
-   cd /path/to/polaris_scratch/omega_pr_oneapi_openmpi
+   cd /path/to/polaris_scratch/omega_pr_intel_openmpi
    sbatch job_script_omega_pr.sh
    ```
 

--- a/docs/tutorials/dev_add_category_of_tasks/creating_category_of_tasks.md
+++ b/docs/tutorials/dev_add_category_of_tasks/creating_category_of_tasks.md
@@ -105,7 +105,7 @@ polaris list
 If you don't have access to the `polaris` command, you probably need to source
 the load script, something like:
 ``` bash
-source load_polaris_chrysalis_oneapi-ifx_openmpi.sh
+source load_polaris_chrysalis_intel_openmpi.sh
 ```
 
 If `polaris list` gives you import errors, something isn't quite hooked up

--- a/docs/tutorials/dev_add_category_of_tasks/getting_started.md
+++ b/docs/tutorials/dev_add_category_of_tasks/getting_started.md
@@ -35,10 +35,10 @@ deployment. If pixi is not already available, `./deploy.py` can install it.
 
 After setup, you should have a file named `load_polaris_*.sh`, where `*`
 depends on your Polaris version, machine, and compilers. For example, on
-Chrysalis, you might have `load_polaris_chrysalis_oneapi-ifx_openmpi.sh`:
+Chrysalis, you might have `load_polaris_chrysalis_intel_openmpi.sh`:
 
 ```bash
-source load_polaris_chrysalis_oneapi-ifx_openmpi.sh
+source load_polaris_chrysalis_intel_openmpi.sh
 ```
 
 Now, get the E3SM source code (used by Polaris to build MPAS-Ocean) via the

--- a/docs/users_guide/machines/chrysalis.md
+++ b/docs/users_guide/machines/chrysalis.md
@@ -24,10 +24,10 @@ polaris_envs = /lcrc/soft/climate/polaris/chrysalis/base
 [deploy]
 
 # the compiler set to use for system libraries and MPAS builds
-compiler = oneapi-ifx
+compiler = intel
 
 # the compiler to use to build software (e.g. ESMF and MOAB) with spack
-software_compiler = oneapi-ifx
+software_compiler = intel
 
 # the system MPI library to use for intel compiler
 mpi_intel = openmpi
@@ -35,8 +35,8 @@ mpi_intel = openmpi
 # the system MPI library to use for gnu compiler
 mpi_gnu = openmpi
 
-# the system MPI library to use for oneapi-ifx compiler
-mpi_oneapi_ifx = openmpi
+# the system MPI library to use for intel-classic compiler
+mpi_intel_classic = openmpi
 
 # the base path for spack environments used by polaris
 spack = /lcrc/soft/climate/polaris/chrysalis/spack

--- a/docs/users_guide/machines/index.md
+++ b/docs/users_guide/machines/index.md
@@ -31,10 +31,10 @@ polaris_envs = /lcrc/soft/climate/polaris/chrysalis/base
 [deploy]
 
 # the compiler set to use for system libraries and MPAS builds
-compiler = oneapi-ifx
+compiler = intel
 
 # the compiler to use to build software (e.g. ESMF and MOAB) with spack
-software_compiler = oneapi-ifx
+software_compiler = intel
 
 # the system MPI library to use for intel compiler
 mpi_intel = openmpi
@@ -42,8 +42,8 @@ mpi_intel = openmpi
 # the system MPI library to use for gnu compiler
 mpi_gnu = openmpi
 
-# the system MPI library to use for oneapi-ifx compiler
-mpi_oneapi_ifx = openmpi
+# the system MPI library to use for intel-classic compiler
+mpi_intel_classic = openmpi
 
 # the base path for spack environments used by polaris
 spack = /lcrc/soft/climate/polaris/chrysalis/spack

--- a/utils/matrix/setup_matrix.py
+++ b/utils/matrix/setup_matrix.py
@@ -11,8 +11,7 @@ from shared import check_call, get_logger
 # https://mpas-dev.github.io/polaris/latest/developers_guide/machines/index.html#supported-machines
 all_build_targets = {
     'chrysalis': {
-        ('intel', 'impi'): 'intel-mpi',
-        ('intel', 'openmpi'): 'ifort',
+        ('intel-classic', 'openmpi'): 'ifort',
         ('gnu', 'openmpi'): 'gfortran',
     },
     'frontier': {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

On Chrysalis, `oneapi-ifx` has been renamed to `intel` and the former `intel` compiler has been renamed to `intel-classic`.  The machine config file `polaris/machines/chrysalis.cfg` was already updated but the docs (and the `utils/matrix` build targets) still used the old names.

Also drop the stale `intel`/`impi` build target from `utils/matrix`, since Chrysalis no longer supports Intel MPI in `chrysalis.cfg`.

I'm also adding instructions about keeping `supported_machines.yaml` up to date, partly as a reminder to myself.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
