### PR TITLE
Support tasks and suites that cross components

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -125,6 +125,10 @@ seaice/api
    Component.add_step
    Component.remove_step
    Component.add_config
+   Component.configure
+   Component.has_model
+   Component.build_model
+   Component.check_model_version
    Component.get_or_create_shared_step
    Component.set_parallel_system
    Component.get_available_resources
@@ -192,6 +196,18 @@ seaice/api
    ModelStep.process_inputs_and_outputs
    ModelStep.update_io_tasks_config
    ModelStep.partition
+```
+
+### component_graph
+
+```{eval-rst}
+.. currentmodule:: polaris.component_graph
+
+.. autosummary::
+   :toctree: generated/
+
+   get_components_in_use
+   get_steps_by_component
 ```
 
 ### config

--- a/docs/developers_guide/command_line.md
+++ b/docs/developers_guide/command_line.md
@@ -92,11 +92,16 @@ The command-line options are:
 
 ```none
 $ polaris setup --help
-usage: polaris setup [-h] [-t PATH [PATH ...]] [-n NUM [NUM ...]] [-f FILE] [-m MACH] -w
-                     PATH [-b PATH] [-p PATH] [--suite_name SUITE]
-                     [--cached STEP [STEP ...]] [--free_running STEP [STEP ...]] [--copy_executable] [--clean_tasks]
-                     [--model MODEL] [--build] [--branch BRANCH] [--clean_build]
-                     [--quiet_build] [--cmake_flags CMAKE_FLAGS] [--debug]
+usage: polaris setup [-h] [-t PATH [PATH ...]] [-n NUM [NUM ...]] [-f FILE]
+                     [-m MACH] -w PATH [-b PATH] [-p PATH]
+                     [--suite_name SUITE] [--cached STEP [STEP ...]]
+                     [--free_running STEP [STEP ...]] [--copy_executable]
+                     [--clean_tasks] [--model MODEL] [--build]
+                     [--branch BRANCH] [--clean_build] [--quiet_build]
+                     [--cmake_flags CMAKE_FLAGS] [--debug]
+                     [--ocean_model OCEAN_MODEL] [--ocean_path PATH]
+                     [--ocean_branch PATH] [--seaice_model SEAICE_MODEL]
+                     [--seaice_path PATH] [--seaice_branch PATH]
 
 ```
 
@@ -127,9 +132,26 @@ The default for the `landice` component is
 `e3sm_submodules/MALI-Dev/components/mpas-albany-landice`.
 For the `ocean` component, the default value of `component_path` comes from the
 ocean configuration file; by default, both MPAS-Ocean and Omega use the
-`build` subdirectory of the base work directory supplied with `-w`.  If you
-use MPAS-Ocean or Omega in a different location, supply that directory
+`ocean_build` subdirectory of the base work directory supplied with `-w`.  If
+you use MPAS-Ocean or Omega in a different location, supply that directory
 explicitly with `-p` or via a config file.
+
+`-p`, `--model` and `--branch` apply to the component that owns the tasks you
+are setting up.  A task may also include shared steps from another component,
+and that component may have a model of its own to find or build.  Each
+component with a model has its own flags for this:
+
+```bash
+polaris setup -t e3sm/init/<mesh>/component_inputs/tasks/all \
+  -m $MACHINE -w $WORKDIR --ocean_path $OCEAN_BUILD
+```
+
+The available flags are `--<component>_model`, `--<component>_path` and
+`--<component>_branch` (`--ocean_model`, `--seaice_path` and so on); a `/` in
+a component name becomes `_`.  If the component that owns the tasks has no
+model of its own, as `e3sm/init` does not, `-p`, `--model` and `--branch` have
+nothing to apply to and polaris raises an error naming the flags to use
+instead.
 
 When `-p` is provided for the `ocean` component, Polaris first checks whether
 the component executable and required files are already present in that
@@ -220,9 +242,10 @@ The following flags give additional control over this behavior:
 
 Defaults and paths:
 
-- Build output directory (`-p`/`--component_path`) defaults to the `build`
-  subdirectory of the base work directory you pass with `-w` for both
-  MPAS-Ocean and Omega.
+- Build output directory (`-p`/`--component_path`) defaults to the
+  `ocean_build` subdirectory of the base work directory you pass with `-w` for
+  both MPAS-Ocean and Omega.  It is named after the component so that two
+  components in the same work directory do not build over one another.
 - Generated build scripts are saved to:
    - Omega: `./build_omega/build_omega_<machine>_<compiler>.sh`
    - MPAS-Ocean: `./build_mpas_ocean/build_mpas_ocean_<machine>_<compiler>_<mpi>.sh`
@@ -264,8 +287,12 @@ options are:
 $ polaris suite --help
 usage: polaris suite [-h] -c COMPONENT -t SUITE [-f FILE] [-m MACH] [-b PATH]
                      -w PATH [-p PATH] [--copy_executable] [--clean_tasks]
-                     [--model MODEL] [--build] [--branch BRANCH] [--clean_build]
-                     [--quiet_build] [--cmake_flags CMAKE_FLAGS] [--debug]
+                     [--model MODEL] [--build] [--branch BRANCH]
+                     [--clean_build] [--quiet_build]
+                     [--cmake_flags CMAKE_FLAGS] [--debug]
+                     [--ocean_model OCEAN_MODEL] [--ocean_path PATH]
+                     [--ocean_branch PATH] [--seaice_model SEAICE_MODEL]
+                     [--seaice_path PATH] [--seaice_branch PATH]
 ```
 
 The `-h` or `--help` options will display the help message describing the

--- a/docs/developers_guide/framework/build.md
+++ b/docs/developers_guide/framework/build.md
@@ -137,8 +137,8 @@ You can trigger these builders directly from the CLI by passing build flags to
 Defaults and directories:
 
 - The build output directory used by Polaris (`-p`/`--component_path`) defaults to
-  the `build` subdirectory of the base work directory you pass with `-w` (for
-  both MPAS-Ocean and Omega).
+  the `ocean_build` subdirectory of the base work directory you pass with `-w`
+  (for both MPAS-Ocean and Omega).
 - MPAS-Ocean copies files required by Polaris into this build directory so you
   can reuse the same source checkout to create builds for different machines,
   compilers, or MPI libraries without conflicts.

--- a/docs/developers_guide/framework/config.md
+++ b/docs/developers_guide/framework/config.md
@@ -181,6 +181,48 @@ class Rpe(Task):
                      indir=self.subdir))
 ```
 
+(dev-component-config)=
+
+## Where a task's or step's config options come from
+
+Every config parser belongs to exactly one component, and gets that
+component's config options and nothing else from any other component.
+
+During setup, polaris builds a config parser for each component **in use** --
+the component that owns the tasks being set up, the components that own steps
+in those tasks and the components of any dependencies of those steps
+({py:func}`polaris.component_graph.get_components_in_use()`).  A component's
+config parser is made up of:
+
+1. the config options for the machine and the command line
+   (`polaris/default.cfg`, the machine config files, a config file passed with
+   `-f` and options like `-p`)
+2. the component's own config file, `polaris/<component>/<component>.cfg`
+3. whatever the component's
+   {py:meth}`polaris.Component.configure()` method adds, such as the ocean's
+   `mpas_ocean.cfg` or `omega.cfg`
+
+That config parser is then prepended to the config parser of each task and
+shared step the component owns, so a task's or step's own config files always
+take precedence over the component's.
+
+This means that a shared step gets the config options of **its own**
+component, not those of the component that owns the task that includes it.  A
+shared ocean step gets the ocean's config options whether it was set up as
+part of an ocean task or as part of an `e3sm/init` task, so a step behaves the
+same however it was reached.  Two rules follow, and setup raises if either is
+broken:
+
+- a step from a component other than its task's must be a shared step with a
+  shared config file, since a step without one would get its config options
+  from the task, and so from the wrong component
+- a shared config file must be used by steps from only one component, since it
+  is that component's config options it will be given
+
+The suite's config file (`polaris/suites/<component>/<suite>.cfg`) is not part
+of any of this.  It applies only to the suite's job script, so that a task or
+step behaves the same whether or not it was set up as part of a suite.
+
 ## Comments in config files
 
 One of the main advantages of {py:class}`tranche.Tranche`

--- a/docs/developers_guide/ocean/index.md
+++ b/docs/developers_guide/ocean/index.md
@@ -33,7 +33,7 @@ MPAS-Ocean tasks also have these config options:
 
 # the relative or absolute path to the root of a branch where MPAS-Ocean
 # or Omega has been built
-component_path = ${paths:base_work_dir}/build
+component_path = ${paths:base_work_dir}/ocean_build
 
 # The namelists section defines paths to example_compact namelists that will
 # be used to generate specific namelists. By default, these point to the
@@ -63,7 +63,7 @@ component = ${paths:component_path}/ocean_model
 ```
 
 By default, Polaris builds MPAS-Ocean or Omega into the `build` subdirectory of
