### PR TITLE
Raise the `dcEdge` floor in unified-mesh ocean/sea-ice domains

### DIFF
--- a/docs/design_docs/index.md
+++ b/docs/design_docs/index.md
@@ -16,6 +16,7 @@ unified_mesh_prepare_river_network
 unified_mesh_build_sizing_field
 unified_mesh_create_base_mesh
 unified_mesh_cull_leak
+unified_mesh_dc_edge_noise
 vector_reconstruction
 template
 ```

--- a/docs/design_docs/unified_mesh_dc_edge_noise.md
+++ b/docs/design_docs/unified_mesh_dc_edge_noise.md
@@ -1,0 +1,370 @@
+# Unified Mesh: Raising the dcEdge Floor in the Ocean/Sea-Ice Domain
+
+date: 2026/08/09
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+## Summary
+
+The shortest edge in a culled ocean/sea-ice domain sets the forward-run time
+step. On the unified meshes that edge was shorter than intended:
+`u.oi6to18.lr6to10` had a 3.945 km edge against a 6 km finest ocean
+background, and `u.oi30.lr10` a 19.931 km edge against 30 km — both about
+0.66 of what the mesh was designed for, costing a third of the time step.
+
+This design makes two changes:
+
+1. **Shape the coastline transition.** The land-side blend from the ocean
+   background to the land background is raised to a power, so the mesh-size
+   gradient vanishes at the coastline and steepens inland. This keeps the
+   steepest part of the sizing field away from the CFL-limited ocean without
+   extending how far the blend reaches inland.
+2. **Guard the CFL floor on absolute `dcEdge`.** The existing guard compared
+   each edge against its *local* ocean background, which detects leaked
+   land/river resolution but is not the CFL question. A second guard
+   compares the *shortest* edge against the *finest* ocean background
+   anywhere in the domain, which is.
+
+Success means every unified mesh clears the new guard with margin. All four
+now do:
+
+| mesh | before | after |
+| --- | --- | --- |
+| u.oi240.lr240 | 0.7991 | 0.7991 (unchanged; uniform mesh) |
+| u.oi30.lr10 | 0.6644 | 0.7730 |
+| u.oi6to18.lr6to10 | 0.6574 | 0.7985 |
+| u.oi.so12to30.lr10 | not measured | 0.8010 |
+
+## Diagnosis
+
+The short edges are not leaked land/river resolution. `dcEdge / cellWidth`
+and `dcEdge / ocean_background` are identical to four decimals for all 12
+million ocean edges of `u.oi6to18.lr6to10`, and `active_control` is
+`background` throughout the low tail — the sizing field prescribes the full
+ocean background at every one of them. The cull emulation from the
+`unified_mesh_cull_leak` design doc is doing its job.
+
+They are instead the seams of pentagon-heptagon dislocation pairs in
+JIGSAW's hexagonal packing. Every ocean edge below 0.80 times its local
+background has a non-hexagonal neighbor cell, against a 2.85% baseline, and
+their Voronoi faces are stretched to roughly 1.6 times the ideal
+`1/sqrt(3)`.
+
+Those dislocations concentrate where the sizing field is steep. JIGSAW never
+sees a coastline — only `cellWidth` and the sphere — so any coastal signal
+has to act through the field. Defect density in ocean cells of
+`u.oi6to18.lr6to10`, by distance to the effective coast in units of the
+local ocean background:
+
+| distance | cells | non-hexagonal |
+| --- | --- | --- |
+| 0-2 | 136,189 | 6.18% |
+| 2-5 | 152,774 | 4.27% |
+| 5-10 | 207,016 | 3.02% |
+| 30+ | 2,947,149 | 1.15% |
+
+The cause is the slope of the land-side blend,
+`|land_background - ocean_background| / coastline_transition_land_km`: 0.333
+on `u.oi30.lr10` and 0.222 on `u.oi6to18.lr6to10`, against an open-ocean
+background gradient near 0.001.
+
+## Requirements
+
+### Requirement: keep the mesh-size gradient away from ocean edges
+
+Date last modified: 2026/08/09
+
+Contributors: Xylar Asay-Davis, Claude
+
+The sizing field must not place a steep mesh-size gradient within a few cell
+widths of the ocean/sea-ice domain. Land and river refinement must still be
+reached, and reached no further inland than before: every unified config
+sets `base_mesh_clip_distance_km` equal to `coastline_transition_land_km` so
+that river geometry begins exactly where the blend ends, and that invariant
+must hold. The control must be a config option whose neutral value
+reproduces the previous sizing field bit for bit.
+
+### Requirement: guard the quantity that sets the time step
+
+Date last modified: 2026/08/09
+
+Contributors: Xylar Asay-Davis, Claude
+
+The `topo/cull` mask step must fail when the culled ocean/sea-ice domain
+contains an edge short enough to constrain the forward-run time step beyond
+what the mesh was designed for. It must not fail on an edge that is short
+only relative to a coarse local background, since such an edge is longer
+than the mesh's own finest intended resolution and costs nothing. Detection
+of leaked land/river resolution must be retained as a separate guard.
+
+## Algorithm Design
+
+### Algorithm Design: keep the mesh-size gradient away from ocean edges
+
+Date last modified: 2026/08/09
+
+Contributors: Xylar Asay-Davis, Claude
+
+Raise the land-side blending factor to a power:
+
+$$
+h(x) = L(x) + \alpha(s)\left(H - L(x)\right), \qquad
+s = \min\left(\frac{|d(x)|}{T},\; 1\right), \qquad
+\alpha(s) = s^{p}
+$$
+
+with $d$ the distance inland from the effective coast, $L$ the local ocean
+background, $H$ the land background, $T$ the transition width and $p$ the
+exponent. The mesh-size gradient is $|H-L|\,\alpha'(s)/T$, so for $p>1$ both
+$\alpha$ and $\alpha'$ vanish at the coastline: the field leaves the ocean
+flat and steepens inland, where only cells the cull removes ever feel it.
+$p=1$ is the previous linear ramp exactly.
+
+The decisive property is that $p$ changes the *shape* of the transition, not
+its *extent*, so the `clip == transition` invariant is preserved.
+
+**Choosing the transition width.** Both the exponent and the width matter,
+and the width matters more than it first appears. At one ocean cell width
+inland the gradient is $p|H-L|L^{p-1}/T^{p}$; for a quadratic with $T=2L$
+this reduces to $|H-L|/2L$, which is *identical* to the linear ramp's
+gradient there. So on a mesh with $T=2L$ the shape change buys nothing at
+the scale JIGSAW resolves, and everything depends on the relative resolution
+jump $|H-L|/L$:
+
+| mesh | jump | gradient at one cell width | result |
+| --- | --- | --- | --- |
+| u.oi6to18.lr6to10 | 0.44 | 0.222 | 0.799 |
+| u.oi30.lr10, T = 2L | 0.67 | 0.333 | 0.699 |
+| u.oi30.lr10, T = 3L | 0.67 | 0.148 | 0.773 |
+
+The two meshes with a 0.67 jump therefore widen $T$ from 60 to 90 km, with
+`base_mesh_clip_distance_km` moved to match. A single exponent of 2 is used
+everywhere; only the per-mesh width varies, and that was already a per-mesh
+parameter.
+
+### Algorithm Design: guard the quantity that sets the time step
+
+Date last modified: 2026/08/09
+
+Contributors: Xylar Asay-Davis, Claude
+
+Add `min_dc_edge_abs_ratio`, checked as
+
+```
+min(dcEdge over ocean-interior edges)
+    >= min_dc_edge_abs_ratio * min(ocean background over those edges)
+```
+
+Both terms come from arrays the diagnostic already builds. This is the CFL
+question: the time step is set by the shortest edge globally, and a mesh is
+already sized for its own finest intended resolution.
+
+`min_dc_edge_ratio` keeps comparing each edge against its *local*
+background, which is what detects a leak, and relaxes from 0.65 to 0.45 so
+it stops gating on coarse-region blemishes. The contaminated meshes that
+motivated it reached 0.29 to 0.34; clean meshes bottom out much higher, but
+not at the 0.76 once assumed — on a 6M-cell mesh, rare packing defects in
+the open ocean reach 0.51, at a different location every build and with no
+sizing-field cause.
+
+## Implementation
+
+### Implementation: keep the mesh-size gradient away from ocean edges
+
+Date last modified: 2026/08/09
+
+Contributors: Xylar Asay-Davis, Claude
+
+- `_apply_transition()` in
+  `polaris/tasks/mesh/spherical/unified/sizing_field/build.py` raises the
+  transition fraction to `exponent`; an exponent of 1 reproduces the previous
+  expression exactly and the `transition_m == 0` special case is untouched.
+  `_build_coastline_candidate()` and `sizing_field_dataset()` pass it
+  through, and `BuildSizingFieldStep.run()` reads the config option.
+- New `[sizing_field]` option `coastline_transition_exponent`, default 2.0.
+- `u.oi30.lr10` and `u.oi.so12to30.lr10` widen
+  `coastline_transition_land_km` and `base_mesh_clip_distance_km` from 60 to
+  90 km. `u.oi6to18.lr6to10` and `u.oi240.lr240` are unchanged.
+
+### Implementation: guard the quantity that sets the time step
+
+Date last modified: 2026/08/09
+
+Contributors: Xylar Asay-Davis, Claude
+
+- `check_ocean_dc_edge()` in
+  `polaris/tasks/e3sm/init/topo/cull/dc_edge_diagnostics.py` gains a
+  `min_abs_ratio` argument, logs the CFL guard line unconditionally and
+  raises before the ratio check when it is violated. `min_dc_edge_abs_ratio`
+  is recorded in `ocean_dc_edge_diagnostics.nc`.
+- New `[cull_mesh]` option `min_dc_edge_abs_ratio`, default 0.70;
+  `min_dc_edge_ratio` moves from 0.65 to 0.45.
+- `u.oi6to18.lr6to10`'s per-mesh `min_dc_edge_ratio` override is removed; no
+  mesh needs one.
+
+### Implementation: supporting changes
+
+Date last modified: 2026/08/09
+
+Contributors: Xylar Asay-Davis, Claude
+
+- `minimum_edge_length_ratio` in `[spherical_mesh_quality]` moves from 1e-4
+  to 1e-5. River-network line constraints degrade land cell polygons by
+  about two orders of magnitude, independently of anything in this design,
+  leaving the old guard on two to five times margin against a floor that
+  drops as meshes get finer.
+- Four `[spherical_mesh]` options — `jigsaw_optm_kern`, `jigsaw_optm_iter`,
+  `jigsaw_optm_qtol` and `jigsaw_optm_qlim` — expose JIGSAW's optimization
+  settings at exactly the values `QuasiUniformSphericalMeshStep` previously
+  hard-coded, so no mesh changes. No mesh overrides them.
+
+## Testing
+
+### Testing and Validation: keep the mesh-size gradient away from ocean edges
+
+Date last modified: 2026/08/09
+
+Contributors: Xylar Asay-Davis, Claude
+
+Unit tests in `tests/mesh/spherical/unified/test_sizing_field.py` cover the
+blend directly: an exponent of 1 reproduces the linear ramp exactly; a
+quadratic stays closer to the ocean background just inland of the coast; and
+every exponent reaches the land background at the same distance, which is
+what keeps river geometry out of the blend. Two further tests pin the
+invariants rather than the numbers — `clip == transition` on every mesh, and
+no mesh exceeding the coastal gradient of the one known to pass — so a new
+mesh with a large relative jump and a narrow transition fails at unit-test
+time rather than after a rebuild.
+
+### Testing and Validation: guard the quantity that sets the time step
+
+Date last modified: 2026/08/09
+
+Contributors: Xylar Asay-Davis, Claude
+
+Tests in `tests/e3sm/init/topo/test_dc_edge_diagnostics.py` exercise the new
+guard on synthetic meshes: it fails on an edge short against the finest
+background, and passes an edge that is short only against a coarse local
+background — the `u.oi6to18.lr6to10` case.
+`tests/e3sm/init/topo/test_unified_tasks.py` checks that every mesh resolves
+to the shared thresholds with no override.
+
+Integration validation is the rebuild of all four unified meshes on
+Chrysalis, reported in the summary table above.
+
+## Findings
+
+This section records what was learned along the way, including approaches
+that were tried and abandoned. None of it is part of the shipped design.
+
+### The threshold this work started from rested on a wrong conclusion
+
+`u.oi6to18.lr6to10` previously carried a per-mesh `min_dc_edge_ratio` of
+0.64, recorded as a "real, if small, resolution leak" on the grounds that
+clean jigsaw noise bottoms out near 0.76. That 0.76 came from meshes 10 to
+500 times smaller. The ratio's 0.01-percentile is 0.810 to 0.814 on all
+three meshes measured, so the distribution does not change with mesh size —
+only the number of draws does, and the minimum falls accordingly: 0.799 at
+21 thousand ocean edges, 0.664 at 1.4 million, 0.643 at 12 million.
+`u.oi30.lr10` was clearing the 0.65 default by luck rather than by margin.
+
+When investigating a future failure, compare `dcEdge` against `cellWidth`
+before suspecting the sizing field. If that ratio agrees with
+`dcEdge / ocean_background`, the field is not the problem.
+
+### A flat collar was tried first, and broke a river-workflow invariant
+
+The first implementation held the ocean background flat for
+`2 x ocean_background` inland before starting the linear ramp. It worked on
+the dcEdge metrics — `u.oi30.lr10` went from 0.664 to 0.778 — but its reach
+is `T + 2L`, which pushed the blend on `u.oi6to18.lr6to10` from 35.6 km to
+71.6 km inland and put river geometry inside it: river-mask cells held above
+1.05 times their target rose from 3.84% to 6.45%. The exponent reaches the
+same place without spending reach.
+
+Shortening `T` to pay for a collar was screened and is worse than doing
+nothing: halving the transition drove the worst ocean ratio to 0.6476 and
+doubled the near-coast tail.
+
+### The centroidal-Voronoi kernel was tried and reverted
+
+`cvt+dqdx` optimizes the Voronoi cells that carry `dcEdge` rather than the
+triangulation, and on synthetic spheres it beat the default on both bulk and
+tail — pooled minimum 0.755 against 0.682 over 2.3M cells uniform, 0.773
+against 0.630 over 1.8M cells graded. It thinned the bulk of the real
+distribution about fourfold. It was reverted anyway: `u.oi30.lr10` failed
+the cell-polygon quality check outright, and the bulk gain never reached the
+metric that matters, since the CFL floor is set by rare defects rather than
+by the bulk.
+
+The discriminator is JIGSAW's line-constraint geometry. Unified meshes hand
+JIGSAW the retained river network as `edge2` constraints — 122,198 vertices
+on `u.oi6to18.lr6to10`. Adding constraint polylines with the same
+segment-length distribution to the synthetic world reproduces the failure:
+far from any constraint, CVT with constraints reaches 0.613 and puts eight
+edges below 0.75, while CVT alone or the default kernel with constraints
+stay near 0.77. Vertices pinned on constraint edges cannot move under
+Voronoi-centroid smoothing, so the pinned network behaves as a rigid
+inclusion and the frustration relieves as defects elsewhere.
+
+The same constraints degrade cell polygons by about two orders of magnitude
+for either kernel, which is why `minimum_edge_length_ratio` moved. That
+degradation is confined to land: the minimum over ocean cells is 0.27 to
+0.40 on every mesh measured, while over land it reaches 2.2e-4 to 5.1e-4.
+
+### Raising the exponent instead of the width does not work
+
+At fixed reach, higher exponents buy coastal suppression monotonically —
+near-coast worst climbs from 0.7880 at quadratic to 0.8005 at quintic — but
+the overall worst falls just as steadily, from 0.7748 to 0.7507, back to the
+linear baseline. The steeper inland kink seeds its own defects that reach
+the ocean score. Widening the transition is the lever that works.
+
+### The river constraints work as intended
+
+Measuring the distance from constraint *vertices* to the nearest cell center
+gives a median of 1.5 km on a 6 km mesh, which looks like the constraints
+are being ignored. Measuring to the constraint *lines* instead shows about
+129,000 cells locked within 250 m — 1.06 per constraint vertex — with the
+count flat from 250 m out to 2 km. JIGSAW conforms to the constraint paths
+and redistributes vertices along them, so cell centers follow the river
+network even though the input nodes are not preserved. Nothing needs fixing
+here, and the obvious measurement gives the wrong answer.
+
+The snap tolerance is likewise correct as designed: it is half
+`river_channel_km` on every mesh, and the median constraint edge comes out at
+0.94 of the river target. About 12% of vertex pairs sit closer than the
+tolerance because `_merge_close_centroids` does not iterate to a fixed point,
+but clipping that tail in the synthetic screen changed the polygon minimum
+from 1.65e-03 to 1.80e-03, so it is not worth fixing on mesh-quality grounds.
+
+### Screening a minimum needs a much larger sample than screening a bulk
+
+Two methodological errors are worth recording. The first screen analyzed the
+JIGSAW triangulation and never the Voronoi polygons, so the cell-polygon
+failure mode was invisible to it. More importantly, CVT at its default 16
+iterations produced a 0.579 outlier in one of five realizations, which was
+read as under-convergence to be cured with more iterations rather than as
+evidence of a heavy extreme tail. The cull diagnostic reports a *minimum*
+over millions of edges; estimating that from a few realizations of a few
+hundred thousand edges cannot resolve a defect rate near one in a million,
+and a screen reporting only bulk percentiles will show a tail-heavy kernel as
+an unambiguous win. Pool enough realizations that the combined edge count
+approaches the target mesh, and report the pooled minimum and the counts
+below the thresholds of interest.
+
+A related trap: an identical sizing field at a point does not imply an
+identical mesh at that point. JIGSAW's front advance and optimization are
+global, so changing the field along every coastline moves the point
+distribution everywhere, including where the field did not change.
+
+### Divergence from the reference workflow
+
+The standalone workflow Polaris' unified base mesh is based on,
+[`mpas_land_mesh`](https://github.com/changliao1025/mpas_land_mesh), applies
+an Eikonal gradient limiter to the spacing field before meshing —
+`spac.slope = dhdx_lim` with a default of 0.25, then `jigsawpy.cmd.marche`.
+Polaris does not. This was noted but not pursued.

--- a/docs/developers_guide/e3sm/init/tasks/topo/cull.md
+++ b/docs/developers_guide/e3sm/init/tasks/topo/cull.md
@@ -49,9 +49,12 @@ The culling steps are configured through the `[cull_mesh]` section in the config
   considered to belong to land ice.
 - `land_ice_min_fraction`: Minimum land-ice fraction for flood-filling the
   land-ice mask.
+- `min_dc_edge_abs_ratio`: The minimum ratio of the shortest `dcEdge` in the
+  culled ocean/sea-ice domain to the finest ocean background cell width
+  anywhere in it (unified meshes only).  This is the CFL guard.
 - `min_dc_edge_ratio` and `max_dc_edge_ratio`: The allowed range of `dcEdge`
-  relative to the local ocean background cell width in the culled
-  ocean/sea-ice domain (unified meshes only).
+  relative to the *local* ocean background cell width (unified meshes only).
+  This is the leak guard.
 
 See `cull.cfg` for the full set of options.
 
@@ -70,6 +73,33 @@ the worst violation clusters if any ratio falls outside
 no sizing field and the check is skipped. The motivation, mechanisms and
 threshold justification are documented in the `unified_mesh_cull_leak`
 design doc (see {ref}`design-docs`).
+
+There are two guards, and they answer different questions.
+`min_dc_edge_abs_ratio` compares the *shortest* edge in the domain against
+the *finest* ocean background anywhere in it: that is what sets the forward
+run's time step, and since a mesh is already sized for its own finest
+intended resolution, an edge that is short only relative to a coarse local
+background costs nothing.  `min_dc_edge_ratio` compares each edge against
+its *local* background, which is what detects a leak.
+
+The thresholds come from `cull.cfg`, and a unified mesh can override them in
+its own `polaris/mesh/spherical/unified/<mesh_name>.cfg`, which is read after
+`cull.cfg` when the cull config is assembled.  No mesh currently needs to:
+`u.oi6to18.lr6to10` once overrode the ratio floor for a single edge, and that
+override went away when the CFL guard was separated out.
+
+A failure here does not by itself mean resolution has leaked.  On
+`u.oi6to18.lr6to10` it does not: the sizing field prescribes the full ocean
+background at every edge in the low tail, and the short edges are the seams
+of pentagon-heptagon dislocation pairs in JIGSAW's hexagonal packing.  That
+distribution is the same on every unified mesh, so the minimum falls as the
+edge count rises -- 0.799 at 21 thousand ocean edges, 0.664 at 1.4 million,
+0.643 at 12 million.  When investigating a failure, first compare `dcEdge`
+against `cellWidth` rather than `ocean_background_cell_width`: if the two
+ratios agree, the sizing field is not the problem.  The
+`unified_mesh_dc_edge_noise` design doc records the diagnosis and the two
+mitigations, the coastline-transition shape in the sizing field and
+JIGSAW's centroidal-Voronoi optimization kernel.
 
 The Antarctic land-ice ownership mask also includes southern cells that have
 already been removed from the open-ocean cull mask, so the cull workflow

--- a/docs/developers_guide/mesh/framework/spherical.md
+++ b/docs/developers_guide/mesh/framework/spherical.md
@@ -68,6 +68,12 @@ jigsaw_hfun_filename = spac.msh
 triangles_filename = mesh_triangles.nc
 mpas_mesh_filename = base_mesh.nc
 
+# JIGSAW mesh-optimization settings
+jigsaw_optm_kern = odt+dqdx
+jigsaw_optm_iter = 16
+jigsaw_optm_qtol = 1.0e-4
+jigsaw_optm_qlim = 0.9375
+
 # options related to mesh name and resolution
 # the prefix (e.g. Icos, QU, SO, RRS)
 prefix = PREFIX
@@ -96,6 +102,32 @@ vtk_dir = base_mesh_vtk
 # whether to extract the vtk output in lat/lon space, rather than on the sphere
 vtk_lat_lon = False
 ```
