### PR TITLE
Fix the pixi cache in Polaris CI workflows

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -86,10 +86,13 @@ jobs:
         uses: actions/cache@v6
         env:
           # Increase this value to reset cache if deploy inputs have not changed in the workflow
-          CACHE_NUMBER: 0
+          CACHE_NUMBER: 1
         with:
+          # cache the content-addressed package tarballs but deliberately not
+          # repodata, which must be refetched each run so a stale index can
+          # never persist across runs
           path: |
-            ~/.cache/rattler/cache
+            ${{ github.workspace }}/.pixi-cache/pkgs
             ~/.pixi/bin
           key: ${{ runner.os }}-${{ matrix.python-version }}-pixi-${{ env.CACHE_NUMBER }}-${{ hashFiles('deploy.py', 'deploy/**', 'pyproject.toml') }}
 

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -54,6 +54,10 @@ jobs:
     name: test polaris - py ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      # mache's bootstrap.py defaults this to a /tmp path that can't be cached
+      # between runs, so pin it to a stable, cacheable location
+      PIXI_CACHE_DIR: ${{ github.workspace }}/.pixi-cache
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -95,6 +95,11 @@ jobs:
             ${{ github.workspace }}/.pixi-cache/pkgs
             ~/.pixi/bin
           key: ${{ runner.os }}-${{ matrix.python-version }}-pixi-${{ env.CACHE_NUMBER }}-${{ hashFiles('deploy.py', 'deploy/**', 'pyproject.toml') }}
+          # a run whose deploy inputs changed can still reuse most tarballs
+          # from the previous key; a partially stale pkgs directory only costs
+          # a few extra downloads
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-pixi-${{ env.CACHE_NUMBER }}-
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install polaris

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -47,6 +47,11 @@ jobs:
             ${{ github.workspace }}/.pixi-cache/pkgs
             ~/.pixi/bin
           key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-pixi-${{ env.CACHE_NUMBER }}-${{ hashFiles('deploy.py', 'deploy/**', 'pyproject.toml') }}
+          # a run whose deploy inputs changed can still reuse most tarballs
+          # from the previous key; a partially stale pkgs directory only costs
+          # a few extra downloads
+          restore-keys: |
+            ${{ runner.os }}-${{ env.PYTHON_VERSION }}-pixi-${{ env.CACHE_NUMBER }}-
 
       - name: Install polaris
         run: |

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -15,6 +15,10 @@ env:
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
+    env:
+      # mache's bootstrap.py defaults this to a /tmp path that can't be cached
+      # between runs, so pin it to a stable, cacheable location
+      PIXI_CACHE_DIR: ${{ github.workspace }}/.pixi-cache
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -38,10 +38,13 @@ jobs:
         uses: actions/cache@v6
         env:
           # Increase this value to reset cache if deploy inputs have not changed in the workflow
-          CACHE_NUMBER: 0
+          CACHE_NUMBER: 1
         with:
+          # cache the content-addressed package tarballs but deliberately not
+          # repodata, which must be refetched each run so a stale index can
+          # never persist across runs
           path: |
-            ~/.cache/rattler/cache
+            ${{ github.workspace }}/.pixi-cache/pkgs
             ~/.pixi/bin
           key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-pixi-${{ env.CACHE_NUMBER }}-${{ hashFiles('deploy.py', 'deploy/**', 'pyproject.toml') }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ docs/_build/
 
 # pixi
 .pixi/
+.pixi-cache/
 pixi.lock
 pixi-env/
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

## Problem

- Both `build_workflow.yml` and `docs_workflow.yml` cache `~/.cache/rattler/cache`, a directory pixi never writes to.
- CI installs via `./deploy.py`, which runs mache's `bootstrap.py`; its `build_pixi_env()` sets `PIXI_CACHE_DIR` to `/tmp/pixi-cache-$USER` whenever the variable is unset, and no Polaris workflow set it.
- So the real cache lived at `/tmp/pixi-cache-runner` and was discarded with the runner, while the cache step preserved only `~/.pixi/bin` — every job re-downloaded every conda package on every run.
- Because nothing was cached, CI could not have been suffering from a stale-repodata cache of its own; the recent `mache ==3.11.0` failures came from upstream, and are out of scope here.

## Changes

- Set `PIXI_CACHE_DIR` to `${{ github.workspace }}/.pixi-cache` at the job level in both workflows, so the workflow and pixi agree on one location, and add `.pixi-cache/` to `.gitignore`.
- Cache `${{ github.workspace }}/.pixi-cache/pkgs` instead of `~/.cache/rattler/cache`; the package tarballs are the expensive part and are content-addressed, so reuse is always safe.
- Deliberately leave repodata out of the cached path: it is only a few MB per subdir, and caching it is what would let a stale index persist across runs.
- Bump `CACHE_NUMBER` from `0` to `1` so entries saved under the old key and layout are not restored.
- Add `restore-keys` on the `<os>-<python>-pixi-<n>-` prefix, so a run whose `deploy/**` hash changed still reuses the tarballs that are unaffected rather than re-downloading everything.

## Notes

- `pkgs` is never pruned, so partial restores let it accumulate tarballs no longer used by any environment; GitHub's 10 GB per-repo LRU bounds this, and bumping `CACHE_NUMBER` clears it if the saved caches start looking bloated.
- `${{ github.workspace }}` is wiped and re-checked-out per job, so the cache step must stay after checkout in both files.

## Testing

- CI-only change; there is nothing meaningful to validate locally.
- Expected in the Actions logs: a cache miss and a large save on the first run, then a hit on the second, with the second run still fetching repodata but not package tarballs.
- If the post-job step reports nothing to save, `PIXI_CACHE_DIR` is not reaching bootstrap.
- `pytest tests/` and the Sphinx build should be unaffected.