-the base work directory (`${paths:base_work_dir}/build`, typically supplied
+the base work directory (`${paths:base_work_dir}/ocean_build`, typically supplied
 on the command line with `-w`), and this is the value used for
 `${paths:component_path}` in the default ocean configuration.  If you
 prefer to store builds elsewhere, supply a different value with `-p` on the

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -399,7 +399,7 @@ one-off setup commands.
 #### Recommended default: automated build from `polaris setup`/`polaris suite`
 
 For MPAS-Ocean, Polaris builds automatically during setup and places the
-build in `${WORKDIR}/build` by default.  If a complete build already exists
+build in `${WORKDIR}/ocean_build` by default.  If a complete build already exists
 there, it is reused:
 
 ```bash
@@ -446,7 +446,7 @@ If you simply wish to run the CTests from Omega, you likely want to use the
 #### Recommended default: automated build from `polaris setup`/`polaris suite`
 
 For Omega, Polaris builds automatically during setup and places the build
-in `${WORKDIR}/build` by default.  If a complete build already exists there,
+in `${WORKDIR}/ocean_build` by default.  If a complete build already exists there,
 it is reused:
 
 ```bash

--- a/docs/developers_guide/seaice/index.md
+++ b/docs/developers_guide/seaice/index.md
@@ -3,7 +3,20 @@
 # Sea ice component
 
 The `seaice` component currently consists of single column tests.  The
-component has the following config options as follows:
+component-wide config options say which model it runs:
+
+```cfg
+# This config file has default config options for the seaice component
+
+# Options related the sea-ice component
+[seaice]
+
+# Which model is used.  MPAS-Seaice is currently the only option.
+model = mpas-seaice
+```
+
+The config options for MPAS-Seaice itself are in `mpas_seaice.cfg`, added
+during setup by `SeaIce.configure()`:
 
 ```cfg
 # This config file has default config options for MPAS-Seaice

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -1,6 +1,7 @@
 import importlib.resources as imp_res
 import json
 import os
+from configparser import RawConfigParser
 
 from mache.parallel import ParallelSystem, get_parallel_system
 from mpas_tools.io import open_dataset, write_netcdf
@@ -53,7 +54,27 @@ class Component:
 
         self.cached_files = dict()
         self.parallel_system: ParallelSystem | None = None
+        self._has_model: bool | None = None
         self._read_cached_files()
+
+    def has_model(self):
+        """
+        Whether this component has a model executable, and therefore whether
+        options like the path to that executable apply to it.
+
+        This is determined by whether any of the component's config files
+        defines ``component`` in the ``[executables]`` section, so a component
+        that gains a model does not also have to be listed somewhere.
+
+        Returns
+        -------
+        has_model : bool
+            Whether this component has a model executable
+        """
+        if self._has_model is None:
+            self._has_model = self._detect_model_configs()
+
+        return self._has_model
 
     def set_parallel_system(self, config: PolarisConfigParser) -> None:
         """
@@ -341,6 +362,29 @@ class Component:
             for Omega). The base implementation ignores it.
         """
         write_netcdf(ds=ds, fileName=filename)
+
+    def _detect_model_configs(self):
+        """
+        Determine whether any of the component's config files describes a
+        model executable
+        """
+        package = f'polaris.{self.name.replace("/", ".")}'
+        try:
+            pkg_files = list(imp_res.files(package).iterdir())
+        except (ModuleNotFoundError, FileNotFoundError, NotADirectoryError):
+            return False
+
+        for pkg_file in pkg_files:
+            if not pkg_file.name.endswith('.cfg'):
+                continue
+            # the config files use extended interpolation, which we don't
+            # want to resolve here
+            config = RawConfigParser()
+            config.read_string(pkg_file.read_text())
+            if config.has_option('executables', 'component'):
+                return True
+
+        return False
 
     def _read_cached_files(self):
         """Read in the dictionary of cached files from cached_files.json"""

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -213,17 +213,18 @@ class Component:
             )
         self.configs[config.filepath] = config
 
-    def configure(self, config, tasks):
+    def configure(self, config, steps):
         """
         Configure the component
 
         Parameters
         ----------
         config : polaris.config.PolarisConfigParser
-            config options to modify
+            the config options for this component, to modify
 
-        tasks : list of polaris.Task
-            The tasks to be set up for this component
+        steps : list of polaris.Step
+            The steps this component owns among those being set up.  These may
+            belong to tasks in another component.
         """
         pass
 

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -228,6 +228,37 @@ class Component:
         """
         pass
 
+    def build_model(self, config, machine):
+        """
+        Build the model for this component.  Components with a model that
+        polaris knows how to build should override this method.
+
+        Parameters
+        ----------
+        config : polaris.config.PolarisConfigParser
+            the config options for this component
+
+        machine : str
+            The name of the machine to build the model on
+        """
+        raise ValueError(
+            f'An automated build is not implemented for the {self.name} '
+            f'component'
+        )
+
+    def check_model_version(self, config):
+        """
+        Check that the model this component will run is compatible with this
+        version of polaris.  Components that have such a check should override
+        this method.
+
+        Parameters
+        ----------
+        config : polaris.config.PolarisConfigParser
+            the config options for this component
+        """
+        pass
+
     def get_or_create_shared_step(
         self, step_cls, subdir, config, config_filename=None, **kwargs
     ):

--- a/polaris/component_graph.py
+++ b/polaris/component_graph.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Dict, List
 
 if TYPE_CHECKING:
     from polaris.component import Component
+    from polaris.step import Step
 
 
 def get_components_in_use(tasks):
@@ -23,37 +24,84 @@ def get_components_in_use(tasks):
     components : list of polaris.Component
         The components in use, in the order they were first encountered
     """
+    components, _ = _walk_tasks(tasks)
+    return components
+
+
+def get_steps_by_component(tasks):
+    """
+    Get the steps in the given tasks and in their dependencies, grouped by the
+    component that owns each step.
+
+    Every component in use has an entry, even if it owns no steps.
+
+    Parameters
+    ----------
+    tasks : dict of polaris.Task
+        Tasks to scan for steps
+
+    Returns
+    -------
+    steps_by_component : dict of list of polaris.Step
+        The steps each component owns, with the component names as keys
+    """
+    _, steps_by_component = _walk_tasks(tasks)
+    return steps_by_component
+
+
+def _walk_tasks(tasks):
+    """
+    Walk the task and step graph, collecting the components in use and the
+    steps each of them owns
+    """
     components: List['Component'] = list()
+    steps_by_component: Dict[str, List['Step']] = dict()
     seen_components: set[int] = set()
     seen_steps: set[int] = set()
 
     for task in tasks.values():
-        _add_component(task.component, components, seen_components)
+        _add_component(
+            task.component, components, steps_by_component, seen_components
+        )
         for step in task.steps.values():
-            _add_step_components(step, components, seen_components, seen_steps)
+            _add_step(
+                step,
+                components,
+                steps_by_component,
+                seen_components,
+                seen_steps,
+            )
 
-    return components
+    return components, steps_by_component
 
 
-def _add_step_components(step, components, seen_components, seen_steps):
+def _add_step(
+    step, components, steps_by_component, seen_components, seen_steps
+):
     """
-    Add a step's component and the components of its dependencies to
-    ``components``
+    Add a step and its dependencies to the components that own them
     """
     step_id = id(step)
     if step_id in seen_steps:
         return
     seen_steps.add(step_id)
 
-    _add_component(step.component, components, seen_components)
+    _add_component(
+        step.component, components, steps_by_component, seen_components
+    )
+    steps_by_component[step.component.name].append(step)
 
     for dependency in step.dependencies.values():
-        _add_step_components(
-            dependency, components, seen_components, seen_steps
+        _add_step(
+            dependency,
+            components,
+            steps_by_component,
+            seen_components,
+            seen_steps,
         )
 
 
-def _add_component(component, components, seen_components):
+def _add_component(component, components, steps_by_component, seen_components):
     """Add a component to ``components`` if it is not already there"""
     component_id = id(component)
     if component_id in seen_components:
@@ -61,3 +109,4 @@ def _add_component(component, components, seen_components):
 
     seen_components.add(component_id)
     components.append(component)
+    steps_by_component[component.name] = list()

--- a/polaris/component_graph.py
+++ b/polaris/component_graph.py
@@ -1,0 +1,63 @@
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from polaris.component import Component
+
+
+def get_components_in_use(tasks):
+    """
+    Get the components referenced by the given tasks: the component of each
+    task, of each step in those tasks and, recursively, of each step
+    dependency.
+
+    A task may include steps from components other than its own, so this is
+    not simply the set of components that own the tasks.
+
+    Parameters
+    ----------
+    tasks : dict of polaris.Task
+        Tasks to scan for referenced components
+
+    Returns
+    -------
+    components : list of polaris.Component
+        The components in use, in the order they were first encountered
+    """
+    components: List['Component'] = list()
+    seen_components: set[int] = set()
+    seen_steps: set[int] = set()
+
+    for task in tasks.values():
+        _add_component(task.component, components, seen_components)
+        for step in task.steps.values():
+            _add_step_components(step, components, seen_components, seen_steps)
+
+    return components
+
+
+def _add_step_components(step, components, seen_components, seen_steps):
+    """
+    Add a step's component and the components of its dependencies to
+    ``components``
+    """
+    step_id = id(step)
+    if step_id in seen_steps:
+        return
+    seen_steps.add(step_id)
+
+    _add_component(step.component, components, seen_components)
+
+    for dependency in step.dependencies.values():
+        _add_step_components(
+            dependency, components, seen_components, seen_steps
+        )
+
+
+def _add_component(component, components, seen_components):
+    """Add a component to ``components`` if it is not already there"""
+    component_id = id(component)
+    if component_id in seen_components:
+        return
+
+    seen_components.add(component_id)
+    components.append(component)

--- a/polaris/ocean/mpas_ocean.cfg
+++ b/polaris/ocean/mpas_ocean.cfg
@@ -11,7 +11,7 @@ write_coeffs_reconstruct = True
 
 # the relative or absolute path to the root of a branch where MPAS-Ocean
 # has been built
-component_path = ${paths:base_work_dir}/build
+component_path = ${paths:base_work_dir}/ocean_build
 
 # The namelists section defines paths to default namelists that will
 # be used to generate specific namelists. By default, these point to the

--- a/polaris/ocean/omega.cfg
+++ b/polaris/ocean/omega.cfg
@@ -6,7 +6,7 @@
 
 # the relative or absolute path to the root of a branch where Omega
 # has been built
-component_path = ${paths:base_work_dir}/build
+component_path = ${paths:base_work_dir}/ocean_build
 
 # The model_config section defines paths to yaml file with default model config
 # options that will be used to generate specific yaml config files for Omega.

--- a/polaris/parallel.py
+++ b/polaris/parallel.py
@@ -1,3 +1,4 @@
+from polaris.component_graph import get_components_in_use
 from polaris.config import PolarisConfigParser
 
 
@@ -14,73 +15,5 @@ def set_parallel_systems(tasks, config: PolarisConfigParser):
     config : polaris.config.PolarisConfigParser
         The config to use in constructing the parallel systems
     """
-    seen_components: set[int] = set()
-    seen_steps: set[int] = set()
-
-    for task in tasks.values():
-        _set_parallel_system_for_component(
-            task.component, config, seen_components
-        )
-        for step in task.steps.values():
-            _set_parallel_systems_for_step(
-                step, config, seen_components, seen_steps
-            )
-
-
-def _set_parallel_systems_for_step(
-    step, config: PolarisConfigParser, seen_components, seen_steps
-):
-    """
-    Set the active parallel system on a step's component and recursively on
-    the components of any step dependencies.
-
-    Parameters
-    ----------
-    step : polaris.Step
-        The step to scan
-
-    config : polaris.config.PolarisConfigParser
-        The config to use in constructing the parallel systems
-
-    seen_components : set of int
-        The ids of components that have already been initialized
-
-    seen_steps : set of int
-        The ids of steps that have already been visited
-    """
-    step_id = id(step)
-    if step_id in seen_steps:
-        return
-    seen_steps.add(step_id)
-
-    _set_parallel_system_for_component(step.component, config, seen_components)
-
-    for dependency in step.dependencies.values():
-        _set_parallel_systems_for_step(
-            dependency, config, seen_components, seen_steps
-        )
-
-
-def _set_parallel_system_for_component(
-    component, config: PolarisConfigParser, seen_components
-):
-    """
-    Set the active parallel system for a component once.
-
-    Parameters
-    ----------
-    component : polaris.Component
-        The component to initialize
-
-    config : polaris.config.PolarisConfigParser
-        The config to use in constructing the parallel system
-
-    seen_components : set of int
-        The ids of components that have already been initialized
-    """
-    component_id = id(component)
-    if component_id in seen_components:
-        return
-
-    seen_components.add(component_id)
-    component.set_parallel_system(config)
+    for component in get_components_in_use(tasks):
+        component.set_parallel_system(config)

--- a/polaris/seaice/mpas_seaice.cfg
+++ b/polaris/seaice/mpas_seaice.cfg
@@ -1,0 +1,37 @@
+# This config file has default config options for MPAS-Seaice
+
+# The paths section points polaris to external paths
+[paths]
+
+# the relative or absolute path to the root of a branch where MPAS-Seaice
+# has been built
+component_path = ${paths:polaris_branch}/e3sm_submodules/E3SM-Project/components/mpas-seaice
+
+# The namelists section defines paths to example_compact namelists that will
+# be used to generate specific namelists. By default, these point to the
+# forward and init namelists in the default_inputs directory after a successful
+# build of the seaice model.  Change these in a custom config file if you need
+# a different location.
+[namelists]
+forward = ${paths:component_path}/default_inputs/namelist.seaice
+
+# The streams section defines paths to example_compact streams files that will
+# be used to generate specific streams files. By default, these point to the
+# forward and init streams files in the default_inputs directory after a
+# successful build of the seaice model. Change these in a custom config file if
+# you need a different location.
+[streams]
+forward = ${paths:component_path}/default_inputs/streams.seaice
+
+# The registry section points to a post-processed registry file that can
+# be used to identify the types (var, var_array, var_struct) of variables in
+# a stream
+[registry]
+processed = ${paths:component_path}/src/Registry_processed.xml
+
+# The executables section defines paths to required executables. These
+# executables are provided for use by specific test cases.  Most tools that
+# polaris needs should be in the deployment environment, so this is only the
+# path to the MPAS-Seaice executable by default.
+[executables]
+component = ${paths:component_path}/seaice_model

--- a/polaris/seaice/seaice.cfg
+++ b/polaris/seaice/seaice.cfg
@@ -1,37 +1,7 @@
-# This config file has default config options for MPAS-Seaice
+# This config file has default config options for the seaice component
 
-# The paths section points polaris to external paths
-[paths]
+# Options related the sea-ice component
+[seaice]
 
-# the relative or absolute path to the root of a branch where MPAS-Seaice
-# has been built
-component_path = ${paths:polaris_branch}/e3sm_submodules/E3SM-Project/components/mpas-seaice
-
-# The namelists section defines paths to example_compact namelists that will
-# be used to generate specific namelists. By default, these point to the
-# forward and init namelists in the default_inputs directory after a successful
-# build of the seaice model.  Change these in a custom config file if you need
-# a different location.
-[namelists]
-forward = ${paths:component_path}/default_inputs/namelist.seaice
-
-# The streams section defines paths to example_compact streams files that will
-# be used to generate specific streams files. By default, these point to the
-# forward and init streams files in the default_inputs directory after a
-# successful build of the seaice model. Change these in a custom config file if
-# you need a different location.
-[streams]
-forward = ${paths:component_path}/default_inputs/streams.seaice
-
-# The registry section points to a post-processed registry file that can
-# be used to identify the types (var, var_array, var_struct) of variables in
-# a stream
-[registry]
-processed = ${paths:component_path}/src/Registry_processed.xml
-
-# The executables section defines paths to required executables. These
-# executables are provided for use by specific test cases.  Most tools that
-# polaris needs should be in the deployment environment, so this is only the
-# path to the MPAS-Seaice executable by default.
-[executables]
-component = ${paths:component_path}/seaice_model
+# Which model is used.  MPAS-Seaice is currently the only option.
+model = mpas-seaice

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -28,6 +28,7 @@ def setup_tasks(
     baseline_dir=None,
     component_path=None,
     suite_name='custom',
+    suite_component=None,
     cached=None,
     free_running=None,
     copy_executable=False,
@@ -75,6 +76,12 @@ def setup_tasks(
     suite_name : str, optional
         The name of the suite if tasks are being set up through a suite or
         ``'custom'`` if not
+
+    suite_component : str, optional
+        The name of the component the suite belongs to, which is where its
+        config file comes from.  A suite may contain tasks from other
+        components, so this is not necessarily the component of any of the
+        tasks.  Defaults to the component of the first task.
 
     cached : list of list of str, optional
         For each task in ``tasks``, which steps (if any) should read their
@@ -153,10 +160,13 @@ def setup_tasks(
     _add_tasks_by_number(numbers, all_tasks, tasks, cached_steps)
     _add_tasks_by_name(task_list, all_tasks, cached, tasks, cached_steps)
 
-    # the component of the first task is the one the suite belongs to and the
-    # one the unqualified command-line options apply to
+    # the unqualified command-line options apply to the component of the
+    # first task
     first_path = next(iter(tasks))
     component = tasks[first_path].component
+
+    if suite_component is None:
+        suite_component = component.name
 
     basic_config = _get_basic_config(
         config_file=config_file,
@@ -294,7 +304,7 @@ def setup_tasks(
 
     if machine is not None:
         suite_config = _get_suite_config(
-            basic_config, component.name, suite_name
+            basic_config, suite_component, suite_name
         )
         job_options = write_job_script(
             config=suite_config,

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -153,8 +153,8 @@ def setup_tasks(
     _add_tasks_by_number(numbers, all_tasks, tasks, cached_steps)
     _add_tasks_by_name(task_list, all_tasks, cached, tasks, cached_steps)
 
-    # get the component of the first task.  We'll ensure that all tasks are
-    # for this component
+    # the component of the first task is the one the suite belongs to and the
+    # one the unqualified command-line options apply to
     first_path = next(iter(tasks))
     component = tasks[first_path].component
 

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -154,8 +154,6 @@ def setup_tasks(
         config_file=config_file,
         machine=machine,
         component_path=component_path,
-        component=component,
-        model=model,
         build=build,
         branch=branch,
         cmake_flags=cmake_flags,
@@ -165,27 +163,33 @@ def setup_tasks(
         work_dir=work_dir,
     )
 
-    component.configure(basic_config, list(tasks.values()))
+    component_config = _get_component_config(
+        basic_config=basic_config,
+        component=component,
+        model=model,
+    )
+
+    component.configure(component_config, list(tasks.values()))
     set_parallel_systems(tasks, basic_config)
 
     provenance.write(
         work_dir,
         tasks,
-        config=basic_config,
+        config=component_config,
         machine=machine,
         baseline_dir=baseline_dir,
     )
-    section = basic_config['build']
+    section = component_config['build']
     build = section.getboolean('build')
 
     if build:
         _build_model(
-            basic_config=basic_config,
+            component_config=component_config,
             component=component,
             machine=machine,
         )
 
-    _check_pcd_version(basic_config=basic_config, component=component)
+    _check_pcd_version(component_config=component_config, component=component)
 
     if clean_tasks:
         print('')
@@ -194,7 +198,7 @@ def setup_tasks(
         print('')
 
     _setup_configs(
-        basic_config=basic_config,
+        component_config=component_config,
         component=component,
         tasks=tasks,
         work_dir=work_dir,
@@ -292,7 +296,7 @@ def setup_tasks(
             provenance.write(
                 work_dir,
                 tasks,
-                config=basic_config,
+                config=component_config,
                 machine=machine,
                 baseline_dir=baseline_dir,
                 job_options=job_options,
@@ -654,7 +658,7 @@ def _expand_and_mark_cached_steps(tasks, cached_steps):
 
 
 def _setup_configs(
-    basic_config,
+    component_config,
     component,
     tasks,
     work_dir,
@@ -662,7 +666,7 @@ def _setup_configs(
 ):
     """Set up config parsers for this component"""
 
-    common_config = basic_config.copy()
+    common_config = component_config.copy()
 
     if copy_executable:
         common_config.set('setup', 'copy_executable', 'True')
@@ -907,8 +911,6 @@ def _get_basic_config(
     config_file,
     machine,
     component_path,
-    component,
-    model,
     build,
     branch,
     cmake_flags,
@@ -918,17 +920,13 @@ def _get_basic_config(
     work_dir,
 ):
     """
-    Get a base config parser for the machine and component but not a specific
-    task
+    Get a base config parser for the machine and the command line but not for
+    any component, task or step
     """
     config = PolarisConfigParser()
 
     if config_file is not None:
         config.add_user_config(config_file)
-
-    # set the model from the command line if provided
-    if model is not None:
-        config.set(component.name, 'model', model, user=True)
 
     # start with default polaris config options
     config.add_from_package('polaris', 'default.cfg')
@@ -949,13 +947,6 @@ def _get_basic_config(
         config.set('paths', 'polaris_branch', polaris_branch)
     else:
         config.set('paths', 'polaris_branch', os.getcwd())
-
-    # add the config options for the component
-    config.add_from_package(
-        f'polaris.{component.name.replace("/", ".")}',
-        f'{component.name}.cfg',
-        exception=False,
-    )
 
     # set the component_path path from the command line if provided
     if component_path is not None:
@@ -995,6 +986,48 @@ def _get_basic_config(
         config.set('build', 'build', 'True', user=True)
 
     config.set('paths', 'base_work_dir', work_dir, user=True)
+
+    return config
+
+
+def _get_component_config(basic_config, component, model=None):
+    """
+    Get the config options for a component: the basic config options plus the
+    component's own config file.
+
+    This is the config that the component's ``configure()`` method modifies
+    and that gets prepended to the config of each task and shared step the
+    component owns.
+
+    Parameters
+    ----------
+    basic_config : polaris.config.PolarisConfigParser
+        The config options for the machine and the command line
+
+    component : polaris.Component
+        The component to get config options for
+
+    model : str, optional
+        The model to run, if provided on the command line
+
+    Returns
+    -------
+    config : polaris.config.PolarisConfigParser
+        The config options for the component
+    """
+    config = PolarisConfigParser()
+    config.prepend(basic_config)
+
+    # set the model from the command line if provided
+    if model is not None:
+        config.set(component.name, 'model', model, user=True)
+
+    # add the config options for the component
+    config.add_from_package(
+        f'polaris.{component.name.replace("/", ".")}',
+        f'{component.name}.cfg',
+        exception=False,
+    )
 
     return config
 
@@ -1087,19 +1120,19 @@ def _check_dependencies(tasks):
                     )
 
 
-def _build_model(basic_config, component, machine):
-    model = basic_config.get(component.name, 'model')
-    section = basic_config['build']
+def _build_model(component_config, component, machine):
+    model = component_config.get(component.name, 'model')
+    section = component_config['build']
     branch = section.get('branch')
     clean_build = section.getboolean('clean')
     quiet_build = section.getboolean('quiet')
     debug = section.getboolean('debug')
     cmake_flags = section.get('cmake_flags')
 
-    build_dir = basic_config.get('paths', 'component_path')
+    build_dir = component_config.get('paths', 'component_path')
 
-    if basic_config.has_option('parallel', 'account'):
-        account = basic_config.get('parallel', 'account')
+    if component_config.has_option('parallel', 'account'):
+        account = component_config.get('parallel', 'account')
     else:
         account = None
 
@@ -1116,7 +1149,7 @@ def _build_model(basic_config, component, machine):
             log_filename=log_filename,
         )
     elif model == 'mpas-ocean':
-        section = basic_config['build']
+        section = component_config['build']
         compiler = section.get('compiler')
         mpilib = section.get('mpi')
         key = f'{compiler}_{mpilib}_target'
@@ -1144,16 +1177,16 @@ def _build_model(basic_config, component, machine):
         )
 
 
-def _check_pcd_version(basic_config, component):
+def _check_pcd_version(component_config, component):
     """Check that Polaris and branch PCD versions match when applicable."""
     if component.name != 'ocean':
         return
 
-    model = basic_config.get('ocean', 'model')
+    model = component_config.get('ocean', 'model')
     if model not in ['mpas-ocean', 'omega']:
         return
 
-    branch = basic_config.get('build', 'branch')
+    branch = component_config.get('build', 'branch')
     check_pcd_version_matches_branch(branch=branch, model=model)
 
 

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -7,14 +7,11 @@ import warnings
 from typing import Dict, List
 
 from polaris import Task, provenance
-from polaris.build.mpas_ocean import build_mpas_ocean
-from polaris.build.omega import build_omega
 from polaris.component_graph import (
     get_components_in_use,
     get_steps_by_component,
 )
 from polaris.config import PolarisConfigParser
-from polaris.constants.pcd import check_pcd_version_matches_branch
 from polaris.io import symlink
 from polaris.job import write_job_script
 from polaris.machines import discover_machine
@@ -195,13 +192,9 @@ def setup_tasks(
     build = section.getboolean('build')
 
     if build:
-        _build_model(
-            component_config=component_config,
-            component=component,
-            machine=machine,
-        )
+        component.build_model(config=component_config, machine=machine)
 
-    _check_pcd_version(component_config=component_config, component=component)
+    component.check_model_version(config=component_config)
 
     if clean_tasks:
         print('')
@@ -1213,76 +1206,6 @@ def _check_dependencies(tasks):
                         f'{task.path} step {step.name} was '
                         f'not set up.'
                     )
-
-
-def _build_model(component_config, component, machine):
-    model = component_config.get(component.name, 'model')
-    section = component_config['build']
-    branch = section.get('branch')
-    clean_build = section.getboolean('clean')
-    quiet_build = section.getboolean('quiet')
-    debug = section.getboolean('debug')
-    cmake_flags = section.get('cmake_flags')
-
-    build_dir = component_config.get('paths', 'component_path')
-
-    if component_config.has_option('parallel', 'account'):
-        account = component_config.get('parallel', 'account')
-    else:
-        account = None
-
-    if model == 'omega':
-        log_filename = os.path.join(build_dir, 'build_omega.log')
-        build_omega(
-            branch=branch,
-            build_dir=build_dir,
-            clean=clean_build,
-            quiet=quiet_build,
-            debug=debug,
-            cmake_flags=cmake_flags,
-            account=account,
-            log_filename=log_filename,
-        )
-    elif model == 'mpas-ocean':
-        section = component_config['build']
-        compiler = section.get('compiler')
-        mpilib = section.get('mpi')
-        key = f'{compiler}_{mpilib}_target'
-        if not section.has_option(key):
-            raise ValueError(
-                f'The build target {key} is not defined in the [build] '
-                f'section of the config file for machine {machine}.'
-            )
-        make_target = section.get(key)
-
-        log_filename = os.path.join(build_dir, 'build_mpas_ocean.log')
-        build_mpas_ocean(
-            branch=branch,
-            build_dir=build_dir,
-            clean=clean_build,
-            quiet=quiet_build,
-            debug=debug,
-            make_flags=cmake_flags,
-            make_target=make_target,
-            log_filename=log_filename,
-        )
-    else:
-        raise ValueError(
-            f'Automated build is not implemented for model {model}'
-        )
-
-
-def _check_pcd_version(component_config, component):
-    """Check that Polaris and branch PCD versions match when applicable."""
-    if component.name != 'ocean':
-        return
-
-    model = component_config.get('ocean', 'model')
-    if model not in ['mpas-ocean', 'omega']:
-        return
-
-    branch = component_config.get('build', 'branch')
-    check_pcd_version_matches_branch(branch=branch, model=model)
 
 
 def _get_suite_config(basic_config, component_name, suite_name):

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 from polaris import Task, provenance
 from polaris.build.mpas_ocean import build_mpas_ocean
 from polaris.build.omega import build_omega
+from polaris.component_graph import get_components_in_use
 from polaris.config import PolarisConfigParser
 from polaris.constants.pcd import check_pcd_version_matches_branch
 from polaris.io import symlink
@@ -163,11 +164,13 @@ def setup_tasks(
         work_dir=work_dir,
     )
 
-    component_config = _get_component_config(
+    component_configs = _get_component_configs(
         basic_config=basic_config,
         component=component,
+        tasks=tasks,
         model=model,
     )
+    component_config = component_configs[component.name]
 
     component.configure(component_config, list(tasks.values()))
     set_parallel_systems(tasks, basic_config)
@@ -198,8 +201,7 @@ def setup_tasks(
         print('')
 
     _setup_configs(
-        component_config=component_config,
-        component=component,
+        component_configs=component_configs,
         tasks=tasks,
         work_dir=work_dir,
         copy_executable=copy_executable,
@@ -658,47 +660,52 @@ def _expand_and_mark_cached_steps(tasks, cached_steps):
 
 
 def _setup_configs(
-    component_config,
-    component,
+    component_configs,
     tasks,
     work_dir,
     copy_executable,
 ):
-    """Set up config parsers for this component"""
+    """Set up config parsers for each component in use"""
 
-    common_config = component_config.copy()
+    common_configs = dict()
+    for name, component_config in component_configs.items():
+        common_config = component_config.copy()
 
-    if copy_executable:
-        common_config.set('setup', 'copy_executable', 'True')
+        if copy_executable:
+            common_config.set('setup', 'copy_executable', 'True')
 
-    if 'POLARIS_BRANCH' in os.environ:
-        polaris_branch = os.environ['POLARIS_BRANCH']
-        common_config.set('paths', 'polaris_branch', polaris_branch)
-    else:
-        common_config.set('paths', 'polaris_branch', os.getcwd())
+        if 'POLARIS_BRANCH' in os.environ:
+            polaris_branch = os.environ['POLARIS_BRANCH']
+            common_config.set('paths', 'polaris_branch', polaris_branch)
+        else:
+            common_config.set('paths', 'polaris_branch', os.getcwd())
 
-    initial_configs = _add_task_configs(component, tasks, common_config)
+        common_configs[name] = common_config
+
+    initial_configs = _add_task_configs(tasks, common_configs)
 
     # okay, we're finally ready to configure all the tasks and add configs
     # to the "owned" steps
     configs = _configure_tasks_and_add_step_configs(
-        tasks, initial_configs, common_config
+        tasks, initial_configs, common_configs
     )
 
-    _write_configs(common_config, configs, component.name, work_dir)
+    _write_configs(common_configs, configs, work_dir)
 
     _symlink_configs(tasks, work_dir)
 
 
-def _add_task_configs(component, tasks, common_config):
+def _add_task_configs(tasks, common_configs):
     """
     Add config parsers for tasks and steps that don't already have shared ones
     """
 
     # get a list of shared steps and add config files for tasks to the
-    # component
+    # component that owns them
     configs = dict()
+    owners = dict()
     for task in tasks.values():
+        component = task.component
         if task.config.filepath is None:
             task.config_filename = f'{task.name}.cfg'
             task.config.filepath = os.path.join(
@@ -706,18 +713,20 @@ def _add_task_configs(component, tasks, common_config):
             )
         component.add_config(task.config)
         configs[task.config.filepath] = task.config
+        owners[task.config.filepath] = component
 
-    # now go through all the configs and prepend the common config options,
-    # then run the setup() method for each in case there is some customization
-    for config in configs.values():
-        config.prepend(common_config)
+    # now go through all the configs and prepend the config options of the
+    # component that owns each one, then run the setup() method for each in
+    # case there is some customization
+    for filepath, config in configs.items():
+        config.prepend(common_configs[owners[filepath].name])
         config.setup()
 
     return configs
 
 
 def _configure_tasks_and_add_step_configs(
-    tasks, initial_configs, common_config
+    tasks, initial_configs, common_configs
 ):
     """
     Call the configure() method for each task and add configs to "owned" steps
@@ -738,8 +747,10 @@ def _configure_tasks_and_add_step_configs(
     # new steps were added
     configs = dict()
     new_configs = dict()
+    owners = dict()
     for task in tasks.values():
         configs[task.config.filepath] = task.config
+        owners[task.config.filepath] = task.component
         for step in task.steps.values():
             if step.has_shared_config:
                 if step.config.filepath is None:
@@ -747,26 +758,62 @@ def _configure_tasks_and_add_step_configs(
                     step.config.filepath = os.path.join(
                         step.component.name, step.subdir, step.config_filename
                     )
+                _check_config_owner(step, owners)
                 configs[step.config.filepath] = step.config
                 if step.config.filepath not in initial_configs:
                     new_configs[step.config.filepath] = step.config
                     step.component.add_config(step.config)
             else:
+                _check_step_component(step, task)
                 step._set_config(task.config, link=task.config_filename)
 
-    for config in new_configs.values():
-        config.prepend(common_config)
+    for filepath, config in new_configs.items():
+        config.prepend(common_configs[owners[filepath].name])
         config.setup()
 
     return configs
 
 
-def _write_configs(common_config, configs, component_name, work_dir):
+def _check_config_owner(step, owners):
+    """
+    Make sure a shared config is used by steps from only one component, and
+    keep track of which component owns it
+    """
+    filepath = step.config.filepath
+    owner = owners.get(filepath)
+    if owner is None:
+        owners[filepath] = step.component
+    elif owner is not step.component:
+        raise ValueError(
+            f'The shared config file {filepath} is used by steps from more '
+            f'than one component: {owner.name} and {step.component.name}.  A '
+            f'shared config file belongs to a single component, which '
+            f'provides its config options.'
+        )
+
+
+def _check_step_component(step, task):
+    """
+    Make sure a step that will get its config options from the task belongs to
+    the same component as the task
+    """
+    if step.component is not task.component:
+        raise ValueError(
+            f'Step {step.name} in {task.path} belongs to component '
+            f'{step.component.name} but the task belongs to component '
+            f'{task.component.name}.  A step from another component must be '
+            f'a shared step with a shared config file, so that it gets the '
+            f'config options of its own component.'
+        )
+
+
+def _write_configs(common_configs, configs, work_dir):
     """Write out all the config files"""
 
-    # add the common config at the component level
-    common_config.filepath = f'{component_name}.cfg'
-    configs[common_config.filepath] = common_config
+    # add the common config for each component at the component level
+    for name, common_config in common_configs.items():
+        common_config.filepath = f'{name}.cfg'
+        configs[common_config.filepath] = common_config
 
     # finally, write out the config files
     for config in configs.values():
@@ -988,6 +1035,45 @@ def _get_basic_config(
     config.set('paths', 'base_work_dir', work_dir, user=True)
 
     return config
+
+
+def _get_component_configs(basic_config, component, tasks, model=None):
+    """
+    Get the config options for each component in use: the component that owns
+    the tasks being set up, the components that own steps in those tasks and
+    the components of any dependencies of those steps.
+
+    Parameters
+    ----------
+    basic_config : polaris.config.PolarisConfigParser
+        The config options for the machine and the command line
+
+    component : polaris.Component
+        The component that owns the tasks being set up
+
+    tasks : dict of polaris.Task
+        The tasks being set up
+
+    model : str, optional
+        The model to run, if provided on the command line
+
+    Returns
+    -------
+    component_configs : dict of polaris.config.PolarisConfigParser
+        The config options for each component in use, with the component names
+        as keys
+    """
+    component_configs = dict()
+    for component_in_use in get_components_in_use(tasks):
+        # --model applies to the component that owns the tasks
+        component_model = model if component_in_use is component else None
+        component_configs[component_in_use.name] = _get_component_config(
+            basic_config=basic_config,
+            component=component_in_use,
+            model=component_model,
+        )
+
+    return component_configs
 
 
 def _get_component_config(basic_config, component, model=None):

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -39,6 +39,7 @@ def setup_tasks(
     quiet_build=None,
     cmake_flags=None,
     debug=None,
+    component_args=None,
 ):
     """
     Set up one or more tasks
@@ -118,6 +119,12 @@ def setup_tasks(
     debug : bool, optional
         Whether to build the model in debug mode
 
+    component_args : dict of dict, optional
+        The model, component path and branch for components other than the one
+        that owns the tasks, with the component names as keys.  These come from
+        the ``--<component>_model``, ``--<component>_path`` and
+        ``--<component>_branch`` flags.
+
     Returns
     -------
     tasks : dict of polaris.Task
@@ -154,9 +161,7 @@ def setup_tasks(
     basic_config = _get_basic_config(
         config_file=config_file,
         machine=machine,
-        component_path=component_path,
         build=build,
-        branch=branch,
         cmake_flags=cmake_flags,
         debug=debug,
         clean_build=clean_build,
@@ -164,16 +169,26 @@ def setup_tasks(
         work_dir=work_dir,
     )
 
+    components_in_use = get_components_in_use(tasks)
+
+    component_args = _get_component_args(
+        component=component,
+        components_in_use=components_in_use,
+        model=model,
+        component_path=component_path,
+        branch=branch,
+        component_args=component_args or dict(),
+    )
+
     component_configs = _get_component_configs(
         basic_config=basic_config,
-        component=component,
-        tasks=tasks,
-        model=model,
+        components_in_use=components_in_use,
+        component_args=component_args,
     )
     component_config = component_configs[component.name]
 
     steps_by_component = get_steps_by_component(tasks)
-    for component_in_use in get_components_in_use(tasks):
+    for component_in_use in components_in_use:
         name = component_in_use.name
         component_in_use.configure(
             component_configs[name], steps_by_component[name]
@@ -188,13 +203,12 @@ def setup_tasks(
         machine=machine,
         baseline_dir=baseline_dir,
     )
-    section = component_config['build']
-    build = section.getboolean('build')
 
-    if build:
-        component.build_model(config=component_config, machine=machine)
-
-    component.check_model_version(config=component_config)
+    _build_models(
+        components_in_use=components_in_use,
+        component_configs=component_configs,
+        machine=machine,
+    )
 
     if clean_tasks:
         print('')
@@ -562,6 +576,7 @@ def main():
         action='store_true',
         help='If the model should be built in debug mode.',
     )
+    add_component_model_args(parser)
 
     args = parser.parse_args(sys.argv[2:])
     cached = None
@@ -610,6 +625,7 @@ def main():
         quiet_build=args.quiet_build,
         cmake_flags=args.cmake_flags,
         debug=args.debug,
+        component_args=get_component_model_args(args),
     )
 
 
@@ -959,9 +975,7 @@ def __get_machine_and_check_params(
 def _get_basic_config(
     config_file,
     machine,
-    component_path,
     build,
-    branch,
     cmake_flags,
     debug,
     clean_build,
@@ -997,15 +1011,8 @@ def _get_basic_config(
     else:
         config.set('paths', 'polaris_branch', os.getcwd())
 
-    # set the component_path path from the command line if provided
-    if component_path is not None:
-        component_path = os.path.abspath(component_path)
-        config.set('paths', 'component_path', component_path, user=True)
-
     if build is not None:
         config.set('build', 'build', str(build), user=True)
-    if branch is not None:
-        config.set('build', 'branch', os.path.abspath(branch), user=True)
     compiler = os.environ['POLARIS_COMPILER']
     mpi = os.environ['POLARIS_MPI']
     config.set('build', 'machine', machine, user=True)
@@ -1039,7 +1046,79 @@ def _get_basic_config(
     return config
 
 
-def _get_component_configs(basic_config, component, tasks, model=None):
+def add_component_model_args(parser):
+    """
+    Add ``--<component>_model``, ``--<component>_path`` and
+    ``--<component>_branch`` flags for each component that has a model.
+
+    The unqualified ``--model``, ``-p``/``--component_path`` and ``--branch``
+    flags apply to the component that owns the tasks being set up.  These flags
+    are how the model, path or branch of any other component is set.
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        The parser to add the flags to
+    """
+    for component in get_components(add_tasks=False):
+        if not component.has_model():
+            continue
+        name = component.name
+        prefix = name.replace('/', '_')
+        parser.add_argument(
+            f'--{prefix}_model',
+            dest=f'{prefix}_model',
+            help=f'The model to run for the {name} component.',
+        )
+        parser.add_argument(
+            f'--{prefix}_path',
+            dest=f'{prefix}_path',
+            help=f'The path where the {name} component executable and '
+            f'default namelists have been (or will be) built.',
+            metavar='PATH',
+        )
+        parser.add_argument(
+            f'--{prefix}_branch',
+            dest=f'{prefix}_branch',
+            help=f'The branch of the {name} component model to build.',
+            metavar='PATH',
+        )
+
+
+def get_component_model_args(args):
+    """
+    Get the model, component path and branch for each component they were
+    provided for on the command line
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        The parsed command-line arguments
+
+    Returns
+    -------
+    component_args : dict of dict
+        The options for each component they were provided for, with the
+        component names as keys
+    """
+    options = dict(model='model', path='component_path', branch='branch')
+
+    component_args: Dict[str, Dict[str, str]] = dict()
+    for component in get_components(add_tasks=False):
+        if not component.has_model():
+            continue
+        prefix = component.name.replace('/', '_')
+        for flag, option in options.items():
+            value = getattr(args, f'{prefix}_{flag}', None)
+            if value is not None:
+                component_args.setdefault(component.name, dict())[option] = (
+                    value
+                )
+
+    return component_args
+
+
+def _get_component_configs(basic_config, components_in_use, component_args):
     """
     Get the config options for each component in use: the component that owns
     the tasks being set up, the components that own steps in those tasks and
@@ -1050,14 +1129,12 @@ def _get_component_configs(basic_config, component, tasks, model=None):
     basic_config : polaris.config.PolarisConfigParser
         The config options for the machine and the command line
 
-    component : polaris.Component
-        The component that owns the tasks being set up
+    components_in_use : list of polaris.Component
+        The components in use for the tasks being set up
 
-    tasks : dict of polaris.Task
-        The tasks being set up
-
-    model : str, optional
-        The model to run, if provided on the command line
+    component_args : dict of dict
+        The model, component path and branch from the command line for each
+        component they were provided for
 
     Returns
     -------
@@ -1066,19 +1143,19 @@ def _get_component_configs(basic_config, component, tasks, model=None):
         as keys
     """
     component_configs = dict()
-    for component_in_use in get_components_in_use(tasks):
-        # --model applies to the component that owns the tasks
-        component_model = model if component_in_use is component else None
-        component_configs[component_in_use.name] = _get_component_config(
+    for component in components_in_use:
+        component_configs[component.name] = _get_component_config(
             basic_config=basic_config,
-            component=component_in_use,
-            model=component_model,
+            component=component,
+            **component_args.get(component.name, dict()),
         )
 
     return component_configs
 
 
-def _get_component_config(basic_config, component, model=None):
+def _get_component_config(
+    basic_config, component, model=None, component_path=None, branch=None
+):
     """
     Get the config options for a component: the basic config options plus the
     component's own config file.
@@ -1097,6 +1174,13 @@ def _get_component_config(basic_config, component, model=None):
 
     model : str, optional
         The model to run, if provided on the command line
+
+    component_path : str, optional
+        The path to the component's build, if provided on the command line
+
+    branch : str, optional
+        The branch to build the component's model from, if provided on the
+        command line
 
     Returns
     -------
@@ -1117,7 +1201,106 @@ def _get_component_config(basic_config, component, model=None):
         exception=False,
     )
 
+    # set the component_path from the command line if provided
+    if component_path is not None:
+        config.set(
+            'paths',
+            'component_path',
+            os.path.abspath(component_path),
+            user=True,
+        )
+
+    if branch is not None:
+        config.set('build', 'branch', os.path.abspath(branch), user=True)
+
     return config
+
+
+def _get_component_args(
+    component, components_in_use, model, component_path, branch, component_args
+):
+    """
+    Work out which component each of the model, component path and branch
+    options from the command line applies to.
+
+    The unqualified options apply to the component that owns the tasks being
+    set up.  The ``--<component>_*`` options apply to the component they name.
+
+    Returns
+    -------
+    component_args : dict of dict
+        The model, component path and branch for each component they were
+        provided for, with the component names as keys
+    """
+    resolved: Dict[str, Dict[str, str]] = dict()
+
+    unqualified = dict(
+        model=model, component_path=component_path, branch=branch
+    )
+    unqualified = {
+        option: value
+        for option, value in unqualified.items()
+        if value is not None
+    }
+
+    if len(unqualified) > 0:
+        if not component.has_model():
+            flags = _get_model_flags(components_in_use)
+            raise ValueError(
+                f'The {component.name} component has no model, so --model, '
+                f'-p/--component_path and --branch do not apply to the tasks '
+                f'being set up.  Use the flags for the component whose model '
+                f'you mean: {flags}.'
+            )
+        resolved[component.name] = unqualified
+
+    names_in_use = [other.name for other in components_in_use]
+    for name, options in component_args.items():
+        if name not in names_in_use:
+            prefix = name.replace('/', '_')
+            raise ValueError(
+                f'--{prefix}_* was provided but the {name} component is not '
+                f'used by the tasks being set up.'
+            )
+        resolved.setdefault(name, dict()).update(options)
+
+    return resolved
+
+
+def _build_models(components_in_use, component_configs, machine):
+    """
+    Build the model of each component that has one and whose config options
+    ask for a build, and check that each model is compatible with polaris
+    """
+    for component in components_in_use:
+        if not component.has_model():
+            continue
+
+        config = component_configs[component.name]
+        if config.getboolean('build', 'build'):
+            component.build_model(config=config, machine=machine)
+
+        component.check_model_version(config=config)
+
+
+def _get_model_flags(components_in_use):
+    """
+    Get a printable list of the per-component command-line flags for the
+    components in use that have a model
+    """
+    flags = list()
+    for component in components_in_use:
+        if not component.has_model():
+            continue
+        prefix = component.name.replace('/', '_')
+        flags.extend(
+            [f'--{prefix}_model', f'--{prefix}_path', f'--{prefix}_branch']
+        )
+
+    if len(flags) == 0:
+        return 'none of the components in use has a model'
+
+    return ', '.join(flags)
 
 
 def _add_tasks_by_number(numbers, all_tasks, tasks, cached_steps):

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -165,8 +165,6 @@ def setup_tasks(
         work_dir=work_dir,
     )
 
-    _add_suite_config(basic_config, component.name, suite_name)
-
     component.configure(basic_config, list(tasks.values()))
     set_parallel_systems(tasks, basic_config)
 
@@ -273,8 +271,11 @@ def setup_tasks(
         print(f'minimum gpus: {max_of_min_gpus}')
 
     if machine is not None:
+        suite_config = _get_suite_config(
+            basic_config, component.name, suite_name
+        )
         job_options = write_job_script(
-            config=basic_config,
+            config=suite_config,
             machine=machine,
             target_cores=max_cores,
             min_cores=max_of_min_cores,
@@ -1154,6 +1155,36 @@ def _check_pcd_version(basic_config, component):
 
     branch = basic_config.get('build', 'branch')
     check_pcd_version_matches_branch(branch=branch, model=model)
+
+
+def _get_suite_config(basic_config, component_name, suite_name):
+    """
+    Get a copy of ``basic_config`` with the suite's config options added.
+
+    The suite's config options are used only for the suite's job script.  They
+    must not be added to ``basic_config`` itself, because that would propagate
+    them to the config options of every task and step in the suite.
+
+    Parameters
+    ----------
+    basic_config : polaris.config.PolarisConfigParser
+        The config options for the machine and the command line
+
+    component_name : str
+        The name of the component that the suite belongs to
+
+    suite_name : str
+        The name of the suite, or ``'custom'`` if tasks are not being set
+        up as part of a suite
+
+    Returns
+    -------
+    suite_config : polaris.config.PolarisConfigParser
+        The config options to use for the suite's job script
+    """
+    suite_config = basic_config.copy()
+    _add_suite_config(suite_config, component_name, suite_name)
+    return suite_config
 
 
 def _add_suite_config(config, component_name, suite_name):

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -9,7 +9,10 @@ from typing import Dict, List
 from polaris import Task, provenance
 from polaris.build.mpas_ocean import build_mpas_ocean
 from polaris.build.omega import build_omega
-from polaris.component_graph import get_components_in_use
+from polaris.component_graph import (
+    get_components_in_use,
+    get_steps_by_component,
+)
 from polaris.config import PolarisConfigParser
 from polaris.constants.pcd import check_pcd_version_matches_branch
 from polaris.io import symlink
@@ -172,7 +175,13 @@ def setup_tasks(
     )
     component_config = component_configs[component.name]
 
-    component.configure(component_config, list(tasks.values()))
+    steps_by_component = get_steps_by_component(tasks)
+    for component_in_use in get_components_in_use(tasks):
+        name = component_in_use.name
+        component_in_use.configure(
+            component_configs[name], steps_by_component[name]
+        )
+
     set_parallel_systems(tasks, basic_config)
 
     provenance.write(

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -1267,11 +1267,41 @@ def _get_component_args(
     return resolved
 
 
+def _check_model_executables(components_in_use, component_configs):
+    """
+    Make sure no two components in use expect their model executable in the
+    same place, which would mean one of them building over the other
+    """
+    executables: Dict[str, str] = dict()
+    for component in components_in_use:
+        if not component.has_model():
+            continue
+
+        config = component_configs[component.name]
+        if not config.has_option('executables', 'component'):
+            continue
+
+        executable = config.get('executables', 'component')
+        other = executables.get(executable)
+        if other is not None:
+            other_prefix = other.replace('/', '_')
+            prefix = component.name.replace('/', '_')
+            raise ValueError(
+                f'The {other} and {component.name} components both expect '
+                f'their model executable at {executable}.  Use '
+                f'--{other_prefix}_path and --{prefix}_path to give them '
+                f'different build directories.'
+            )
+        executables[executable] = component.name
+
+
 def _build_models(components_in_use, component_configs, machine):
     """
     Build the model of each component that has one and whose config options
     ask for a build, and check that each model is compatible with polaris
     """
+    _check_model_executables(components_in_use, component_configs)
+
     for component in components_in_use:
         if not component.has_model():
             continue

--- a/polaris/suite.py
+++ b/polaris/suite.py
@@ -3,7 +3,11 @@ import importlib.resources as imp_res
 import sys
 from typing import List
 
-from polaris.setup import setup_tasks
+from polaris.setup import (
+    add_component_model_args,
+    get_component_model_args,
+    setup_tasks,
+)
 
 
 def setup_suite(component, suite_name, work_dir, **kwargs):
@@ -159,6 +163,7 @@ def main():
         action='store_true',
         help='If the model should be built in debug mode.',
     )
+    add_component_model_args(parser)
 
     args = parser.parse_args(sys.argv[2:])
 
@@ -179,6 +184,7 @@ def main():
         quiet_build=args.quiet_build,
         cmake_flags=args.cmake_flags,
         debug=args.debug,
+        component_args=get_component_model_args(args),
     )
 
 

--- a/polaris/suite.py
+++ b/polaris/suite.py
@@ -17,7 +17,8 @@ def setup_suite(component, suite_name, work_dir, **kwargs):
     Parameters
     ----------
     component : str
-        The component ('ocean', 'landice', etc.) of the suite
+        The component ('ocean', 'landice', etc.) of the suite.  The tasks in
+        the suite need not all belong to this component.
 
     suite_name : str
         The name of the suite.  A file ``<suite_name>.txt`` must exist
@@ -45,6 +46,7 @@ def setup_suite(component, suite_name, work_dir, **kwargs):
         task_list=tasks,
         cached=cached,
         suite_name=suite_name,
+        suite_component=component,
         **kwargs,
     )
 

--- a/polaris/task.py
+++ b/polaris/task.py
@@ -147,8 +147,10 @@ class Task:
             The step to add if adding by Step object, not subdirectory
 
         subdir : str, optional
-            The subdirectory of the step within the component if wish to add
-            the step by path, and it has already been added to the component
+            The subdirectory of the step within this task's component if you
+            wish to add the step by path, and it has already been added to
+            that component.  A step from another component has to be added by
+            ``step``.
 
         symlink : str, optional
             A location for a symlink to the step, relative to the test case's
@@ -165,8 +167,6 @@ class Task:
         if step is not None and subdir is not None:
             raise ValueError('Only one of step or subdir should be provided.')
 
-        component = self.component
-
         if subdir is not None:
             if subdir not in self.component.steps:
                 raise ValueError(
@@ -174,7 +174,7 @@ class Task:
                     f'the component.  Add the step to the '
                     f'component first, then to the task.'
                 )
-            step = component.steps[subdir]
+            step = self.component.steps[subdir]
 
         if step.name in self.steps:
             raise ValueError(
@@ -182,8 +182,9 @@ class Task:
                 f'with name {step.name}'
             )
 
-        # add the step to the component (if it's not already there)
-        component.add_step(step)
+        # add the step to its own component (if it's not already there), which
+        # may not be the component this task belongs to
+        step.component.add_step(step)
 
         self.steps[step.name] = step
         step.tasks[self.subdir] = self
@@ -208,7 +209,7 @@ class Task:
         step.tasks.pop(self.subdir)
         if not step.tasks:
             # no tasks are using this step
-            self.component.remove_step(step)
+            step.component.remove_step(step)
         if step.name in self.step_symlinks:
             self.step_symlinks.pop(step.name)
         if step.name in self.steps_to_run:

--- a/polaris/tasks/__init__.py
+++ b/polaris/tasks/__init__.py
@@ -23,12 +23,25 @@ _components: List[Component] = [
 _tasks_added = False
 
 
-def get_components():
+def get_components(add_tasks=True):
     """
-    Add all tasks to the Polaris components
+    Get the Polaris components
+
+    Parameters
+    ----------
+    add_tasks : bool, optional
+        Whether to add all tasks to the components.  Building the tasks is by
+        far the most expensive part of getting the components, so this can be
+        ``False`` for callers that only need the components themselves (e.g.
+        to add command-line arguments for each of them).
+
+    Returns
+    -------
+    components : list of polaris.Component
+        The components
     """
     global _tasks_added
-    if not _tasks_added:
+    if add_tasks and not _tasks_added:
         # add tasks to each component
         add_e3sm_init_tasks(component=e3sm_init)
         add_mesh_tasks(component=mesh)

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -73,22 +73,23 @@ class Ocean(Component):
         self.state_vars: Union[None, list[str]] = None
         self.omega_only_horiz_mesh_vars: Union[None, list[str]] = None
 
-    def configure(self, config, tasks):
+    def configure(self, config, steps):
         """
         Configure the component
 
         Parameters
         ----------
         config : polaris.config.PolarisConfigParser
-            config options to modify
+            the config options for this component, to modify
 
-        tasks : list of polaris.Task
-            The tasks to be set up for this component
+        steps : list of polaris.Step
+            The steps this component owns among those being set up.  These may
+            belong to tasks in another component.
         """
         section = config['ocean']
         model = section.get('model')
         has_ocean_io_steps, has_ocean_model_steps = (
-            self._has_ocean_io_model_steps(tasks)
+            self._has_ocean_io_model_steps(steps)
         )
         if not (has_ocean_model_steps or has_ocean_io_steps):
             # No ocean I/O or model steps, so no model detection or build
@@ -908,9 +909,9 @@ class Ocean(Component):
                 'missing from the dataset: ' + ', '.join(missing)
             )
 
-    def _has_ocean_io_model_steps(self, tasks) -> Tuple[bool, bool]:
+    def _has_ocean_io_model_steps(self, steps) -> Tuple[bool, bool]:
         """
-        Determine if any steps in this component descend from OceanIOStep or
+        Determine if any of the steps descend from OceanIOStep or
         OceanModelStep
         """
         # local import to avoid circular imports
@@ -918,14 +919,10 @@ class Ocean(Component):
         from polaris.ocean.model.ocean_model_step import OceanModelStep
 
         has_ocean_model_steps = any(
-            isinstance(step, OceanModelStep)
-            for task in tasks
-            for step in task.steps.values()
+            isinstance(step, OceanModelStep) for step in steps
         )
         has_ocean_io_steps = any(
-            isinstance(step, OceanIOStep)
-            for task in tasks
-            for step in task.steps.values()
+            isinstance(step, OceanIOStep) for step in steps
         )
 
         return has_ocean_io_steps, has_ocean_model_steps

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -9,7 +9,10 @@ from mpas_tools.vector.reconstruct import reconstruct_variable
 from ruamel.yaml import YAML
 
 from polaris import Component
+from polaris.build.mpas_ocean import build_mpas_ocean
+from polaris.build.omega import build_omega
 from polaris.constants import get_constant
+from polaris.constants.pcd import check_pcd_version_matches_branch
 from polaris.mesh.reconstruct import (
     cartesian_to_local_geographic,
     tangential_reconstruction,
@@ -132,6 +135,89 @@ class Ocean(Component):
         self.model = model
         if model == 'omega':
             self._read_var_map()
+
+    def build_model(self, config, machine):
+        """
+        Build MPAS-Ocean or Omega
+
+        Parameters
+        ----------
+        config : polaris.config.PolarisConfigParser
+            the config options for this component
+
+        machine : str
+            The name of the machine to build the model on
+        """
+        model = config.get('ocean', 'model')
+        section = config['build']
+        branch = section.get('branch')
+        clean_build = section.getboolean('clean')
+        quiet_build = section.getboolean('quiet')
+        debug = section.getboolean('debug')
+        cmake_flags = section.get('cmake_flags')
+
+        build_dir = config.get('paths', 'component_path')
+
+        if config.has_option('parallel', 'account'):
+            account = config.get('parallel', 'account')
+        else:
+            account = None
+
+        if model == 'omega':
+            log_filename = os.path.join(build_dir, 'build_omega.log')
+            build_omega(
+                branch=branch,
+                build_dir=build_dir,
+                clean=clean_build,
+                quiet=quiet_build,
+                debug=debug,
+                cmake_flags=cmake_flags,
+                account=account,
+                log_filename=log_filename,
+            )
+        elif model == 'mpas-ocean':
+            compiler = section.get('compiler')
+            mpilib = section.get('mpi')
+            key = f'{compiler}_{mpilib}_target'
+            if not section.has_option(key):
+                raise ValueError(
+                    f'The build target {key} is not defined in the [build] '
+                    f'section of the config file for machine {machine}.'
+                )
+            make_target = section.get(key)
+
+            log_filename = os.path.join(build_dir, 'build_mpas_ocean.log')
+            build_mpas_ocean(
+                branch=branch,
+                build_dir=build_dir,
+                clean=clean_build,
+                quiet=quiet_build,
+                debug=debug,
+                make_flags=cmake_flags,
+                make_target=make_target,
+                log_filename=log_filename,
+            )
+        else:
+            raise ValueError(
+                f'Automated build is not implemented for model {model}'
+            )
+
+    def check_model_version(self, config):
+        """
+        Check that the PCD version in polaris matches the one in the branch of
+        the ocean model that will be run
+
+        Parameters
+        ----------
+        config : polaris.config.PolarisConfigParser
+            the config options for this component
+        """
+        model = config.get('ocean', 'model')
+        if model not in ['mpas-ocean', 'omega']:
+            return
+
+        branch = config.get('build', 'branch')
+        check_pcd_version_matches_branch(branch=branch, model=model)
 
     def map_to_native_model_vars(self, ds):
         """

--- a/polaris/tasks/seaice/__init__.py
+++ b/polaris/tasks/seaice/__init__.py
@@ -2,11 +2,37 @@ from polaris import Component
 
 
 class SeaIce(Component):
+    """
+    The collection of all tasks for the MPAS-Seaice core
+    """
+
     def __init__(self):
         """
-        Construct the collection of MPAS-Ocean test cases
+        Construct the collection of MPAS-Seaice test cases
         """
         super().__init__(name='seaice')
+
+    def configure(self, config, steps):
+        """
+        Configure the component
+
+        Parameters
+        ----------
+        config : polaris.config.PolarisConfigParser
+            the config options for this component, to modify
+
+        steps : list of polaris.Step
+            The steps this component owns among those being set up.  These may
+            belong to tasks in another component.
+        """
+        model = config.get('seaice', 'model')
+
+        configs = {'mpas-seaice': 'mpas_seaice.cfg'}
+
+        if model not in configs:
+            raise ValueError(f'Unknown sea-ice model {model}')
+
+        config.add_from_package('polaris.seaice', configs[model])
 
 
 # create a single module-level instance available to other components

--- a/tests/test_component_configs.py
+++ b/tests/test_component_configs.py
@@ -197,7 +197,7 @@ def test_a_shared_config_belongs_to_one_component(basic_config, tmp_path):
     mesh = Component(name='mesh')
     e3sm_init = Component(name='e3sm/init')
     ocean_step = get_shared_step(ocean, 'an_ocean_step', 'shared')
-    mesh_step = Step(component=mesh, name='a_mesh_step', subdir='mesh_shared')
+    mesh_step = Step(component=mesh, name='a_mesh_step', subdir='shared')
     mesh_step.set_shared_config(ocean_step.config, link='an_ocean_step.cfg')
     task = Task(component=e3sm_init, name='a_task')
     task.add_step(step=ocean_step)

--- a/tests/test_component_configs.py
+++ b/tests/test_component_configs.py
@@ -1,0 +1,335 @@
+import os
+
+import pytest
+
+from polaris import Component, Step, Task
+from polaris.component_graph import (
+    get_components_in_use,
+    get_steps_by_component,
+)
+from polaris.config import PolarisConfigParser
+from polaris.setup import (
+    _get_basic_config,
+    _get_component_args,
+    _get_component_configs,
+    _setup_configs,
+)
+
+
+class RecordingComponent(Component):
+    """A component that records what its configure() method was given"""
+
+    def __init__(self, name):
+        super().__init__(name=name)
+        self.configured_steps = None
+
+    def configure(self, config, steps):
+        self.configured_steps = steps
+        config.set('recording', 'configured', self.name)
+
+
+@pytest.fixture
+def basic_config(tmp_path, monkeypatch):
+    """The machine and command-line config options, with no component"""
+    monkeypatch.setenv('POLARIS_COMPILER', 'gnu')
+    monkeypatch.setenv('POLARIS_MPI', 'openmpi')
+    return _get_basic_config(
+        config_file=None,
+        machine='chrysalis',
+        build=None,
+        cmake_flags=None,
+        debug=None,
+        clean_build=None,
+        quiet_build=None,
+        work_dir=str(tmp_path),
+    )
+
+
+def get_shared_step(component, name, subdir):
+    """Build a step in ``component`` with a shared config of its own"""
+    step = Step(component=component, name=name, subdir=subdir)
+    config = PolarisConfigParser(
+        filepath=os.path.join(component.name, subdir, f'{name}.cfg')
+    )
+    step.set_shared_config(config, link=f'{name}.cfg')
+    return step
+
+
+def setup_configs(basic_config, tasks, work_dir):
+    """Run the config half of setup for ``tasks``"""
+    component = next(iter(tasks.values())).component
+    components_in_use = get_components_in_use(tasks)
+    component_args = _get_component_args(
+        component=component,
+        components_in_use=components_in_use,
+        model=None,
+        component_path=None,
+        branch=None,
+        component_args=dict(),
+    )
+    component_configs = _get_component_configs(
+        basic_config=basic_config,
+        components_in_use=components_in_use,
+        component_args=component_args,
+    )
+    steps_by_component = get_steps_by_component(tasks)
+    for component_in_use in components_in_use:
+        name = component_in_use.name
+        component_in_use.configure(
+            component_configs[name], steps_by_component[name]
+        )
+    _setup_configs(
+        component_configs=component_configs,
+        tasks=tasks,
+        work_dir=work_dir,
+        copy_executable=False,
+    )
+    return component_configs
+
+
+def test_a_shared_step_gets_its_own_components_options(basic_config, tmp_path):
+    """
+    A shared ocean step in a task from another component gets the ocean's
+    config options, which is what its own component provides and the task's
+    component knows nothing about.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+    step = get_shared_step(ocean, 'a_shared_step', 'shared')
+    task = Task(component=e3sm_init, name='a_task')
+    task.add_step(step=step)
+    tasks = {task.path: task}
+
+    setup_configs(basic_config, tasks, str(tmp_path))
+
+    # [ocean] model is defined in polaris/ocean/ocean.cfg and nowhere else
+    assert step.config.get('ocean', 'model') == 'detect'
+
+
+def test_a_task_does_not_get_another_components_options(
+    basic_config, tmp_path
+):
+    """
+    The task's own config gets its own component's options, not those of the
+    components its shared steps belong to.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+    step = get_shared_step(ocean, 'a_shared_step', 'shared')
+    task = Task(component=e3sm_init, name='a_task')
+    task.add_step(step=step)
+    tasks = {task.path: task}
+
+    setup_configs(basic_config, tasks, str(tmp_path))
+
+    assert not task.config.has_option('ocean', 'model')
+
+
+def test_a_shared_step_does_not_depend_on_who_set_it_up(
+    basic_config, tmp_path
+):
+    """
+    The config options of a shared step are the same whether the task that
+    pulls it in belongs to its own component or to another one.
+    """
+    options = list()
+    for task_component_name in ['ocean', 'e3sm/init']:
+        ocean = Component(name='ocean')
+        task_component = (
+            ocean
+            if task_component_name == 'ocean'
+            else Component(name=task_component_name)
+        )
+        step = get_shared_step(ocean, 'a_shared_step', 'shared')
+        task = Task(component=task_component, name='a_task')
+        task.add_step(step=step)
+        tasks = {task.path: task}
+
+        work_dir = os.path.join(str(tmp_path), task_component_name)
+        setup_configs(basic_config, tasks, work_dir)
+
+        step.config.combine(raw=True)
+        options.append(
+            {
+                (section, option): value
+                for section in step.config.combined.sections()
+                for option, value in step.config.combined.items(section)
+                # the task's own section names the task, not the step
+                if section != 'a_task'
+            }
+        )
+
+    assert options[0] == options[1]
+
+
+def test_each_component_in_use_is_configured(basic_config, tmp_path):
+    """
+    Every component in use has its configure() method called, on its own
+    config options and with the steps it owns.
+    """
+    shared_component = RecordingComponent(name='ocean')
+    task_component = RecordingComponent(name='e3sm/init')
+    step = get_shared_step(shared_component, 'a_shared_step', 'shared')
+    task = Task(component=task_component, name='a_task')
+    task.add_step(step=step)
+    tasks = {task.path: task}
+
+    component_configs = setup_configs(basic_config, tasks, str(tmp_path))
+
+    assert shared_component.configured_steps == [step]
+    assert task_component.configured_steps == []
+    assert component_configs['ocean'].get('recording', 'configured') == 'ocean'
+    assert (
+        component_configs['e3sm/init'].get('recording', 'configured')
+        == 'e3sm/init'
+    )
+    # what each component's configure() set reaches the configs it owns
+    assert step.config.get('recording', 'configured') == 'ocean'
+    assert task.config.get('recording', 'configured') == 'e3sm/init'
+
+
+def test_a_shared_config_belongs_to_one_component(basic_config, tmp_path):
+    """
+    A shared config used by steps from two components has no single component
+    to get its config options from, so setup refuses it.
+    """
+    ocean = Component(name='ocean')
+    mesh = Component(name='mesh')
+    e3sm_init = Component(name='e3sm/init')
+    ocean_step = get_shared_step(ocean, 'an_ocean_step', 'shared')
+    mesh_step = Step(component=mesh, name='a_mesh_step', subdir='mesh_shared')
+    mesh_step.set_shared_config(ocean_step.config, link='an_ocean_step.cfg')
+    task = Task(component=e3sm_init, name='a_task')
+    task.add_step(step=ocean_step)
+    task.add_step(step=mesh_step)
+    tasks = {task.path: task}
+
+    with pytest.raises(ValueError, match='more than one component'):
+        setup_configs(basic_config, tasks, str(tmp_path))
+
+
+def test_a_step_from_another_component_must_be_shared(basic_config, tmp_path):
+    """
+    A step from another component with no shared config would get its config
+    options from the task, and so from the wrong component.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+    step = Step(component=ocean, name='a_step')
+    task = Task(component=e3sm_init, name='a_task')
+    task.add_step(step=step)
+    tasks = {task.path: task}
+
+    with pytest.raises(ValueError, match='must be a shared step'):
+        setup_configs(basic_config, tasks, str(tmp_path))
+
+
+def test_unqualified_flags_go_to_the_tasks_component():
+    """
+    --model, -p and --branch apply to the component that owns the tasks, as
+    they always have.
+    """
+    ocean = Component(name='ocean')
+
+    component_args = _get_component_args(
+        component=ocean,
+        components_in_use=[ocean],
+        model='omega',
+        component_path='/a/build',
+        branch=None,
+        component_args=dict(),
+    )
+
+    assert component_args == {
+        'ocean': {'model': 'omega', 'component_path': '/a/build'}
+    }
+
+
+def test_unqualified_flags_need_a_component_with_a_model():
+    """
+    A task in a component with no model gives -p nothing to apply to, so
+    setup says which flag to use instead rather than quietly ignoring it.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+
+    with pytest.raises(ValueError, match='--ocean_path'):
+        _get_component_args(
+            component=e3sm_init,
+            components_in_use=[e3sm_init, ocean],
+            model=None,
+            component_path='/a/build',
+            branch=None,
+            component_args=dict(),
+        )
+
+
+def test_a_qualified_flag_reaches_another_components_config(
+    basic_config, tmp_path
+):
+    """
+    --ocean_path points the ocean's steps at an ocean build even though the
+    task belongs to another component.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+    step = get_shared_step(ocean, 'a_shared_step', 'shared')
+    task = Task(component=e3sm_init, name='a_task')
+    task.add_step(step=step)
+    tasks = {task.path: task}
+
+    component_configs = _get_component_configs(
+        basic_config=basic_config,
+        components_in_use=get_components_in_use(tasks),
+        component_args=_get_component_args(
+            component=e3sm_init,
+            components_in_use=get_components_in_use(tasks),
+            model=None,
+            component_path=None,
+            branch=None,
+            component_args={'ocean': {'component_path': '/a/build'}},
+        ),
+    )
+
+    assert (
+        component_configs['ocean'].get('paths', 'component_path') == '/a/build'
+    )
+    assert not component_configs['e3sm/init'].has_option(
+        'paths', 'component_path'
+    )
+
+
+def test_a_qualified_flag_needs_its_component_to_be_in_use():
+    """
+    --ocean_path in a setup with no ocean steps would have no effect, so it
+    is an error rather than a silent no-op.
+    """
+    mesh = Component(name='mesh')
+
+    with pytest.raises(ValueError, match='not\nused|not used'):
+        _get_component_args(
+            component=mesh,
+            components_in_use=[mesh],
+            model=None,
+            component_path=None,
+            branch=None,
+            component_args={'ocean': {'component_path': '/a/build'}},
+        )
+
+
+def test_a_single_component_setup_gets_its_own_options(basic_config, tmp_path):
+    """
+    The common case: a task and its steps all belong to one component, which
+    provides the config options for all of them.
+    """
+    ocean = Component(name='ocean')
+    step = get_shared_step(ocean, 'a_shared_step', 'shared')
+    task = Task(component=ocean, name='a_task')
+    task.add_step(step=step)
+    tasks = {task.path: task}
+
+    setup_configs(basic_config, tasks, str(tmp_path))
+
+    assert task.config.get('ocean', 'model') == 'detect'
+    assert step.config.get('ocean', 'model') == 'detect'
+    assert os.path.exists(os.path.join(str(tmp_path), 'ocean.cfg'))

--- a/tests/test_component_graph.py
+++ b/tests/test_component_graph.py
@@ -1,0 +1,81 @@
+from polaris import Component, Step, Task
+from polaris.component_graph import get_components_in_use
+
+
+def get_task(component, name, steps=()):
+    """Build a task in ``component`` containing ``steps``"""
+    task = Task(component=component, name=name)
+    for step in steps:
+        task.add_step(step=step)
+    return task
+
+
+def test_the_task_component_is_in_use():
+    """A task with no steps still puts its own component in use."""
+    ocean = Component(name='ocean')
+    task = get_task(ocean, 'a_task')
+
+    assert get_components_in_use({task.path: task}) == [ocean]
+
+
+def test_a_step_from_another_component_is_in_use():
+    """
+    A task that includes a step from another component puts that component in
+    use, too.  This is what makes a cross-component task possible.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+    step = Step(component=ocean, name='a_shared_step')
+    task = get_task(e3sm_init, 'a_task', steps=[step])
+
+    assert get_components_in_use({task.path: task}) == [e3sm_init, ocean]
+
+
+def test_the_component_of_a_dependency_is_in_use():
+    """
+    A step's dependencies may live in yet another component, which is in use
+    even though no task refers to it directly.
+    """
+    ocean = Component(name='ocean')
+    mesh = Component(name='mesh')
+    e3sm_init = Component(name='e3sm/init')
+    dependency = Step(component=mesh, name='a_mesh_step')
+    step = Step(component=ocean, name='a_shared_step')
+    step.add_dependency(dependency)
+    task = get_task(e3sm_init, 'a_task', steps=[step])
+
+    components = get_components_in_use({task.path: task})
+
+    assert components == [e3sm_init, ocean, mesh]
+
+
+def test_each_component_appears_once():
+    """
+    Components are not repeated, however many tasks and steps refer to them,
+    and the order they were encountered in is preserved.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+    first = get_task(
+        e3sm_init, 'first', steps=[Step(component=ocean, name='first_step')]
+    )
+    second = get_task(
+        ocean, 'second', steps=[Step(component=ocean, name='second_step')]
+    )
+    tasks = {first.path: first, second.path: second}
+
+    assert get_components_in_use(tasks) == [e3sm_init, ocean]
+
+
+def test_a_circular_dependency_does_not_recurse_forever():
+    """
+    Steps that depend on one another are visited once each.
+    """
+    ocean = Component(name='ocean')
+    first = Step(component=ocean, name='first_step')
+    second = Step(component=ocean, name='second_step')
+    first.add_dependency(second)
+    second.add_dependency(first)
+    task = get_task(ocean, 'a_task', steps=[first, second])
+
+    assert get_components_in_use({task.path: task}) == [ocean]

--- a/tests/test_component_graph.py
+++ b/tests/test_component_graph.py
@@ -13,6 +13,53 @@ def get_task(component, name, steps=()):
     return task
 
 
+def test_a_step_is_registered_with_its_own_component():
+    """
+    A step belongs to its own component, whichever component's task adds it.
+    Registering it with the task's component would put it in a component that
+    does not provide its config options and does not know how to run it.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+    step = Step(component=ocean, name='a_shared_step')
+    get_task(e3sm_init, 'a_task', steps=[step])
+
+    assert ocean.steps == {step.subdir: step}
+    assert e3sm_init.steps == {}
+
+
+def test_steps_in_different_components_may_share_a_subdir():
+    """
+    Two steps in one task may have the same subdirectory as long as they are
+    in different components, since the component name is part of the path.
+    """
+    ocean = Component(name='ocean')
+    mesh = Component(name='mesh')
+    e3sm_init = Component(name='e3sm/init')
+    ocean_step = Step(component=ocean, name='an_ocean_step', subdir='shared')
+    mesh_step = Step(component=mesh, name='a_mesh_step', subdir='shared')
+
+    get_task(e3sm_init, 'a_task', steps=[ocean_step, mesh_step])
+
+    assert ocean.steps == {'shared': ocean_step}
+    assert mesh.steps == {'shared': mesh_step}
+
+
+def test_removing_a_step_removes_it_from_its_own_component():
+    """
+    A step no task is using is removed from the component it belongs to, not
+    from the component of the task it was removed from.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+    step = Step(component=ocean, name='a_shared_step')
+    task = get_task(e3sm_init, 'a_task', steps=[step])
+
+    task.remove_step(step)
+
+    assert ocean.steps == {}
+
+
 def test_the_task_component_is_in_use():
     """A task with no steps still puts its own component in use."""
     ocean = Component(name='ocean')

--- a/tests/test_component_graph.py
+++ b/tests/test_component_graph.py
@@ -1,5 +1,8 @@
 from polaris import Component, Step, Task
-from polaris.component_graph import get_components_in_use
+from polaris.component_graph import (
+    get_components_in_use,
+    get_steps_by_component,
+)
 
 
 def get_task(component, name, steps=()):
@@ -65,6 +68,36 @@ def test_each_component_appears_once():
     tasks = {first.path: first, second.path: second}
 
     assert get_components_in_use(tasks) == [e3sm_init, ocean]
+
+
+def test_steps_are_grouped_by_the_component_that_owns_them():
+    """
+    Each step goes with its own component, not with the component of the task
+    it belongs to.  This is what a component's configure() method is given.
+    """
+    ocean = Component(name='ocean')
+    e3sm_init = Component(name='e3sm/init')
+    ocean_step = Step(component=ocean, name='an_ocean_step')
+    e3sm_init_step = Step(component=e3sm_init, name='an_e3sm_init_step')
+    task = get_task(e3sm_init, 'a_task', steps=[ocean_step, e3sm_init_step])
+
+    steps_by_component = get_steps_by_component({task.path: task})
+
+    assert steps_by_component == {
+        'e3sm/init': [e3sm_init_step],
+        'ocean': [ocean_step],
+    }
+
+
+def test_a_component_with_no_steps_has_an_entry():
+    """
+    The component that owns a task always has an entry, so that its
+    configure() method gets called with an empty list rather than not at all.
+    """
+    mesh = Component(name='mesh')
+    task = get_task(mesh, 'a_task')
+
+    assert get_steps_by_component({task.path: task}) == {'mesh': []}
 
 
 def test_a_circular_dependency_does_not_recurse_forever():

--- a/tests/test_suite_config.py
+++ b/tests/test_suite_config.py
@@ -2,9 +2,11 @@ import os
 
 import pytest
 
+import polaris.suite
 from polaris.config import PolarisConfigParser
 from polaris.job import write_job_script
 from polaris.setup import _add_suite_config, _get_suite_config
+from polaris.suite import setup_suite
 
 
 def get_basic_config(machine):
@@ -60,6 +62,27 @@ def test_suite_config_reaches_the_job_script(tmp_path):
     """The suite's wall time ends up in the suite's job script."""
     text = get_job_script(tmp_path, 'chrysalis', 'omega_pr', nodes=2)
     assert '#SBATCH --time=00:30:00' in text
+
+
+def test_the_suites_component_reaches_setup(tmp_path, monkeypatch):
+    """
+    A suite's config file comes from the component the suite belongs to.  The
+    tasks in a suite may belong to other components, so setup cannot work this
+    out from the tasks themselves.
+    """
+    passed = dict()
+
+    def fake_setup_tasks(**kwargs):
+        passed.update(kwargs)
+
+    monkeypatch.setattr(polaris.suite, 'setup_tasks', fake_setup_tasks)
+
+    setup_suite(
+        component='ocean', suite_name='framework_pr', work_dir=str(tmp_path)
+    )
+
+    assert passed['suite_component'] == 'ocean'
+    assert passed['suite_name'] == 'framework_pr'
 
 
 def test_suite_config_stays_out_of_the_basic_config():

--- a/tests/test_suite_config.py
+++ b/tests/test_suite_config.py
@@ -4,14 +4,20 @@ import pytest
 
 from polaris.config import PolarisConfigParser
 from polaris.job import write_job_script
-from polaris.setup import _add_suite_config
+from polaris.setup import _add_suite_config, _get_suite_config
+
+
+def get_basic_config(machine):
+    """Build a config for ``machine`` without any suite config options."""
+    config = PolarisConfigParser()
+    config.add_from_package('polaris', 'default.cfg')
+    config.add_from_package('mache.machines', f'{machine}.cfg')
+    return config
 
 
 def get_config(machine, suite_name):
     """Build a config for ``machine`` with ``suite_name``'s options added."""
-    config = PolarisConfigParser()
-    config.add_from_package('polaris', 'default.cfg')
-    config.add_from_package('mache.machines', f'{machine}.cfg')
+    config = get_basic_config(machine)
     _add_suite_config(config, 'ocean', suite_name)
     return config
 
@@ -54,6 +60,19 @@ def test_suite_config_reaches_the_job_script(tmp_path):
     """The suite's wall time ends up in the suite's job script."""
     text = get_job_script(tmp_path, 'chrysalis', 'omega_pr', nodes=2)
     assert '#SBATCH --time=00:30:00' in text
+
+
+def test_suite_config_stays_out_of_the_basic_config():
+    """
+    The suite's options go only into the config for the suite's job script.
+    The basic config is the source of the config options for every task and
+    step in the suite, so the suite must leave it alone.
+    """
+    basic_config = get_basic_config('chrysalis')
+    suite_config = _get_suite_config(basic_config, 'ocean', 'omega_pr')
+
+    assert suite_config.get('job', 'wall_time') == '00:30:00'
+    assert basic_config.get('job', 'wall_time') == '1:00:00'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Polaris lets a task include shared steps that belong to another component -- an `e3sm/init` task that runs the ocean's initialization chain, or an ocean task that uses a base mesh from `mesh` -- and lets a suite gather tasks from wherever they live. Setup did not support either: it assumed that everything in a task belonged to the task's component, and that everything in a suite belonged to the suite's. This PR makes each component responsible for the things it owns, so a task and a suite may both cross components.

## What was broken

**Steps from another component.** A shared step got the config options of the component that owns the *task*, so a shared ocean step in an `e3sm/init` task was set up without `polaris/ocean/ocean.cfg` and without `Ocean.configure()` ever running. Setting up such a task failed outright with `NoOptionError: No option 'model' in section: 'ocean'`. A task also registered every one of its steps in its own component, so a step could end up in a component that neither provides its config options nor knows how to run it.

**Suites.** A suite's config file was added to every task and step in the suite, so a suite quietly rewrote config options for the tasks it contained -- and, for a shared step, changed how that step was set up depending on which suite it happened to be in. A suite's config file was also looked up under the first task's component rather than the suite's own, so a suite whose first task came from elsewhere would silently lose its own options.

**The model and the build.** `-p`, `--model` and `--branch` applied to the task's component, so there was no way to point a task in one component at the model build of another. Both ocean models also defaulted their build to `<work_dir>/build`, a name any second component would collide with.

## What should work now

A task may include shared steps from any component, and each step gets its own component's config options, `configure()`, model and build path -- identically whether an ocean task or an `e3sm/init` task pulls it in, and whether or not it is part of a suite. That last property is what makes a shared step reusable across components at all.

A suite may contain tasks from more than one component. Each task gets its own component's config options, each component in use gets its own top-level config file, and the suite's own config file comes from the component the suite belongs to.

Two cases that used to go wrong silently now raise with a clear message: a step from another component with no shared config, and a shared config used by steps from two components.

One thing to know about a mixed task list: the unqualified `-p`, `--model` and `--branch` still bind to the component of the first task, so use the per-component flags below when more than one component's model is involved.

## What changes for existing users

- The ocean's default build directory is now `<work_dir>/ocean_build` rather than `<work_dir>/build`. Only the default changed; a setup that passes `-p` explicitly is unaffected. An existing `<work_dir>/build` needs `-p` or a rebuild.
- New `--<component>_model`, `--<component>_path` and `--<component>_branch` flags set the model, build path and branch of any component other than the tasks' own. If the tasks' component has no model, the unqualified flags now raise and name the flag to use instead.
- Suite config files no longer reach the tasks and steps in the suite; they apply to the suite's job script, which is what they were for.
- For component developers: `Component.configure(config, tasks)` is now `configure(config, steps)`, and building the model moved from the framework to `Component.build_model()`. `Ocean` is the only component affected.

## Testing

`pytest tests` passes (358 tests, 23 of them new). A scan of every task in the repo finds 247 cross-component steps already on `main`, all of which satisfy the new ownership rules, and no step registered in the wrong component. Config assembly was checked against real tasks for the single-component case (unchanged), the cross-component case, and a task list spanning two components.

Two limits worth stating. No suite in the repo crosses components yet, so that path is new capability rather than something exercised here. And the acceptance test -- `polaris setup` of the `e3sm/init` `component_inputs` target, where this was found -- is being verified separately on `add-e3sm-init-component-inputs`, since `main` has no cross-component task that needs another component's config options. That command now takes `--ocean_path <mpaso build>` rather than `-p`.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] `docs/developers_guide/supported_machines.yaml` has been updated if machines, compilers or MPI libraries were added, removed or renamed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