+
+## JIGSAW mesh optimization
+
+`jigsaw_optm_kern`, `jigsaw_optm_iter`, `jigsaw_optm_qtol` and
+`jigsaw_optm_qlim` are passed through to JIGSAW by
+{py:class}`polaris.mesh.QuasiUniformSphericalMeshStep`. The defaults are
+the values the step used before they were configurable, which are also what
+`mpas_tools` passes, so a mesh that does not set them is unaffected.
+({py:class}`polaris.mesh.IcosahedralMeshStep` keeps its own settings and
+does not read these.)
+
+`jigsaw_optm_kern` chooses between an Optimal Delaunay Tessellation
+(`odt+dqdx`) and a Centroidal Voronoi Tessellation (`cvt+dqdx`). MPAS cells
+are the Voronoi dual of the JIGSAW triangulation, so `cvt+dqdx` optimizes
+the cells that carry `dcEdge` rather than the triangulation, and it does
+give a tighter *bulk* `dcEdge` distribution at roughly 1.8 times the
+mesh-build time.
+
+It is not currently used by any mesh, and it should not be selected without
+reading the {ref}`design doc <design-docs>` `unified_mesh_dc_edge_noise`
+first. On real unified meshes it thinned the bulk about fourfold while
+introducing rare severe defects: the minimum `dcEdge` ratio on
+`u.oi6to18.lr6to10` fell from 0.643 to 0.515, and `u.oi30.lr10` failed the
+cell-polygon quality check outright. Because the cull diagnostic reports a
+*minimum* over millions of edges, a kernel that improves the bulk and
+worsens the tail is a net loss.
 
 ## Supported Base Mesh Steps
 

