### PR TITLE
Fix the single-column tasks by splitting the initial state from the forcing

### DIFF
--- a/docs/developers_guide/ocean/tasks/single_column.md
+++ b/docs/developers_guide/ocean/tasks/single_column.md
@@ -68,6 +68,13 @@ A forcing netCDF file is also created based on the config options given in the
 | `evaporation_flux`, `rain_flux` | Surface freshwater fluxes |
 | `wind_stress_zonal`, `wind_stress_meridional` | Wind stress values |
 
+The forcing file holds only these forcing fields and the initial condition
+holds only the initial state, so both ocean models read their forcing from
+`forcing.nc`.  The one exception is Omega's `TracersMonthlySurfClimoCell`,
+the surface restoring climatology, which Omega registers as an auxiliary
+state variable rather than a member of its `Forcing` group and reads from
+the initial condition.
+
 ### forward
 
 The class {py:class}`polaris.tasks.ocean.single_column.forward.Forward`

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -641,7 +641,6 @@ class Ocean(Component):
             and 'PseudoThickness' in ds.keys()
             and 'SpecVol' in ds.keys()
         ):
-            print('call geom_thickness_from_ds')
             ds['layerThickness'] = geom_thickness_from_ds(ds, config=config)
         if (
             self.model == 'omega'

--- a/polaris/tasks/ocean/single_column/ekman/forward.yaml
+++ b/polaris/tasks/ocean/single_column/ekman/forward.yaml
@@ -30,7 +30,7 @@ mpas-ocean:
   streams:
     forcing_data:
       type: input
-      filename_template: init.nc
+      filename_template: forcing.nc
       input_interval: initial_only
       contents:
       - windStressZonal

--- a/polaris/tasks/ocean/single_column/ekman/forward.yaml
+++ b/polaris/tasks/ocean/single_column/ekman/forward.yaml
@@ -73,6 +73,12 @@ Omega:
       Contents:
       - State
       - GeomZMid
+      # Tracers supplies Temperature and Salinity, and Eos supplies the
+      # SpecVol that layerThickness is derived from, as the baseline
+      # comparison for this task requires.  Eos also lets the analysis step
+      # use the model's own specific volume rather than a reference density
+      - Tracers
+      - Eos
     Forcing:
       UsePointerFile: false
       Filename: forcing.nc

--- a/polaris/tasks/ocean/single_column/inertial/forward.yaml
+++ b/polaris/tasks/ocean/single_column/inertial/forward.yaml
@@ -27,3 +27,8 @@ Omega:
       Contents:
       - State
       - GeomZMid
+      # Tracers supplies Temperature and Salinity, and Eos supplies the
+      # SpecVol that layerThickness is derived from, as the baseline
+      # comparison for this task requires
+      - Tracers
+      - Eos

--- a/polaris/tasks/ocean/single_column/init.py
+++ b/polaris/tasks/ocean/single_column/init.py
@@ -234,16 +234,19 @@ class Init(OceanIOStep):
         ds_forcing['icebergFreshWaterFlux'] = (
             iceberg_flux * forcing_array_surface
         )
-        # In Omega, TracersMonthlySurfClimoCell belongs to the AuxiliaryState
-        # field group, not the Forcing group, and the Forcing stream is read
-        # before the auxiliary state fields are registered.  It therefore has
-        # to travel with the initial state rather than with the forcing.
-        restoring_values = np.zeros((2, ds.sizes['nCells']))
-        restoring_values[0, :] = temperature_surface_restoring_value
-        restoring_values[1, :] = salinity_surface_restoring_value
-        ds['TracersMonthlySurfClimoCell'] = xr.DataArray(
-            restoring_values[np.newaxis, :, :],
-            dims=('time', 'NTracers', 'NCells'),
-        )
+        # TracersMonthlySurfClimoCell is an Omega field with no MPAS-Ocean
+        # equivalent, and it carries Omega dimension names, so it is only
+        # written for Omega.  It belongs to Omega's AuxiliaryState field
+        # group, not the Forcing group, and the Forcing stream is read before
+        # the auxiliary state fields are registered.  It therefore has to
+        # travel with the initial state rather than with the forcing.
+        if config.get('ocean', 'model') == 'omega':
+            restoring_values = np.zeros((2, ds.sizes['nCells']))
+            restoring_values[0, :] = temperature_surface_restoring_value
+            restoring_values[1, :] = salinity_surface_restoring_value
+            ds['TracersMonthlySurfClimoCell'] = xr.DataArray(
+                restoring_values[np.newaxis, :, :],
+                dims=('time', 'NTracers', 'NCells'),
+            )
         self.write_initial_state_dataset(ds, 'init.nc', config)
         self.write_model_dataset(ds_forcing, 'forcing.nc', config)

--- a/polaris/tasks/ocean/single_column/init.py
+++ b/polaris/tasks/ocean/single_column/init.py
@@ -149,8 +149,9 @@ class Init(OceanIOStep):
 
         self.write_vert_coord_dataset(ds, 'vert_coord.nc', config)
 
-        # create forcing stream
-        ds_forcing = ds.copy()
+        # create the forcing dataset, which contains only forcing fields (the
+        # initial state stays in ``ds``)
+        ds_forcing = xr.Dataset()
         forcing_array = xr.ones_like(temperature)
         forcing_array_surface = xr.ones_like(ds.bottomDepth)
         forcing_array_surface = forcing_array_surface.expand_dims(
@@ -233,12 +234,16 @@ class Init(OceanIOStep):
         ds_forcing['icebergFreshWaterFlux'] = (
             iceberg_flux * forcing_array_surface
         )
-        restoring_values = np.zeros((2, ds_forcing.sizes['nCells']))
+        # In Omega, TracersMonthlySurfClimoCell belongs to the AuxiliaryState
+        # field group, not the Forcing group, and the Forcing stream is read
+        # before the auxiliary state fields are registered.  It therefore has
+        # to travel with the initial state rather than with the forcing.
+        restoring_values = np.zeros((2, ds.sizes['nCells']))
         restoring_values[0, :] = temperature_surface_restoring_value
         restoring_values[1, :] = salinity_surface_restoring_value
-        ds_forcing['TracersMonthlySurfClimoCell'] = xr.DataArray(
+        ds['TracersMonthlySurfClimoCell'] = xr.DataArray(
             restoring_values[np.newaxis, :, :],
             dims=('time', 'NTracers', 'NCells'),
         )
-        self.write_initial_state_dataset(ds_forcing, 'init.nc', config)
+        self.write_initial_state_dataset(ds, 'init.nc', config)
         self.write_model_dataset(ds_forcing, 'forcing.nc', config)

--- a/tests/ocean/single_column/test_init.py
+++ b/tests/ocean/single_column/test_init.py
@@ -1,0 +1,134 @@
+"""
+Tests that the single-column init step keeps the initial state and the
+forcing in separate files.
+
+The step is run for real (it builds a tiny 4x4 mesh with a handful of
+vertical levels), since the split only shows up in the files it writes.
+"""
+
+import logging
+import os
+
+import pytest
+import xarray as xr
+
+from polaris.config import PolarisConfigParser
+from polaris.tasks.ocean import Ocean
+from polaris.tasks.ocean.single_column.init import Init
+
+# fields the model reads as forcing, in MPAS-Ocean and Omega names
+FORCING_VARS = {
+    'mpas-ocean': ['windStressZonal', 'windStressMeridional'],
+    'omega': ['SfcStressZonal', 'SfcStressMeridional'],
+}
+
+# initial-state fields, which belong in the initial condition alone
+STATE_VARS = {
+    'mpas-ocean': [
+        'temperature',
+        'salinity',
+        'layerThickness',
+        'normalVelocity',
+    ],
+    'omega': [
+        'Temperature',
+        'Salinity',
+        'PseudoThickness',
+        'SurfacePressure',
+        'NormalVelocity',
+    ],
+}
+
+# vertical coordinate fields, which Omega reads from its own file
+VERT_COORD_VARS = {
+    'mpas-ocean': ['bottomDepth', 'restingThickness'],
+    'omega': ['BottomGeomDepth', 'RefPseudoThickness'],
+}
+
+
+def _make_config(model):
+    config = PolarisConfigParser()
+    config.add_from_package('polaris', 'default.cfg')
+    config.add_from_package('polaris.ocean', 'ocean.cfg')
+    config.add_from_package(
+        'polaris.tasks.ocean.single_column', 'single_column.cfg'
+    )
+    # the wind stress is what the ekman task reads from the forcing file
+    config.add_from_package('polaris.tasks.ocean.single_column', 'wind.cfg')
+    # the single-column tasks all use a linear equation of state
+    config.add_from_package('polaris.ocean.eos', 'linear.cfg')
+    config.set('ocean', 'model', model)
+    # keep the test cheap; the split does not depend on the vertical grid
+    config.set('vertical_grid', 'vert_levels', '4')
+    return config
+
+
+@pytest.fixture(scope='module', params=['mpas-ocean', 'omega'])
+def init_outputs(request, tmp_path_factory):
+    """Run the init step once per model and return the model name and the
+    directory the step wrote its files to."""
+    model = request.param
+
+    component = Ocean()
+    component.model = model
+    component._read_variables_yaml()
+    if model == 'omega':
+        component._read_var_map()
+
+    step = Init(component=component, subdir='init')
+    step.config = _make_config(model)
+    step.logger = logging.getLogger(f'single_column_init_{model}')
+
+    workdir = tmp_path_factory.mktemp(f'single_column_init_{model}')
+    cwd = os.getcwd()
+    os.chdir(workdir)
+    try:
+        step.run()
+    finally:
+        os.chdir(cwd)
+
+    return model, workdir
+
+
+def test_forcing_file_has_only_forcing(init_outputs):
+    """The forcing file must not carry the mesh, the vertical coordinate or
+    the model state.  For Omega, a layer thickness in the forcing dataset
+    would send write_model_dataset() looking for a surface pressure that
+    only the initial state has."""
+    model, workdir = init_outputs
+
+    with xr.open_dataset(workdir / 'forcing.nc') as ds_forcing:
+        for var in FORCING_VARS[model]:
+            assert var in ds_forcing
+        for var in STATE_VARS[model] + VERT_COORD_VARS[model]:
+            assert var not in ds_forcing
+        # a horizontal mesh variable stands in for the mesh as a whole
+        assert 'xCell' not in ds_forcing
+
+
+def test_initial_state_file_has_no_forcing(init_outputs):
+    """The forcing fields belong in the forcing file alone, and the state
+    fields in the initial condition."""
+    model, workdir = init_outputs
+
+    with xr.open_dataset(workdir / 'init.nc') as ds_init:
+        for var in FORCING_VARS[model]:
+            assert var not in ds_init
+        assert 'temperatureSurfaceRestoringValue' not in ds_init
+        for var in STATE_VARS[model]:
+            assert var in ds_init
+
+
+def test_surface_restoring_climatology_goes_with_the_initial_state(
+    init_outputs,
+):
+    """In Omega, TracersMonthlySurfClimoCell is an auxiliary state variable
+    registered in the AuxiliaryState field group, and the Forcing stream is
+    read before those fields are defined.  It has to travel with the initial
+    state, not with the forcing."""
+    _, workdir = init_outputs
+
+    with xr.open_dataset(workdir / 'init.nc') as ds_init:
+        assert 'TracersMonthlySurfClimoCell' in ds_init
+    with xr.open_dataset(workdir / 'forcing.nc') as ds_forcing:
+        assert 'TracersMonthlySurfClimoCell' not in ds_forcing

--- a/tests/ocean/single_column/test_init.py
+++ b/tests/ocean/single_column/test_init.py
@@ -125,10 +125,11 @@ def test_surface_restoring_climatology_goes_with_the_initial_state(
     """In Omega, TracersMonthlySurfClimoCell is an auxiliary state variable
     registered in the AuxiliaryState field group, and the Forcing stream is
     read before those fields are defined.  It has to travel with the initial
-    state, not with the forcing."""
-    _, workdir = init_outputs
+    state, not with the forcing.  It has no MPAS-Ocean equivalent, so it is
+    not written at all for MPAS-Ocean."""
+    model, workdir = init_outputs
 
     with xr.open_dataset(workdir / 'init.nc') as ds_init:
-        assert 'TracersMonthlySurfClimoCell' in ds_init
+        assert ('TracersMonthlySurfClimoCell' in ds_init) == (model == 'omega')
     with xr.open_dataset(workdir / 'forcing.nc') as ds_forcing:
         assert 'TracersMonthlySurfClimoCell' not in ds_forcing

--- a/tests/ocean/single_column/test_output_streams.py
+++ b/tests/ocean/single_column/test_output_streams.py
@@ -1,0 +1,75 @@
+"""
+Tests that each single-column forward step writes the variables it validates
+against a baseline.
+
+A variable that a step lists in ``validate_vars`` but never writes to
+``output.nc`` makes the baseline comparison fail no matter what the model
+computes, so the two have to be kept in step with one another.
+"""
+
+from polaris.tasks.ocean import Ocean
+from polaris.tasks.ocean.single_column import add_single_column_tasks
+from polaris.yaml import PolarisYaml
+
+# Omega field groups that supply each MPAS-Ocean variable name a step may
+# validate.  layerThickness is not an Omega field of its own: it is derived
+# in open_model_dataset() from PseudoThickness, which the State group
+# supplies, and SpecVol, which the Eos group supplies.
+REQUIRED_GROUPS = {
+    'temperature': ['Tracers'],
+    'salinity': ['Tracers'],
+    'normalVelocity': ['State'],
+    'layerThickness': ['State', 'Eos'],
+}
+
+
+def _omega_history_contents(step):
+    """Return the Omega History stream contents a step's yaml files ask for,
+    or None if none of them define a History stream."""
+    contents = None
+    for entry in step.model_config_data:
+        yaml_filename = entry.get('yaml')
+        if yaml_filename is None:
+            continue
+        yaml = PolarisYaml.read(
+            filename=yaml_filename,
+            package=entry['package'],
+            model='Omega',
+            streams_section='IOStreams',
+        )
+        history = yaml.streams.get('History')
+        if history is None:
+            continue
+        if contents is None:
+            contents = []
+        contents.extend(history.get('Contents', []))
+    return contents
+
+
+def test_omega_history_supplies_the_validated_variables():
+    """Tasks without an Omega History stream are not run with Omega and are
+    skipped; the rest have to write what they validate."""
+    component = Ocean()
+    add_single_column_tasks(component)
+
+    checked = 0
+    for subdir, task in component.tasks.items():
+        for step_name, step in task.steps.items():
+            validate_vars = getattr(step, 'validate_vars', None)
+            if not validate_vars:
+                continue
+            contents = _omega_history_contents(step)
+            if contents is None:
+                continue
+            for variables in validate_vars.values():
+                for variable in variables:
+                    for group in REQUIRED_GROUPS.get(variable, []):
+                        assert group in contents, (
+                            f'{subdir}/{step_name} validates {variable} but '
+                            f'its Omega History stream does not include the '
+                            f'{group} group'
+                        )
+                        checked += 1
+
+    # guard against the loop silently checking nothing
+    assert checked > 0


### PR DESCRIPTION
After #435 was merged, all four single-column tasks fail in their `init` step for Omega with `ValueError: pseudothickness_from_ds() requires SurfacePressure in the dataset or an explicit surf_pressure argument.` The PR was tested without a test merge with `main`, so the interaction with the p-star work was missed.

The step built its forcing dataset as a full copy of the initial-condition dataset, so `forcing.nc` carried the mesh, the vertical coordinate and the model state, and `init.nc` carried the forcing fields. Because `layerThickness` was present, writing `forcing.nc` for Omega tried to convert it to `PseudoThickness`, which now needs a surface pressure. `write_initial_state_dataset()` adds `SurfacePressure` to its own copy of the dataset, so the copy the step still held never gained one.

This branch builds the forcing dataset from an empty `xarray.Dataset`, as `barotropic_gyre` and `barotropic_channel` already do, so the two files no longer overlap:

- `init.nc` holds only the initial state, and is bit-identical to before apart from no longer carrying the forcing fields.
- `forcing.nc` holds only forcing, so no thickness conversion is attempted and both models read their forcing from it. MPAS-Ocean's `forcing_data` stream for the ekman task is pointed at `forcing.nc`, since the wind stress it reads no longer lives in `init.nc`.
- `TracersMonthlySurfClimoCell` stays with the initial state and is now written only for Omega. It is an Omega auxiliary state variable in the `AuxiliaryState` field group rather than the `Forcing` group, and `Forcing::init()` reads the `Forcing` stream before `AuxiliaryState::init()` defines the field, so a `Forcing` stream naming it would abort in `IOStream::validate()`.

It also fixes a second problem that kept the column tasks from comparing against a baseline. The `inertial` and `ekman` tasks validate `temperature`, `salinity`, `layerThickness` and `normalVelocity`, but their Omega `History` streams asked only for the `State` group and `GeomZMid`. Omega's `State` group holds `NormalVelocity`, `PseudoThickness` and `SurfacePressure`, so three of the four were absent from `output.nc` and the comparison failed regardless of what the model computed. Both streams now also ask for `Tracers` and `Eos`, as `vmix` already did. This is Omega-only; MPAS-Ocean's `output` stream carries all four.

Also removes a debug `print()` left behind in `open_model_dataset()` by the commit that stopped mapping `layerThickness` to `GeomLayerThickness` outside of that function.

## Testing

New unit tests run the init step for both models on a tiny mesh and check that the forcing file carries only forcing, that the initial condition carries only the initial state, and that the surface restoring climatology is written only for Omega. Another checks that every single-column forward step's Omega `History` stream includes the field groups needed to supply the variables it validates. All of them fail on `main` and pass here, and the full `pytest tests/` suite passes.

Not fixed here: `ocean/column/ekman` fails its own analysis step with `L2 norm of normal velocity 1.7e+00 exceeds tolerance 3.0e-14`. This is pre-existing — the same value appears on other branches — and needs its own look at whether the tolerance or the solution is wrong.

Omega results are unchanged by this branch: `init.nc` is bit-identical, `vert_coord.nc` goes through an unchanged code path, and Omega's `Forcing` stream reads only `SfcStressZonal` and `SfcStressMeridional`, whose values are the same.

Checklist
* [x] Developer's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

Fixes #690 