### PR TITLE
Lower min threshold on `dcEdge` for `u.oi6to18.lr6to10`

### DIFF
--- a/docs/developers_guide/e3sm/init/tasks/topo/cull.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/cull.md
@@ -70,6 +70,19 @@ no sizing field and the check is skipped. The motivation, mechanisms and
 threshold justification are documented in the `unified_mesh_cull_leak`
 design doc (see {ref}`design-docs`).
 
+The thresholds come from `cull.cfg`, but a unified mesh can override them in
+its own `polaris/mesh/spherical/unified/<mesh_name>.cfg`, which is read after
+`cull.cfg` when the cull config is assembled.  `u.oi6to18.lr6to10` does this:
+one ocean-interior edge sits at 0.643 times the local ocean background width,
+so that mesh sets `min_dc_edge_ratio = 0.64` while every other mesh keeps the
+0.65 default.
+
+Prefer a per-mesh override to lowering the shared default, and prefer either
+to tolerating a number of violating edges.  A single fine edge constrains the
+global time step just as much as a cluster does, so the useful output of this
+diagnostic is the *lower bound* on edge size -- a count tolerance would hide
+exactly the number a forward run needs to size its time step from.
+
 The Antarctic land-ice ownership mask also includes southern cells that have
 already been removed from the open-ocean cull mask, so the cull workflow
 remains consistent with the remapped topography masks.

--- a/docs/users_guide/e3sm/init/tasks/topo.md
+++ b/docs/users_guide/e3sm/init/tasks/topo.md
@@ -130,4 +130,7 @@ Common user-tunable options are:
 	culled ocean/sea-ice domain.  The mask step fails if resolution intended for
 	the land/river domain has leaked into the CFL-limited ocean/sea-ice domain
 	(see the {ref}`design doc <design-docs>` `unified_mesh_cull_leak` for the
-	motivation and choice of defaults).
+	motivation and choice of defaults).  A mesh whose known minimum sits below
+	the default overrides these in its own unified-mesh config rather than
+	relaxing the default for every mesh; `u.oi6to18.lr6to10` sets
+	`min_dc_edge_ratio = 0.64` for a single edge at a ratio of 0.643.

--- a/polaris/mesh/spherical/unified/u.oi6to18.lr6to10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi6to18.lr6to10.cfg
@@ -54,3 +54,19 @@ coastline_transition_land_km = 36.0
 
 # Target cell width (km) along rasterized river channels
 river_channel_km = 6.0
+
+[cull_mesh]
+# This mesh's culled ocean/sea-ice domain contains a single edge at 0.643
+# times the local ocean background cell width (lon -97.15, lat 77.89, in the
+# Canadian Arctic Archipelago), just under the 0.65 default in
+# polaris/tasks/e3sm/init/topo/cull/cull.cfg.  The default is kept for every
+# other mesh; it is lowered here so that the known bound is recorded rather
+# than the guard being weakened everywhere.
+#
+# This is a real, if small, resolution leak, not jigsaw noise -- clean jigsaw
+# dcEdge noise bottoms out near 0.76 times the background.  A forward run on
+# this mesh must size its time step for a finest ocean edge of 0.643 times the
+# local ocean background, since one fine edge constrains the global CFL just
+# as much as a cluster would.  Raise this back toward 0.65 if the leak is
+# closed by a future sizing-field change.
+min_dc_edge_ratio = 0.64

--- a/tests/e3sm/init/topo/test_unified_tasks.py
+++ b/tests/e3sm/init/topo/test_unified_tasks.py
@@ -15,6 +15,7 @@ from polaris.tasks.mesh.base.steps import get_base_mesh_steps
 
 COARSE_MESH_NAME = 'u.oi240.lr240'
 FINE_MESH_NAME = 'u.oi30.lr10'
+LEAKY_MESH_NAME = 'u.oi6to18.lr6to10'
 
 
 def test_get_remap_topo_steps_includes_upstream_base_mesh_steps():
@@ -247,6 +248,37 @@ def test_coarse_unified_mesh_uses_ne120_topography():
     )
     assert cull_task.steps[combine_topo_step_name].subdir.endswith(
         'cubed_sphere/ne120'
+    )
+
+
+def test_cull_config_uses_the_default_dc_edge_floor():
+    """
+    The dcEdge floor is the CFL guard, so every mesh keeps the shared default
+    unless it has a documented reason not to.
+    """
+    _reset_shared_components()
+
+    _, config = get_cull_topo_steps(mesh_name=FINE_MESH_NAME)
+
+    assert config.getfloat('cull_mesh', 'min_dc_edge_ratio') == 0.65
+
+
+def test_leaky_mesh_overrides_the_dc_edge_floor():
+    """
+    u.oi6to18.lr6to10 has a single ocean-interior edge at 0.643 times the
+    local ocean background width, so its own config lowers the floor rather
+    than the shared default being weakened for every mesh.  A forward run on
+    this mesh has to size its time step for that edge.
+    """
+    _reset_shared_components()
+
+    _, config = get_cull_topo_steps(mesh_name=LEAKY_MESH_NAME)
+
+    override = config.getfloat('cull_mesh', 'min_dc_edge_ratio')
+    assert override == 0.64
+    assert override < 0.643, (
+        'the override has to sit below the measured minimum ratio for this '
+        'mesh, or the cull step fails again'
     )
 
 


### PR DESCRIPTION
The culled ocean/sea-ice domain of this mesh contains one edge at 0.643 times the local ocean background cell width, in the Canadian Arctic Archipelago, so CullMaskStep's dcEdge guard fails it against the 0.65 default.  The mesh passed this check when the guard was added in #672; it has since been regenerated under a different JIGSAW build, and the mesh-generation code is unchanged, so the difference is in the mesh rather than in the check.

Override the floor in this mesh's own config rather than lowering the shared default, so the guard keeps its full strength on every other mesh and this mesh's actual bound is written down.  The cull config already reads `<mesh_name>.cfg` after cull.cfg for exactly this purpose.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