--- a/docs/developers_guide/mesh/tasks/unified/sizing_field.md
+++ b/docs/developers_guide/mesh/tasks/unified/sizing_field.md
@@ -75,7 +75,8 @@ The public helper `sizing_field_dataset()` combines:
   lat-lon grid);
 - the land background (`land_background_km`);
 - an optional coastline-proximity refinement controlled by
-  `enable_coastline_refinement` and `coastline_transition_land_km`; and
+  `enable_coastline_refinement`, `coastline_transition_land_km` and
+  `coastline_transition_exponent`; and
 - optional river-channel refinement controlled by
   `enable_river_channel_refinement` and `river_channel_km`.
 
@@ -108,6 +109,10 @@ All sizing-field steps use mesh-specific configs built through
 - `land_background_km` — cell width for land cells
 - `enable_coastline_refinement` — toggle coastline-proximity refinement
 - `coastline_transition_land_km` — width of the land-side transition zone
+- `coastline_transition_exponent` — exponent of the land-side blending
+  factor; values above 1 make the mesh-size gradient vanish at the
+  coastline and steepen inland, keeping it away from the CFL-limited ocean
+  edges without extending the transition's inland reach
 - `enable_river_channel_refinement` — toggle river-channel refinement
 - `river_channel_km` — target cell width along river channels
 - `enable_cull_emulation` — toggle the effective ocean mask built by

--- a/docs/users_guide/e3sm/init/tasks/topo.md
+++ b/docs/users_guide/e3sm/init/tasks/topo.md
@@ -124,12 +124,21 @@ Common user-tunable options are:
 	critical land transects as land ice.
 - `land_ice_min_fraction`: Minimum land-ice fraction used in south-pole flood
 	filling for the land-ice mask.
+- `min_dc_edge_abs_ratio`: For unified meshes, the minimum allowed ratio of
+	the *shortest* `dcEdge` in the culled ocean/sea-ice domain to the
+	*finest* ocean background cell width anywhere in it.  This is the CFL
+	guard: the time step is set by the shortest edge globally, and a mesh is
+	already sized for its own finest intended resolution, so an edge that is
+	short only relative to a coarse local background costs nothing.
 - `min_dc_edge_ratio` and `max_dc_edge_ratio`: For unified meshes, the allowed
-	range of `dcEdge` relative to the local ocean background cell width in the
-	culled ocean/sea-ice domain.  The mask step fails if resolution intended for
-	the land/river domain has leaked into the CFL-limited ocean/sea-ice domain
-	(see the {ref}`design doc <design-docs>` `unified_mesh_cull_leak` for the
-	motivation and choice of defaults).
+	range of `dcEdge` relative to the *local* ocean background cell width.
+	This is the leak guard: land/river resolution reaching the ocean shows up
+	as a locally anomalous ratio even where the absolute edge length is
+	unremarkable.  It is set to catch leaks (the contaminated meshes that
+	motivated it reached 0.29 to 0.34) rather than the rare packing defects
+	that reach 0.51 on the finest meshes, at a different location every
+	build.  See the {ref}`design docs <design-docs>` `unified_mesh_cull_leak`
+	and `unified_mesh_dc_edge_noise`.
 
 Cull tasks produce three culled meshes: `ocean`, `ocean_no_cavities` and
 `land`.  The land mesh is the exact complement of `ocean_no_cavities`, so

--- a/docs/users_guide/mesh/tasks/unified/sizing_field.md
+++ b/docs/users_guide/mesh/tasks/unified/sizing_field.md
@@ -51,7 +51,24 @@ Two optional refinements can be enabled independently:
 Sets the target cell width at the coastline raster edge to the finest cell
 width between ocean and land backgrounds. A linear transition of width
 `coastline_transition_land_km` can be applied on the land side of the
