### PR TITLE
Fix IO tasks and stride for runs on GPUs

### DIFF
--- a/docs/developers_guide/framework/model.md
+++ b/docs/developers_guide/framework/model.md
@@ -410,6 +410,14 @@ default.  When running with PIO v2, we have found little performance difference
 between the MPAS default and the polaris default of one task per node, so we
 feel this is a safe default.
 
+The number of MPI tasks that land on each node (and therefore the stride
+between IO tasks) comes from the machine's resources in
+[mache](https://github.com/E3SM-Project/mache) -- `cores_per_node`,
+`gpus_per_node` and `max_mpi_tasks_per_node` -- combined with the
+`cpus_per_task` and `gpus_per_task` the step requests.  On GPU builds, where
+there is typically one MPI task per GPU, the stride is the number of GPUs per
+node rather than the number of CPU cores per node.
+
 For Omega runs, these same MPAS options are mapped to `Omega/IO/IOTasks` and
 `Omega/IO/IOStride` in yaml config files.
 

--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -602,8 +602,15 @@ class ModelStep(Step):
     def update_io_tasks_config(self, config_model=None):
         """
         Modify model config options so the number of IO tasks and the stride
-        between them are consistent with the number of nodes and cores (one
-        IO task per node).
+        between them are consistent with how MPI tasks are distributed across
+        nodes (one IO task per node).
+
+        The number of tasks per node is based on the machine's resources from
+        mache (cores and GPUs per node, and the maximum MPI tasks per node)
+        together with the CPUs and GPUs this step requests per task.  In
+        particular, on GPU-enabled builds where there is typically one task
+        per GPU, the stride is the number of GPUs per node rather than the
+        number of CPU cores per node.
 
         This updates MPAS-Ocean namelist options directly.  For Omega runs,
         ``OceanModelStep`` maps these MPAS options to Omega yaml config
@@ -615,27 +622,12 @@ class ModelStep(Step):
             If config options are available for multiple models, the model
             that the config options are from.
         """
-        cores = self.ntasks * self.cpus_per_task
+        tasks_per_node = self._get_tasks_per_node()
 
-        parallel_system = self.component.parallel_system
-        if parallel_system is None:
-            raise ValueError(
-                f'Parallel system has not been set for component '
-                f'{self.component.name}'
-            )
-        cores_per_node = parallel_system.get_config_int('cores_per_node')
-        if cores_per_node is None:
-            raise ValueError('cores_per_node must be set in parallel config')
-
-        # update IO tasks based on machine settings and the available cores
-        pio_num_iotasks = int(np.ceil(cores / cores_per_node))
+        # update IO tasks based on how tasks are distributed across nodes
+        # (one IO task per node)
+        pio_num_iotasks = int(np.ceil(self.ntasks / tasks_per_node))
         pio_stride = self.ntasks // pio_num_iotasks
-        if pio_stride > cores_per_node:
-            raise ValueError(
-                f'Not enough nodes for the number of cores.  '
-                f'cores: {cores}, cores per node: '
-                f'{cores_per_node}'
-            )
 
         replacements = {
             'config_pio_num_iotasks': pio_num_iotasks,
@@ -649,6 +641,60 @@ class ModelStep(Step):
     def update_namelist_pio(self, config_model=None):
         """Deprecated alias for :py:meth:`update_io_tasks_config`."""
         self.update_io_tasks_config(config_model=config_model)
+
+    def _get_tasks_per_node(self):
+        """
+        Get the number of MPI tasks that will be placed on each node, based on
+        the machine's resources (from mache) and the resources this step
+        requests per task.
+
+        Returns
+        -------
+        tasks_per_node : int
+            The number of MPI tasks per node
+        """
+        parallel_system = self.component.parallel_system
+        if parallel_system is None:
+            raise ValueError(
+                f'Parallel system has not been set for component '
+                f'{self.component.name}'
+            )
+
+        cores_per_node = parallel_system.cores_per_node
+        if not cores_per_node:
+            raise ValueError('cores_per_node must be set in parallel config')
+
+        # how many tasks fit on a node given the CPUs each task needs
+        tasks_per_node = cores_per_node // self.cpus_per_task
+
+        # the machine (or the compiler-specific config for it) may allow fewer
+        # tasks per node than the cores alone would suggest, e.g. one task per
+        # GPU on GPU-enabled builds
+        max_tasks_per_node = parallel_system.get_config_int(
+            'max_mpi_tasks_per_node'
+        )
+        if max_tasks_per_node:
+            tasks_per_node = min(tasks_per_node, max_tasks_per_node)
+
+        # if this step requires GPUs, tasks are placed according to the GPUs
+        # available on each node, not the CPU cores
+        if self.gpus_per_task > 0:
+            gpus_per_node = parallel_system.gpus_per_node
+            if not gpus_per_node:
+                raise ValueError(
+                    f'Step {self.name} requests {self.gpus_per_task} GPUs per '
+                    f'task but gpus_per_node is not set in the parallel '
+                    f'config'
+                )
+            tasks_per_node = min(
+                tasks_per_node, gpus_per_node // self.gpus_per_task
+            )
+
+        # never more tasks per node than the step has in total, and always at
+        # least one
+        tasks_per_node = max(1, min(tasks_per_node, self.ntasks))
+
+        return tasks_per_node
 
     def partition(self, graph_file='graph.info'):
         """

--- a/tests/test_io_tasks.py
+++ b/tests/test_io_tasks.py
@@ -1,0 +1,206 @@
+from configparser import ConfigParser
+
+import pytest
+from mache.parallel import ParallelSystem
+
+from polaris import Component, ModelStep
+
+# resources taken from mache's frontier.cfg: the [parallel] section describes
+# the CPU-only compilers while [parallel.craygnu_mphipcc] describes a
+# GPU-enabled compiler with one MPI task per GPU
+FRONTIER_CORES_PER_NODE = 56
+FRONTIER_GPUS_PER_NODE = 8
+
+
+def _make_parallel_system(nodes, gpu_compiler):
+    """
+    Build a parallel system with Frontier's resources, as
+    ``SlurmSystem.__init__()`` would if we were in a job on that machine
+    """
+    config = ConfigParser()
+    config.add_section('parallel')
+    config.set('parallel', 'system', 'slurm')
+    config.set('parallel', 'cores_per_node', f'{FRONTIER_CORES_PER_NODE}')
+    config.set(
+        'parallel', 'max_mpi_tasks_per_node', f'{FRONTIER_CORES_PER_NODE}'
+    )
+    config.set('parallel', 'gpus_per_node', '0')
+
+    config.add_section('parallel.craygnu_mphipcc')
+    config.set(
+        'parallel.craygnu_mphipcc',
+        'max_mpi_tasks_per_node',
+        f'{FRONTIER_GPUS_PER_NODE}',
+    )
+    config.set(
+        'parallel.craygnu_mphipcc',
+        'gpus_per_node',
+        f'{FRONTIER_GPUS_PER_NODE}',
+    )
+
+    config.add_section('build')
+    compiler = 'craygnu-mphipcc' if gpu_compiler else 'craygnu'
+    config.set('build', 'compiler', compiler)
+
+    parallel_system = ParallelSystem(config)
+    parallel_system.nodes = nodes
+    parallel_system.cores_per_node = parallel_system.get_config_int(
+        'cores_per_node'
+    )
+    parallel_system.cores = parallel_system.cores_per_node * nodes
+    parallel_system.gpus_per_node = parallel_system.get_config_int(
+        'gpus_per_node'
+    )
+    parallel_system.gpus = parallel_system.gpus_per_node * nodes
+    parallel_system.mpi_allowed = True
+    return parallel_system
+
+
+def _make_step(
+    nodes,
+    ntasks,
+    cpus_per_task=1,
+    gpus_per_task=0,
+    gpu_compiler=False,
+):
+    component = Component(name='ocean')
+    component.parallel_system = _make_parallel_system(
+        nodes=nodes, gpu_compiler=gpu_compiler
+    )
+    # ModelStep uses openmp_threads as cpus_per_task
+    return ModelStep(
+        component=component,
+        name='forward',
+        ntasks=ntasks,
+        min_tasks=ntasks,
+        openmp_threads=cpus_per_task,
+        gpus_per_task=gpus_per_task,
+    )
+
+
+def _get_io_options(step):
+    """Get the options passed to add_model_config_options"""
+    assert len(step.model_config_data) == 1
+    return step.model_config_data[0]['options']
+
+
+def test_gpu_one_io_task_per_node():
+    """
+    On 19 GPU nodes with one MPI task per GPU, there should be one IO task
+    per node and a stride of one node's worth of tasks (the GPUs per node,
+    not the cores per node)
+    """
+    step = _make_step(
+        nodes=19,
+        ntasks=19 * FRONTIER_GPUS_PER_NODE,
+        gpus_per_task=1,
+        gpu_compiler=True,
+    )
+    step.update_io_tasks_config()
+    assert _get_io_options(step) == {
+        'config_pio_num_iotasks': 19,
+        'config_pio_stride': FRONTIER_GPUS_PER_NODE,
+    }
+
+
+@pytest.mark.parametrize('nodes', [1, 2, 5, 19, 64])
+def test_gpu_io_tasks_fit_within_ntasks(nodes):
+    """
+    The IO tasks must fit within the tasks the GPU step is running on, with
+    at most one IO task per node
+    """
+    ntasks = nodes * FRONTIER_GPUS_PER_NODE
+    step = _make_step(
+        nodes=nodes, ntasks=ntasks, gpus_per_task=1, gpu_compiler=True
+    )
+    step.update_io_tasks_config()
+    options = _get_io_options(step)
+    num_iotasks = options['config_pio_num_iotasks']
+    stride = options['config_pio_stride']
+    assert num_iotasks == nodes
+    assert stride <= FRONTIER_GPUS_PER_NODE
+    # the last IO task must be a rank that actually exists
+    assert (num_iotasks - 1) * stride < ntasks
+
+
+def test_gpu_partially_filled_last_node():
+    """
+    When the tasks don't fill the last node, the IO tasks must still be valid
+    ranks
+    """
+    ntasks = 150
+    step = _make_step(
+        nodes=19, ntasks=ntasks, gpus_per_task=1, gpu_compiler=True
+    )
+    step.update_io_tasks_config()
+    options = _get_io_options(step)
+    num_iotasks = options['config_pio_num_iotasks']
+    stride = options['config_pio_stride']
+    assert num_iotasks == 19
+    assert (num_iotasks - 1) * stride < ntasks
+
+
+def test_gpu_single_task():
+    step = _make_step(nodes=1, ntasks=1, gpus_per_task=1, gpu_compiler=True)
+    step.update_io_tasks_config()
+    assert _get_io_options(step) == {
+        'config_pio_num_iotasks': 1,
+        'config_pio_stride': 1,
+    }
+
+
+def test_gpu_two_gpus_per_task():
+    """
+    With 2 GPUs per task, only 4 tasks fit on each of Frontier's 8-GPU nodes
+    """
+    step = _make_step(nodes=3, ntasks=12, gpus_per_task=2, gpu_compiler=True)
+    step.update_io_tasks_config()
+    assert _get_io_options(step) == {
+        'config_pio_num_iotasks': 3,
+        'config_pio_stride': 4,
+    }
+
+
+def test_gpu_without_gpus_available_raises():
+    step = _make_step(nodes=2, ntasks=8, gpus_per_task=1, gpu_compiler=False)
+    with pytest.raises(ValueError, match='gpus_per_node is not set'):
+        step.update_io_tasks_config()
+
+
+@pytest.mark.parametrize(
+    'nodes,ntasks,cpus_per_task,expected_num_iotasks,expected_stride',
+    [
+        # one full CPU node
+        (1, FRONTIER_CORES_PER_NODE, 1, 1, FRONTIER_CORES_PER_NODE),
+        # two full CPU nodes
+        (2, 2 * FRONTIER_CORES_PER_NODE, 1, 2, FRONTIER_CORES_PER_NODE),
+        # fewer tasks than a full node
+        (1, 4, 1, 1, 4),
+        # 4 CPUs per task means only 14 tasks fit on each 56-core node
+        (2, 28, 4, 2, 14),
+    ],
+)
+def test_cpu_io_tasks(
+    nodes, ntasks, cpus_per_task, expected_num_iotasks, expected_stride
+):
+    """CPU-only behavior must be unchanged by the GPU-aware task placement"""
+    step = _make_step(
+        nodes=nodes,
+        ntasks=ntasks,
+        cpus_per_task=cpus_per_task,
+        gpu_compiler=False,
+    )
+    step.update_io_tasks_config()
+    assert _get_io_options(step) == {
+        'config_pio_num_iotasks': expected_num_iotasks,
+        'config_pio_stride': expected_stride,
+    }
+
+
+def test_no_parallel_system_raises():
+    component = Component(name='ocean')
+    step = ModelStep(
+        component=component, name='forward', ntasks=1, openmp_threads=1
+    )
+    with pytest.raises(ValueError, match='Parallel system has not been set'):
+        step.update_io_tasks_config()


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Polaris sets the number of PIO tasks and the stride between them so that there is one IO task per node. On GPU runs, it was computing both from the number of CPU cores per node, even though the run places one MPI task per GPU. The result was far too few IO tasks, spread with a stride that does not line up with node boundaries.

## Symptom

- On Frontier, a run on 19 nodes with 8 GPUs per node (152 MPI tasks) produced `IOTasks: 3` and `IOStride: 50` in the Omega config.
- The correct values for one IO task per node are `IOTasks: 19` and `IOStride: 8`.
- The same problem affects MPAS-Ocean's `config_pio_num_iotasks` and `config_pio_stride` on any GPU build, not just Omega.
- CPU-only runs were never affected.

## Cause

- The IO task count was `ceil(cores / cores_per_node)`, using the CPU cores per node (56 on Frontier) rather than the MPI tasks that actually land on each node (8, one per GPU).
- Because a GPU run has far fewer MPI tasks than CPU cores, this undercounted the nodes by roughly the ratio of cores per node to GPUs per node, and the stride was then stretched to compensate.

## Fix

- Polaris now works out how many MPI tasks land on each node and uses that directly: one IO task per node, with the stride set to the tasks per node.
- The tasks per node account for the GPUs per node and the GPUs each task requests, the machine's maximum MPI tasks per node, and the CPUs each task requests.
- All of these values come from the machine's mache configuration, including the settings specific to the compiler being used, so GPU builds pick up their own GPU and task-per-node limits automatically.
- The stride is capped so that the last IO task is always a rank the run actually has, even when the final node is not completely filled.
- CPU-only runs produce exactly the same IO tasks and stride as before.

## Testing

- Adds `tests/test_io_tasks.py`, which checks the IO tasks and stride against Frontier's CPU and GPU resources.
- GPU cases cover the reported 19-node run, 1 through 64 nodes, a partially filled last node, a single task, 2 GPUs per task, and a step asking for GPUs on a machine that has none.
- CPU cases cover full nodes, a partial node, and more than one CPU per task.
- Eight of the tests fail on `main` and all 15 pass with this branch; the CPU cases pass both before and after, confirming CPU behavior is unchanged.
- The rest of the `tests/` suite is unaffected. Note that six errors in `tests/ocean/single_column/test_init.py` are present on `main` as well and are unrelated to this change.

## Still to verify

- The `IOTasks: 19` / `IOStride: 8` result has been confirmed by unit test but not yet by an actual Frontier GPU run.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