-coastline to smooth the transition back to the land background.
+coastline to smooth the transition back to the land background, and
+`coastline_transition_exponent` controls the shape of that transition.
+
+The transition is by far the steepest feature in the sizing field -- its
+slope is `|land_background - ocean_background|` divided by the transition
+width, roughly a hundred times the open-ocean gradient. Where that gradient
+meets the ocean it seeds defects in JIGSAW's hexagonal packing, and those
+defects carry the shortest `dcEdge` values, which in turn cap the
+forward-run time step.
+
+An exponent of 2 (the default) makes the blending factor and its first
+derivative both vanish at the coastline, so the field leaves the ocean flat
+and does its steepening at the inland end, where only cells that get culled
+away feel it. An exponent of 1 is the plain linear ramp. Because the
+exponent changes the *shape* rather than the *extent* of the transition, it
+costs no extra inland reach: river geometry still begins exactly where the
+blend ends. See the {ref}`design doc <design-docs>`
+`unified_mesh_dc_edge_noise`.
 
 **River-channel refinement** (`enable_river_channel_refinement`)
 Reduces the target cell width to `river_channel_km` on rasterized river
@@ -92,6 +109,10 @@ relevant options are in the `[sizing_field]` section:
 - `coastline_transition_land_km`: width in km of the linear-transition zone
   on the land side of the coastline. Set to `0` to apply only at the
   raster edge.
+- `coastline_transition_exponent`: exponent of the land-side blending
+  factor. `1` is linear; `2` (the default) flattens the mesh-size gradient
+  at the coastline and steepens it inland without extending the
+  transition's reach.
 - `enable_river_channel_refinement`: whether to refine cells on the
   river-channel mask.
 - `river_channel_km`: target cell width in km along river channels.

--- a/polaris/mesh/spherical/__init__.py
+++ b/polaris/mesh/spherical/__init__.py
@@ -328,7 +328,6 @@ class QuasiUniformSphericalMeshStep(SphericalBaseStep):
         self.opts.hfun_hmin = 0.0
         # 2-dim. simplexes
         self.opts.mesh_dims = 2
-        self.opts.optm_qlim = 0.9375
         self.opts.verbosity = 1
 
     def setup(self):
@@ -340,6 +339,10 @@ class QuasiUniformSphericalMeshStep(SphericalBaseStep):
         self.opts.geom_file = section.get('jigsaw_geom_filename')
         self.opts.jcfg_file = section.get('jigsaw_jcfg_filename')
         self.opts.hfun_file = section.get('jigsaw_hfun_filename')
+        self.opts.optm_kern = section.get('jigsaw_optm_kern')
+        self.opts.optm_iter = section.getint('jigsaw_optm_iter')
+        self.opts.optm_qtol = section.getfloat('jigsaw_optm_qtol')
+        self.opts.optm_qlim = section.getfloat('jigsaw_optm_qlim')
         super().setup()
 
     def run(self):

--- a/polaris/mesh/spherical/spherical.cfg
+++ b/polaris/mesh/spherical/spherical.cfg
@@ -14,6 +14,31 @@ triangles_filename = mesh_triangles.nc
 mpas_mesh_filename = base_mesh.nc
 reconstruction_weights_filename = reconstruction_weights.nc
 
+# JIGSAW mesh-optimization settings.  The defaults reproduce what JIGSAW is
+# given by mpas_tools.
+#
+# jigsaw_optm_kern selects the optimization kernel: 'odt+dqdx' for an
+# Optimal Delaunay Tessellation or 'cvt+dqdx' for a Centroidal Voronoi
+# Tessellation.  MPAS cells are the Voronoi dual of the JIGSAW
+# triangulation, so 'cvt+dqdx' optimizes the cells themselves and does give
+# a tighter *bulk* dcEdge distribution, at roughly 1.8x the mesh-build
+# time.  It is not used by any mesh: on real unified meshes it also
+# produced rare severe defects, dropping the minimum dcEdge ratio on
+# u.oi6to18.lr6to10 from 0.643 to 0.515 and failing the cell-polygon
+# quality check on u.oi30.lr10.  Read the unified_mesh_dc_edge_noise
+# design doc before selecting it.
+jigsaw_optm_kern = odt+dqdx
+
+# maximum number of mesh-optimization iterations
+jigsaw_optm_iter = 16
+
+# convergence tolerance on the mesh cost function
+jigsaw_optm_qtol = 1.0e-4
+
+# threshold on the mesh cost function above which gradient-based
+# optimization is attempted
+jigsaw_optm_qlim = 0.9375
+
 # whether to compute vector-reconstruction weights and stencils at cell
 # centers for the base mesh. Needed by Omega, not by MPAS-Ocean. Meshes
 # that get culled afterward (e.g. unified meshes) can skip this, since
@@ -60,8 +85,23 @@ vtk_lat_lon = False
 # whether to check MPAS cell polygons for geometry that can trip remapping
 check_cell_geometry = True
 
-# minimum edge length as a fraction of the median edge length in the cell
-minimum_edge_length_ratio = 1.0e-4
+# minimum edge length as a fraction of the median edge length in the cell.
+#
+# Unified meshes hand jigsaw the river network as line constraints, which
+# pins mesh vertices at spacings well below the target cell size and
+# degrades cell polygons by about two orders of magnitude wherever those
+# lines run.  The effect is inherent to the constraints rather than to any
+# optimization kernel, and it is confined to land: across u.oi30.lr10 and
+# u.oi6to18.lr6to10 the minimum over ocean cells is 0.27 to 0.40, while
+# over land it reaches 2.2e-4 to 5.1e-4 -- only two to five times this
+# guard, and drifting lower as meshes get finer simply because there are
+# more cells to draw from.
+#
+# 1.0e-5 keeps 20 to 50 times margin on those meshes while remaining four
+# to five orders of magnitude above genuine degeneracy: on a 6 km cell it
+# is a 6 cm polygon edge, harmless in double precision, whereas coincident
+# vertices give ~1e-12 or exactly zero.
+minimum_edge_length_ratio = 1.0e-5
 
 # minimum sine of each cell corner angle.  Small values indicate nearly
 # collinear or spiked consecutive vertices.

--- a/polaris/mesh/spherical/unified/sizing_field/sizing_field.cfg
+++ b/polaris/mesh/spherical/unified/sizing_field/sizing_field.cfg
@@ -26,6 +26,26 @@ land_background_km = 240.0
 # transitions back to the land background cell width
 coastline_transition_land_km = 0.0
 
+# Exponent of the blending factor across the land-side coastline
+# transition, as a function of distance inland normalized by
+# coastline_transition_land_km.  1 is a plain linear ramp.
+#
+# The transition is by far the steepest feature in the sizing field --
+# |land_background - ocean_background| / coastline_transition_land_km is
+# order 0.2 to 0.3 against an open-ocean gradient near 0.001 -- and where
+# that gradient meets the ocean it seeds the packing defects that carry the
+# smallest dcEdge values (see the unified_mesh_dc_edge_noise design doc).
+#
+# An exponent of 2 makes the blending factor and its first derivative both
+# vanish at the coastline, so the field leaves the ocean flat and steepens
+# inland, reaching twice the linear slope at the far end where only culled
+# land cells feel it.  Unlike widening the transition or adding a flat
+# collar, this costs no extra inland reach, so river geometry still begins
+# exactly where the blend ends -- base_mesh_clip_distance_km is kept equal
+# to coastline_transition_land_km for that reason, and the two should be
+# changed together.
+coastline_transition_exponent = 2.0
+
 # Target cell width (km) along rasterized river channels
 river_channel_km = 240.0
 

--- a/polaris/mesh/spherical/unified/u.oi.so12to30.lr10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi.so12to30.lr10.cfg
@@ -11,7 +11,9 @@ resolution_latlon = 0.0625
 
 [river_network]
 # inland clip distance used for base-mesh river products (km)
-base_mesh_clip_distance_km = 60.0
+# Kept equal to coastline_transition_land_km so that river geometry begins
+# exactly where the coastline blend ends; change the two together.
+base_mesh_clip_distance_km = 90.0
 
 # geometry simplification tolerance used for base-mesh river products (km)
 base_mesh_simplify_tolerance_km = 5.0
@@ -44,8 +46,18 @@ ocean_background_max_km = 30.0
 land_background_km = 10.0
 
 # Distance (km) over which the land side of the coastline refinement
-# transitions back to the land background cell width
-coastline_transition_land_km = 60.0
+# transitions back to the land background cell width.
+#
+# Wider than twice the ocean background, unlike u.oi6to18.lr6to10, because
+# this mesh asks for a larger *relative* resolution jump at the coast:
+# (30 - 10) / 30 = 0.67 against 0.44 there.  With the quadratic blend the
+# mesh-size gradient one cell width inland is 2 |H - L| L / T^2, so at the
+# T = 2 L this mesh used to have it equalled the linear ramp's and the
+# shaped transition bought nothing at the scale jigsaw resolves -- the
+# dcEdge CFL guard came out at 0.699 against u.oi6to18.lr6to10's 0.799.
+# T = 90 km puts that gradient at 0.148, a third below the mesh that
+# passes comfortably.  See the unified_mesh_dc_edge_noise design doc.
+coastline_transition_land_km = 90.0
 
 # Target cell width (km) along rasterized river channels
 river_channel_km = 10.0

--- a/polaris/mesh/spherical/unified/u.oi30.lr10.cfg
+++ b/polaris/mesh/spherical/unified/u.oi30.lr10.cfg
@@ -8,7 +8,9 @@ resolution_latlon = 0.125
 
 [river_network]
 # inland clip distance used for base-mesh river products (km)
-base_mesh_clip_distance_km = 60.0
+# Kept equal to coastline_transition_land_km so that river geometry begins
+# exactly where the coastline blend ends; change the two together.
+base_mesh_clip_distance_km = 90.0
 
 # geometry simplification tolerance used for base-mesh river products (km)
 base_mesh_simplify_tolerance_km = 5.0
@@ -47,8 +49,18 @@ ocean_background_max_km = 30.0
 land_background_km = 10.0
 
 # Distance (km) over which the land side of the coastline refinement
-# transitions back to the land background cell width
-coastline_transition_land_km = 60.0
+# transitions back to the land background cell width.
+#
+# Wider than twice the ocean background, unlike u.oi6to18.lr6to10, because
+# this mesh asks for a larger *relative* resolution jump at the coast:
+# (30 - 10) / 30 = 0.67 against 0.44 there.  With the quadratic blend the
+# mesh-size gradient one cell width inland is 2 |H - L| L / T^2, so at the
+# T = 2 L this mesh used to have it equalled the linear ramp's and the
+# shaped transition bought nothing at the scale jigsaw resolves -- the
+# dcEdge CFL guard came out at 0.699 against u.oi6to18.lr6to10's 0.799.
+# T = 90 km puts that gradient at 0.148, a third below the mesh that
+# passes comfortably.  See the unified_mesh_dc_edge_noise design doc.
+coastline_transition_land_km = 90.0
 
 # Target cell width (km) along rasterized river channels
 river_channel_km = 10.0

--- a/polaris/tasks/e3sm/init/topo/cull/cull.cfg
+++ b/polaris/tasks/e3sm/init/topo/cull/cull.cfg
@@ -26,15 +26,32 @@ land_ice_max_latitude = -60.0
 #       the land-ice mask
 land_ice_min_fraction = 0.01
 
-# the allowed range of dcEdge relative to the local ocean background cell
-# width for edges in the culled ocean/sea-ice domain (unified meshes only);
-# violations indicate that land/river resolution has leaked into the
-# CFL-limited ocean/sea-ice domain (see the unified_mesh_cull_leak design
-# doc).  Clean jigsaw noise spans roughly [0.76, 1.39] times the background.
-# The lower bound is the meaningful guard: fine cells leaking into the
-# ocean are a CFL hazard.  The upper bound only catches anomalously coarse
-# edges, which are a mild mesh-quality issue rather than a stability
-# hazard, so it is set loose enough to tolerate isolated jigsaw outliers
-# (whose magnitude grows with the number of edges) on large meshes.
-min_dc_edge_ratio = 0.65
+# Two guards on dcEdge in the culled ocean/sea-ice domain (unified meshes
+# only).  They answer different questions and are set independently; see
+# the unified_mesh_cull_leak and unified_mesh_dc_edge_noise design docs.
+#
+# min_dc_edge_abs_ratio is the CFL guard.  The forward-run time step is set
+# by the shortest edge anywhere in the domain, and a mesh is already sized
+# for its own finest intended ocean resolution, so what matters is the
+# shortest edge measured against the *finest* ocean background anywhere --
+# not against the local one.  An edge that is short only relative to a
+# coarse local background costs nothing.  With a shaped coastline
+# transition the unified meshes reach 0.78 to 0.80 here, against 0.66 with
+# the old linear ramp.
+min_dc_edge_abs_ratio = 0.70
+
+# min_dc_edge_ratio and max_dc_edge_ratio bound dcEdge against the *local*
+# ocean background, which is what detects land/river resolution leaking
+# into the ocean: a leak shows up as a locally anomalous ratio even where
+# the absolute edge length is unremarkable.  The contaminated meshes that
+# motivated this check reached 0.29 to 0.34.  Clean meshes bottom out much
+# higher but not at the 0.76 once assumed -- on a 6M-cell mesh, rare
+# packing defects in the open ocean reach 0.51, at a different location
+# every build, with no sizing-field cause.  0.45 separates the two.
+#
+# The upper bound only catches anomalously coarse edges, a mild
+# mesh-quality issue rather than a stability hazard, so it is loose enough
+# to tolerate isolated jigsaw outliers (whose magnitude grows with the
+# number of edges) on large meshes.
+min_dc_edge_ratio = 0.45
 max_dc_edge_ratio = 2.0

--- a/polaris/tasks/e3sm/init/topo/cull/dc_edge_diagnostics.py
+++ b/polaris/tasks/e3sm/init/topo/cull/dc_edge_diagnostics.py
@@ -9,6 +9,7 @@ def check_ocean_dc_edge(
     ds_sizing,
     min_ratio,
     max_ratio,
+    min_abs_ratio,
     logger,
     out_filename='ocean_dc_edge_diagnostics.nc',
     max_clusters=10,
@@ -43,12 +44,22 @@ def check_ocean_dc_edge(
         (km) on ``lat``/``lon`` coordinates (degrees)
 
     min_ratio : float
-        The minimum allowed ratio of ``dcEdge`` to the local ocean
-        background cell width
+        The minimum allowed ratio of ``dcEdge`` to the *local* ocean
+        background cell width.  This guards against land/river resolution
+        leaking into the ocean, which shows up as a locally anomalous
+        ratio.
 
     max_ratio : float
         The maximum allowed ratio of ``dcEdge`` to the local ocean
         background cell width
+
+    min_abs_ratio : float
+        The minimum allowed ratio of the *shortest* ``dcEdge`` anywhere in
+        the domain to the *finest* ocean background cell width anywhere in
+        it.  This is the CFL guard: the time step is set by the shortest
+        edge globally, and a mesh is already sized for its finest intended
+        resolution, so an edge that is short only relative to a coarse
+        local background costs nothing.
 
     logger : logging.Logger
         The logger for summary output
@@ -62,7 +73,8 @@ def check_ocean_dc_edge(
     Raises
     ------
     ValueError
-        If any ocean-interior edge violates the ratio bounds
+        If any ocean-interior edge violates the ratio bounds, or if the
+        shortest edge violates the absolute bound
     """
     dc_edge = ds_base_mesh.dcEdge.values / 1e3
     lat_edge = np.degrees(ds_base_mesh.latEdge.values)
@@ -107,6 +119,7 @@ def check_ocean_dc_edge(
     )
     ds_out.attrs['min_dc_edge_ratio'] = min_ratio
     ds_out.attrs['max_dc_edge_ratio'] = max_ratio
+    ds_out.attrs['min_dc_edge_abs_ratio'] = min_abs_ratio
     write_netcdf(ds_out, out_filename)
 
     n_ocean = int(ocean_edge.sum())
@@ -121,8 +134,34 @@ def check_ocean_dc_edge(
         f'allowed [{min_ratio}, {max_ratio}].'
     )
 
+    dc_ocean = dc_edge[ocean_edge]
+    background_ocean = background[ocean_edge]
+    finest_background = float(background_ocean.min())
+    shortest_edge = float(dc_ocean.min())
+    abs_ratio = shortest_edge / finest_background
+    logger.info(
+        f'dcEdge CFL guard: shortest ocean edge {shortest_edge:.3f} km '
+        f'against a finest ocean background of {finest_background:.3f} km, '
+        f'ratio {abs_ratio:.3f}, minimum allowed {min_abs_ratio}.'
+    )
+
     n_small = int(too_small.sum())
     n_large = int(too_large.sum())
+    if abs_ratio < min_abs_ratio:
+        index = int(np.argmin(dc_ocean))
+        lon = float(np.mod(lon_edge[ocean_edge][index] + 180.0, 360.0) - 180.0)
+        lat = float(lat_edge[ocean_edge][index])
+        message = (
+            f'The shortest edge in the culled ocean/sea-ice domain is '
+            f'{shortest_edge:.3f} km, only {abs_ratio:.3f} times the '
+            f'{finest_background:.3f} km finest ocean background, below the '
+            f'{min_abs_ratio} minimum.  This sets the forward-run time step '
+            f'(see {out_filename} and the unified_mesh_dc_edge_noise design '
+            f'doc).  Worst edge at lon={lon:.3f}, lat={lat:.3f}.'
+        )
+        logger.error(message)
+        raise ValueError(message)
+
     if n_small == 0 and n_large == 0:
         logger.info('dcEdge diagnostic passed.')
         return

--- a/polaris/tasks/e3sm/init/topo/cull/mask.py
+++ b/polaris/tasks/e3sm/init/topo/cull/mask.py
@@ -797,6 +797,7 @@ class CullMaskStep(Step):
         section = config['cull_mesh']
         min_ratio = section.getfloat('min_dc_edge_ratio')
         max_ratio = section.getfloat('max_dc_edge_ratio')
+        min_abs_ratio = section.getfloat('min_dc_edge_abs_ratio')
 
         ds_base_mesh = open_dataset('base_mesh.nc')
         ds_masks = open_dataset('cull_masks.nc')
@@ -808,6 +809,7 @@ class CullMaskStep(Step):
             ds_sizing=ds_sizing,
             min_ratio=min_ratio,
             max_ratio=max_ratio,
+            min_abs_ratio=min_abs_ratio,
             logger=logger,
         )
 

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
@@ -194,6 +194,9 @@ class BuildSizingFieldStep(Step):
                     coastline_transition_land_km=section.getfloat(
                         'coastline_transition_land_km'
                     ),
+                    coastline_transition_exponent=section.getfloat(
+                        'coastline_transition_exponent'
+                    ),
                     enable_river_channel_refinement=section.getboolean(
                         'enable_river_channel_refinement'
                     ),
@@ -324,6 +327,7 @@ def sizing_field_dataset(
     land_background_km=240.0,
     enable_coastline_refinement=True,
     coastline_transition_land_km=0.0,
+    coastline_transition_exponent=1.0,
     enable_river_channel_refinement=True,
     river_channel_km=240.0,
 ):
@@ -362,6 +366,11 @@ def sizing_field_dataset(
         Width in km of the linear-transition zone on the land side of the
         coastline; 0 means apply the ocean background only at the coastline
         raster edge
+
+    coastline_transition_exponent : float, optional
+        Exponent of the land-side blending factor.  1 is linear; values
+        above 1 flatten the mesh-size gradient at the coastline and steepen
+        it at the inland end of the transition
 
     enable_river_channel_refinement : bool, optional
         Whether to refine cells on the river-channel mask
@@ -425,6 +434,7 @@ def sizing_field_dataset(
         signed_distance=signed_distance,
         enabled=enable_coastline_refinement,
         land_transition_km=coastline_transition_land_km,
+        transition_exponent=coastline_transition_exponent,
     )
     final_cell_width = coastline_candidate
 
@@ -543,6 +553,7 @@ def _build_coastline_candidate(
     signed_distance,
     enabled,
     land_transition_km,
+    transition_exponent=1.0,
 ):
     """
     Build the coastline candidate field in km.
@@ -561,18 +572,34 @@ def _build_coastline_candidate(
         signed_distance=np.abs(signed_distance),
         mask=land_side,
         transition_m=land_transition_m,
+        exponent=transition_exponent,
     )
     return candidate
 
 
 def _apply_transition(
-    candidate, target, background, signed_distance, mask, transition_m
+    candidate,
+    target,
+    background,
+    signed_distance,
+    mask,
+    transition_m,
+    exponent=1.0,
 ):
     """
-    Apply a linear transition from the coastline target back to background.
+    Apply a transition from the coastline target back to background.
+
+    The blending factor is ``(d / transition_m) ** exponent``.  An
+    exponent above one makes the factor and its first derivative both
+    vanish at the coastline, so the mesh-size gradient is smallest
+    exactly where the CFL-limited ocean edges are, and steepest at the
+    inland end where only culled land cells feel it.  An exponent of one
+    is the plain linear ramp.
     """
     if transition_m < 0.0:
         raise ValueError('Transition widths must be nonnegative.')
+    if exponent <= 0.0:
+        raise ValueError('The transition exponent must be positive.')
 
     if transition_m == 0.0:
         zero_mask = mask & np.isclose(signed_distance, 0.0)
@@ -580,7 +607,7 @@ def _apply_transition(
         return
 
     transition_mask = mask & (signed_distance <= transition_m)
-    fraction = signed_distance[transition_mask] / transition_m
+    fraction = (signed_distance[transition_mask] / transition_m) ** exponent
     candidate[transition_mask] = target[transition_mask] + fraction * (
         background[transition_mask] - target[transition_mask]
     )

--- a/tests/e3sm/init/topo/test_dc_edge_diagnostics.py
+++ b/tests/e3sm/init/topo/test_dc_edge_diagnostics.py
@@ -23,6 +23,7 @@ def test_check_ocean_dc_edge_passes(tmp_path):
         ds_sizing=ds_sizing,
         min_ratio=0.65,
         max_ratio=1.5,
+        min_abs_ratio=0.0,
         logger=LOGGER,
         out_filename=str(tmp_path / 'diags.nc'),
     )
@@ -46,6 +47,7 @@ def test_check_ocean_dc_edge_too_small(tmp_path):
             ds_sizing=ds_sizing,
             min_ratio=0.65,
             max_ratio=1.5,
+            min_abs_ratio=0.0,
             logger=LOGGER,
             out_filename=str(tmp_path / 'diags.nc'),
         )
@@ -67,6 +69,7 @@ def test_check_ocean_dc_edge_too_large(tmp_path):
             ds_sizing=ds_sizing,
             min_ratio=0.65,
             max_ratio=1.5,
+            min_abs_ratio=0.0,
             logger=LOGGER,
             out_filename=str(tmp_path / 'diags.nc'),
         )
@@ -87,6 +90,7 @@ def test_check_ocean_dc_edge_ignores_culled_and_boundary(tmp_path):
         ds_sizing=ds_sizing,
         min_ratio=0.65,
         max_ratio=1.5,
+        min_abs_ratio=0.0,
         logger=LOGGER,
         out_filename=str(tmp_path / 'diags.nc'),
     )
@@ -112,9 +116,71 @@ def test_check_ocean_dc_edge_local_background(tmp_path):
         ds_sizing=ds_sizing,
         min_ratio=0.65,
         max_ratio=1.5,
+        min_abs_ratio=0.0,
         logger=LOGGER,
         out_filename=str(tmp_path / 'diags.nc'),
     )
+
+
+def test_check_ocean_dc_edge_abs_guard_fails_on_a_short_edge(tmp_path):
+    """
+    The CFL guard measures the shortest edge against the finest ocean
+    background anywhere, since that is what sets the time step.
+    """
+    ds_sizing = _sizing(background_km=None)
+    # 6 km edge where the fine background is 12 km: half the finest
+    # background anywhere, so the time step has to shrink
+    ds_base_mesh = _base_mesh(
+        dc_edge_km=[6.0, 11.0, 28.0, 28.0],
+        lat_edge=[-70.0, -70.0, 40.0, 40.0],
+    )
+    ocean_cull_mask = np.zeros(4, dtype=int)
+
+    with pytest.raises(ValueError, match='shortest edge'):
+        check_ocean_dc_edge(
+            ds_base_mesh=ds_base_mesh,
+            ocean_cull_mask=ocean_cull_mask,
+            ds_sizing=ds_sizing,
+            min_ratio=0.0,
+            max_ratio=10.0,
+            min_abs_ratio=0.70,
+            logger=LOGGER,
+            out_filename=str(tmp_path / 'diags.nc'),
+        )
+
+
+def test_check_ocean_dc_edge_abs_guard_ignores_coarse_region_blemish(
+    tmp_path,
+):
+    """
+    An edge that is short only relative to a *coarse* local background is
+    still longer than the mesh's finest intended resolution, so it cannot
+    constrain the global time step.  This is the u.oi6to18.lr6to10 case:
+    an 8 km edge in a 15.9 km background on a mesh whose finest ocean
+    background is 6 km.
+    """
+    ds_sizing = _sizing(background_km=None)
+    # the 15 km edge sits in the 30 km background: local ratio 0.5, but it
+    # is comfortably longer than the 12 km finest background
+    ds_base_mesh = _base_mesh(
+        dc_edge_km=[11.0, 11.0, 15.0, 30.0],
+        lat_edge=[-70.0, -70.0, 40.0, 40.0],
+    )
+    ocean_cull_mask = np.zeros(4, dtype=int)
+
+    check_ocean_dc_edge(
+        ds_base_mesh=ds_base_mesh,
+        ocean_cull_mask=ocean_cull_mask,
+        ds_sizing=ds_sizing,
+        min_ratio=0.0,
+        max_ratio=10.0,
+        min_abs_ratio=0.70,
+        logger=LOGGER,
+        out_filename=str(tmp_path / 'diags.nc'),
+    )
+
+    with xr.open_dataset(tmp_path / 'diags.nc') as ds:
+        assert ds.attrs['min_dc_edge_abs_ratio'] == 0.70
 
 
 def _base_mesh(dc_edge_km, lat_edge=None):

--- a/tests/e3sm/init/topo/test_unified_tasks.py
+++ b/tests/e3sm/init/topo/test_unified_tasks.py
@@ -15,6 +15,7 @@ from polaris.tasks.mesh.base.steps import get_base_mesh_steps
 
 COARSE_MESH_NAME = 'u.oi240.lr240'
 FINE_MESH_NAME = 'u.oi30.lr10'
+FINEST_MESH_NAME = 'u.oi6to18.lr6to10'
 
 
 def test_get_remap_topo_steps_includes_upstream_base_mesh_steps():
@@ -248,6 +249,40 @@ def test_coarse_unified_mesh_uses_ne120_topography():
     assert cull_task.steps[combine_topo_step_name].subdir.endswith(
         'cubed_sphere/ne120'
     )
+
+
+def test_cull_config_exposes_both_dc_edge_guards():
+    """
+    The two guards answer different questions: the absolute one is the CFL
+    gate, measured against the finest ocean background anywhere, while the
+    ratio one detects land/river resolution leaking into the ocean.
+    """
+    _reset_shared_components()
+
+    _, config = get_cull_topo_steps(mesh_name=FINE_MESH_NAME)
+
+    assert config.getfloat('cull_mesh', 'min_dc_edge_abs_ratio') == 0.70
+    assert config.getfloat('cull_mesh', 'min_dc_edge_ratio') == 0.45
+
+
+def test_every_unified_mesh_uses_the_shared_dc_edge_guards():
+    """
+    u.oi6to18.lr6to10 used to override the ratio floor down to 0.64 for a
+    single edge.  With the CFL guard measured against the finest ocean
+    background, and the ratio guard set to catch leaks rather than rare
+    packing defects, no mesh needs an override.
+    """
+    for mesh_name in (COARSE_MESH_NAME, FINE_MESH_NAME, FINEST_MESH_NAME):
+        _reset_shared_components()
+
+        _, config = get_cull_topo_steps(mesh_name=mesh_name)
+
+        assert config.getfloat('cull_mesh', 'min_dc_edge_abs_ratio') == (
+            0.70
+        ), mesh_name
+        assert config.getfloat('cull_mesh', 'min_dc_edge_ratio') == 0.45, (
+            mesh_name
+        )
 
 
 def _reset_shared_components():

--- a/tests/mesh/spherical/test_base_mesh_opts.py
+++ b/tests/mesh/spherical/test_base_mesh_opts.py
@@ -1,0 +1,88 @@
+from polaris.component import Component
+from polaris.config import PolarisConfigParser
+from polaris.mesh.spherical import QuasiUniformSphericalMeshStep
+from polaris.mesh.spherical.unified import UNIFIED_MESH_NAMES
+from polaris.mesh.spherical.unified.configs import get_unified_mesh_config
+
+# the values QuasiUniformSphericalMeshStep hard-coded, or left at jigsaw's
+# defaults, before they became config options
+PREVIOUS_DEFAULTS = dict(
+    jigsaw_optm_kern='odt+dqdx',
+    jigsaw_optm_iter=16,
+    jigsaw_optm_qtol=1.0e-4,
+    jigsaw_optm_qlim=0.9375,
+)
+
+
+def test_shipped_defaults_match_the_previous_hard_coded_values():
+    """
+    Making these configurable must not change any mesh that has not opted
+    into different settings.
+    """
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+
+    assert (
+        config.get('spherical_mesh', 'jigsaw_optm_kern')
+        == (PREVIOUS_DEFAULTS['jigsaw_optm_kern'])
+    )
+    assert (
+        config.getint('spherical_mesh', 'jigsaw_optm_iter')
+        == (PREVIOUS_DEFAULTS['jigsaw_optm_iter'])
+    )
+    assert (
+        config.getfloat('spherical_mesh', 'jigsaw_optm_qtol')
+        == (PREVIOUS_DEFAULTS['jigsaw_optm_qtol'])
+    )
+    assert (
+        config.getfloat('spherical_mesh', 'jigsaw_optm_qlim')
+        == (PREVIOUS_DEFAULTS['jigsaw_optm_qlim'])
+    )
+
+
+def test_quasi_uniform_step_passes_the_options_to_jigsaw():
+    step = QuasiUniformSphericalMeshStep(
+        component=Component(name='mesh'),
+        subdir='spherical/test/base_mesh',
+        cell_width=240.0,
+    )
+    step.config = PolarisConfigParser()
+    step.config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+    step.config.set('spherical_mesh', 'jigsaw_optm_kern', 'cvt+dqdx')
+    step.config.set('spherical_mesh', 'jigsaw_optm_iter', '64')
+    step.config.set('spherical_mesh', 'jigsaw_optm_qtol', '1.0e-6')
+
+    step.setup()
+
+    assert step.opts.optm_kern == 'cvt+dqdx'
+    assert step.opts.optm_iter == 64
+    assert step.opts.optm_qtol == 1.0e-6
+    assert step.opts.optm_qlim == PREVIOUS_DEFAULTS['jigsaw_optm_qlim']
+
+
+def test_unified_meshes_keep_the_default_optimisation_kernel():
+    """
+    cvt+dqdx was tried for unified meshes and reverted: it thinned the bulk
+    of the dcEdge distribution but introduced rare severe defects that the
+    diagnostic, being a minimum, is precisely sensitive to.  Guard the
+    revert so it is not reintroduced without revisiting the design doc.
+    """
+    for mesh_name in UNIFIED_MESH_NAMES:
+        config = get_unified_mesh_config(mesh_name=mesh_name)
+
+        assert (
+            config.get('spherical_mesh', 'jigsaw_optm_kern')
+            == (PREVIOUS_DEFAULTS['jigsaw_optm_kern'])
+        ), mesh_name
+        assert (
+            config.getint('spherical_mesh', 'jigsaw_optm_iter')
+            == (PREVIOUS_DEFAULTS['jigsaw_optm_iter'])
+        ), mesh_name
+        assert (
+            config.getfloat('spherical_mesh', 'jigsaw_optm_qtol')
+            == (PREVIOUS_DEFAULTS['jigsaw_optm_qtol'])
+        ), mesh_name
+        assert (
+            config.getfloat('spherical_mesh', 'jigsaw_optm_qlim')
+            == (PREVIOUS_DEFAULTS['jigsaw_optm_qlim'])
+        ), mesh_name

--- a/tests/mesh/spherical/test_quality.py
+++ b/tests/mesh/spherical/test_quality.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from polaris.config import PolarisConfigParser
 from polaris.mesh.spherical.quality import check_cell_polygon_quality
 
 
@@ -77,6 +78,31 @@ def test_cell_polygon_quality_rejects_collinear_corner():
             minimum_corner_sine=1.0e-3,
             max_bad_cells_to_report=10,
         )
+
+
+def test_shipped_edge_length_ratio_clears_the_river_constraint_floor():
+    """
+    Unified meshes pin mesh vertices on river-network line constraints,
+    which drives land cell polygons down to 2.2e-4 to 5.1e-4 on
+    u.oi6to18.lr6to10 and u.oi30.lr10.  The guard has to sit well below
+    that floor, since it drifts lower as meshes get finer, while staying
+    far above genuine degeneracy.
+    """
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.mesh.spherical', 'spherical.cfg')
+    threshold = config.getfloat(
+        'spherical_mesh_quality', 'minimum_edge_length_ratio'
+    )
+
+    assert threshold == 1.0e-5
+    assert threshold < 0.1 * 2.2e-4, (
+        'the guard must keep an order of magnitude below the observed '
+        'land-cell floor, or river constraints alone will fail a build'
+    )
+    assert threshold > 1.0e-9, (
+        'the guard must stay far above numerical degeneracy to remain '
+        'meaningful'
+    )
 
 
 def _cell_polygon_mesh_dataset(vertex_coords):

--- a/tests/mesh/spherical/unified/test_sizing_field.py
+++ b/tests/mesh/spherical/unified/test_sizing_field.py
@@ -11,6 +11,9 @@ from polaris.mesh.spherical.unified import (
     UnifiedBaseMeshStep,
     get_unified_mesh_family,
 )
+from polaris.mesh.spherical.unified.configs import (
+    get_unified_mesh_config,
+)
 from polaris.mesh.spherical.unified.families.default import (
     build_ocean_background_from_mode,
 )
@@ -140,6 +143,140 @@ def test_sizing_field_coastline_transition_on_land():
         ds_sizing.active_control.values[0],
         np.array([0, 0, 1, 0], dtype=np.int8),
     )
+
+
+def test_sizing_field_transition_exponent_of_one_is_linear():
+    """
+    An exponent of 1 must reproduce the plain linear ramp exactly, so a
+    mesh that has not opted in builds the field it built before.
+    """
+    lon = np.array([-30.0, -10.0, 10.0, 30.0])
+    ds_coastline = _make_coastline_dataset(
+        ocean_mask=np.array([[1, 1, 0, 0]], dtype=np.int8),
+        signed_distance=np.array([[0.0, 1000.0, -1000.0, -3000.0]]),
+        lat=np.array([0.0]),
+        lon=lon,
+    )
+    ds_river = _make_river_dataset(
+        river_channel_mask=np.zeros((1, lon.size), dtype=np.int8),
+        lat=np.array([0.0]),
+        lon=lon,
+    )
+
+    ds_sizing = sizing_field_dataset(
+        ds_coastline=ds_coastline,
+        ds_river=ds_river,
+        resolution=0.125,
+        mesh_name='exponent_test',
+        ocean_background=_constant_ocean_background(
+            ds_coastline=ds_coastline, value=30.0
+        ),
+        land_background_km=10.0,
+        coastline_transition_land_km=2.0,
+        coastline_transition_exponent=1.0,
+        enable_river_channel_refinement=False,
+    )
+
+    np.testing.assert_allclose(
+        ds_sizing.cellWidth.values[0], np.array([30.0, 30.0, 20.0, 10.0])
+    )
+
+
+def test_sizing_field_transition_exponent_flattens_the_coastal_gradient():
+    """
+    A quadratic blend leaves the ocean background nearly untouched just
+    inland of the coast and does its steepening at the far end, without
+    reaching any further inland than the linear ramp.
+    """
+    lon = np.array([-30.0, -10.0, 10.0, 30.0, 50.0, 70.0])
+    # 1, 2, 3 and 4 km inland across a 4 km transition
+    ds_coastline = _make_coastline_dataset(
+        ocean_mask=np.array([[1, 0, 0, 0, 0, 0]], dtype=np.int8),
+        signed_distance=np.array(
+            [[1000.0, -1000.0, -2000.0, -3000.0, -4000.0, -8000.0]]
+        ),
+        lat=np.array([0.0]),
+        lon=lon,
+    )
+    ds_river = _make_river_dataset(
+        river_channel_mask=np.zeros((1, lon.size), dtype=np.int8),
+        lat=np.array([0.0]),
+        lon=lon,
+    )
+    kwargs = dict(
+        ds_coastline=ds_coastline,
+        ds_river=ds_river,
+        resolution=0.125,
+        mesh_name='exponent_test',
+        ocean_background=_constant_ocean_background(
+            ds_coastline=ds_coastline, value=30.0
+        ),
+        land_background_km=10.0,
+        coastline_transition_land_km=4.0,
+        enable_river_channel_refinement=False,
+    )
+
+    linear = sizing_field_dataset(
+        coastline_transition_exponent=1.0, **kwargs
+    ).cellWidth.values[0]
+    quadratic = sizing_field_dataset(
+        coastline_transition_exponent=2.0, **kwargs
+    ).cellWidth.values[0]
+
+    # linear: fractions 1/4, 2/4, 3/4, 1 -> 25, 20, 15, 10
+    np.testing.assert_allclose(
+        linear, np.array([30.0, 25.0, 20.0, 15.0, 10.0, 10.0])
+    )
+    # quadratic: fractions 1/16, 4/16, 9/16, 1 -> 28.75, 25, 18.75, 10
+    np.testing.assert_allclose(
+        quadratic, np.array([30.0, 28.75, 25.0, 18.75, 10.0, 10.0])
+    )
+
+    # nearest the coast the quadratic blend stays closer to the ocean
+    # background, and it reaches the land background at the same distance
+    assert quadratic[1] > linear[1]
+    assert quadratic[2] > linear[2]
+    np.testing.assert_allclose(quadratic[4], linear[4])
+    np.testing.assert_allclose(quadratic[5], linear[5])
+
+
+def test_sizing_field_transition_exponent_does_not_extend_inland_reach():
+    """
+    The whole point of the exponent over a flat collar is that it costs no
+    extra inland reach, so river geometry still begins exactly where the
+    blend ends.
+    """
+    lon = np.array([-30.0, -10.0, 10.0, 30.0])
+    ds_coastline = _make_coastline_dataset(
+        ocean_mask=np.array([[1, 0, 0, 0]], dtype=np.int8),
+        signed_distance=np.array([[1000.0, -3000.0, -4000.0, -5000.0]]),
+        lat=np.array([0.0]),
+        lon=lon,
+    )
+    ds_river = _make_river_dataset(
+        river_channel_mask=np.zeros((1, lon.size), dtype=np.int8),
+        lat=np.array([0.0]),
+        lon=lon,
+    )
+
+    for exponent in (1.0, 2.0, 3.0):
+        ds_sizing = sizing_field_dataset(
+            ds_coastline=ds_coastline,
+            ds_river=ds_river,
+            resolution=0.125,
+            mesh_name='exponent_test',
+            ocean_background=_constant_ocean_background(
+                ds_coastline=ds_coastline, value=30.0
+            ),
+            land_background_km=10.0,
+            coastline_transition_land_km=4.0,
+            coastline_transition_exponent=exponent,
+            enable_river_channel_refinement=False,
+        )
+        values = ds_sizing.cellWidth.values[0]
+        # beyond the 4 km transition every exponent is at the land value
+        np.testing.assert_allclose(values[2], 10.0)
+        np.testing.assert_allclose(values[3], 10.0)
 
 
 def test_sizing_field_rivers_composed_before_coastline_transition():
@@ -468,6 +605,62 @@ def test_so_mesh_family_links_shared_region_and_builds_field(
     assert ocean_background.shape == (3, 4)
     assert np.min(ocean_background) < np.max(ocean_background)
     assert np.mean(ocean_background[0, :]) < np.mean(ocean_background[-1, :])
+
+
+def test_river_clip_matches_the_coastline_transition():
+    """
+    River geometry must begin exactly where the coastline blend ends.  If
+    the blend reaches further inland than the clip, river channels sit
+    inside it and come out coarser than their target -- which is what a
+    flat collar did before it was replaced by the transition exponent.
+    """
+    for mesh_name in UNIFIED_MESH_NAMES:
+        config = get_unified_mesh_config(mesh_name=mesh_name)
+
+        transition = config.getfloat(
+            'sizing_field', 'coastline_transition_land_km'
+        )
+        clip = config.getfloat('river_network', 'base_mesh_clip_distance_km')
+
+        assert clip == transition, (
+            f'{mesh_name}: base_mesh_clip_distance_km ({clip}) must equal '
+            f'coastline_transition_land_km ({transition})'
+        )
+
+
+def test_steep_meshes_widen_the_transition():
+    """
+    With a quadratic blend the mesh-size gradient one cell width inland is
+    2 |H - L| L / T^2, so a mesh with a larger relative resolution jump
+    needs a wider transition to reach the same gradient.  u.oi30.lr10 and
+    u.oi.so12to30.lr10 ask for (30 - 10) / 30 = 0.67 against
+    u.oi6to18.lr6to10's 0.44, and failed the dcEdge CFL guard at T = 2 L.
+    """
+    gradients = {}
+    for mesh_name in UNIFIED_MESH_NAMES:
+        config = get_unified_mesh_config(mesh_name=mesh_name)
+        section = config['sizing_field']
+        ocean = section.getfloat('ocean_background_max_km')
+        land = section.getfloat('land_background_km')
+        transition = section.getfloat('coastline_transition_land_km')
+        exponent = section.getfloat('coastline_transition_exponent')
+        if transition == 0.0 or ocean == land:
+            continue
+        # d(h)/dd at one ocean cell width inland
+        gradients[mesh_name] = (
+            exponent
+            * abs(land - ocean)
+            * (ocean / transition) ** (exponent - 1.0)
+            / transition
+        )
+
+    passing = gradients['u.oi6to18.lr6to10']
+    for mesh_name, gradient in gradients.items():
+        assert gradient <= passing + 1e-12, (
+            f'{mesh_name}: coastal mesh-size gradient {gradient:.3f} exceeds '
+            f"u.oi6to18.lr6to10's {passing:.3f}, which is the steepest "
+            f'value known to pass the dcEdge CFL guard'
+        )
 
 
 def _make_coastline_dataset(ocean_mask, signed_distance, lat=None, lon=None):


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

The shortest edge in a culled ocean/sea-ice domain sets the forward-run time step, and on the unified meshes it was about two thirds of what the mesh was designed for: 3.945 km against a 6 km finest ocean background on `u.oi6to18.lr6to10`, 19.931 km against 30 km on `u.oi30.lr10`.

Those short edges are not leaked land/river resolution — the sizing field prescribes the full ocean background at every one of them. They are pentagon-heptagon packing defects, concentrated where the coastline blend puts a steep mesh-size gradient next to the ocean.

## Changes

- **Shape the coastline transition.** New `[sizing_field]` option `coastline_transition_exponent` (default 2) raises the land-side blending factor to a power, so the mesh-size gradient vanishes at the coastline and steepens inland. It changes the shape of the transition, not its extent, so `base_mesh_clip_distance_km` still equals `coastline_transition_land_km` and river geometry begins where the blend ends. An exponent of 1 reproduces the previous linear ramp.
- **Widen the transition where the resolution jump is largest.** For a quadratic with `T = 2L` the gradient one cell width inland equals the linear ramp's, so the relative jump decides: `u.oi30.lr10` and `u.oi.so12to30.lr10` go from 60 to 90 km, with the clip distance moved to match. `u.oi6to18.lr6to10` and `u.oi240.lr240` are unchanged.
- **Guard the CFL floor on absolute `dcEdge`.** New `[cull_mesh]` option `min_dc_edge_abs_ratio` (default 0.70) compares the shortest ocean-interior edge against the finest ocean background anywhere in the domain, which is what sets the time step. `min_dc_edge_ratio` keeps the leak-detection job and relaxes to 0.45 so it stops gating on edges that are short only against a coarse local background. `u.oi6to18.lr6to10`'s per-mesh override is removed.
- **Supporting:** `minimum_edge_length_ratio` moves from 1e-4 to 1e-5, since river-network line constraints degrade land cell polygons by two orders of magnitude independently of this work; and jigsaw's optimisation settings become `[spherical_mesh]` options at their existing values.

## Results

All four unified meshes rebuilt on Chrysalis. The figure is the shortest ocean edge over the finest ocean background:

| mesh | before | after |
| --- | --- | --- |
| `u.oi240.lr240` | 0.7991 | 0.7991 (uniform; unaffected) |
| `u.oi30.lr10` | 0.6644 | 0.7730 |
| `u.oi6to18.lr6to10` | 0.6574 | 0.7985 |
| `u.oi.so12to30.lr10` | not measured | 0.8010 |

Base meshes and downstream `e3sm/init` topography products change for the three variable-resolution meshes and must be regenerated. See the `unified_mesh_dc_edge_noise` design doc for the diagnosis, and its Findings section for the approaches that were tried and abandoned.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
