### PR TITLE
Design docs for Omega analysis

### DIFF
--- a/docs/design_docs/index.md
+++ b/docs/design_docs/index.md
@@ -8,6 +8,7 @@
 horiz_press_grad_reference
 land_locked_cells
 ocean_analysis
+ocean_analysis_initial
 overflow_nonlinear_eos
 pstar_init
 shared_steps

--- a/docs/design_docs/index.md
+++ b/docs/design_docs/index.md
@@ -7,6 +7,7 @@
 
 horiz_press_grad_reference
 land_locked_cells
+ocean_analysis
 overflow_nonlinear_eos
 pstar_init
 shared_steps

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -282,7 +282,7 @@ simulation years, and how Polaris job scripts interact with zppy's.
 
 ### Requirement: concurrent execution of independent analysis
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -315,20 +315,25 @@ Three consequences for the analysis design:
   a shared step so only one instance of it exists --- but "launches
   subprocesses" and "writes into a shared location" are exactly the properties
   the eligibility mechanism is meant to catch.
-- **The per-year decomposition is the real prize, and Phase 1 already has
-  it.**  Vertically integrated heat content and offline mixed-layer depth are
-  computed by one shared step per simulation year, a structure Phase 1 adopts
-  for reuse across date ranges rather than for parallelism.  Those steps are
-  independent, non-MPI, and numerous --- forty of them for a forty-year record
-  --- so they are exactly the workload Phase 2 of task parallelism is built to
-  overlap, and they should benefit with no restructuring at all.
+- **The largest source of concurrency is deliberately *inside* a step, not
+  across steps.**  An earlier draft decomposed the expensive passes over the
+  simulation record into one shared step per simulation year, and treated those
+  forty-odd independent non-MPI steps as the prize for task parallelism Phase
+  2.  They are now a single seeded accumulator per product, whose remaining
+  months are spread over a process pool within the step.  This is a
+  deliberate trade in favor of a capability that exists today, and it follows
+  principle 3: steps are for caching and selection, and parallelism inside a
+  step is the cheaper way to get concurrency.  The consequence for task
+  parallelism is that analysis needs it less than this document previously
+  claimed, and what it stands to gain is the coarse overlap of independent
+  products described in the first bullet.
 
 *Further details to be added* once the analysis workload has been profiled and
 task parallelism is available to measure against.
 
 ### Requirement: scalability and restartability
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -338,15 +343,33 @@ to extend an existing analysis with additional simulation years without
 recomputing what it has already computed.
 
 Phase 1 establishes the pattern the rest of the capability should follow:
-**every expensive computation is decomposed into a per-year product keyed by
-the year rather than by the requested date range**, and given its own shared
-step, so that it is computed once and reused by every later analysis.  Reuse is
-then not a caching mechanism of our own but a consequence of Polaris's ordinary
-shared-step and step-completion behavior.  Phase 1 also streams over monthly
-files rather than loading a whole record at once.
+**every expensive computation over the simulation record is a seeded
+accumulator**, as described under the organizing principles above.  One step
+per product, keyed by what the user asked for, inherits whatever earlier runs
+of the same product already computed, does only the difference, and writes a
+complete result for its own key.  Extending an analysis from twenty years to
+forty therefore costs twenty years of work.
+
+An earlier draft got this by giving each simulation year its own shared step
+and letting Polaris's step-completion behavior do the reuse.  That worked, but
+it paid a step's overhead --- a directory, a pickle, a config copy, a log file
+--- for a chunk no user ever asked for, and it made the completion marker the
+only cache-validity check there was, so a changed kernel or a changed constant
+would have been inherited silently.  An accumulator is both cheaper and safer:
+see principles 6 and 7 above.
+
+Two further properties come with the pattern rather than being added to it.  A
+partially written cache in a step's own directory is a valid starting point for
+a retry, which is most of what restartability asks for.  And because the
+accumulator's remaining work is a set of independent units inside a single
+step, it can be spread across cores with a process pool now, rather than
+waiting on concurrency across steps.
+
+Phase 1 also streams over monthly files rather than loading a whole record at
+once.
 
 *Remaining details to be added*, in particular how analysis is chunked across
-compute nodes.  Running the per-year products concurrently is covered by the
+compute nodes.  Overlapping independent products is covered by the
 task-parallelism requirement above.
 
 ## Algorithm Design

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -727,9 +727,6 @@ is explained in context in {ref}`design-ocean-analysis-initial`.
   Omega's in-situ density-threshold diagnostic.  A mixed-layer depth derived
   from monthly-mean profiles cannot represent deep winter mixing events and
   cannot produce a monthly maximum at all.
-- **Compute the ocean heat content climatology from per-month integrals**
-  rather than from a climatology of conservative temperature, if the neglected
-  $\overline{\Theta' h'}$ covariance term proves large enough to matter.
 - **Regional overturning**, in particular the Atlantic MOC and the standard
   maximum-AMOC-near-26.5°N metric, which arrives with the regional analysis
   described in the requirements above.

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -309,6 +309,53 @@ below.
 MPAS-Analysis's component/group/gallery structure to adopt.  Polaris already
 records provenance for a setup in `polaris/provenance.py`.
 
+### Requirement: pruning and archiving
+
+Date last modified: 2026/08/25
+
+Contributors: Xylar Asay-Davis, Claude
+
+Analysis produces far more bytes than it publishes, and repeated analysis of a
+growing simulation produces them again.  Polaris shall provide a way to reduce
+an analysis directory to what is worth keeping, without the user having to work
+out by hand which files those are.
+
+Two distinct operations, which should not be conflated:
+
+- **Prune to the published set.**  Keep the plots and data products that were
+  published, and discard the intermediates behind them --- climatologies,
+  accumulator caches, and the step directories that held them.  This is the
+  operation for an analysis that is finished and wants to be archived or
+  handed on: what survives is a self-contained, browsable result.
+- **De-duplicate intermediates.**  Keep the analysis re-runnable, but stop
+  storing the same array more than once.  Repeated analyses over overlapping
+  ranges are the main source: two climatologies covering different ranges share
+  no files, but every year they have in common has been read and reduced twice,
+  and each range's accumulator cache repeats the months it inherited.  This is
+  the operation for an analysis that is still in use on a filesystem with a
+  quota.
+
+Pruning shall be safe to the extent that it can be: it shall report what it
+would remove before removing it, and removing the intermediates shall never
+remove something that cannot be recomputed from the simulation output.
+
+Two things Phase 1 does are what make this implementable later, and neither is
+an accident:
+
+- **The manifest is the definition of "published".**  Pruning to the published
+  set is a set difference between what the merged manifest names and what is on
+  disk, rather than a heuristic over file names.  This is the second reason the
+  manifest is in Phase 1 rather than deferred with the gallery.
+- **Products are published by symlink from the step that owns them**, so every
+  file has exactly one owner and pruning never has to decide which of two
+  copies is canonical.  The gridded accumulator caches already symlink
+  inherited months forward for the same reason, which is why they are the one
+  intermediate that does not duplicate across ranges.
+
+*Details to be added.*  Open questions include whether pruning is a Polaris
+command or a step, and whether an analysis pruned to its published set should
+remain something `polaris serial` can be pointed at without confusion.
+
 ### Requirement: workflow integration
 
 Date last modified: 2026/08/11

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -1,0 +1,469 @@
+(design-ocean-analysis)=
+
+# Ocean Analysis in Polaris
+
+date: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+```{note}
+This is an umbrella design document.  It records the long-term goals and the
+shared vocabulary for ocean analysis in Polaris, and it points to the more
+detailed design documents that describe individual pieces of that capability.
+Most sections below are deliberately sketches that will be filled in as each
+piece is designed.  The one piece that is designed in detail today is the
+initial set of Omega analysis capabilities described in
+{ref}`design-ocean-analysis-initial`.
+```
+
+## Summary
+
+Polaris can build meshes, create initial conditions, run Omega and MPAS-Ocean,
+and visualize the output of the tasks it runs.  What it cannot do today is
+analyze a simulation it did not run.  For MPAS-Ocean and MPAS-Seaice, that role
+is filled by MPAS-Analysis, which is driven by zppy as part of the standard
+E3SM post-processing workflow.  Omega has no equivalent.
+
+The capability designed in this family of documents is a general-purpose
+analysis capability in Polaris: given a completed Omega (or MPAS-Ocean)
+simulation and a config file describing it, Polaris produces a set of
+diagnostic plots and the intermediate data products behind them.  The
+long-term goal is that this capability grows to cover the ocean analysis that
+E3SM developers rely on today, and that it is ultimately driven by zppy in the
+same way MPAS-Analysis is.
+
+The near-term goal is much narrower and is driven by a concrete commitment: the
+E3SM Ocean Team has offered to deliver a first set of analysis capabilities for
+Omega's initial coupled runs by September 15, 2026.  That deliverable is
+designed in {ref}`design-ocean-analysis-initial`.
+
+Success for this umbrella design is that the near-term deliverable is built on
+foundations that the longer-term capability can reuse rather than replace:
+shared depth-selection and integration kernels, a suite that can be pointed at
+an arbitrary simulation, plots that always come with the data behind them, and
+a clean separation between what Omega computes in situ and what Polaris
+computes offline.
+
+## Background
+
+### What Polaris does today
+
+Polaris has a number of visualization steps, but each of them is tied to a task
+that produced the data it plots.  `Viz` and `StatsAnalysis` in the
+`realistic_global` tasks read output from a `forward` step in the same task.
+The `customizable_viz` task is the closest thing to a general-purpose analysis
+tool: it takes a mesh file and a data file as config options and plots
+horizontal fields and transects from them.  It is limited to a single file, a
+single time index, and a single vertical level, and it has no notion of
+climatologies, time series, or integrated quantities.
+
+The framework pieces that a broader analysis capability needs are, however,
+largely in place: shared steps (see [Shared steps](shared_steps.md)), config
+files supplied by the user at setup time, the Omega/MPAS-Ocean name mapping
+in `polaris.ocean.model`, spherical plotting in `polaris.viz`, remapping
+infrastructure in `polaris.remap`, and vertical-coordinate helpers in
+`polaris.ocean.vertical`.
+
+### What MPAS-Analysis does today
+
+MPAS-Analysis provides roughly a hundred analysis tasks for MPAS-Ocean and
+MPAS-Seaice: climatology maps compared against observational climatologies,
+regional and global time series, transects, Hovmoller diagrams, transports,
+overturning circulation, and more.  It has its own task/subtask framework, its
+own parallel-execution model, its own caching scheme for climatologies and
+region masks, and its own HTML-gallery generation.
+
+### Why this is not a port of MPAS-Analysis
+
+Analysis capabilities in Polaris are intended to be written from scratch with
+Polaris and Omega in mind, using MPAS-Analysis as a scientific reference for
+what each diagnostic means, rather than as a source of code.  The reasons:
+
+- **Framework duplication.**  MPAS-Analysis's task, subtask, and parallelism
+  machinery predates and duplicates Polaris's task, step, and suite machinery.
+  Porting the tasks means porting or shimming that machinery too.
+- **Model conventions.**  MPAS-Analysis is built around MPAS-Ocean's output
+  conventions --- `xtime`, `timeSeriesStatsMonthly_avg_*`, and the analysis
+  members that produce them --- not merely around MPAS-Ocean's variable names.
+  Polaris also uses MPAS-Ocean variable and dimension names as its internal
+  standard, but it reaches them by translating Omega's names on read, so the
+  rest of the code is unaware of the difference.  Omega's output differs from
+  MPAS-Ocean's in time metadata, in the in-situ analysis that produces it, in
+  its pseudo-thickness vertical coordinate, and in the fact that it carries
+  TEOS-10 conservative temperature and absolute salinity.
+- **Division of labor.**  Omega's Analysis module computes diagnostics in situ
+  (see below).  Several diagnostics that MPAS-Analysis computes offline from
+  high-volume output will instead be read directly from Omega output, which
+  changes the shape of the analysis code substantially.
+- **Accumulated scope.**  A large fraction of MPAS-Analysis exists to support
+  observational comparisons and regional diagnostics that are not needed in the
+  first delivery, and that we would want to redesign rather than reproduce.
+
+The intent is not to replace MPAS-Analysis.  MPAS-Seaice analysis continues to
+be delivered through zppy's MPAS-Analysis, and MPAS-Ocean analysis will
+continue to be available there for as long as it is useful.
+
+### Division of labor with Omega's in-situ Analysis module
+
+Omega's Analysis module computes diagnostics during the simulation and writes
+them to output streams, with both temporal reduction (e.g. monthly means) and
+instantaneous snapshots.  The initial delivery provides a `GlobalStats` group,
+and a meridional overturning circulation (MOC) group is in development.  Omega
+requires that analysis output be usable by Polaris for post-processing.
+
+The dividing line we assume throughout this family of documents is:
+
+- **In Omega** belong diagnostics that require the model state at every time
+  step, or that would require writing prohibitively large volumes of output to
+  compute offline: global statistics, mixed-layer depth, overturning
+  streamfunctions, eddy statistics, and other quantities that are nonlinear in
+  the instantaneous state.
+- **In Polaris** belong diagnostics that can be computed from monthly means
+  without loss: climatologies, depth slices, depth integrals of linear
+  quantities, area integrals, time series assembled from per-period reductions,
+  observational comparison, and everything to do with plotting.
+
+Where a diagnostic could go either way, the initial preference is to compute it
+in Polaris, because Polaris code is faster to write and change, and to migrate
+it into Omega later if the required output volume or the loss of accuracy from
+working with monthly means becomes a problem.
+
+## Roadmap
+
+| Phase | Target | Content |
+| --- | --- | --- |
+| 1 | September 15, 2026 | Climatology maps, ocean heat content, global-stats time series, MOC plot; run manually.  See {ref}`design-ocean-analysis-initial`. |
+| 2 | End of CY2026 | A more complete zppy/MPAS-Analysis-style workflow for Omega, including observational comparison, integration with zppy, and concurrent execution of independent analysis under Polaris task parallelism. |
+| 3 | Beyond | Regional analysis, transports and transects, run-to-run comparison, and parity with the ocean tasks E3SM developers rely on today. |
+
+Phase 1 explicitly does not include integration with zppy.  During Phase 1, the
+analysis of Omega output is run by hand and made available to the coupled group
+within several days of each simulation period completing.
+
+## Requirements
+
+### Requirement: analysis of simulations Polaris did not run
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall be able to analyze a completed Omega or MPAS-Ocean simulation
+that it did not set up or run.  All information about the simulation --- where
+its output lives, which mesh it used, which period to analyze, and which fields
+to analyze --- shall come from a config file the user supplies at setup time.
+Setting up and running the analysis shall not require a model build.
+
+This requirement is met in Phase 1; see the `analysis-suite` requirement in
+{ref}`design-ocean-analysis-initial`.
+
+### Requirement: plots are always accompanied by their data
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Every plot the analysis produces shall be accompanied by a netCDF file
+containing the data that were plotted.  Intermediate data products that are
+expensive to recompute shall be written to netCDF so that later steps, later
+runs, and other tools can use them without repeating the computation.
+
+This requirement is met in Phase 1; see the `data-products` requirement in
+{ref}`design-ocean-analysis-initial`.
+
+### Requirement: analysis is written against Polaris's naming standard
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Analysis shall be written against MPAS-Ocean variable and dimension names,
+which are Polaris's internal standard, and shall rely on
+`OceanIOStep.open_model_dataset` to translate Omega's names on read using
+`polaris/ocean/model/mpaso_to_omega.yaml`.  Analysis code shall not branch on
+which model produced the data in order to choose a field or dimension name; a
+step that needs to do so indicates a missing entry in the mapping.  Where a
+model does not provide a required field, the analysis shall report that clearly
+rather than failing obscurely.
+
+A consequence is that analysis written for Omega also works on MPAS-Ocean
+output wherever the two models provide equivalent fields.  That is a useful
+property, but it is not a testing strategy: MPAS-Ocean differs from Omega in
+time metadata and in which analysis members produce its output, so validating
+against MPAS-Ocean would exercise code paths we do not ship.  Validation is
+against Omega output as Omega capabilities become available.
+
+### Requirement: comparison with observations
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The analysis shall be able to compare simulated climatologies against
+observational climatologies, producing model, observation, and bias maps
+together with summary error metrics.
+
+Comparison shall happen **on the MPAS mesh**: observational data sets are
+remapped onto the mesh and compared there, rather than the model being remapped
+onto a lat-lon comparison grid.  Model output is therefore never interpolated
+away from the grid it was computed on, and the error metrics are area-weighted
+sums over model cells.
+
+*Remaining details to be added.*  Open topics include: which observational data
+sets to support first (WOA23, and the standard MPAS-Analysis suite of SST, SSS,
+MLD, and velocity products); where the mapping files and remapped observations
+are cached, since remapping observations onto each new mesh is the expensive
+part; and how the conservative temperature and absolute salinity that Omega
+carries are converted for comparison with observational potential temperature
+and practical salinity.
+
+### Requirement: regional analysis, transects, and transports
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The analysis shall support diagnostics restricted to named ocean regions
+(basins, marginal seas, Antarctic shelf regions) and along named transects, and
+shall support transports through transects.
+
+*Details to be added.*  Open topics include: how region masks are generated and
+cached (`geometric_features` and `mpas_tools` today); whether region masks are
+computed in Polaris or read from files produced elsewhere; which regional
+quantities are computed in Omega in situ versus in Polaris; and how regional
+time series relate to the global time series designed in Phase 1.
+
+### Requirement: run-to-run comparison
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The analysis shall be able to compare two simulations against one another,
+producing difference maps and overlaid time series, in the way that
+MPAS-Analysis compares a run against a control run.
+
+*Details to be added.*
+
+### Requirement: presentation and provenance
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The analysis shall present its results in a form that a reviewer can browse
+without a filesystem tour, and shall record enough provenance that any plot can
+be traced back to the simulation, the date range, the code version, and the
+config options that produced it.
+
+Phase 1 delivers the substrate: a staging tree, keyed by product and date
+range, into which every plot and its netCDF are published, separate from the
+Polaris work directories where the computation happens.  Results accumulate
+there across repeated analyses of different ranges.  See the
+`repeated-analysis` requirement in {ref}`design-ocean-analysis-initial`.
+
+*Details of the presentation layer to be added.*  What is missing is the
+gallery or index over that tree, comparable to MPAS-Analysis's HTML output.
+Polaris already records provenance for a setup in `polaris/provenance.py`.
+
+### Requirement: workflow integration
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Analysis of Omega output shall eventually be launched by zppy as part of the
+standard E3SM post-processing workflow, in the same way MPAS-Analysis is today.
+
+*Details to be added.*  In Phase 1 this requirement is explicitly deferred: the
+analysis is run by hand by the Ocean Team.  Open topics include what the zppy
+interface to Polaris looks like, how the analysis suite is chunked over
+simulation years, and how Polaris job scripts interact with zppy's.
+
+### Requirement: concurrent execution of independent analysis
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+An analysis suite is a collection of independent, non-MPI Python steps, which
+is precisely the workload that Polaris's task-parallelism work targets.  The
+analysis capability shall be able to take advantage of that concurrency as it
+becomes available, and shall not be written in ways that make its steps
+ineligible for it.
+
+Task parallelism is designed separately, in the `task_parallelism` family of
+design documents --- an umbrella plus one document per phase --- developed on
+the task-parallelism branch.  Its Phase 2 enables concurrent execution of
+eligible non-MPI steps across a multi-node allocation, with non-MPI steps
+eligible by default and step authors marking a step unsafe only when it relies
+on shared mutable state, external side effects, or uncontrolled process
+launching.  That phase is what analysis stands to gain from, and it lines up
+with Phase 2 of this roadmap.
+
+Three consequences for the analysis design:
+
+- **The Phase 1 products already overlap.**  Climatology maps, ocean heat
+  content, global stats, and the MOC plot are four independent tasks, so they
+  can run concurrently as soon as the capability lands, with no changes to
+  them.
+- **Two Phase 1 details need checking against the eligibility rules** rather
+  than being assumed safe: the climatology step launches `ncclimo`, which
+  itself forks up to twelve background processes, and every plotting step
+  symlinks its results into a shared staging tree.  Neither looks like a
+  problem --- products stage into disjoint directories, and the climatology is
+  a shared step so only one instance of it exists --- but "launches
+  subprocesses" and "writes into a shared location" are exactly the properties
+  the eligibility mechanism is meant to catch.
+- **The per-year decomposition is the real prize, and Phase 1 already has
+  it.**  Vertically integrated heat content and offline mixed-layer depth are
+  computed by one shared step per simulation year, a structure Phase 1 adopts
+  for reuse across date ranges rather than for parallelism.  Those steps are
+  independent, non-MPI, and numerous --- forty of them for a forty-year record
+  --- so they are exactly the workload Phase 2 of task parallelism is built to
+  overlap, and they should benefit with no restructuring at all.
+
+*Further details to be added* once the analysis workload has been profiled and
+task parallelism is available to measure against.
+
+### Requirement: scalability and restartability
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The analysis shall handle multi-decade simulations on high-resolution meshes
+within the resources of a single compute node where possible, and shall be able
+to extend an existing analysis with additional simulation years without
+recomputing what it has already computed.
+
+Phase 1 establishes the pattern the rest of the capability should follow:
+**every expensive computation is decomposed into a per-year product keyed by
+the year rather than by the requested date range**, and given its own shared
+step, so that it is computed once and reused by every later analysis.  Reuse is
+then not a caching mechanism of our own but a consequence of Polaris's ordinary
+shared-step and step-completion behavior.  Phase 1 also streams over monthly
+files rather than loading a whole record at once.
+
+*Remaining details to be added*, in particular how analysis is chunked across
+compute nodes.  Running the per-year products concurrently is covered by the
+task-parallelism requirement above.
+
+## Algorithm Design
+
+*To be added as individual capabilities are designed.*  Algorithm designs for
+the Phase 1 capabilities are in {ref}`design-ocean-analysis-initial`.
+
+## Implementation
+
+### Implementation: code organization
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The intended organization, established in Phase 1 and expected to hold as the
+capability grows:
+
+- **Shared, dependency-light kernels** live in leaf modules under
+  `polaris/ocean/` alongside `conservation.py`, `rpe.py`, and
+  `surface_pressure.py`, or beside related helpers in an existing subpackage.
+  Phase 1 adds `polaris/ocean/vertical/elevation.py` (elevation selection and
+  layer-overlap weights) and `polaris/ocean/heat_content.py`.  These are
+  ordinary functions on `xarray` objects with no dependence on Polaris steps,
+  so they can be unit tested directly and reused by any step.
+- **Analysis steps and tasks** live under `polaris/tasks/ocean/analysis/`.
+- **Suites** that run analysis live in `polaris/suites/ocean/`, named for the
+  model they target, as `omega_analysis` is.
+- **Plotting primitives** live in `polaris/viz/`, extended as new plot types
+  are needed rather than duplicated inside analysis steps.
+
+Analysis asks for something no existing task needed --- the same simulation
+analyzed repeatedly over different date ranges, reusing what does not depend on
+the range --- but it turns out to need no framework changes to get it.  The
+mechanism is the one the cosine bell task family already uses for resolutions:
+a task rebuilds its step list in `Task.configure()`, which runs after the
+user's config has been merged, so step subdirectories can be keyed by date
+range, and expensive per-year work can be a shared step per year created with
+`Component.get_or_create_shared_step()`.  Re-running and reuse then both follow
+from ordinary step-completion behavior.  Later phases should reach for this
+pattern before reaching for new framework capabilities.
+
+### Implementation: items deferred from Phase 1
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Things that Phase 1 knowingly does the simpler way because of its September 15
+deadline, recorded here so that they are picked up rather than forgotten.  Each
+is explained in context in {ref}`design-ocean-analysis-initial`.
+
+- **Use the TEOS-10 heat capacity for ocean heat content.**  Omega carries
+  conservative temperature, for which $\rho_0 c_p^0 \Theta$ with
+  $c_p^0 = 3991.86795711963$ J kg⁻¹ K⁻¹ is the *definition* of heat content
+  rather than an approximation.  That constant is not in the Physical Constants
+  Dictionary, and adding it is not achievable by September 15, so Phase 1 uses
+  the PCD's `seawater_specific_heat_capacity_reference` (3996 J kg⁻¹ K⁻¹)
+  instead --- a 0.1% systematic offset.  The follow-up is to add $c_p^0$ to the
+  PCD and switch to it.
+- **Replace the offline mixed-layer depth fallback**, if it is what ships, with
+  Omega's in-situ density-threshold diagnostic.  A mixed-layer depth derived
+  from monthly-mean profiles cannot represent deep winter mixing events and
+  cannot produce a monthly maximum at all.
+- **Compute the ocean heat content climatology from per-month integrals**
+  rather than from a climatology of conservative temperature, if the neglected
+  $\overline{\Theta' h'}$ covariance term proves large enough to matter.
+- **Regional overturning**, in particular the Atlantic MOC and the standard
+  maximum-AMOC-near-26.5°N metric, which arrives with the regional analysis
+  described in the requirements above.
+
+### Implementation: design documents in this family
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+- {ref}`design-ocean-analysis-initial` --- the Phase 1 deliverable: monthly,
+  seasonal, and annual climatologies from Omega monthly means; global maps at
+  selected elevations; ocean heat content over elevation ranges as maps and as
+  a global time series; time series from Omega's `GlobalStats` output; and a
+  latitude-elevation plot of the global MOC.
+
+*Additional documents to be added for Phases 2 and 3.*
+
+## Testing
+
+### Testing and Validation: umbrella
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Two testing strategies apply across the whole capability and are established in
+Phase 1:
+
+1. **Unit tests on the shared kernels against analytic answers.**  Elevation
+   selection, layer-overlap weights, integrals, and averaging are pure
+   functions of `xarray` inputs and are tested on small synthetic columns whose
+   correct answers can be written down.  These are the parts where a silent
+   error would corrupt every plot downstream, they are cheap to test, and an
+   analytic answer is a stronger reference than another code's output.
+2. **Staged validation against Omega output.**  Each diagnostic is run against
+   real Omega output at low resolution as soon as the Omega capability it
+   depends on lands, rather than waiting for the full set.  This front-loads
+   discovery of mismatches between what the analysis assumes and what Omega
+   actually writes, which is where the schedule risk lives.
+
+We do not validate by running the analysis on MPAS-Ocean output.  It would
+exercise code paths --- different time metadata, different analysis members ---
+that we do not ship for Omega, giving false confidence.  Where the *magnitude*
+of a diagnostic needs a sanity check, published MPAS-Analysis results for E3SM
+simulations are a reasonable thing to eyeball against, but that is a science
+judgment rather than an automated test.
+
+Analysis suites are user-facing and are not intended for the `pr` or `nightly`
+suites: they require a completed simulation as input, and their cost is
+dominated by that simulation rather than by anything a PR could break.
+Regression coverage comes from the unit tests plus, once Omega can write
+monthly means, a short end-to-end smoke test on a low-resolution run.

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -946,6 +946,20 @@ is explained in context in {ref}`design-ocean-analysis-initial`.
 - **Measure Polaris's per-step overhead** --- setup and run of a step that does
   nothing --- and record it under the organizing principles, so that the step
   sizing targets in principle 9 rest on a number rather than on judgment.
+- **Put the gallery where a reader can open it, with permissions that let them
+  read it.**  Phase 1 publishes into a staging tree wherever `output_path`
+  points and stops there; getting that tree onto a machine's web portal is a
+  manual copy, and nothing sets permissions.  Part of the answer is already at
+  hand: mache carries `[web_portal] base_path` and `base_url` for each
+  machine, and Polaris's merged config already exposes them, so publishing
+  under `base_path` and reporting the URL by substituting `base_url` for it is
+  the same move MPAS-Analysis makes.  Two parts are ours to settle.  Every
+  file and directory has to be world readable, which the default umask on
+  these machines does not give and which MPAS-Analysis does not handle either.
+  And products are published by symlink into the work tree, which a web server
+  cannot usefully follow into a private scratch directory --- so a staging
+  tree headed for a portal either holds copies rather than links, or the
+  single-owner rule in the publication design gives way somewhere else.
 
 Phase 1 also ships without concurrency of any kind, and without the presentation
 and verification layers designed around it.  These are deferred to Phase 2

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -144,7 +144,7 @@ within several days of each simulation period completing.
 
 ### Requirement: analysis of simulations Polaris did not run
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -153,6 +153,21 @@ that it did not set up or run.  All information about the simulation --- where
 its output lives, which mesh it used, which period to analyze, and which fields
 to analyze --- shall come from a config file the user supplies at setup time.
 Setting up and running the analysis shall not require a model build.
+
+**Wherever the simulation already describes itself, Polaris shall read that
+description rather than ask the user to restate it.**  A completed Omega run
+has a configuration file that names its mesh, its output streams and the
+file-name templates and reduction periods of each, so the intended default is
+that the user points at that file and Polaris derives what it can.  Config
+options naming individual file-name templates remain, as overrides and for
+simulations whose configuration is unavailable or in another form, but they are
+not what a user should have to fill in.
+
+The reason is not brevity.  Anything the user restates is something they can
+restate wrongly, and a mis-typed file-name template fails as "no files found"
+long after setup, which is among the least informative ways for this analysis
+to go wrong.  Reading the simulation's own configuration also means the
+analysis cannot silently disagree with it about what was written.
 
 This requirement is met in Phase 1; see the `analysis-suite` requirement in
 {ref}`design-ocean-analysis-initial`.

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -893,6 +893,23 @@ consumers were written first --- which is why publication branches from the
 scaffolding rather than from the products, as described in
 {ref}`design-ocean-analysis-initial`.
 
+**A branch that changes a dependency ends with the alpha version bump.**
+Adding or re-pinning a package leaves every existing environment stale, and
+the load scripts notice only by comparing `polaris/version.py`.  Two habits
+follow, and they pull in opposite directions:
+
+- *Add the bump as soon as the dependency changes*, even though later commits
+  will land on top of it.  A bump in the wrong place is a rebase; a forgotten
+  one leaves everyone running against an environment that no longer matches
+  the code, and nothing reports it.
+- *Rebase it to the end before merge*, because a release marker sitting under
+  later work claims a version for a tree that is not the one released.
+
+The number depends on merge order, so it is provisional until the branch
+lands.  Say so in the commit message rather than leaving the next person to
+work out which assumption it rests on.  Several branches in flight at once can
+each expect the same next number, and only the first to merge is right.
+
 ### Implementation: items deferred from Phase 1
 
 Date last modified: 2026/08/29

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -468,6 +468,17 @@ The rule that follows:
 > balance, and use an in-step pool only for what is left below that
 > granularity.
 
+**Phase 1 uses neither.**  It runs serially, because task parallelism will not
+exist by its deadline and it does not need to be fast --- it needs to handle
+many decades of high-resolution output without falling over, which streaming
+bounded amounts of data achieves on its own.  What matters is that both forms
+of concurrency can be added afterwards *without invalidating anything already
+computed*: splitting a product into more steps is safe because inheritance is
+decided by content rather than by path (principle 6), and adding a pool inside
+a step changes nothing a step produces.  Designing for concurrency and shipping
+without it are compatible here, and Phase 1 takes that option deliberately
+rather than by omission.
+
 "Enough to balance" is a property of the machine, not of the science, so where
 a workload divides freely it should divide into a **configurable** number of
 steps rather than a number derived from the data.  A count fixed by config also

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -367,7 +367,7 @@ steps, the manifest, or the published paths has to change when it arrives.
 
 ### Requirement: pruning and archiving
 
-Date last modified: 2026/08/29
+Date last modified: 2026/08/30
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -830,7 +830,7 @@ designed.*  Algorithm designs for the Phase 1 capabilities are in
 
 ### Implementation: code organization
 
-Date last modified: 2026/08/29
+Date last modified: 2026/08/30
 
 Contributors: Xylar Asay-Davis, Claude
 

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -775,6 +775,27 @@ is explained in context in {ref}`design-ocean-analysis-initial`.
   nothing --- and record it under the organizing principles, so that the step
   sizing targets in principle 9 rest on a number rather than on judgment.
 
+Phase 1 also ships without concurrency of any kind, and without the presentation
+and verification layers designed around it.  These are deferred to Phase 2
+rather than dropped, and each is designed above or in
+{ref}`design-ocean-analysis-initial` already:
+
+- **Split accumulators into several steps**, so that the scheduler has
+  independent pieces to place.  Phase 1's heat content accumulator is a single
+  step and is the bulk of a first run, which is the one place Phase 1 knowingly
+  misses principle 9.  Splitting it costs nothing in reuse, since inheritance
+  is decided by content rather than by path, so months cached by the
+  single-step version are inherited unchanged.
+- **Process pools inside steps**, for whatever is left below step granularity.
+- **Generate a gallery over the staging tree.**  Phase 1 publishes the products
+  and the merged manifest, which is everything a generator needs; what is
+  missing is the generator.
+- **Build the mechanical conformance checks** for the task-parallel
+  groundrules.  Phase 1 follows the rules; nothing verifies that it still does.
+- **The `analysis_test` task and its suite**, which runs a short Omega
+  simulation and analyzes it.  It cannot run until Omega writes monthly means,
+  and is the first thing to build once the Phase 1 products are out.
+
 ### Implementation: design documents in this family
 
 Date last modified: 2026/08/11

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -416,6 +416,28 @@ an accident:
 command or a step, and whether an analysis pruned to its published set should
 remain something `polaris serial` can be pointed at without confusion.
 
+One of those questions is worth stating now, because the answer probably
+shapes the others: **what counts as a product depends on who is asking.**  For
+publication a product is a figure and the data behind it, which is what
+`Product` describes today --- `group`, `gallery` and `title` are gallery
+vocabulary, and an intermediate has no place in a gallery.  For archiving the
+set is different: an analysis that outlives the simulation it came from cannot
+recompute the climatologies and accumulator caches this requirement otherwise
+treats as discardable, and those are exactly the files that were expensive.
+
+The likely shape is a second collector rather than a second list --- an
+archiver beside the publisher, reading the same fragments and selecting by its
+own rule --- since the two differ in what they select and in the vocabulary
+they need, not in how they learn what a step made.  That would make the
+fragment a description of what a step produced rather than a list of gallery
+entries, which is principle 2 applied one level further: the manifest
+describes, and each consumer selects.
+
+Nothing here is settled, and Phase 1 builds none of it.  What Phase 1 should
+avoid is foreclosing it: a step's fragment is written by the base class rather
+than by the publisher's consumers, and whether a step writes one is kept
+separable from whether it makes something the gallery shows.
+
 ### Requirement: workflow integration
 
 Date last modified: 2026/08/11

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -169,6 +169,13 @@ long after setup, which is among the least informative ways for this analysis
 to go wrong.  Reading the simulation's own configuration also means the
 analysis cannot silently disagree with it about what was written.
 
+This is the principle MPAS-Analysis already works on, locating output by
+reading the MPAS-Ocean and MPAS-Seaice streams files rather than asking the
+user where each file lives.  The experience there is the argument for it: a
+known-good pattern with a decade of use, not an invention of this design.  What
+differs is only the file being read, Omega's configuration in place of a
+streams file.
+
 This requirement is met in Phase 1; see the `analysis-suite` requirement in
 {ref}`design-ocean-analysis-initial`.
 

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -269,7 +269,7 @@ MPAS-Analysis compares a run against a control run.
 
 ### Requirement: presentation and provenance
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -285,10 +285,12 @@ shared directory structure.  Concretely:
 - **Every step writes a manifest fragment** alongside its outputs, naming each
   product it made and the facets that identify it: file, field, season,
   elevation, date range, region, group, and title.
-- **A collector publishes and indexes.**  A cheap step gathers the fragments,
-  publishes each product into the staging tree, and generates the index over
-  it.  Because it works from the fragments rather than from directory
-  structure, re-chunking the work does not disturb the output.
+- **A collector publishes and indexes.**  One step gathers the fragments,
+  publishes each product into the staging tree, renders a thumbnail for it, and
+  generates the index over the result.  Because it works from the fragments
+  rather than from directory structure, re-chunking the work does not disturb
+  the output.  It is the only place that knows how results are presented, so
+  changing the presentation changes one step and no others.
 - **The staging tree is shallow, with descriptive filenames, plus a generated
   index.**  A gallery is generated, not navigated, and a shallow tree is easier
   to archive, to serve, and to diff between two analyses.  This follows
@@ -305,13 +307,67 @@ in each cache record and refused when it does not match.  A content-addressed
 scheme covering the full dependency graph is deferred; see the deferred items
 below.
 
-*Details of the index itself to be added*, including how much of
-MPAS-Analysis's component/group/gallery structure to adopt.  Polaris already
-records provenance for a setup in `polaris/provenance.py`.
+Polaris already records provenance for a setup in `polaris/provenance.py`.
+
+#### The index is a generated static site, and it must be cheap to serve
+
+The index shall be a set of static HTML pages generated from the merged
+manifest, needing no server-side code, no build step, and no network access of
+its own, so that the same staging tree can be opened from a local filesystem,
+served by `python -m http.server`, or copied to a web portal unchanged.
+
+Two properties of that site are requirements rather than styling choices,
+because they are what decide whether a large result set is usable at all.
+
+**Every plot shall have a thumbnail, and thumbnails shall be small.**  A few
+hundred plots cannot be triaged by reading file names, and thumbnails are what
+let a reader decide which full images to open --- often answering the question
+without opening any.  This is not negotiable, and it is not satisfied by
+scaling the full image down in the browser, which costs the full image's bytes.
+Thumbnails are therefore separate, lossy, and deliberately small files.
+
+**No page shall require more bytes or more requests than the link can
+deliver.**  Analysis results are hosted on the LCRC public web portal, which
+throttles, and the failure mode is not a slow page but a stalled one.  The
+scale is real and measured: one page of the MPAS-Analysis output linked below
+carries 1641 thumbnails at roughly 46 kB each, all fetched eagerly, which is
+about 75 MB in 1641 requests before the page settles.  The presentation layer
+shall therefore bound what a page costs --- by keeping thumbnails small, by
+bounding how many appear on one page, and by not fetching images the reader has
+not scrolled to.  The design shall keep the levers for this in config rather
+than in code, since the binding constraint is a property of the host and not of
+the analysis.
+
+#### What to take from the two references, and what not to
+
+Two existing E3SM viewers are the relevant prior art, and the useful position
+is not to pick one but to take the strength of each.
+
+**MPAS-Analysis** organizes results as components, gallery groups, and
+galleries of captioned thumbnails, and that layout has worked well for the
+people who will read our output --- it is what they already know how to
+navigate, which is reason enough to follow it rather than invent.  What it does
+not do is bound the cost of a page, as the numbers above show.  We take the
+layout and fix the cost.
+
+**E3SM-Diags** provides, for each figure, a page carrying the metadata and the
+code that reproduces that figure.  That is genuinely valuable and is something
+MPAS-Analysis cannot offer.  Its weakness is the near-absence of thumbnails,
+which makes finding the figure you want harder than it should be.  We take the
+per-figure page as the eventual target of clicking a thumbnail, and keep the
+thumbnails.
+
+Beyond that, how results are best displayed --- what a reader wants to compare
+side by side, how facets should be filtered, how run-to-run comparison should
+read --- deserves deliberate thought against what our users are accustomed to
+and what other tools do.  This document records the constraints that any such
+design must satisfy; the display design itself is Phase 2 work and is listed
+among the deferred items below.  What Phase 1 owes it is that nothing in the
+steps, the manifest, or the published paths has to change when it arrives.
 
 ### Requirement: pruning and archiving
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -345,7 +401,11 @@ an accident:
 - **The manifest is the definition of "published".**  Pruning to the published
   set is a set difference between what the merged manifest names and what is on
   disk, rather than a heuristic over file names.  This is the second reason the
-  manifest is in Phase 1 rather than deferred with the gallery.
+  manifest is in Phase 1 rather than deferred with the gallery.  The thumbnails
+  and the generated pages are derived from the published set rather than being
+  members of it, so pruning keeps them --- they are most of what makes the
+  surviving result browsable --- and re-publishing regenerates them from the
+  manifest if they are ever lost.
 - **Products are published by symlink from the step that owns them**, so every
   file has exactly one owner and pruning never has to decide which of two
   copies is canonical.  The gridded accumulator caches already symlink
@@ -466,7 +526,7 @@ task-parallelism requirement above.
 
 ### Algorithm Design: organizing principles
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -498,6 +558,11 @@ interface serves.
 Neither is compromised for the other.  In particular, the work tree does not
 need to be browsable, and the staging tree does not need to mirror how the work
 was chunked.
+
+The staging tree is also the only part of this design that is read over a
+network we do not control, which makes the cost of *serving* it a design
+constraint rather than a detail of presentation.  That constraint is developed
+under `presentation and provenance` below.
 
 #### 2. Products are described by a manifest, not by their path
 
@@ -743,7 +808,7 @@ designed.*  Algorithm designs for the Phase 1 capabilities are in
 
 ### Implementation: code organization
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -765,10 +830,17 @@ capability grows:
 
 Two further pieces are added by Phase 1 and are expected to be reused:
 
-- **Manifest and publication** live in `polaris/tasks/ocean/analysis/`
-  alongside the steps in Phase 1, and should move to a component-neutral home
-  when a second component wants them.  Steps depend on the manifest writer, not
-  on the collector.
+- **Manifest and publication** are three pieces, and the split matters more
+  than where they live: the **manifest writer** that steps call, the
+  **collector** that merges fragments and publishes, and the **site generator**
+  that renders the index.  Steps depend on the writer and never on the other
+  two, so how results are presented can change without touching a step.  None
+  of the three contains anything ocean-specific --- the writer takes arbitrary
+  facets and the generator renders whatever the manifest holds --- so they go
+  in a component-neutral `polaris/analysis/` package from the start, beside
+  `polaris/viz/`, rather than under `polaris/tasks/ocean/analysis/` to be moved
+  later.  Only the vocabulary of facets is the ocean suite's, and that lives in
+  the steps that emit it.
 - **Accumulator support** --- discovering candidate caches among sibling
   directories, checking provenance stamps, and reporting what was inherited ---
   is a shared helper rather than something each product reimplements, since
@@ -870,9 +942,25 @@ rather than dropped, and each is designed above or in
   is decided by content rather than by path, so months cached by the
   single-step version are inherited unchanged.
 - **Process pools inside steps**, for whatever is left below step granularity.
-- **Generate a gallery over the staging tree.**  Phase 1 publishes the products
-  and the merged manifest, which is everything a generator needs; what is
-  missing is the generator.
+- **Design how results are best displayed.**  Phase 1 ships a working gallery
+  that follows MPAS-Analysis's layout because that is what our readers know,
+  and deliberately spends no time on visual design beyond that.  What is
+  deferred is the considered version: what a reader wants side by side, how
+  facets are filtered and searched, and how run-to-run comparison reads.  The
+  Phase 1 site is a set of templates over the merged manifest, so this is a
+  rewrite of templates and CSS rather than of anything upstream of them.
+- **Per-product pages carrying provenance and a recipe.**  E3SM-Diags's best
+  idea --- each figure accompanied by the code that reproduces it --- needs a
+  per-product page and a manifest field to hold the recipe.  Phase 1 links a
+  thumbnail straight to its full image, which is the one link target that has
+  to change.
+- **Reduce what a gallery page costs, if measurement says it is still too
+  much.**  Phase 1's levers are small lossy thumbnails, bounded page size, and
+  not fetching what has not been scrolled to, which address a throttle on
+  bytes.  If the LCRC portal turns out to throttle on requests instead, the
+  answers are different --- combining thumbnails into a sprite sheet, or
+  inlining them in the page --- and which applies should be settled by
+  measuring against the portal rather than by guessing.
 - **Build the mechanical conformance checks** for the task-parallel
   groundrules.  Phase 1 follows the rules; nothing verifies that it still does.
 - **The `analysis_test` task and its suite**, which runs a short Omega

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -442,15 +442,51 @@ work to be re-chunked later without breaking output paths, links, or the
 gallery.  A path is a poor place to store metadata: it has one dimension and
 the metadata has six.
 
-#### 3. Steps are for caching and selection, not for parallelism
+#### 3. The step is the unit of load balancing; in-step parallelism fills in below it
 
-A step can use a process pool over its own work.  Parallelism inside a step is
-cheaper than parallelism across steps, costs no inodes, and --- unlike
-concurrency across steps --- is available today rather than when task
-parallelism lands.
+Two kinds of concurrency are available and they are not interchangeable.
 
-So the question "how fine should steps be?" is not "how much can run at once?"
-but "along which axes do we need independent invalidation?"
+**Across steps.**  Polaris's task parallelism schedules whole steps, and only
+whole steps, so a step is the smallest thing that can be sent to another node.
+This is the concurrency that scales past one node.
+
+**Inside a step.**  A step can run a process pool over its own work.  This
+costs no inodes, needs no framework support, and is available today, but it is
+confined to the node the step is running on.
+
+The temptation is to reach for the second, because it is free and it is here
+now.  Resist it past a point: **a step that absorbs the whole workload into an
+internal pool is not task-parallel at all, however parallel it is inside.**
+That is exactly MPAS-Analysis's ceiling --- it parallelizes with
+`multiprocessing.Process`, which cannot span nodes, and that ceiling is a known
+choke point at the resolutions Omega targets.  Rebuilding it in Polaris would
+defeat the purpose of task parallelism.
+
+The rule that follows:
+
+> Decompose a workload into enough steps that the scheduler has something to
+> balance, and use an in-step pool only for what is left below that
+> granularity.
+
+"Enough to balance" is a property of the machine, not of the science, so where
+a workload divides freely it should divide into a **configurable** number of
+steps rather than a number derived from the data.  A count fixed by config also
+keeps principle 9's step budget from growing with the length of a simulation.
+
+So "how fine should steps be?" has two answers that must both be satisfied:
+fine enough that the scheduler can balance them, and no finer than the axes
+along which we need independent invalidation (principle 4).  Where those pull
+in different directions, the load-balancing floor wins, because a cache that is
+coarser than ideal costs a recomputation while a step that is coarser than
+ideal costs a node.
+
+The properties a step must have to be *eligible* for concurrent scheduling ---
+no process-global state, no dependence on the working directory, temporary
+files in its own work directory, logging through its own logger, declared
+resources, and internal parallelism sized from those resources rather than from
+the machine --- are set out in
+[Task-Parallel-Safe Analysis Steps](task_parallel_analysis_steps.md).  Analysis
+steps are written to them from the start.
 
 #### 4. Decompose along the axes a user edits between runs
 
@@ -512,6 +548,17 @@ file remains owned by the step that wrote it.
 A partially written cache in the step's own directory is a valid starting point
 for a retry, so restartability comes with the pattern rather than being added
 to it.
+
+**An accumulator may be more than one step**, and usually should be, by
+principle 3.  Splitting one into shards that each cover a slice of the request
+costs nothing here, because inheritance is decided by *content* rather than by
+path: a shard asks which units it needs and which of them some earlier run
+already produced, and neither question refers to how that earlier run was
+divided.  A cheap merge step assembles the shards' results.  This is the
+property that distinguishes an accumulator from a chunk keyed by its path ---
+chunking the latter restricts what can be reused, while chunking the former is
+purely a decision about load balancing and can be changed at any time, even
+between two runs over the same record.
 
 The pattern applies wherever we own the reduction kernel, and nowhere else.
 `ncclimo` has no incremental mode, so a climatology is recomputed in full for
@@ -582,8 +629,16 @@ The targets, which later phases should hold themselves to:
 
 - a step should do at least tens of seconds of work at production resolution,
   so that Polaris's per-step overhead is a few percent at most;
+- a step should do no more than a fraction of the suite's total work, so that
+  the scheduler has something to balance --- principle 3's floor, and the
+  binding constraint for anything expensive;
 - a suite should contain steps numbering in the low hundreds, and should stay
   there as regions and observational comparisons are added.
+
+The middle target is the one most easily lost, because nothing fails when it is
+missed: the suite still runs, it just runs on one node.  A product whose cost is
+concentrated in a single step should say so explicitly and say why that is
+acceptable, rather than leaving it to be discovered.
 
 Polaris's actual per-step overhead --- setup and run of a step that does
 nothing --- should be measured once and recorded here, so that this stops being

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -785,9 +785,45 @@ of principle 6, which needs nothing from the framework beyond the ability to
 declare an input discovered at setup time.  Later phases should reach for these
 patterns before reaching for new framework capabilities.
 
+#### How this work is divided into branches
+
+Date last modified: 2026/08/29
+
+This capability is built as a series of branches rather than one, and the
+division has been settled once here so that each new piece of work does not
+reopen it.
+
+**Design documents change only on the design branch.**  Every edit to the
+documents in this family lands on `add-analysis-designs`, and never on a
+branch that implements one of them.  The design is then one reviewable thing
+whose history reads as a design discussion, implementation branches rebase onto
+it, and a reviewer is never asked to judge a design change and the code that
+assumes it in the same diff.
+
+**Each work item is a branch, and carries everything that item needs to be
+complete.**  A branch holds its code, its unit tests, and its User's Guide
+documentation.  Documentation is not a separate work item to be swept up at the
+end: a capability that ships undocumented is not finished, and the moment its
+behavior is fresh is the moment to write it down.
+
+**Within a branch, each piece of code is followed by its tests, and the
+documentation comes last.**  This is the order the branches built so far
+already follow --- a kernel, then the tests for that kernel, then the step that
+uses it, then the tests for the step, then the page that documents the result.
+It keeps every commit reviewable on its own and keeps a test from being
+attributed to code it did not accompany.
+
+**A branch is cut from the branch it actually depends on.**  Where two items
+are independent they branch from the same parent and stay independent rather
+than being stacked for convenience; where one needs another, it is cut from it.
+Shared infrastructure is therefore cut low, below its consumers, even when the
+consumers were written first --- which is why publication branches from the
+scaffolding rather than from the products, as described in
+{ref}`design-ocean-analysis-initial`.
+
 ### Implementation: items deferred from Phase 1
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -907,13 +907,21 @@ uses it, then the tests for the step, then the page that documents the result.
 It keeps every commit reviewable on its own and keeps a test from being
 attributed to code it did not accompany.
 
-**A branch is cut from the branch it actually depends on.**  Where two items
-are independent they branch from the same parent and stay independent rather
-than being stacked for convenience; where one needs another, it is cut from it.
-Shared infrastructure is therefore cut low, below its consumers, even when the
-consumers were written first --- which is why publication branches from the
-scaffolding rather than from the products, as described in
-{ref}`design-ocean-analysis-initial`.
+**The branches form a line, in dependency order.**  Shared infrastructure is
+cut low, below its consumers, even when the consumers were written first: the
+vertical reduction and the manifest writer are both dependencies of every
+product that plots, so both land before any of them.
+
+This replaces an earlier rule that let independent items branch from a common
+parent and stay independent.  It was tried, and the cost was higher than the
+independence was worth.  Siblings cannot see each other, so a helper written
+on one arm was out of reach on the other and had to wait for a merge; the
+integrated tree existed only as a throwaway merge branch that had to be
+rebuilt and its documentation conflicts re-resolved every time anything moved;
+and a rebase low in the tree forked it silently more than once.  A line costs
+a rebase up the chain when something below changes, which is the price of
+having every branch reviewable against the one beneath it and of the top of
+the chain being the integrated tree.
 
 **A branch that changes a dependency ends with the alpha version bump.**
 Adding or re-pinning a package leaves every existing environment stale, and

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -247,7 +247,7 @@ MPAS-Analysis compares a run against a control run.
 
 ### Requirement: presentation and provenance
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -256,15 +256,36 @@ without a filesystem tour, and shall record enough provenance that any plot can
 be traced back to the simulation, the date range, the code version, and the
 config options that produced it.
 
-Phase 1 delivers the substrate: a staging tree, keyed by product and date
-range, into which every plot and its netCDF are published, separate from the
-Polaris work directories where the computation happens.  Results accumulate
-there across repeated analyses of different ranges.  See the
-`repeated-analysis` requirement in {ref}`design-ocean-analysis-initial`.
+By principle 1, presentation is the job of the staging tree and not of the work
+tree, and by principle 2 the two are connected by a manifest rather than by a
+shared directory structure.  Concretely:
 
-*Details of the presentation layer to be added.*  What is missing is the
-gallery or index over that tree, comparable to MPAS-Analysis's HTML output.
-Polaris already records provenance for a setup in `polaris/provenance.py`.
+- **Every step writes a manifest fragment** alongside its outputs, naming each
+  product it made and the facets that identify it: file, field, season,
+  elevation, date range, region, group, and title.
+- **A collector publishes and indexes.**  A cheap step gathers the fragments,
+  publishes each product into the staging tree, and generates the index over
+  it.  Because it works from the fragments rather than from directory
+  structure, re-chunking the work does not disturb the output.
+- **The staging tree is shallow, with descriptive filenames, plus a generated
+  index.**  A gallery is generated, not navigated, and a shallow tree is easier
+  to archive, to serve, and to diff between two analyses.  This follows
+  MPAS-Analysis, where the experience is good.
+- **Products are published by symlink** from the step that owns them, so that
+  each file has exactly one owner and Polaris's output checking continues to
+  work.  The staging tree is a view, not a second source of truth.
+
+Provenance has a second job beyond presentation, introduced by principle 7: it
+is what makes an inherited cache safe to inherit.  Phase 1 ships a minimal
+version --- the identity of the simulation, the config options that govern the
+product, and a hand-maintained version for the kernel that produced it, carried
+in each cache record and refused when it does not match.  A content-addressed
+scheme covering the full dependency graph is deferred; see the deferred items
+below.
+
+*Details of the index itself to be added*, including how much of
+MPAS-Analysis's component/group/gallery structure to adopt.  Polaris already
+records provenance for a setup in `polaris/provenance.py`.
 
 ### Requirement: workflow integration
 
@@ -587,7 +608,7 @@ designed.*  Algorithm designs for the Phase 1 capabilities are in
 
 ### Implementation: code organization
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -607,20 +628,31 @@ capability grows:
 - **Plotting primitives** live in `polaris/viz/`, extended as new plot types
   are needed rather than duplicated inside analysis steps.
 
+Two further pieces are added by Phase 1 and are expected to be reused:
+
+- **Manifest and publication** live in `polaris/tasks/ocean/analysis/`
+  alongside the steps in Phase 1, and should move to a component-neutral home
+  when a second component wants them.  Steps depend on the manifest writer, not
+  on the collector.
+- **Accumulator support** --- discovering candidate caches among sibling
+  directories, checking provenance stamps, and reporting what was inherited ---
+  is a shared helper rather than something each product reimplements, since
+  principle 7 is only as good as its least careful implementation.
+
 Analysis asks for something no existing task needed --- the same simulation
 analyzed repeatedly over different date ranges, reusing what does not depend on
 the range --- but it turns out to need no framework changes to get it.  The
 mechanism is the one the cosine bell task family already uses for resolutions:
 a task rebuilds its step list in `Task.configure()`, which runs after the
-user's config has been merged, so step subdirectories can be keyed by date
-range, and expensive per-year work can be a shared step per year created with
-`Component.get_or_create_shared_step()`.  Re-running and reuse then both follow
-from ordinary step-completion behavior.  Later phases should reach for this
-pattern before reaching for new framework capabilities.
+user's config has been merged, so step subdirectories can be keyed by the date
+range the user asked for.  Reuse across ranges is then the seeded accumulator
+of principle 6, which needs nothing from the framework beyond the ability to
+declare an input discovered at setup time.  Later phases should reach for these
+patterns before reaching for new framework capabilities.
 
 ### Implementation: items deferred from Phase 1
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -646,6 +678,17 @@ is explained in context in {ref}`design-ocean-analysis-initial`.
 - **Regional overturning**, in particular the Atlantic MOC and the standard
   maximum-AMOC-near-26.5°N metric, which arrives with the regional analysis
   described in the requirements above.
+- **A content-addressed provenance scheme for inherited caches.**  Phase 1
+  stamps each cache record with the simulation identity, the config options
+  that govern the product, and a hand-maintained kernel version integer, and
+  refuses to inherit a record whose stamp does not match.  Bumping that integer
+  by hand is the weak link: it is correct only if it is remembered.  The
+  follow-up is a stamp derived from the code and configuration themselves,
+  covering the full dependency graph of a product, so that correctness does not
+  rest on discipline.
+- **Measure Polaris's per-step overhead** --- setup and run of a step that does
+  nothing --- and record it under the organizing principles, so that the step
+  sizing targets in principle 9 rest on a number rather than on judgment.
 
 ### Implementation: design documents in this family
 

--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -351,8 +351,214 @@ task-parallelism requirement above.
 
 ## Algorithm Design
 
-*To be added as individual capabilities are designed.*  Algorithm designs for
-the Phase 1 capabilities are in {ref}`design-ocean-analysis-initial`.
+### Algorithm Design: organizing principles
+
+Date last modified: 2026/08/25
+
+Contributors: Xylar Asay-Davis, Claude
+
+Analysis is a combinatorial workload: products multiply over fields, seasons,
+elevations, date ranges, and --- later --- regions and observational
+references.  How that work is divided into steps and directories is the
+decision most likely to be regretted, because it is cheap to get wrong early
+and expensive to change once results have been archived and linked to.  The
+principles below govern that division.  Individual design documents in this
+family apply them; they do not re-litigate them.
+
+Three questions are easy to conflate, and most of the confusion in an early
+draft of {ref}`design-ocean-analysis-initial` came from answering all three
+with one mechanism:
+
+1. **What is a step?**  The unit of caching, selection, and scheduling.
+2. **What is a directory level?**  The unit of navigation.
+3. **What is a product?**  The unit a human archives, browses, and cites.
+
+#### 1. Two trees, two audiences
+
+The **work tree** is machine-facing.  One goes there to debug a step, not to
+look at results, so it should be shallow, uniform, and predictable.
+
+The **staging tree** is human-facing.  It is where plots and their netCDF files
+are published, where results from repeated analyses accumulate, and what a web
+interface serves.
+
+Neither is compromised for the other.  In particular, the work tree does not
+need to be browsable, and the staging tree does not need to mirror how the work
+was chunked.
+
+#### 2. Products are described by a manifest, not by their path
+
+Each step writes, alongside its outputs, a small manifest fragment describing
+every product it made: file, field, season, elevation, date range, region,
+group, and title.  A cheap final step collects the fragments, publishes into
+the staging tree, and generates the index.
+
+This is the connective tissue between the two trees, and it is what allows the
+work to be re-chunked later without breaking output paths, links, or the
+gallery.  A path is a poor place to store metadata: it has one dimension and
+the metadata has six.
+
+#### 3. Steps are for caching and selection, not for parallelism
+
+A step can use a process pool over its own work.  Parallelism inside a step is
+cheaper than parallelism across steps, costs no inodes, and --- unlike
+concurrency across steps --- is available today rather than when task
+parallelism lands.
+
+So the question "how fine should steps be?" is not "how much can run at once?"
+but "along which axes do we need independent invalidation?"
+
+#### 4. Decompose along the axes a user edits between runs
+
+| Axis | Edited between runs? | A step axis? |
+| --- | --- | --- |
+| Date range | yes, constantly | yes |
+| Years available, as a run is extended | yes | yes, but see principle 6 |
+| Field or plot list | yes; analysts iterate on it | yes, by field *group* |
+| Season, elevation | rarely, and bounded | no --- loop inside a step |
+| Region, observational reference | rarely, and multiplies | no --- loop inside a step |
+| Colormaps and other styling | yes, but should be cheap | no --- a replot option |
+
+The field axis is chunked by *group* rather than by variable: things computed
+together belong in one step.  Zonal and meridional velocity share a vector
+reconstruction, so they share a step.
+
+The bottom two rows matter more than they look.  Regions and observational
+references multiply against fields and seasons, so a rule that survives later
+phases cannot put them on a step axis.  One step per plot is never the answer.
+
+#### 5. Directory levels must earn their keep, and name things rather than mechanisms
+
+A level is justified by one of two things: enough siblings that clutter is
+real, or a name someone would actually navigate by.  A level that fails both is
+noise, and every level makes reaching a given depth harder.
+
+The corollary is the more useful half: **if a level's best name describes how
+the work was chunked rather than what it holds, the level is wrong.**  A
+directory called `years/`, or `offline_metrics/`, is a bucket named after a
+mechanism.  The fix is not a better bucket name; it is to make the thing inside
+a product with a name of its own, or to remove the level.
+
+#### 6. Steps cache what the user asked for; files cache what the computation needed
+
+Polaris's caching primitive is a completion marker in a step's work directory,
+so the only way to get incremental reuse from the framework alone is to create
+a directory per unit of reuse.  That is right when the unit is something a user
+asked for --- a date range, a field group.  It is wrong when the unit is an
+internal chunk of a divisible computation, such as a simulation year: it pays a
+step's overhead, a pickle, a config copy, and a log file for a chunk no user
+ever named.
+
+For those, use a **seeded accumulator**: one step, still keyed by what the user
+asked for, which
+
+- at setup, searches for cache files written by earlier runs of the same
+  product, works out which of them cover part of what is being asked for, and
+  declares them as ordinary inputs;
+- at run, computes only the difference between what is asked for and what it
+  inherited, and writes a complete cache for its own key.
+
+This needs no framework change and no manipulation of completion markers.  The
+step is still keyed by the user's request, so a new request is a new directory
+that has never run, and Polaris's ordinary skip-if-complete behavior is
+untouched.  The seed is a declared input, so provenance and input checking work
+normally and nothing reaches into another step's directory undeclared.  Every
+file remains owned by the step that wrote it.
+
+A partially written cache in the step's own directory is a valid starting point
+for a retry, so restartability comes with the pattern rather than being added
+to it.
+
+The pattern applies wherever we own the reduction kernel, and nowhere else.
+`ncclimo` has no incremental mode, so a climatology is recomputed in full for
+each new date range.
+
+#### 7. Discovery is scoped by construction and validated by content
+
+Principle 6 has software hunting for data on disk, which is worth being
+uncomfortable about.  The discomfort is resolved by separating two jobs that a
+path is often asked to do at once:
+
+> **The path establishes the search scope.  The content establishes
+> admissibility.**
+
+The scope is only ever what construction guarantees: sibling directories of the
+same product, written by the same step class with the same outputs, differing
+only in the key.  It is never widened to arbitrary locations on disk.
+
+Nothing, however, is trusted because of where it sits.  "Same location"
+guarantees less than it appears to: work-directory paths do not encode which
+simulation was analyzed, so the same directory re-used against a different
+simulation would otherwise cross-contaminate silently, as would a changed
+constant or a changed elevation range.  Every cache record therefore carries a
+provenance stamp --- the identity of the simulation, the config options that
+govern the product, and a version for the kernel that produced it --- and a
+record whose stamp does not match what is being asked for is not inherited.  It
+is recomputed, without ceremony.
+
+Three further rules keep this auditable rather than magical:
+
+- **Only a completed step is a candidate.**  A directory without a completion
+  marker is never inherited from, which also disposes of the half-written cache.
+- **Reuse is loud.**  Every run reports what it inherited and from where, and
+  the provenance travels in the output.  An auditable decision is a different
+  thing from an invisible one.
+- **Explicit mode exists.**  Reuse can be disabled outright, and an additional
+  search location can be named, for anyone who wants determinism rather than
+  discovery.  Discovery is the default, not the only option.
+
+#### 8. A cache is an intermediate product, so its form follows its consumer
+
+A cache is not a private data structure; it is an intermediate product with a
+known consumer, and it should be written in the form that consumer reads.  A
+reduced time series consumed whole by a plotting step is one file with an
+unlimited time dimension, appended to as the record grows.  A monthly field
+consumed by `ncclimo` is monthly files, because that is `ncclimo`'s interface.
+
+Two guardrails bound the space, in place of a target file size, which cannot be
+stated without becoming resolution-dependent:
+
+- never more cache files than there are input files;
+- never rewrite more than one chunk in order to append one unit.
+
+Beyond that this is deliberately **not a load-bearing decision**.  An
+accumulator exists to avoid re-reading gigabytes of three-dimensional monthly
+output, and that pass dominates cache I/O in every case we have.  Accumulators
+are for reductions, and reductions are small.
+
+#### 9. Size steps for the production case
+
+Any granularity looks absurd at the resolution of a regression test.  Step size
+is chosen against a production run --- a multi-decade, high-resolution coupled
+simulation --- where a pass over a year of three-dimensional monthly output is
+gigabytes and minutes.  A test configuration has few enough years that the
+overhead is irrelevant.
+
+The targets, which later phases should hold themselves to:
+
+- a step should do at least tens of seconds of work at production resolution,
+  so that Polaris's per-step overhead is a few percent at most;
+- a suite should contain steps numbering in the low hundreds, and should stay
+  there as regions and observational comparisons are added.
+
+Polaris's actual per-step overhead --- setup and run of a step that does
+nothing --- should be measured once and recorded here, so that this stops being
+a matter of judgment.
+
+#### 10. Split computation from plotting only where computation dominates
+
+Writing the data behind a plot is required in all cases; see the
+`plots are always accompanied by their data` requirement.  Making the
+computation a *separate step* from the plot is a different question, and it
+earns its keep only where recomputing is expensive relative to replotting.  For
+a map on the native grid, the plotting is the expensive part, so splitting buys
+nothing and costs a level and a step.  Where a plot is a cheap rendering of an
+expensive reduction, the reduction is an accumulator by principle 6 and the
+split has already happened for a better reason.
+
+*Further algorithm designs to be added as individual capabilities are
+designed.*  Algorithm designs for the Phase 1 capabilities are in
+{ref}`design-ocean-analysis-initial`.
 
 ## Implementation
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -32,9 +32,15 @@ expensive intermediate products (climatologies, reduced monthly heat content)
 are written to netCDF as well.
 
 The same simulation can be analyzed repeatedly over different date ranges.
-Results accumulate in a range-keyed staging tree that a web interface can serve
-later, and re-analyzing a new range inherits the reduced monthly values
-earlier ranges already computed instead of recomputing them.
+Results accumulate in a range-keyed staging tree, and re-analyzing a new range
+inherits the reduced monthly values earlier ranges already computed instead of
+recomputing them.
+
+The staging tree is published with a thumbnail for every plot and a generated
+gallery over them, as static HTML that a web server serves unchanged.  The
+gallery follows MPAS-Analysis's familiar layout, and is designed around the
+fact that the portal hosting it throttles: what a page costs to load is a
+requirement here, not a detail of presentation.
 
 MPAS-Analysis is the scientific reference for what each of these diagnostics
 means, but the implementation is written from scratch with Polaris and Omega in
@@ -249,19 +255,16 @@ silent.
 
 ### Requirement: repeated-analysis
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 
 Polaris shall support analyzing the same simulation repeatedly with different
 climatology and time-series date ranges.
 
-Results shall be published to a single location that a reader can browse
-without knowing anything about Polaris work directories, and that a web
-interface can serve when one is added.  That location shall carry an index over
-the results rather than requiring the reader to navigate directories.
 Analyzing a new range shall not overwrite or remove the results of a range
-analyzed earlier.
+analyzed earlier, and ranges analyzed at different times shall appear together
+in the published output described under `publication` below.
 
 Re-running the analysis with a changed range shall recompute the products that
 depend on that range.  It shall not be necessary to delete the work directory
@@ -276,6 +279,47 @@ Re-running with an unchanged range shall recompute nothing by default, and it
 shall be possible to ask for the plots to be redrawn --- after a change to
 colormaps or other styling --- without recomputing the intermediate results
 behind them.
+
+### Requirement: publication
+
+Date last modified: 2026/08/29
+
+Contributors: Xylar Asay-Davis, Claude
+
+Results shall be published to a single location that a reader can browse
+without knowing anything about Polaris work directories, and that a web server
+can serve unchanged.  That location shall carry a generated index over the
+results rather than requiring the reader to navigate directories.
+
+The index shall be static HTML, generated from the merged manifest, and shall
+require no server-side code, no build step, and no network access of its own,
+so that it works equally from a local filesystem and from a web portal.
+
+**Every plot shall have a thumbnail.**  With a few hundred plots, thumbnails
+are what let a reader decide which full images to open, and they frequently
+answer the question without any full image being opened at all.  A thumbnail
+shall be a separate, small, lossy file rather than the full image scaled down
+by the browser, which would cost the full image's bytes.
+
+**A page shall stay within what a throttled link can deliver.**  The analysis
+is hosted on the LCRC public web portal, which throttles in a way that stalls a
+page asking for too much at once, and this is the constraint that the
+presentation has to be designed around rather than discovering later.  Three
+things shall bound what a page costs: thumbnails shall be small, no page shall
+carry the whole result set, and images the reader has not scrolled to shall not
+be fetched.  The parameters controlling this shall be config options, since the
+binding constraint is a property of the host rather than of the analysis.
+
+**The published output shall not need to be regenerated to be extended.**  The
+index shall be derived from the manifest alone, so that facets added later ---
+region, observational reference, a second simulation to compare against --- and
+richer presentation --- per-product pages carrying provenance and the code that
+reproduces a figure, filtering, search --- can be added without changing any
+step, any manifest fragment already written, or any published path.  The
+broader intent this serves is in {ref}`design-ocean-analysis`.
+
+What this deliverable does *not* owe is a considered visual design.  A gallery
+following MPAS-Analysis's familiar layout, and no more, is what Phase 1 ships.
 
 ### Requirement: omega-monthly-means
 
@@ -1075,7 +1119,7 @@ open questions.
 
 ### Implementation: analysis-suite
 
-Date last modified: 2026/08/27
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1181,8 +1225,10 @@ simulation_path =
 # A short name for the simulation, used in plot titles and file names
 simulation_name = omega
 
-# Where to stage plots and their netCDF files for browsing, organized by
-# product and date range.  Defaults to <work_dir>/analysis_output.
+# Where to publish plots, their netCDF files, thumbnails, and the generated
+# gallery.  Defaults to <work_dir>/analysis_output.  Point this somewhere
+# web-servable if you want to share the results.  The thumbnail options that
+# go with it are given under `publication`.
 output_path =
 
 # The horizontal mesh file, absolute or relative to simulation_path.  Defaults
@@ -1484,7 +1530,7 @@ list above rather than from a spot measurement of one configuration.
 
 ### Implementation: data-products
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1493,7 +1539,7 @@ name containing the plotted field, its coordinates, units, and the config
 options --- including the date range --- that produced it as global attributes.
 Both go in the step's own subdirectory, are described in the step's manifest
 fragment, and are published into the staging tree by symlink, as described
-under `repeated-analysis`.
+under `publication`.
 
 The manifest is what carries the facets that identify a product --- field,
 season, vertical reduction, date range, and later region and observational
@@ -1513,7 +1559,7 @@ provenance stamp that makes them safe to inherit across runs.
 
 ### Implementation: repeated-analysis
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1655,74 +1701,6 @@ pool inside the step rather than over steps.  This follows principle 3 in
 {ref}`design-ocean-analysis`, and it means the analysis gets its concurrency
 from a capability that exists today rather than from task parallelism.
 
-#### Publishing results
-
-The work tree is built for predictability, not for browsing, so results are
-published into a separate staging tree whose root is a config option.  This is
-principle 1 in {ref}`design-ocean-analysis`: two trees, two audiences.
-
-```ini
-[ocean_analysis]
-
-# Where to publish plots and their netCDF files for browsing.  Defaults to
-# <work_dir>/analysis_output.  Point this somewhere web-servable if you want
-# to share the results.
-output_path =
-```
-
-**Every step writes a manifest fragment.**  Alongside its outputs, each step
-writes `manifest.json` describing every product it made and the facets that
-identify it:
-
-```json
-{"products": [
-  {"png": "temperature_ANN_-100m.png",
-   "nc": "temperature_ANN_-100m.nc",
-   "group": "climatology_maps", "field": "temperature",
-   "season": "ANN", "reduction": "-100m",
-   "start_year": 21, "end_year": 40,
-   "title": "Potential temperature at 100 m, ANN, years 21-40"}]}
-```
-
-**A `publish` step collects them.**  One cheap step per suite reads every
-fragment, symlinks each product into the staging tree, and writes the merged
-manifest.  It works from the fragments rather than from directory structure,
-which is what lets the work be re-chunked later without disturbing output
-paths, links, or a gallery --- principle 2.  A product whose fragment is
-present but whose file is missing is reported rather than silently omitted.
-
-**Generating an index over that tree is not in Phase 1.**  A flat directory of
-PNGs and netCDF is enough for the Ocean Team to work from, and the gallery is
-Phase 2 in {ref}`design-ocean-analysis`.  What Phase 1 owes it is the merged
-manifest, which is everything a gallery generator needs and is the reason it
-can be added later without touching a single step.
-
-**The staging tree is shallow, with descriptive filenames.**  A shallow tree is
-easier to archive, to serve, and to diff between two analyses, and it is what a
-generated index wants underneath it when one arrives:
-
-```none
-<output_path>/
-├── manifest.json                                   (the merged manifest)
-└── plots/
-    ├── climatology_maps_temperature_ANN_-100m_0021-0040.png
-    ├── climatology_maps_temperature_ANN_-100m_0021-0040.nc
-    ├── climatology_maps_heat_content_ANN_top_to_-700m_0021-0040.png
-    ├── heat_content_series_0001-0060.png
-    └── …
-```
-
-The filename is the facets in a fixed order, so it sorts usefully, greps
-usefully, and cannot collide between two ranges.  Range keys are the
-zero-padded start and end years, matching the convention `ncclimo` already uses
-in its file names.  This follows MPAS-Analysis, where the experience with a
-flat plot directory plus a generated gallery has been good.
-
-**Products are published by symlink** from the step that owns them, so each
-file has exactly one owner, Polaris's output checking continues to work, and
-the staging tree is a view rather than a second source of truth.  Results from
-different ranges coexist because the range is in the filename.
-
 #### Replotting
 
 Re-running with an unchanged range recomputes nothing, which is what the
@@ -1761,6 +1739,264 @@ earlier range nearly free, but it is worth knowing about on a filesystem with a
 quota.  The climatology files dominate: an accumulator cache for a reduced
 series is kilobytes, while a full set of `ncclimo` output is a copy of the
 requested fields for every season.
+
+### Implementation: publication
+
+Date last modified: 2026/08/29
+
+Contributors: Xylar Asay-Davis, Claude
+
+The work tree is built for predictability, not for browsing, so results are
+published into a separate staging tree whose root is a config option.  This is
+principle 1 in {ref}`design-ocean-analysis`: two trees, two audiences.
+
+#### Where the code lives, and on which branch
+
+Publication is three pieces, and keeping them apart is what lets presentation
+change without touching a step:
+
+- the **manifest writer**, which a plotting step calls once per product;
+- the **collector**, which merges the fragments, publishes each product, and
+  renders its thumbnail;
+- the **site generator**, which renders the index from the merged manifest.
+
+None of the three knows anything about the ocean --- the writer takes arbitrary
+facets, and the generator renders whatever the manifest holds --- so all three
+live in a component-neutral `polaris/analysis/` package beside `polaris/viz/`,
+rather than under `polaris/tasks/ocean/analysis/` to be moved when a second
+component wants them.  The templates ship as package data named `*.template`,
+which `MANIFEST.in` already includes.  `jinja2` and `pillow` are both already
+in the environment --- `jinja2` is used by `polaris/streams.py` and `pillow`
+arrives with `matplotlib` --- but both become direct dependencies here and are
+declared as such in `pyproject.toml`.
+
+Following the branch rules in {ref}`design-ocean-analysis`, this work is a
+branch cut from the analysis scaffolding rather than from either arm of
+products, because the manifest writer is a dependency of every plotting step
+and shared infrastructure is cut below its consumers.  The consequence is
+deliberate and is recorded here so that it is not rediscovered: the branches
+that add products rebase onto this one, and each gains one commit that emits
+its own manifest fragments.
+
+#### Config options
+
+```ini
+[ocean_analysis]
+
+# Where to publish plots, their netCDF files, thumbnails, and the generated
+# gallery.  Defaults to <work_dir>/analysis_output.  Point this somewhere
+# web-servable if you want to share the results.
+output_path =
+
+# The width in pixels of the thumbnail generated for each plot.  Thumbnails
+# are what make a few hundred plots browsable, and their total size is what
+# decides whether a gallery page loads over a throttled link, so this is the
+# first thing to reduce if pages are slow to appear.
+thumbnail_width = 320
+
+# The image format for thumbnails, jpeg or webp.  webp is roughly a quarter
+# smaller at the same quality and every current browser reads it; jpeg is the
+# safer default.
+thumbnail_format = jpeg
+
+# The compression quality of thumbnails, from 1 to 100.  Above about 80 the
+# bytes grow quickly and a thumbnail does not look better.
+thumbnail_quality = 75
+```
+
+#### Every step writes a manifest fragment
+
+Alongside its outputs, each step writes `manifest.json` describing every
+product it made and the facets that identify it:
+
+```json
+{"products": [
+  {"png": "temperature_ANN_-100m.png",
+   "nc": "temperature_ANN_-100m.nc",
+   "group": "climatology_maps", "gallery": "temperature",
+   "field": "temperature", "season": "ANN", "reduction": "-100m",
+   "start_year": 21, "end_year": 40,
+   "title": "Potential temperature at 100 m, ANN, years 21-40"}]}
+```
+
+Three rules keep this from growing into a format that needs a specification.
+
+**A step fills the facets; the collector fills everything else.**  The
+published name and the thumbnail are added by the collector when it publishes,
+so a step never has to know the staging tree's layout, and a change to that
+layout is a change to one step.
+
+**Only `group` and `gallery` shape the site.**  Every other facet is caption
+material today and filter material later.  This is the hinge that makes the
+extensibility requirement cheap: adding a `region` facet adds a key to the
+fragment and a word to the caption, and changes nothing in the generator.
+
+**Order is meaning, so the collector preserves it.**  Products keep the order
+they appear in within a fragment, and fragments are ordered by group and
+gallery.  A gallery therefore reads ANN, DJF, MAM, JJA, SON because that is the
+order the step plotted them in, and no sort key, season-ordering table, or
+comparator has to exist anywhere.
+
+The manifest is what carries the facets that identify a product --- field,
+season, vertical reduction, date range, and later region and observational
+reference.  Encoding those in the path instead would mean a directory level per
+facet, and a path has one dimension where the metadata has six.
+
+#### A `publish` step collects, thumbnails, and generates
+
+One cheap step per suite reads every fragment and, in order: symlinks each
+product into the staging tree, renders a thumbnail for each plot, writes the
+merged manifest, and generates the site over it.  It works from the fragments
+rather than from directory structure, which is what lets the work be re-chunked
+later without disturbing output paths, links, or the gallery --- principle 2.
+A product whose fragment is present but whose file is missing is reported
+rather than silently omitted.
+
+Because it is the only step that knows how results are presented, everything in
+the two sections below can change without a single plotting step changing.
+
+#### The staging tree
+
+The staging tree is shallow, with descriptive filenames.  A shallow tree is
+easier to archive, to serve, and to diff between two analyses:
+
+```none
+<output_path>/
+├── index.html                                      (the gallery groups)
+├── manifest.json                                   (the merged manifest)
+├── galleries/
+│   ├── climatology_maps_temperature_0021-0040.html
+│   └── …
+├── plots/
+│   ├── climatology_maps_temperature_ANN_-100m_0021-0040.png
+│   ├── climatology_maps_temperature_ANN_-100m_0021-0040.nc
+│   ├── climatology_maps_heat_content_ANN_top_to_-700m_0021-0040.png
+│   ├── heat_content_series_0001-0060.png
+│   └── …
+└── thumbnails/
+    └── climatology_maps_temperature_ANN_-100m_0021-0040.jpg
+```
+
+The filename is the facets in a fixed order, so it sorts usefully, greps
+usefully, and cannot collide between two ranges.  Range keys are the
+zero-padded start and end years, matching the convention `ncclimo` already uses
+in its file names.  This follows MPAS-Analysis, where the experience with a
+flat plot directory plus a generated gallery has been good.
+
+**Products are published by symlink** from the step that owns them, so each
+file has exactly one owner, Polaris's output checking continues to work, and
+the staging tree is a view rather than a second source of truth.  Results from
+different ranges coexist because the range is in the filename.
+
+Thumbnails are the exception: they are generated files with no owner upstream,
+so they are real files in the staging tree rather than symlinks, and they are
+regenerated only when missing or older than the plot they came from.  Adding
+one product to an existing analysis therefore costs one thumbnail, not three
+hundred.
+
+#### Thumbnails
+
+Each thumbnail is made from the published PNG with `pillow`: the image is
+flattened onto white, since the plots are written with an alpha channel and
+neither JPEG nor a gallery wants transparency, scaled to `thumbnail_width`
+preserving aspect ratio, and written in `thumbnail_format` at
+`thumbnail_quality`.
+
+Making them here rather than in the plotting steps is deliberate.  It keeps the
+plotting steps ignorant of presentation, it keeps the policy in one place where
+changing it re-renders everything consistently, and it means a thumbnail can be
+regenerated from what was published without re-running any analysis.
+
+The measured cost, on the three-panel MPAS-Analysis figure used for the
+comparison below, is 20 ms per image to decode, scale, and encode.  A default
+Phase 1 analysis is on the order of a hundred products, so the whole pass is a
+few seconds.  Memory is one image at a time.  The loop is embarrassingly
+parallel and is an obvious candidate for principle 3's in-step pool if the
+product count ever grows enough to matter; Phase 1 runs it serially with
+`cpus_per_task = 1`.
+
+#### The generated site
+
+The site follows MPAS-Analysis's shape, because that is what the Ocean Team
+already knows how to navigate:
+
+- a **gallery group** is a section of the landing page: a product group for one
+  date range, such as "Climatology maps, years 0021-0040".  The collector
+  composes this from the `group` facet and the range rather than the step
+  naming it, so a step stays unaware that ranges accumulate side by side.
+- a **gallery** is one page of thumbnails within a group, such as the maps of
+  potential temperature, and is identified by the `gallery` facet.
+- the landing page shows each group with one representative thumbnail per
+  gallery --- the gallery's first product, which is deterministic because order
+  is preserved --- so the reader chooses a gallery by looking rather than by
+  reading names.
+
+Clicking a thumbnail opens the full PNG, with the netCDF linked beside it.
+That link target is the one thing that changes when per-product pages arrive.
+
+The pages are rendered from `jinja2` templates with the CSS inlined, so a page
+costs one HTML request and its images, and no stylesheet request.  There is no
+JavaScript: the site works from `file://`, from `python -m http.server`, and
+from the LCRC portal identically, and there is nothing to break when a browser
+changes.  Every `<img>` carries `loading="lazy"` so that thumbnails below the
+fold are not fetched until they are scrolled to, and explicit `width` and
+`height` so that lazy loading does not make the page reflow as images arrive.
+Both are plain HTML attributes supported by every current browser.
+
+Every page carries the simulation name, the date ranges, and the Polaris
+provenance from `polaris/provenance.py`, so a page found later can be traced
+back to what produced it.
+
+#### What a page costs
+
+This is the number the design exists to control, so it is worth writing down
+rather than asserting.
+
+The reference is a real MPAS-Analysis result: one page of its ocean output
+carries **1641 thumbnails at roughly 46 kB each**, all fetched eagerly, which
+is about **75 MB in 1641 requests** before the page settles.  Its thumbnails
+are 480 px wide and lightly compressed.  This is the behavior that stalls on a
+throttled link.
+
+Measured against a Polaris single-panel global map reduced to the defaults
+above, a thumbnail is **about 13 kB** as JPEG at 320 px and quality 75, or
+about 10 kB as WebP.  With the default field and season lists a climatology-map
+gallery holds roughly fifteen products, so a gallery page is a ~10 kB document
+plus ~200 kB of thumbnails, of which lazy loading fetches only the visible rows
+--- on the order of **100 kB** before the page is usable.  The landing page
+carries one thumbnail per gallery, so it is of the same order.
+
+The three levers act independently, which is why all three are used: small
+thumbnails cut the bytes per image by a factor of three or four against the
+reference, gallery pages cut the images per page by two orders of magnitude,
+and lazy loading cuts what is fetched before the page settles to the handful
+that are visible.  A single page never asks for a full PNG.
+
+What is *not* known is whether the LCRC portal throttles bytes or requests.
+Everything above helps with either, but the remedies differ if requests are the
+binding constraint --- a sprite sheet, or thumbnails inlined in the page as
+data URIs --- and both are worse in every other way.  Deciding between them
+should follow a measurement against the portal rather than a guess; that
+measurement is listed under testing below, and the alternatives are recorded
+among the deferred items in {ref}`design-ocean-analysis`.
+
+#### Where this is extended
+
+Four extensions are expected, and none requires a step, a fragment, or a
+published path to change:
+
+- **New facets** --- region, an observational reference, a second simulation to
+  compare against --- are new keys in the fragment and new words in a caption.
+  Only a facet that should become a new gallery or group touches the generator.
+- **Per-product pages**, carrying the provenance and the code that reproduces a
+  figure in the way E3SM-Diags does, are a new template and a changed link
+  target.  The manifest already holds everything such a page would show except
+  the recipe itself.
+- **Filtering and search** across facets are a client-side layer over
+  `manifest.json`, which the site already publishes beside the pages for
+  exactly this reason.
+- **A different visual design** is templates and CSS.
+
 
 ### Implementation: omega-monthly-means
 
@@ -2382,13 +2618,15 @@ quietly, so this is the first thing to build once the products are out.
 
 ### Implementation: order of work
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/29
 
 Contributors: Xylar Asay-Davis, Claude
 
-Each entry below is a coherent, independently reviewable piece of work, not a
-single commit --- most will take several --- and each leaves the suite working
-for the products delivered so far.
+Each entry below is a branch, following the branch rules in
+{ref}`design-ocean-analysis`: a coherent, independently reviewable piece of
+work carrying its code, its unit tests, and its User's Guide documentation,
+leaving the suite working for the products delivered so far.  Design changes
+are not among them, since those land on the design branch.
 
 The order is by deliverable priority rather than by dependency depth, which is
 why the vertical machinery comes late.  Slicing by layer index needs no
@@ -2417,9 +2655,13 @@ product that already works rather than gating it.
 5. The `ClimatologyMaps` step, restricted to fields with no vertical dimension
    and to slicing by layer index.  The first maps on disk, and no vertical
    geometry needed.
-6. The manifest writer and the `publish` step.  Here rather than earlier so
-   that it is built against products that exist, and here rather than later so
-   that only one step needs its manifest fragment retrofitted.
+6. Publication: the manifest writer, the `publish` step that collects and
+   renders thumbnails, and the generated gallery over the staging tree, as
+   designed under `publication`.  Its position in this list is a priority
+   rather than a dependency: it is cut from item 2 and not from the products,
+   because the manifest writer is a dependency of every plotting step.  The
+   product branches above it therefore rebase onto it, each gaining one commit
+   that emits its own fragments.
 7. `polaris/ocean/heat_content.py` and whole-column mass weights, with unit
    tests.
 8. The `heat_content` field group of `ClimatologyMaps`, whole column only.
@@ -2436,15 +2678,20 @@ product that already works rather than gating it.
 13. The `replot` option.
 14. The offline `mixed_layer_depth` accumulator and its climatology, only if
     Omega's in-situ diagnostic will not be ready in time.
-15. User's Guide documentation: a page under `docs/users_guide/ocean/tasks/`
-    describing the analysis suite and its config options, and an entry in
-    `docs/users_guide/ocean/suites.md`.
+
+User's Guide documentation is not a work item of its own.  Each branch above
+brings the page or the section that documents what it added --- a page under
+`docs/users_guide/ocean/tasks/` for the suite and its config options, and an
+entry in `docs/users_guide/ocean/suites.md` --- because a capability that ships
+undocumented is not finished, and the moment its behavior is fresh is the
+moment to write it down.
 
 Deferred past this deliverable, and designed in
 {ref}`design-ocean-analysis` rather than here: splitting accumulators into
-several steps, process pools inside steps, the generated gallery over the
-staging tree, the mechanical conformance checks, and the `analysis_test` task
-and its suite.
+several steps, process pools inside steps, a considered visual design for the
+gallery and the per-product pages that would carry a figure's provenance and
+recipe, the mechanical conformance checks, and the `analysis_test` task and its
+suite.
 
 ## Testing
 
@@ -2531,6 +2778,57 @@ it ran:
 Finally, a check that the range recorded in a netCDF file's attributes matches
 the range in its path, which is what would catch a plot labeled with the wrong
 range if the step tree and the metadata ever drifted apart.
+
+### Testing and Validation: publication
+
+Date last modified: 2026/08/29
+
+Contributors: Xylar Asay-Davis, Claude
+
+Publication is cheap to test properly because none of it needs a simulation: a
+few hand-written manifest fragments and a handful of small PNGs exercise every
+path.  The unit tests live with the branch that adds them.
+
+On the manifest and the collector:
+
+- fragments written by the writer round-trip through the collector, and the
+  merged manifest names every product the fragments did;
+- a fragment naming a file that is not on disk is reported rather than
+  silently omitted, which is the failure this design promises to catch;
+- order is preserved --- products keep their within-fragment order and
+  fragments are ordered by group and gallery --- since a gallery reading ANN,
+  DJF, MAM, JJA, SON rests on nothing else;
+- two ranges of the same product publish to distinct names and both survive,
+  which is the same guarantee `repeated-analysis` makes, checked here on the
+  staging tree rather than the work tree.
+
+On thumbnails:
+
+- one is generated for every plot, at the configured width, in the configured
+  format, and is smaller than its PNG by the order of magnitude the design
+  claims --- a bound rather than an exact size, since encoders differ;
+- a thumbnail already newer than its plot is not regenerated, which is what
+  keeps adding one product from costing three hundred;
+- a PNG with an alpha channel produces a thumbnail with no transparency,
+  since that is what silently produces black backgrounds otherwise.
+
+On the generated site:
+
+- every link and every `src` in the generated HTML resolves to a file that
+  exists, which is the check that a broken gallery fails on;
+- every product in the merged manifest appears on exactly one gallery page,
+  and every gallery is reachable from the landing page;
+- every `<img>` carries `loading="lazy"` and explicit dimensions.  This is a
+  test of the thing that is easiest to lose in a template edit and whose loss
+  is invisible until a page is served over a throttled link.
+
+One thing here cannot be a unit test and should not be pretended into one.
+**Whether the LCRC portal throttles bytes or requests is unknown**, and it
+decides which further measures are worth taking.  The measurement is to publish
+a realistic result set to the portal and time a cold load of the largest
+gallery page, with the browser's network panel showing whether the limit is
+reached in bytes or in concurrent requests.  This should be done once the first
+real analysis is published, and the answer recorded here.
 
 ### Testing and Validation: climatology
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -713,7 +713,7 @@ already encodes the range in its output file names
 
 ### Algorithm Design: climatology-maps
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/30
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1576,7 +1576,7 @@ provenance stamp that makes them safe to inherit across runs.
 
 ### Implementation: repeated-analysis
 
-Date last modified: 2026/08/29
+Date last modified: 2026/08/30
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1761,7 +1761,7 @@ requested fields for every season.
 
 ### Implementation: publication
 
-Date last modified: 2026/08/29
+Date last modified: 2026/08/30
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -2756,7 +2756,7 @@ quietly, so this is the first thing to build once the products are out.
 
 ### Implementation: order of work
 
-Date last modified: 2026/08/29
+Date last modified: 2026/08/30
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -2997,7 +2997,7 @@ The test is skipped if `ncclimo` is not on the path.
 
 ### Testing and Validation: climatology-maps
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/30
 
 Contributors: Xylar Asay-Davis, Claude
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -952,25 +952,33 @@ $$
                       \overline{\Theta' \tilde{h}'}
 $$
 
-The neglected term is small for heat content over fixed elevation ranges ---
-the range boundaries are fixed in $z$, so the covariance enters only through
-the partial layers at the boundaries and through the free surface --- but it is
-not identically zero, particularly in regions with a large seasonal cycle in
-sea surface height and layer thickness.  Note that this means the climatology
-must include both `PseudoThickness` and the geometric interfaces: the former
-sets the mass weight, the latter sets the partial-layer fraction at the range
-boundaries.
+This term is already dropped at every timescale shorter than a month, the
+moment the analysis works from monthly means rather than from model time steps.
+Neglecting it again from month to season is the same approximation applied over
+a longer averaging period, not a new one, so there is little sense in being
+scrupulous about the second while accepting the first in silence.
 
-The heat content time series does not have this issue, because it integrates
-each monthly mean separately and averages afterward.
+Its size settles the question.  Over a fixed elevation range the term enters
+only through the partial layers at the range boundaries and through the free
+surface, and for the $0$ to $-700$ m range a seasonal sea surface height of
+order $0.1$ m against a near-surface seasonal temperature anomaly of a few
+kelvin gives order $10^6$ J m⁻², against a total near $2.9 \times 10^{10}$
+J m⁻².  That is order $10^{-4}$ of the signal --- an order-of-magnitude sketch
+rather than a bound, but several orders below anything that would change a
+conclusion drawn from these maps.  The sub-monthly version is of similar
+magnitude and partly cancels, being eddy-driven rather than systematic.
 
-If the covariance term turns out to matter, the alternative is to compute the
-per-month vertically integrated heat content maps first, as the time series
-step already does, and then average those maps into a climatology.  That is a
-potential follow-up after September 15, not a fallback available before it: it
-costs a full pass over the three-dimensional monthly output for every season
-plotted, and the requirement asks for heat content from a climatology of
-conservative temperature.
+We therefore compute the maps from the climatology and do not plan to revisit
+it.  The alternative --- computing per-month vertically integrated maps and
+averaging those --- would cost a full pass over the three-dimensional monthly
+output for every season plotted, which is a large price for $10^{-4}$.
+
+What this does require is that the climatology include both `PseudoThickness`
+and the geometric interfaces: the former sets the mass weight, the latter the
+partial-layer fraction at the range boundaries.
+
+The heat content time series does not have the issue at all, because it
+integrates each monthly mean separately and averages afterward.
 
 ### Algorithm Design: moc-plot
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -40,8 +40,14 @@ MPAS-Analysis is the scientific reference for what each of these diagnostics
 means, but the implementation is written from scratch with Polaris and Omega in
 mind rather than ported.  The reasoning is in {ref}`design-ocean-analysis`.
 
-Three things are deliberately **out of scope** for this deliverable:
+Four things are deliberately **out of scope** for this deliverable:
 
+- **Analyzing MPAS-Ocean output.**  The analysis locates a simulation's output
+  by reading the simulation's own Omega configuration, and MPAS-Ocean describes
+  its output with namelists and streams files instead.  Supporting it means
+  writing a translator from those into the same form, which is separate work.
+  This costs the deliverable nothing, since the design already develops against
+  Omega output for the reasons given under `omega-monthly-means`.
 - **Integration with zppy.**  For September 15, the analysis is run by hand by
   members of the Ocean Team, who make the results available to the coupled
   group within several days of each simulation period completing.  MPAS-Seaice
@@ -165,18 +171,19 @@ such as `bottomDepth`, and says so.
 
 ### Requirement: analysis-suite
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/27
 
 Contributors: Xylar Asay-Davis, Claude
 
 Polaris shall provide a suite that computes all of the analysis in this
-document for a single simulation.
+document for a single Omega simulation, run standalone or within E3SM.
+Analyzing MPAS-Ocean output is out of scope for this deliverable.
 
 The user shall supply a config file that provides:
 
-- the path to the E3SM or Omega standalone simulation to be analyzed, together
-  with enough information to find its mesh, vertical coordinate, and output
-  files;
+- the path to the simulation's own Omega configuration file, from which the
+  mesh, the vertical coordinate and the output files shall be found without
+  the user restating any of them;
 - the start and end dates of the climatology;
 - the fields for which climatology maps should be produced (if different from
   the defaults);
@@ -1047,7 +1054,7 @@ open questions.
 
 ### Implementation: analysis-suite
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/27
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1137,15 +1144,17 @@ proposed starting point:
 ```ini
 [ocean_analysis]
 
-# The absolute path to the simulation's Omega configuration file.  Polaris
+# The absolute path to the simulation's Omega configuration file.  This is the
+# analysis' only description of where the simulation's output lives: Polaris
 # reads the mesh, the output streams and their file-name templates from it, so
-# that they do not have to be restated below.  Leave empty and fill in the
-# templates by hand for MPAS-Ocean, or for a run whose config file is not
-# available.
+# that none of them have to be restated here.  It is required, since an Omega
+# run always has one.  MPAS-Ocean output is not supported; reading it would
+# need a translator from its namelists and streams into the same form.
 omega_config_filename =
 
 # The absolute path to the directory containing the simulation's output.
-# Defaults to the output directory the Omega config names.
+# Defaults to the directory containing the Omega configuration file, which is
+# what its relative file names are resolved against.
 simulation_path =
 
 # A short name for the simulation, used in plot titles and file names
@@ -1163,14 +1172,6 @@ mesh_filename =
 # simulation_path
 vert_coord_filename =
 
-# File-name templates for the simulation output the analysis reads, relative
-# to simulation_path.  $Y and $M are replaced by the four-digit year and
-# two-digit month.  Each defaults to the template of the corresponding Omega
-# output stream; set one only to override what the config file says.
-monthly_mean_template =
-global_stats_template =
-moc_template =
-
 
 [ocean_analysis_climatology]
 
@@ -1186,7 +1187,7 @@ plot_seasons = ANN, DJF, JJA
 
 # The fields for which climatology maps are produced, using MPAS-Ocean
 # (Polaris standard) names
-fields = temperature, salinity, velocityZonal, velocityMeridional,
+fields = temperature, salinity, velocityZonal, velocityMeridional, ssh,
          mixedLayerDepth
 
 # The elevations at which fields with a vertical dimension are plotted.
@@ -1309,23 +1310,52 @@ exist, reporting the missing years clearly.  It is shared by every step that
 reads simulation output.  This is deliberately a separate module rather than a
 method on a step, so that it can be unit tested and reused.
 
-Where the templates come from is the point.  The user's normal input is
+Where the templates come from is the point.  The user's input is
 `omega_config_filename`, the path to the simulation's own Omega configuration,
 and the same module reads the output streams from it: each stream gives a
 file-name template, a reduction period and a directory, which is enough to
 identify the monthly means, the `GlobalStats` output and the MOC output without
-the user restating any of it.  The mesh file is read from the same place.
+the user restating any of it.  The mesh and the vertical coordinate are read
+from the same place.
 
-The explicit templates remain as overrides, and are the only way in for
-MPAS-Ocean output or a run whose configuration file is not to hand.  An option
-the user sets always wins over what the config file says, and the step logs
-which source each path came from, so that a surprising file list can be
-diagnosed without guessing.
+**The templates are not config options, and the Omega configuration is
+required.**  An earlier draft had `monthly_mean_template` and its siblings as
+config options overriding what the Omega configuration says, which cannot
+work: Polaris config files use `ExtendedInterpolation`, so a bare `$Y` in a
+value raises `invalid interpolation syntax` and takes down the whole config
+combine, not merely that option.  Escaping it as `$$Y` would work and would be
+a trap, since a template pasted out of `omega.yml` would then fail
+confusingly.
 
-Reading Omega's configuration is done defensively --- a missing or unfamiliar
-stream is reported as such, naming the option to set by hand instead --- since
-its schema is Omega's to change and this is the one place Polaris depends on
-its shape rather than on its output.
+Removing the override layer rather than escaping it is the better trade in any
+case.  An Omega run always writes an `omega.yml`, so there is no case where the
+configuration is genuinely unavailable and the fallback would earn its keep;
+making it required removes the precedence rules, the reporting of which source
+won, and the one path by which a `$` could reach a config value.  What remains
+in the config file are plain paths with no templating in them ---
+`simulation_path`, `mesh_filename` and `vert_coord_filename` --- for output or
+a mesh that has moved since the run.  Each may be absolute or relative to
+`simulation_path`, and the step reports which of the two sources each path came
+from, so that a surprising file list can be diagnosed without guessing.
+
+**MPAS-Ocean output is therefore not supported, and says so.**  Reading it
+needs a translator from its namelists and streams into the form this module
+reads, which is separate work and is not in scope here.  This costs the
+deliverable nothing: the design already develops against Omega output rather
+than MPAS-Ocean output, for the reasons given under `omega-monthly-means`.  A
+step set up against a simulation whose `[ocean] model` is `mpas-ocean` reports
+that rather than failing obscurely later.
+
+Reading Omega's configuration is done defensively --- a missing stream, a
+stream that names no file, and an analysis group that is turned off are told
+apart and reported as such --- since its schema is Omega's to change and this
+is the one place Polaris depends on its shape rather than on its output.  The
+names of an analysis group's output streams have to be reconstructed the way
+Omega's analysis manager builds them, as
+`<prefix>_<period><TimeStats|Instants><template>`.  A group can write both time
+means and snapshots, under different names, and today's simulations write only
+snapshots, so neither spelling can be assumed: the time mean is preferred where
+there is one.
 
 The pattern is MPAS-Analysis's, which locates MPAS-Ocean and MPAS-Seaice output
 by reading their streams files rather than asking the user where each file
@@ -1683,16 +1713,16 @@ requested fields for every season.
 
 ### Implementation: omega-monthly-means
 
-Date last modified: 2026/08/25
+Date last modified: 2026/08/27
 
 Contributors: Xylar Asay-Davis, Claude
 
 This is Omega work and is implemented in the Omega repository, not in Polaris.
 What Polaris needs to do:
 
-- add config options for the monthly-mean file-name template, as above ---
-  though the templates normally come from the simulation's Omega configuration
-  rather than from the user, so these are overrides;
+- nothing for the monthly-mean file names: they come from the `History` stream
+  of the simulation's own Omega configuration, so a change to the stream is
+  picked up without a Polaris change;
 - add any new Omega fields, including a mixed-layer depth diagnostic, to
   `polaris/ocean/model/mpaso_to_omega.yaml` once their Omega names are fixed;
 - add an Omega YAML fragment that turns on monthly-mean output of the required
@@ -2148,11 +2178,11 @@ products for a saving that only matters on a first run.
 
 ### Implementation: moc-plot
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/27
 
 Contributors: Xylar Asay-Davis, Claude
 
-The `moc/plot` step reads Omega's global MOC output over the climatology years,
+The `moc` step reads Omega's global MOC output over the climatology years,
 averages over time weighted by the length of each reduction period, and plots
 the result as filled contours with overlaid contour lines against the interface
 elevations Omega provides.

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -589,7 +589,7 @@ climatology --- this design produces:
 | `ncclimo` climatology | 1 |
 | Climatology maps, one per field group | 6 |
 | Heat content series: shards plus merge | 9 |
-| Offline mixed-layer depth, shards plus merge (fallback only) | 9 |
+| Offline mixed-layer depth, shards plus its climatology (fallback only) | 9 |
 | Global stats, MOC | 2 |
 | **Total** | **27** |
 
@@ -1046,7 +1046,7 @@ ocean/analysis/
 │   └── heat_content/
 ├── mixed_layer_depth/0021-0040/              (only if computed offline)
 │   ├── 0021-0023/ … 0038-0040/               (accumulator shards)
-│   └── merge/
+│   └── climatology/                          (second ncclimo call)
 ├── heat_content_series/0001-0060/
 │   ├── 0001-0008/ … 0053-0060/               (accumulator shards)
 │   └── merge/
@@ -1814,15 +1814,43 @@ Velocity reconstruction uses the weights on the mesh via
 the step reports that clearly and skips the zonal and meridional velocity maps
 rather than failing the whole step.
 
-If `compute_mixed_layer_depth` is set, the task adds an accumulator structured
-exactly like the heat content one: its kernel computes a month of mixed-layer
-depth with `gsw` as described in the algorithm design.  Because its consumer is
-`ncclimo`, which reads monthly files, its cache is one file per month rather
-than a single series --- principle 8 in {ref}`design-ocean-analysis` --- and
-inherited months are symlinked forward rather than copied.  The climatology
-step then averages those into the seasonal and annual means that are plotted.
-Its
-outputs carry an attribute recording that they were computed offline from
+If `compute_mixed_layer_depth` is set, the task adds a sharded accumulator
+structured exactly like the heat content one: its kernel computes a month of
+mixed-layer depth with `gsw` as described in the algorithm design.  Its cache
+is one gridded file per month, so inherited months are symlinked forward rather
+than copied or rewritten --- and, per principle 8 in
+{ref}`design-ocean-analysis`, because that is the form its consumer reads.
+
+#### A second climatology
+
+That consumer is `ncclimo`, run a second time over the accumulator's monthly
+files.  It is a second instance of the same `Climatology` step class, at
+`mixed_layer_depth/<range>/climatology`, taking the shards' outputs as inputs
+and a variable list of one.
+
+Doing the seasonal averaging with `ncclimo` rather than ourselves keeps a
+single implementation of what a season is.  The seasonally discontinuous
+December convention, the length-of-month weighting, and the set of seasons are
+then the same for a derived field as for a model field by construction rather
+than by test, and there is no second averaging path to keep in step.
+
+The cost is that the usual pattern --- one `ncclimo` call per component, once
+and for all, plus perhaps a reference climatology --- does not hold here.  A
+derived field arrives in its own files, written by a different step, with a
+different variable list, and not until an expensive pass over the record has
+finished, so it cannot join the call that covers model output.  This is a
+deliberate departure and the only one in the design: a second call, for the one
+product Polaris computes rather than reads.
+
+The scheduling consequence is worth being explicit about, since a serial chain
+behind an expensive step is what principle 3 warns against.  It is confined to
+this product: the main climatology reads model output only and does not wait on
+the accumulator, so every other map step is free to run beside it.  Only the
+mixed-layer depth maps sit behind the chain of shards, second climatology, and
+maps --- and only in the fallback case, which exists precisely because we would
+rather Omega computed this diagnostic in situ.
+
+Its outputs carry an attribute recording that they were computed offline from
 monthly means, and the step adds a note to the plot titles, so that a reader
 cannot mistake them for an in-situ diagnostic.
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1862,28 +1862,53 @@ later without disturbing output paths, links, or the gallery --- principle 2.
 A product whose fragment is present but whose file is missing is reported
 rather than silently omitted.
 
-It runs after everything it reads because it is wired to.  The `publish` step
-declares every step that writes a fragment as a dependency, through
-`Step.add_dependency()`.  That method exists for exactly this case: what the
-step consumes is not known at setup, since the fragments name themselves from
-facets that config options decide.  Ordering by dependency rather than by
-position in the suite is what keeps the step correct when the work is
-re-chunked, which principle 2 promises it can be.
+**The step never discovers its inputs by looking at the filesystem.**  It
+would be easy to walk the work directory for anything named `manifest.json`,
+and it would be wrong: Polaris steps declare what they read and write at setup
+so that the framework can check it and a scheduler can order it, and a step
+that crawls for its own inputs is invisible to both.  The groundrules in the
+task-parallel analysis steps design rest on the same declaration.
 
-Those dependencies cross task boundaries --- the `publish` step belongs to
-its own task and depends on the steps of every other analysis task.  Polaris
-allows this, and the cost is small and worth stating: each dependency pickles
-itself after it runs, and the `publish` step's directory gains one symlink per
-dependency under `dependencies/`.  Neither changes how steps are listed or
-run.
+The fragments need nothing more than that declaration, because their paths are
+known at setup: the filename is a constant and each step's `path` is fixed when
+the suite is constructed.  So the `publish` step declares one input per
+fragment-writing step, pointing at that step's work directory:
 
-One consequence needs deciding before the step is written.  A dependency's
-pickle is an input file of the step that depends on it, so a `publish` step
-that lists every analysis step cannot run until all of them have.  Running the
-whole suite is fine, and running a single product task is fine because
-`publish` is not in it.  What is not yet settled is the case in between ---
-asking for the gallery after only some products have been computed, which is
-what a developer iterating on one plot would want.
+```python
+self.add_input_file(
+    filename=f'fragments/{name}.json',
+    work_dir_target=f'{step.path}/{FRAGMENT_FILENAME}',
+)
+```
+
+This is the idiom the convergence and `baroclinic_channel` visualization steps
+already use for their dependencies' outputs.  It gives the step a complete and
+explicit input list, and Polaris checks before running any step that every
+declared input exists, naming the ones that do not.
+
+`Step.add_dependency()` is the fallback for what that cannot reach, and the
+`publish` step also declares each of those steps as a dependency.  It buys two
+things.  Anything resolvable only after a step has run is readable from the
+dependency's post-run pickle, which the framework loads back into
+`self.dependencies[name]` before `run()`, so an attribute the plotting step
+set is simply there.  And a dependency that did not run is reported as such,
+by name, rather than producing an empty gallery.  The cost is one pickle and
+one symlink per dependency; neither changes how steps are listed or run.
+
+Those dependencies cross task boundaries --- the `publish` step is in its own
+task and depends on the steps of every other analysis task --- which Polaris
+allows.
+
+Neither mechanism reorders anything: steps run in the order the suite lists
+them, so `publish` goes last.  What the declarations buy is that running it
+too early fails, and says why.
+
+One question is left open deliberately.  If every analysis step must write a
+fragment, then a step that made no products writes an empty one, and a suite
+run with some products skipped fails on a missing input.  If fragments are
+instead optional, `publish` reports what it did not find and publishes the
+rest, which is what a developer iterating on a single plot wants.  Which of
+those two is right should be settled when the step is written.
 
 Because it is the only step that knows how results are presented, everything in
 the two sections below can change without a single plotting step changing.

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1,0 +1,1682 @@
+(design-ocean-analysis-initial)=
+
+# Initial Omega Analysis Capabilities
+
+date: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+## Summary
+
+The E3SM Ocean Team has committed to delivering a first set of analysis
+capabilities for Omega's initial coupled runs by **September 15, 2026**, as a
+stepping stone to a more complete zppy/MPAS-Analysis-style workflow later in
+the calendar year.  This document designs that deliverable.  The broader
+context is in {ref}`design-ocean-analysis`.
+
+The deliverable is a Polaris suite, `omega_analysis`, that is pointed at a
+completed Omega simulation through a user-supplied config file and produces:
+
+1. **Map-view climatologies** (monthly, seasonal, and annual) of sea surface
+   temperature, sea surface salinity, zonal and meridional velocity,
+   mixed-layer depth, and vertically integrated ocean heat content.  Fields
+   with a vertical dimension are plotted at a configurable set of elevations.
+2. **Global time series** of the quantities in Omega's `GlobalStats` output.
+3. **A global time series of ocean heat content** integrated over configurable
+   elevation ranges.
+4. **A latitude-elevation plot of the global meridional overturning circulation
+   (MOC)** from the MOC diagnostic that Omega computes in situ.
+
+Every plot is accompanied by a netCDF file containing the data plotted, and the
+expensive intermediate products (climatologies, per-year heat content) are
+written to netCDF as well.
+
+The same simulation can be analyzed repeatedly over different date ranges.
+Results accumulate in a range-keyed staging tree that a web interface can serve
+later, and re-analyzing a new range reuses the per-year intermediates from
+earlier ranges instead of recomputing them.
+
+MPAS-Analysis is the scientific reference for what each of these diagnostics
+means, but the implementation is written from scratch with Polaris and Omega in
+mind rather than ported.  The reasoning is in {ref}`design-ocean-analysis`.
+
+Three things are deliberately **out of scope** for this deliverable:
+
+- **Integration with zppy.**  For September 15, the analysis is run by hand by
+  members of the Ocean Team, who make the results available to the coupled
+  group within several days of each simulation period completing.  MPAS-Seaice
+  analysis continues to be delivered through zppy's MPAS-Analysis.
+- **Comparison with observations.**  When observational comparison arrives, the
+  intent is to remap the observations onto the MPAS mesh and compare there, not
+  to remap the model onto a comparison grid.  Everything in this document
+  therefore stays on the native mesh, and nothing here should be read as a step
+  toward interpolating model output to a lat-lon grid.
+- **A global MOC time series.**  This was in the original proposal but has been
+  dropped: MOC strength integrated globally is not a standard metric.  The
+  standard metric --- maximum Atlantic MOC near 26.5°N --- is deferred to a
+  later delivery along with the rest of the regional analysis.
+
+The deliverable depends on Omega work that is outside this design: monthly-mean
+output of full model fields, including the geometric vertical coordinate, and
+a mixed-layer-depth diagnostic.  These are described in the
+`omega-monthly-means` requirement below so that the dependencies are explicit,
+along with the fallback for mixed-layer depth if it cannot be delivered in
+time.
+
+Success is that a member of the Ocean Team can, with a config file and two
+Polaris commands, produce the full set of plots above for an Omega coupled run
+on a machine where that run's output lives.
+
+### Conventions
+
+Two conventions are used throughout this document and throughout the code it
+describes.  Both are Polaris-wide conventions rather than choices made here.
+
+**Names are MPAS-Ocean names.**  MPAS-Ocean variable and dimension names are
+Polaris's internal standard.  Analysis code refers to `temperature`,
+`salinity`, `layerThickness`, `zMid`, `zInterface`, `minLevelCell`,
+`maxLevelCell`, `bottomDepth`, and `areaCell`, and to the dimensions `nCells`,
+`nEdges`, `nVertLevels`, `nVertLevelsP1`, and `Time`, regardless of which model
+produced the data.  Omega's names --- `Temperature`, `PseudoThickness`,
+`GeomZMid`, `GeomZInterface`, `NCells`, `NVertLayers`, and so on --- are
+translated to the Polaris standard automatically when a dataset is opened with
+`OceanIOStep.open_model_dataset`, using the mapping in
+`polaris/ocean/model/mpaso_to_omega.yaml`.  Analysis steps therefore never
+branch on the model to get a field name, and config options that name fields
+use the MPAS-Ocean names.  Where a field is new to Omega and has no MPAS-Ocean
+counterpart, a Polaris-standard name is chosen and added to that mapping.
+
+**The vertical coordinate is elevation, positive up.**  All vertical positions
+in config options, algorithms, and output are elevations $z$ in meters with
+$z = 0$ at the resting sea surface and $z$ increasing upward, so that positions
+within the ocean are negative.  A map "at 100 m below the surface" is requested
+as `-100.0`, and the ocean heat content range conventionally called "0 to
+700 m" is written `0.0:-700.0`.  This matches `zMid` and `zInterface` as the
+models write them and avoids sign flips scattered through the code.  Where the
+text uses the word "depth" it is describing a quantity that is positive down,
+such as `bottomDepth`, and says so.
+
+## Requirements
+
+### Requirement: analysis-suite
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall provide a suite that computes all of the analysis in this
+document for a single simulation.
+
+The user shall supply a config file that provides:
+
+- the path to the E3SM or Omega standalone simulation to be analyzed, together
+  with enough information to find its mesh, vertical coordinate, and output
+  files;
+- the start and end dates of the climatology;
+- the fields for which climatology maps should be produced (if different from
+  the defaults);
+- the elevations at which climatology maps should be plotted, for fields that
+  have a vertical dimension (if different from the defaults);
+- the start and end dates of the time series;
+- the fields from Omega's global statistics for which time series should be
+  plotted (if different from the defaults);
+- the elevation ranges over which ocean heat content should be integrated (if
+  different from the defaults).
+
+Setting up and running the suite shall not require an Omega or MPAS-Ocean
+build, since no model is run.  The suite shall be usable on the machine where
+the simulation output resides, without copying that output.
+
+Each analysis product shall be a separate task within the suite, so that a user
+can run a single product without running the rest, and the expensive
+climatology computation shall be shared between the tasks that need it.
+
+### Requirement: data-products
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Every plot the suite produces shall be accompanied by a netCDF file containing
+exactly the data that were plotted, so that the values can be inspected,
+compared against other tools, or re-plotted without recomputation.
+
+Intermediate products that are expensive to compute --- climatologies and
+per-year ocean heat content in particular --- shall be written to netCDF, and a
+step that finds a complete intermediate product from a previous run shall be
+able to reuse it rather than recomputing it.
+
+### Requirement: repeated-analysis
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall support analyzing the same simulation repeatedly with different
+climatology and time-series date ranges.
+
+Results shall be staged in a single, range-keyed location that a reader can
+navigate without knowing anything about Polaris work directories, and that a
+web interface can serve when one is added.  Analyzing a new range shall not
+overwrite or remove the results of a range analyzed earlier.
+
+Re-running the analysis with a changed range shall recompute the products that
+depend on that range.  It shall not be necessary to delete the work directory
+or to pass a flag to force recomputation, and it shall not be possible to
+obtain a plot labeled with one range whose contents were computed for another.
+
+Re-running with a changed range shall reuse the intermediate results that do
+not depend on the range.  Extending a time series from twenty years to forty
+shall cost twenty years of work, not forty.
+
+Re-running with an unchanged range shall recompute nothing.
+
+### Requirement: omega-monthly-means
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+*This requirement describes work in Omega, not in Polaris.  It is stated here
+because everything else in this document depends on it.*
+
+Omega shall be able to write monthly means of a configurable list of model
+fields.  The monthly-mean output shall:
+
+- cover, at minimum, the fields needed by this analysis: conservative
+  temperature, absolute salinity, pseudo-thickness, sea surface height, normal
+  velocity (or reconstructed zonal and meridional velocity), and mixed-layer
+  depth;
+- include the **geometric vertical coordinate**, `GeomZMid` and
+  `GeomZInterface`, so that Polaris does not have to reconstruct it (see the
+  vertical-geometry algorithm design for why it cannot);
+- carry CF-compliant time metadata, with a time coordinate and time bounds that
+  identify the averaging period, so that standard tools can identify the month
+  each average represents;
+- use a file-name convention that encodes the year and month, or that groups
+  whole years into one file, and that is stable across a simulation.
+
+Omega's Analysis module already provides temporal reduction with a configurable
+`ReductionPeriod`, including `1Month`, for the `GlobalStats` group.  The work
+required is to make the same reduction available for full model fields.
+
+Checkpointing the monthly reduction so that it resumes correctly across a
+restart is a longer-term goal and is not required for this deliverable: the
+simulations to be analyzed are not expected to restart more often than once a
+month, so a reduction period that divides the restart interval is sufficient.
+
+#### Mixed-layer depth
+
+Omega should provide a **mixed-layer depth** diagnostic computed in situ from
+the instantaneous state, using a density-threshold criterion, and make it
+available for monthly averaging.  This is the scientifically correct source:
+mixed-layer depth is a strongly nonlinear function of the temperature and
+salinity profiles, so a mixed-layer depth computed from monthly-mean
+temperature and salinity is not the monthly mean of the mixed-layer depth.
+
+Whether this can be delivered in Omega by September 15 is a question for the
+team rather than something this design can settle.  **If it cannot**, Polaris
+shall fall back to computing mixed-layer depth offline from the monthly-mean
+conservative temperature and absolute salinity, using the same density
+threshold criterion, and shall label the resulting plots to make clear that
+they are computed from monthly means.  The fallback is described in the
+mixed-layer-depth algorithm design, along with what it does and does not
+capture.
+
+### Requirement: climatology
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall compute monthly, seasonal, and annual climatologies from a
+simulation's monthly means, over a start and end year given by the user.
+
+The seasons shall include, at minimum, the annual mean (`ANN`) and the four
+standard three-month seasons (`DJF`, `MAM`, `JJA`, `SON`), and the user shall
+be able to request additional seasons.  The twelve monthly climatologies shall
+also be available.
+
+Climatologies shall be computed only for the fields that are needed, so that
+the cost of the computation scales with what is being analyzed rather than with
+the full contents of the monthly-mean files.
+
+### Requirement: climatology-maps
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall produce global maps of climatological fields on the native MPAS
+mesh, for each requested field and each requested season.
+
+For fields that have a vertical dimension, the user shall be able to request
+maps at any combination of:
+
+- **the sea surface** --- the topmost valid layer of each column;
+- **a fixed geometric elevation** --- a given elevation $z$ (positive up, so
+  negative within the ocean), obtained by linear interpolation in the vertical;
+- **a fixed layer index** --- a given vertical index, common to all columns;
+- **the seafloor** --- the bottommost valid layer of each column.
+
+The "topmost" and "bottommost" valid layers shall respect `minLevelCell` and
+`maxLevelCell`, so that columns under ice-shelf cavities and columns with
+partial bottom cells are handled correctly.  Where a requested elevation falls
+outside a column --- below the seafloor, or under land --- the map shall be
+masked rather than showing an extrapolated value.
+
+Sea surface temperature and sea surface salinity are obtained by requesting the
+sea surface for the temperature and salinity fields; they are not separate
+fields.
+
+Where a model does not output reconstructed zonal and meridional velocity,
+Polaris shall reconstruct them from the normal velocity on edges.
+
+### Requirement: ocean-heat-content-maps
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall compute ocean heat content integrated over elevation ranges from
+a climatology of conservative temperature, and shall produce a global map for
+each elevation range and each requested season.
+
+The elevation ranges shall be set by config options.  The defaults shall be the
+whole ocean, the surface to $-700$ m, $-700$ m to $-2000$ m, and $-2000$ m to
+the seafloor.  A range boundary that falls in the interior of a model layer
+shall contribute that layer in proportion to the fraction of the layer within
+the range, and a range boundary below the seafloor of a given column shall be
+truncated at the seafloor.
+
+### Requirement: global-stats-time-series
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall plot time series of the global statistics that Omega's
+`GlobalStats` analysis group writes, over a start and end year given by the
+user, for a list of fields given by the user.
+
+Polaris shall ship a config file defining a default list of fields and
+statistics, so that a user who has not thought about which quantities to plot
+gets a useful set.  A field or statistic in that list that the simulation did
+not write shall be **skipped with a message in the log, not treated as an
+error**: the defaults describe what we would like to see, and any given
+simulation will have written some subset of it.  A field the user has asked for
+explicitly is treated the same way, since the user has no more control over
+what the completed simulation wrote than we do.
+
+For each field, the plot shall show the global mean together with the global
+minimum, maximum, and standard deviation, and shall show the change relative to
+the beginning of the time series as well as the absolute values, since drift is
+usually what the reader is looking for.  Statistics that are absent are simply
+omitted from that field's plot.
+
+The time axis shall be labeled in simulation years.
+
+### Requirement: ocean-heat-content-time-series
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall compute a time series of globally integrated ocean heat content,
+over the same elevation ranges as the ocean heat content maps, from each
+monthly-mean conservative temperature field over a start and end year given by
+the user, and shall plot that time series.
+
+The plot shall show both the absolute heat content and the anomaly relative to
+the start of the time series, since the anomaly is the quantity of interest for
+drift and for the planetary energy budget while the absolute value is dominated
+by the mean state.
+
+The computation shall stream over the monthly files rather than loading the
+full record into memory, and shall write per-year intermediate results so that
+extending the time series with additional simulation years does not require
+recomputing the years already processed.
+
+### Requirement: moc-plot
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall produce a latitude-elevation plot of the global meridional
+overturning streamfunction from the MOC diagnostic that Omega computes in situ,
+averaged over the climatology period.
+
+The plot shall be in Sverdrups, with a diverging color map centered on zero,
+contour lines at a configurable interval, and elevation on the vertical axis so
+that the sea surface is at the top.
+
+Omega shall provide, alongside the streamfunction, the mean geometric elevation
+of each layer interface over the same period, so that the vertical axis is
+meaningful.  Polaris shall not reconstruct it.
+
+Polaris shall not compute the MOC itself.  The overturning streamfunction
+requires the full three-dimensional velocity field at every time step to be
+computed correctly, and Omega computes it in situ for exactly that reason.
+
+## Algorithm Design
+
+### Algorithm Design: climatology
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Climatologies are computed with `ncclimo` from the NCO package, which Polaris
+already depends on.  `ncclimo` is used rather than an `xarray` implementation
+because it is the tool the rest of the E3SM post-processing workflow uses, it
+is substantially faster than a naive `xarray` implementation on large files, it
+handles the season-weighting conventions correctly, and using it keeps our
+climatologies comparable with those produced by zppy.
+
+The monthly climatology for month $m$ is the unweighted mean over the requested
+years of the monthly means for that month:
+
+$$
+\overline{\phi}_m = \frac{1}{N_{yr}} \sum_{y=y_0}^{y_1} \phi_{y,m}
+$$
+
+The seasonal climatology weights each month by the number of days in that
+month:
+
+$$
+\overline{\phi}_s = \frac{\sum_{m \in s} d_m \overline{\phi}_m}
+                         {\sum_{m \in s} d_m}
+$$
+
+and the annual mean is the same expression with $s$ running over all twelve
+months.  `ncclimo` implements both, using the calendar of the input files.
+
+Two conventions matter and are worth stating explicitly:
+
+- **December handling.**  `DJF` needs a December, and the December that is
+  contemporaneous with a given January and February belongs to the previous
+  year.  `ncclimo`'s `-a sdd` ("seasonally discontinuous December") option
+  takes December from the same year as January and February, which means every
+  year in the requested range contributes exactly one December and no data
+  outside the range are needed.  This is the convention MPAS-Analysis uses, and
+  we adopt it for consistency.
+- **Averaging is over the fields written, not over derived quantities.**  A
+  climatology of layer thickness and a climatology of temperature are not the
+  same as a climatology of their product.  This matters for heat content and is
+  discussed under the heat content algorithm below.
+
+### Algorithm Design: repeated-analysis
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The whole approach rests on separating what depends on the requested range from
+what does not:
+
+| Product | Depends on the range? | Cost |
+| --- | --- | --- |
+| Monthly means (model output) | no | read-only input |
+| Per-year ocean heat content integrals | no, keyed by year | expensive |
+| Per-year offline mixed-layer depth | no, keyed by year | expensive |
+| `ncclimo` climatologies | yes | expensive |
+| Climatology and heat content maps | yes | cheap, from the climatology |
+| Global stats time series | yes | cheap |
+| MOC time average | yes | cheap |
+
+The rule that follows: **every expensive computation is decomposed into a
+per-year product keyed by the year, not by the range**, and is given its own
+step at a year-keyed subdirectory.  A given year's vertically integrated heat
+content is the same quantity no matter which range asked for it, so it is
+computed once and reused forever.  Everything that is range-keyed is then
+either cheap to redo from those per-year products, or is the climatology
+itself.
+
+The climatology is the one expensive computation that genuinely depends on the
+range, and it is recomputed for each new range.  In principle a climatology
+over a new range could be assembled incrementally from per-year seasonal
+partial sums, but `ncclimo` has no such mode, and writing our own incremental
+climatology to save a rerun is not a trade we should make for this deliverable.
+Two ranges' climatologies coexist without special handling, because `ncclimo`
+already encodes the range in its output file names
+(`<caseid>_<season>_<YYYYMM>_<YYYYMM>_climo.nc`).
+
+### Algorithm Design: climatology-maps
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+#### Vertical geometry
+
+Everything in this document that involves a vertical position needs the
+geometric elevation of layer midpoints, $z^{mid}_{k}$, and of layer interfaces,
+$z^{int}_{k}$, for each column.  These are read directly from `zMid` and
+`zInterface` --- Omega's `GeomZMid` and `GeomZInterface` --- which is why the
+`omega-monthly-means` requirement asks for them as monthly-mean output.
+
+Polaris cannot reconstruct them from the monthly means of the other fields.
+Omega builds the geometric coordinate by accumulating upward from
+$-\mathrm{BottomGeomDepth}$ using $\mathrm{SpecVol} \times
+\mathrm{PseudoThickness}$, and it does so the same way regardless of which
+vertical coordinate the simulation uses --- the choice of z-star, p-star, or
+sigma determines how `PseudoThickness` is initialized and how it evolves, not
+how geometric elevation is computed from it.  Reconstructing $z$ offline
+therefore requires specific volume, which means evaluating the TEOS-10 equation
+of state on the monthly-mean state.  That is not the monthly mean of
+$\mathrm{SpecVol} \times \mathrm{PseudoThickness}$, so the reconstruction would
+introduce an error that has nothing to do with the diagnostic being computed.
+Having Omega write the geometric coordinate removes the problem entirely, since
+the monthly mean of $z$ is exactly the mean layer geometry we want.
+
+Because the input to the map steps is a climatology, the $z^{mid}_{k}$ they use
+is the climatological-mean layer geometry.  This does mean that a $-100$ m map
+is a map on the time-mean position of the $-100$ m surface rather than the time
+mean of maps on the instantaneous $-100$ m surface.  The difference is small
+away from regions with a large seasonal cycle in layer thickness.
+
+#### Elevation selection
+
+Let $f_k$ be the field in a given column, $k_{min}$ = `minLevelCell` and
+$k_{max}$ = `maxLevelCell` be the zero-based indices of the topmost and
+bottommost valid layers, and let the requested elevation specification be one
+of `top`, `bottom`, `k<n>`, or an elevation $z$ in meters (negative within the
+ocean).
+
+- `top`: $f = f_{k_{min}}$.
+- `bottom`: $f = f_{k_{max}}$.
+- `k<n>`: $f = f_n$, masked in columns where $n < k_{min}$ or $n > k_{max}$.
+- elevation $z$: find $k_1$, the largest valid index with
+  $z^{mid}_{k_1} \ge z$, and interpolate linearly between $k_1$ and $k_1 + 1$:
+
+  $$
+  w = \frac{z - z^{mid}_{k_1+1}}{z^{mid}_{k_1} - z^{mid}_{k_1+1}},
+  \qquad
+  f = w f_{k_1} + (1 - w) f_{k_1+1}
+  $$
+
+  If $z$ is above the midpoint of the topmost layer, $f = f_{k_{min}}$; if it
+  is below the midpoint of the bottommost layer but above the seafloor,
+  $f = f_{k_{max}}$.  If $z < z^{int}_{k_{max}+1}$ --- below the seafloor ---
+  or the column is land, the result is masked.
+
+  Clamping rather than masking between the top layer midpoint and the sea
+  surface matters in practice: a request for $0$ m or $-5$ m would otherwise be
+  masked everywhere, which is not what a user asking for a near-surface map
+  intends.
+
+The search for $k_1$ is vectorized over columns as the count of valid layer
+midpoints at or above $z$, which avoids a Python loop over cells:
+
+```python
+k1 = (z_mid >= z).sum(dim='nVertLevels') - 1
+```
+
+with `z_mid` set to `NaN` outside the valid range so invalid layers do not
+contribute, followed by a clip into `[k_min, k_max - 1]` and a mask for the
+out-of-column cases.
+
+#### Reconstructed velocities
+
+Omega writes `normalVelocity` on edges.  Zonal and meridional velocity at cell
+centers are obtained by the least-squares reconstruction designed in
+[Vector Reconstruction](vector_reconstruction.md), whose weights are stored on
+the mesh.
+
+Reconstruction is a linear operator on the edge field, so reconstructing from a
+climatology of normal velocity gives exactly the climatology of the
+reconstructed velocity.  There is therefore no accuracy argument for doing the
+reconstruction in the model, and doing it offline avoids adding a dependency on
+Omega work.  If Omega later writes reconstructed velocities directly, the step
+uses them in preference.
+
+### Algorithm Design: mixed-layer depth (fallback only)
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+*This algorithm applies only if Omega cannot deliver an in-situ mixed-layer
+depth diagnostic in time.  If Omega provides one, mixed-layer depth is an
+ordinary monthly-mean field and flows through the climatology and map steps
+like any other, and none of this section applies.*
+
+The fallback computes mixed-layer depth from each monthly-mean profile of
+conservative temperature and absolute salinity using the same density-threshold
+criterion Omega plans to use: the mixed layer extends to the elevation at which
+the potential density referenced to $10$ m exceeds the density at $10$ m by
+$\Delta \rho = 0.03$ kg m⁻³, with linear interpolation between the bounding
+layers.  Density is evaluated with `gsw`, which Polaris already depends on and
+which implements the same TEOS-10 formulation Omega uses.
+
+The mixed-layer depth is computed for each month and then averaged over the
+climatology period, rather than being computed from the climatology.  Computing
+it from the seasonal or annual climatology would be a second, much larger
+approximation on top of the one described next.
+
+What this fallback does *not* capture, and what should be said on the plots and
+in the netCDF metadata:
+
+- Monthly-mean profiles are smoother than instantaneous profiles.  Averaging
+  over a month blends the stratification before, during, and after a mixing
+  event, so the mixed-layer depth derived from the mean profile is not the mean
+  of the mixed-layer depths.
+- The effect is largest exactly where mixed-layer depth matters most: winter
+  deep-convection regions, where a few days of deep mixing set the monthly mean
+  of the true mixed-layer depth but leave only a muted signature in the
+  monthly-mean profile.
+- Monthly maximum mixed-layer depth, which MPAS-Analysis reports and which is
+  the more useful deep-convection diagnostic, cannot be recovered at all from
+  monthly means.
+
+The fallback is therefore adequate for a first look at the seasonal cycle of
+the mixed layer in a coupled run and is not adequate as a deep-convection
+diagnostic.  Replacing it with Omega's in-situ diagnostic should be the first
+follow-up after September 15 if the fallback is what ships.
+
+### Algorithm Design: ocean-heat-content
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+*This algorithm is shared by the heat content maps and the heat content time
+series; the two differ in what they integrate over and in what they read, not
+in the kernel.*
+
+Ocean heat content per unit area, integrated over an elevation range
+$[z_{bot}, z_{top}]$ with $z_{bot} < z_{top} \le 0$, is
+
+$$
+Q(z_{bot}, z_{top}) = \rho_0 c_p^0 \int_{z_{bot}}^{z_{top}} \Theta \, dz
+            \approx \rho_0 c_p^0 \sum_k \Theta_k \, w_k
+$$
+
+where $\Theta$ is conservative temperature and $w_k$ is the thickness of the
+overlap between layer $k$ and the requested range:
+
+$$
+w_k = \max\left(0, \;
+      \min\left(z^{int}_{k}, z_{top}\right) -
+      \max\left(z^{int}_{k+1}, z_{bot}\right)\right)
+$$
+
+for layers within `[minLevelCell, maxLevelCell]` and $w_k = 0$ elsewhere.  This
+expression handles all of the cases the requirement calls for without special
+casing: a range boundary in the interior of a layer contributes a partial
+thickness; a range extending below the seafloor is truncated because
+$z^{int}_{k_{max}+1} = -H$; a `bottom` boundary is expressed as
+$z_{bot} = -\infty$; and a column whose seafloor lies above $z_{top}$
+contributes zero.
+
+The globally integrated heat content used for the time series is the
+area-weighted sum
+
+$$
+Q_{tot} = \sum_i A_i \, Q_i
+$$
+
+over cells $i$ with area `areaCell`.
+
+#### Choice of constants
+
+Omega uses TEOS-10, in which conservative temperature is *defined* so that
+potential enthalpy is $c_p^0 \Theta$ with the exact constant
+$c_p^0 = 3991.86795711963$ J kg⁻¹ K⁻¹.  Using that constant with conservative
+temperature is therefore not an approximation but the definition of heat
+content.
+
+Polaris's Physical Constants Dictionary provides
+`seawater_specific_heat_capacity_reference` = 3996.0 J kg⁻¹ K⁻¹ and
+`seawater_density_reference` = 1026.0 kg m⁻³, which are the values
+MPAS-Analysis uses.  The specific heat capacity differs from the TEOS-10
+constant by 0.1%, which is small compared to other uncertainties but is a
+systematic offset in any comparison.
+
+**Decision:** Phase 1 uses the PCD values.  $c_p^0$ is not in the PCD today,
+and adding a constant to it is not something we can complete by September 15,
+so using the PCD is what keeps Polaris consistent with the constants the rest
+of E3SM is using in the meantime.  Both constants are exposed as config options
+so that a user can experiment with the TEOS-10 value without a code change.
+
+In the long run we do want $c_p^0$: because Omega carries conservative
+temperature, $\rho_0 c_p^0 \Theta$ is the definition of heat content rather
+than an approximation to it.  Adding $c_p^0$ to the PCD and switching to it is
+recorded as a deferred item in {ref}`design-ocean-analysis`.
+
+A constant reference density is used rather than in-situ density.  This is the
+MPAS-Analysis convention and keeps the diagnostic comparable; the difference is
+a few tenths of a percent and is nearly uniform, so it affects the absolute
+heat content much more than the anomaly, which is the quantity of interest.
+
+#### Heat content from a climatology versus from monthly means
+
+The heat content maps are computed from the climatology of $\Theta$ and of the
+layer geometry, per the requirement.  Because heat content is a product of
+those two, this omits the covariance term:
+
+$$
+\overline{\Theta h} = \overline{\Theta}\,\overline{h} +
+                      \overline{\Theta' h'}
+$$
+
+The neglected term is small for heat content over fixed elevation ranges ---
+the range boundaries are fixed in $z$, so the covariance enters only through
+the partial layers at the boundaries and through the free surface --- but it is
+not identically zero, particularly in regions with a large seasonal cycle in
+sea surface height and layer thickness.
+
+The heat content time series does not have this issue, because it integrates
+each monthly mean separately and averages afterward.
+
+If the covariance term turns out to matter, the alternative is to compute the
+per-month vertically integrated heat content maps first, as the time series
+step already does, and then average those maps into a climatology.  That is a
+potential follow-up after September 15, not a fallback available before it: it
+costs a full pass over the three-dimensional monthly output for every season
+plotted, and the requirement asks for heat content from a climatology of
+conservative temperature.
+
+### Algorithm Design: moc-plot
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Omega's MOC analysis group computes the overturning streamfunction on latitude
+bins and layer interfaces, in Sverdrups, and writes it with the same
+temporal-reduction machinery as `GlobalStats`.  Polaris averages the reductions
+over the requested climatology years and plots the result.
+
+Only the **global** streamfunction is plotted.  Omega's MOC group can compute
+the streamfunction for named regions, but regional analysis is out of scope for
+this deliverable, so no region masks, region names, or region config options
+appear here.  Regional overturning --- the Atlantic MOC in particular --- comes
+with the rest of the regional analysis in a later delivery, and the plotting
+primitive introduced below is written so that it will not need changing then.
+
+Two details need care:
+
+- **The vertical coordinate of the plot.**  The streamfunction lives on layer
+  interfaces (`nVertLevelsP1`), which are not at a fixed elevation.  Omega
+  shall provide the mean interface elevation alongside the streamfunction; the
+  natural way to produce it is a climatology of `GeomZInterface` over the same
+  period as the MOC, reduced to a mean per layer interface.  Polaris plots what
+  Omega provides and does not reconstruct it: a Polaris-side reconstruction
+  would either repeat that averaging on a different period or fall back on
+  resting thicknesses, and in both cases the plot's vertical axis would quietly
+  disagree with the diagnostic it is labeling.
+- **Averaging over the requested period.**  Omega writes per-period reductions
+  (e.g. monthly or annual means).  The streamfunction is linear in the
+  velocity, so a mean of the reductions weighted by the length of each
+  reduction period is the streamfunction of the mean flow over the period.
+
+The exact variable, dimension, and coordinate names in Omega's MOC output must
+be confirmed against the implementation before this step is written; see the
+open questions.
+
+## Implementation
+
+### Implementation: analysis-suite
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+#### Tasks, steps, and the suite
+
+New tasks live in `polaris/tasks/ocean/analysis/`, added to the ocean component
+by `add_analysis_tasks(component)` in `polaris/tasks/ocean/add_tasks.py`.  The
+work-directory layout is:
+
+```none
+ocean/analysis/
+├── climatology/
+│   └── 0021-0040/                (shared step: ncclimo, per range)
+├── years/                        (shared per-year steps, range-independent)
+│   ├── ocean_heat_content/0021/ … 0060/
+│   └── mixed_layer_depth/0021/ … 0060/   (only if computed offline)
+├── climatology_maps/             (task)
+│   └── maps/0021-0040/           (step, per range)
+├── ocean_heat_content/           (task)
+│   ├── maps/0021-0040/           (step, from the climatology)
+│   └── time_series/0001-0060/    (step, from the per-year steps)
+├── global_stats/                 (task)
+│   └── time_series/0001-0060/    (step)
+└── moc/                          (task)
+    └── plot/0021-0040/           (step)
+```
+
+Step subdirectories are keyed by the date range they cover, and the expensive
+per-year work lives in shared steps keyed by year rather than by range.  The
+`repeated-analysis` implementation below explains why, and why this structure
+is what makes re-running with a new range work.
+
+The `climatology` and `years` steps are shared steps in the sense of
+[Shared steps](shared_steps.md): the climatology for a given range is used by
+`climatology_maps/maps` and by `ocean_heat_content/maps`, and both sit at
+`ocean/analysis`, the highest level at or below which all of the tasks that use
+them live.  Each runs once no matter how many of the tasks are run.
+
+Ocean heat content is one task with two steps rather than two tasks: the maps
+and the time series share the elevation ranges and the heat content kernel, and
+are one product from the reader's point of view even though they read different
+inputs.  Running only one of them is still possible with `polaris serial
+--steps`.
+
+The suite is `polaris/suites/ocean/omega_analysis.txt`, named to match the
+existing `omega_pr` and `omega_nightly` suites:
+
+```none
+ocean/analysis/climatology_maps
+ocean/analysis/ocean_heat_content
+ocean/analysis/global_stats
+ocean/analysis/moc
+```
+
+A user analyzes a simulation with:
+
+```bash
+polaris suite -c ocean -t omega_analysis -w <work_dir> -f analysis.cfg \
+    --model omega
+polaris serial
+```
+
+No `-p`/`--component_path` is given, because no model executable is needed.
+The `--model` flag (or an `[ocean] model` option in the config file) tells
+Polaris which model's naming conventions to expect on read.
+
+Analyzing two simulations means two work directories.  The simulation name is
+not part of the work-directory path, because task subdirectories are fixed when
+the component is constructed, before the user's config file has been read.
+
+#### Config options
+
+Defaults ship in `polaris/tasks/ocean/analysis/analysis.cfg` and the user
+overrides the ones that describe their simulation.  The sections below are the
+proposed starting point:
+
+```ini
+[ocean_analysis]
+
+# The absolute path to the directory containing the simulation's output
+simulation_path =
+
+# A short name for the simulation, used in plot titles and file names
+simulation_name = omega
+
+# Where to stage plots and their netCDF files for browsing, organized by
+# product and date range.  Defaults to <work_dir>/analysis_output.
+output_path =
+
+# The horizontal mesh file, absolute or relative to simulation_path
+mesh_filename =
+
+# The vertical-coordinate file (Omega only), absolute or relative to
+# simulation_path
+vert_coord_filename =
+
+# File-name templates for the simulation output the analysis reads, relative
+# to simulation_path.  $Y and $M are replaced by the four-digit year and
+# two-digit month.
+monthly_mean_template = ocean.hist.MonthlyMean.$Y-$M.nc
+global_stats_template = ocean.hist.GlobalStats_1MonthTimeStats.$Y.nc
+moc_template = ocean.hist.Moc_1MonthTimeStats.$Y.nc
+
+
+[ocean_analysis_climatology]
+
+# The first and last year of the climatology, inclusive
+start_year = 1
+end_year = 10
+
+# The seasons to compute, in addition to the 12 monthly climatologies
+seasons = ANN, DJF, MAM, JJA, SON
+
+# The seasons to plot; may include the monthly climatologies JAN through DEC
+plot_seasons = ANN, DJF, JJA
+
+# The fields for which climatology maps are produced, using MPAS-Ocean
+# (Polaris standard) names
+fields = temperature, salinity, velocityZonal, velocityMeridional,
+         mixedLayerDepth
+
+# The elevations at which fields with a vertical dimension are plotted.
+# Elevations are in m, positive up, so values within the ocean are negative:
+#   top      the topmost valid layer of each column (the sea surface)
+#   bottom   the bottommost valid layer of each column (the seafloor)
+#   <z>      an elevation in m, linearly interpolated
+#   k<index> a fixed, zero-based vertical index
+elevations = top, -100.0, -500.0, -2000.0, bottom
+
+# Whether to compute mixed-layer depth offline from monthly-mean temperature
+# and salinity, for simulations whose output does not include it
+compute_mixed_layer_depth = False
+
+# The density threshold used when computing mixed-layer depth offline, in
+# kg m-3, relative to a reference elevation of -10 m
+mixed_layer_depth_threshold = 0.03
+
+
+[ocean_analysis_ohc]
+
+# The elevation ranges over which heat content is integrated, given as
+# <top>:<bottom> in m, positive up.  "bottom" means the seafloor.
+elevation_ranges = 0.0:-700.0, -700.0:-2000.0, -2000.0:bottom, 0.0:bottom
+
+# The reference density and specific heat capacity used to convert
+# conservative temperature to heat content.  By default, these come from the
+# Physical Constants Dictionary.
+#seawater_density = 1026.0
+#seawater_specific_heat_capacity = 3996.0
+
+
+[ocean_analysis_time_series]
+
+# The first and last year of the time series, inclusive
+start_year = 1
+end_year = 10
+
+# The fields from the model's global statistics output to plot.  Fields the
+# simulation did not write are skipped with a message, not an error.
+fields = temperature, salinity, normalVelocity, kineticEnergyCell, ssh
+
+# The statistics to plot for each field.  As with fields, missing statistics
+# are skipped.
+stats = mean, min, max, std
+
+
+[ocean_analysis_moc]
+
+# The contour interval in Sv
+contour_interval = 2.0
+
+# The maximum absolute value of the color map in Sv; the color map is
+# symmetric about zero
+#max_streamfunction = 30.0
+```
+
+Per-field plotting options follow the existing Polaris convention of a section
+per field, as in `realistic_global.cfg`:
+
+```ini
+[ocean_analysis_map_temperature]
+colormap_name = cmo.thermal
+norm_type = linear
+norm_args = {'vmin': -2., 'vmax': 32.}
+```
+
+Sections for the fields we expect to plot ship with defaults; fields without a
+section fall back to the defaults in `polaris.viz.get_viz_defaults`.
+
+#### Field and dimension naming
+
+Per the conventions stated in the summary, config options name fields using
+MPAS-Ocean names, and analysis code uses MPAS-Ocean variable and dimension
+names throughout.  `OceanIOStep.open_model_dataset` performs the translation
+from Omega names on read, driven by `polaris/ocean/model/mpaso_to_omega.yaml`,
+which already maps the vertical geometry this design depends on:
+
+```yaml
+  zMid: GeomZMid
+  zInterface: GeomZInterface
+```
+
+Fields that are new to Omega and have no MPAS-Ocean counterpart --- a
+mixed-layer depth diagnostic, for instance --- get a Polaris-standard name and
+an entry in that mapping as they become available.  No analysis step branches
+on `config.get('ocean', 'model')` to choose a field or dimension name; if a
+step needs to do so, that is a signal the mapping file is missing an entry.
+
+#### Locating input files
+
+A small helper module, `polaris/tasks/ocean/analysis/sim_files.py`, expands the
+file-name templates over a year range into lists of files and checks that they
+exist, reporting the missing years clearly.  It is shared by every step that
+reads simulation output.  This is deliberately a separate module rather than a
+method on a step, so that it can be unit tested and reused.
+
+Input files are symlinked into each step's work directory in `setup()` using
+`Step.add_input_file`, which gives the usual Polaris provenance and dependency
+checking without copying data.
+
+### Implementation: data-products
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Each plotting step writes, alongside each PNG, a netCDF file with the same base
+name containing the plotted field, its coordinates, units, and the config
+options --- including the date range --- that produced it as global attributes.
+Both go in the step's range-keyed subdirectory and are symlinked into the
+staging tree, as described under `repeated-analysis`.
+
+The expensive intermediates are:
+
+- the `ncclimo` output in `ocean/analysis/climatology/<range>/`, already a set
+  of netCDF files;
+- the per-year heat content file written by each
+  `ocean/analysis/years/ocean_heat_content/<year>` step;
+- the equivalent per-year mixed-layer depth files, if it is computed offline.
+
+Because each of these is the output of a shared step keyed by year or by range,
+reuse across repeated analyses is Polaris's ordinary step-completion behavior
+rather than a caching layer of our own.
+
+### Implementation: repeated-analysis
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Everything this requirement asks for falls out of machinery Polaris already
+has, provided the step tree is keyed correctly.  No framework changes are
+needed.
+
+#### Steps can be built from the user's config
+
+The `Task` subdirectory is fixed when the component is constructed, before the
+`-f` config file is read --- but a task's *steps* are not.  `polaris setup`
+merges the user's config into each task's config parser and then calls
+`Task.configure()` on every task, and only afterward adds configs to the steps,
+explicitly so that steps created during `configure()` are handled.  A task may
+therefore discard and rebuild its entire step list from config options that the
+user supplied at setup time, with subdirectories derived from those options.
+
+This is not a new pattern.  The cosine bell task family does exactly this: its
+`configure()` calls `_setup_steps()` again "in case a user has provided new
+resolutions", removing every step and re-adding one per resolution at a
+subdirectory named for the resulting mesh.  Shared steps are created at a
+computed subdirectory with `Component.get_or_create_shared_step()`, which
+returns the existing step if one has already been created at that
+subdirectory.
+
+The analysis tasks use the same pattern with date ranges in place of
+resolutions.
+
+#### Re-running comes from range-keyed step subdirectories
+
+Every range-dependent step lives at a subdirectory named for the range it
+covers: `climatology/0021-0040`, `climatology_maps/maps/0021-0040`,
+`global_stats/time_series/0001-0060`.  A setup with a new range therefore
+creates *new steps in new directories*, which have never run and so are not
+complete, and they run.  A setup with the same range lands on the same
+directories, which are complete, and nothing is recomputed.
+
+This is the behavior the requirement asks for, and it needs nothing beyond the
+existing rule that a step is complete when `polaris_step_complete.log` exists
+in its work directory.  It also makes it structurally impossible to get a plot
+labeled with one range whose contents came from another, since the two ranges
+never share a directory.
+
+#### Reuse comes from per-year shared steps
+
+The expensive per-year work --- vertically integrated heat content, and
+mixed-layer depth if it is computed offline --- is one shared step per
+simulation year, at `years/ocean_heat_content/0021` and so on, created with
+`get_or_create_shared_step()`.  Each reads that year's twelve monthly-mean
+files and writes one small netCDF.
+
+Because these steps are keyed by year rather than by range, a later analysis
+over a different range asks for the same step for any year the two ranges have
+in common, finds it already complete, and skips it.  Extending a time series
+from twenty years to forty creates twenty new steps and reuses twenty existing
+ones, which is exactly the cost the requirement asks for --- and again with no
+mechanism beyond shared steps and the completion marker.
+
+A per-year step is also a well-sized unit of work: roughly 1.8 GB of monthly
+means read, one small file written.  Making these steps rather than a loop
+inside a single step has a second payoff, which is that they are embarrassingly
+parallel and become eligible for concurrent execution as soon as Polaris's task
+parallelism lands.  See the task-parallelism requirement in
+{ref}`design-ocean-analysis`.
+
+#### Staging results
+
+The step directories are already range-keyed, but they are scattered across
+four products several levels down in a work directory.  Plots and their netCDF
+files are therefore also symlinked into a staging tree whose root is a config
+option, so that there is one place to browse and, later, one tree for a web
+interface to serve:
+
+```ini
+[ocean_analysis]
+
+# Where to stage plots and their netCDF files for browsing.  Defaults to
+# <work_dir>/analysis_output.  Point this somewhere web-servable if you want
+# to share the results.
+output_path =
+```
+
+The tree is organized product first, then range, because the climatology range
+and the time series range are independent and a range-first tree would have to
+repeat products under two different range directories:
+
+```none
+<output_path>/
+├── climatology_maps/0021-0040/
+├── ocean_heat_content/maps/0021-0040/
+├── ocean_heat_content/time_series/0001-0060/
+├── global_stats/0001-0060/
+└── moc/0021-0040/
+```
+
+Range keys are the zero-padded start and end years, matching the convention
+`ncclimo` already uses in its file names.
+
+Writing into the step directory and symlinking, rather than writing directly
+into the staging tree, keeps every file owned by the step that produced it, so
+Polaris's output checking and provenance continue to work and the staging tree
+is a view rather than a second source of truth.
+
+#### Caveats
+
+`polaris setup` rewrites the suite pickle at the root of the work directory, so
+the most recently set-up range is the one `polaris serial` will run.  Step
+directories from earlier ranges are untouched --- they have their own pickles,
+outputs, and completion markers --- so re-running an earlier range means
+re-running setup with that range's config, after which everything it needs is
+already complete except whatever it is being asked to redo.
+
+Analyzing many ranges accumulates step directories and climatology files.  This
+is deliberate, since it is what makes re-analyzing an earlier range nearly
+free, but it is worth knowing about on a filesystem with a quota.
+
+Per-year steps also mean a suite with a forty-year time series contains forty
+extra steps per per-year product.  That is a larger step count than existing
+Polaris tasks produce, though not by orders of magnitude, and it is worth a
+look at setup time on a long record before committing to per-year rather than,
+say, per-decade granularity.
+
+### Implementation: omega-monthly-means
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+This is Omega work and is implemented in the Omega repository, not in Polaris.
+What Polaris needs to do:
+
+- add config options for the monthly-mean file-name template, as above;
+- add any new Omega fields, including a mixed-layer depth diagnostic, to
+  `polaris/ocean/model/mpaso_to_omega.yaml` once their Omega names are fixed;
+- add an Omega YAML fragment that turns on monthly-mean output of the required
+  fields, so that a Polaris-run simulation can produce input for its own
+  analysis, in the same way `analysis_members.cfg` and `forward.yaml` configure
+  `GlobalStats` today.
+
+Development of the Polaris side proceeds against Omega output as each Omega
+capability lands, rather than against MPAS-Ocean output.  MPAS-Ocean would be a
+misleading development target: its variable and dimension names differ, its
+time metadata is not CF compliant, and its monthly means come from a different
+analysis member with different conventions, so code that works against
+MPAS-Ocean output tells us little about whether it will work against Omega's.
+Before Omega can write monthly means at all, development is limited to the
+shared kernels, which are exercised by unit tests on synthetic data and do not
+need model output of either kind.
+
+The steps are written so that they degrade gracefully: a step whose input
+fields are not yet available reports which fields are missing from which file
+and skips the affected products, rather than failing the suite.  This is what
+makes it possible to run the suite against a partially-capable Omega and get
+the products that are ready.
+
+### Implementation: climatology
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+`polaris/tasks/ocean/analysis/climatology.py` defines a `Climatology` step:
+
+```python
+class Climatology(OceanIOStep):
+    def setup(self):
+        # expand the monthly-mean template over [start_year, end_year] and
+        # symlink each file into the step's work directory
+        # register the expected ncclimo output files as outputs
+
+    def run(self):
+        # assemble the list of variables needed by the steps that use this
+        # climatology, plus the vertical-geometry variables
+        # run ncclimo
+```
+
+The `ncclimo` command:
+
+```none
+ncclimo --no_stdin -4 --clm_md=mth -a sdd \
+    -p <parallel_mode> -j <threads> \
+    -v <variables> --seasons=<seasons> \
+    -s <start_year> -e <end_year> -o . <input files>
+```
+
+Notes on the arguments:
+
+- `-a sdd` selects the seasonally discontinuous December convention discussed
+  in the algorithm design.
+- `-v` restricts the climatology to the union of the fields requested for maps,
+  the fields needed for heat content (`temperature`), the fields needed for
+  velocity reconstruction (`normalVelocity`, when zonal and meridional velocity
+  are requested and not written by the model), and the vertical geometry
+  (`zMid`, `zInterface`).  Building this list is the reason `Climatology` needs
+  to know which steps depend on it; the list is assembled from config options
+  at runtime rather than passed in by each task, so that the step stays neutral
+  with respect to which tasks pulled it in.
+
+  Note that `-v` takes the names as they appear *in the files*, which are Omega
+  names, so the step maps its Polaris-standard list back through
+  `mpaso_to_omega.yaml` before building the command.  This is the one place in
+  the design where the model-specific names are unavoidable, because `ncclimo`
+  operates on the files rather than on an opened dataset.
+- Omega's monthly means carry CF time metadata, so `ncclimo`'s generic handling
+  should apply and the MPAS-specific `-P mpaso` processing type should not be
+  needed.  **This needs to be confirmed against real Omega output**; if
+  `ncclimo` cannot read Omega files directly, the fallback is either an
+  NCO-side change or a small preprocessing pass, and this should be checked as
+  soon as Omega can write monthly means because it is on the critical path.
+- `-p`/`-j` set the parallel mode and thread count.  `ncclimo` in `bck` mode
+  runs up to twelve background processes, one per month, so the step requests
+  `cpus_per_task = 12` and `ntasks = 1`.
+
+The output file names produced by `ncclimo` follow the pattern
+`<caseid>_<season>_<YYYYMM>_<YYYYMM>_climo.nc`.  Rather than reconstructing
+that pattern, downstream steps locate climatology files by globbing on the
+season, which is robust to `ncclimo` naming changes.
+
+### Implementation: climatology-maps
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Two new shared modules carry the reusable logic.
+
+`polaris/ocean/vertical/elevation.py`, a dependency-light leaf module beside
+the existing vertical-coordinate helpers, unit tested directly:
+
+```python
+def get_z_mid_and_interface(ds):
+    """Return zMid and zInterface, raising a clear error if absent."""
+
+
+def parse_elevation_spec(spec):
+    """Parse 'top', 'bottom', 'k<n>' or an elevation in m."""
+
+
+def extract_elevation_slice(da, spec, z_mid, min_level_cell, max_level_cell):
+    """Extract a horizontal slice at the requested elevation."""
+
+
+def elevation_range_weights(z_interface, min_level_cell, max_level_cell,
+                            z_top, z_bot):
+    """Return the per-layer overlap thickness w_k for an elevation range."""
+```
+
+`polaris/ocean/heat_content.py`:
+
+```python
+def heat_content(temperature, weights, density, specific_heat):
+    """Vertically integrated heat content per unit area [J m-2]."""
+```
+
+`elevation_range_weights` lives with the other elevation utilities rather than
+with heat content because it is a property of the vertical coordinate, and it
+will be reused by any future vertically integrated diagnostic.
+
+The `ClimatologyMaps` step then loops over seasons, fields, and elevations:
+
+```python
+for season in plot_seasons:
+    ds = self.open_model_dataset(climo_filename(season), self.config)
+    z_mid, _ = get_z_mid_and_interface(ds)
+    for field in fields:
+        da = self._get_field(ds, field)   # reconstructs velocities if needed
+        if 'nVertLevels' in da.dims:
+            specs = [parse_elevation_spec(spec) for spec in elevations]
+        else:
+            specs = [None]
+        for spec in specs:
+            da_slice = (da if spec is None else
+                        extract_elevation_slice(da, spec, z_mid,
+                                                k_min, k_max))
+            write_netcdf(da_slice, out_filename)
+            plot_global_mpas_field(
+                da=da_slice, out_filename=..., config=self.config,
+                colormap_section=f'ocean_analysis_map_{field}',
+                mesh_filename='mesh.nc', ...)
+```
+
+Output names are `<field>_<season>_<elevation_label>.png` with elevation labels
+`top`, `bottom`, `-100m`, and `k10`, so that the set of files in the step
+directory is self-describing.
+
+Maps are plotted on the native mesh with the existing
+`polaris.viz.plot_global_mpas_field`, which is `mosaic`-based and needs no
+remapping.  Native-mesh plotting is not a temporary expedient: it is where
+observational comparison is headed too, with observations remapped onto the
+MPAS mesh rather than the model remapped onto a comparison grid.
+
+The `mosaic` descriptor is constructed once and reused across all plots, since
+building it is the expensive part of plotting a global mesh.
+
+Velocity reconstruction uses the weights on the mesh via
+`polaris.mesh.reconstruct`.  If the mesh does not carry reconstruction weights,
+the step reports that clearly and skips the zonal and meridional velocity maps
+rather than failing the whole step.
+
+If `compute_mixed_layer_depth` is set, the task adds a shared per-year step for
+each year of the climatology, structured exactly like the per-year heat content
+steps: each computes monthly mixed-layer depth with `gsw` as described in the
+algorithm design and writes one file for its year.  A range-keyed step then
+averages those into the seasonal and annual means that `maps` plots.  Its
+outputs carry an attribute recording that they were computed offline from
+monthly means, and the step adds a note to the plot titles, so that a reader
+cannot mistake them for an in-situ diagnostic.
+
+### Implementation: ocean-heat-content-maps
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The `maps` step of the `ocean_heat_content` task reads the same climatology
+files, computes
+
+```python
+weights = elevation_range_weights(z_interface, k_min, k_max, z_top, z_bot)
+ohc = heat_content(ds.temperature, weights, rho0, cp0)
+```
+
+for each configured elevation range and each plotted season, writes the result
+to netCDF in J m⁻² and plots it in GJ m⁻² (a range of $0$ to $-700$ m at a
+typical 10 °C is about 29 GJ m⁻², which is a readable number).
+
+Output names are `ohc_<season>_<z_top>_<z_bot>.png`, for example
+`ohc_ANN_0m_-700m.png` and `ohc_ANN_-2000m_bottom.png`.  Plot titles state the
+elevation range and the season explicitly, and the netCDF carries the range as
+attributes, so that a plot cannot be mistaken for a different range.
+
+### Implementation: global-stats-time-series
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Omega's `GlobalStats` group writes variables named
+`<Field>_<SpatialStat>_TimeMean<Period>` --- for example
+`Temperature_SpatialMean_TimeMean1Month` --- to streams named
+`GlobalStats_<Freq>TimeStats`.  The step builds the variable names from the
+configured fields and statistics, opens the files for the requested years with
+`xr.open_mfdataset`, and concatenates along time.  The existing entries in
+`mpaso_to_omega.yaml` already map several of these to Polaris-standard names
+(`normalVelocityAvg`, and so on) and are extended as more fields are analyzed.
+
+Before plotting, the step intersects the configured `(field, statistic)` pairs
+with what the dataset actually contains, logs one line per missing pair, and
+plots the rest.  A field with no surviving statistics is skipped entirely.  The
+step fails only if *nothing* it was asked for is present, which is the case
+worth interrupting the user for, since it usually means the file-name template
+or the year range is wrong rather than that a variable is missing.
+
+The existing `StatsAnalysis` step in
+`polaris/tasks/ocean/realistic_global/analysis_members/` already produces
+exactly the plot we want, but takes its input from a `forward` step in the same
+task.  Rather than duplicating it, the plotting is factored into a function in
+`polaris/ocean/analysis_plots.py`:
+
+```python
+def plot_global_stats(ds, time, fields, stats, out_dir, title_prefix):
+    """Plot absolute and relative-to-start time series with a std envelope."""
+```
+
+used by both the existing `StatsAnalysis` step and the new one.  This keeps the
+`realistic_global` task's behavior unchanged while avoiding a second copy of
+the plotting logic.
+
+The time axis is converted to simulation years from the CF time coordinate.
+`polaris.ocean.model.time.get_days_since_start` provides the days-since-start
+conversion already used elsewhere; the new code divides by the length of the
+year in the file's calendar.
+
+### Implementation: ocean-heat-content-time-series
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+This product is two kinds of step.  A shared `OceanHeatContentYear` step per
+simulation year does the expensive work for that year:
+
+```python
+class OceanHeatContentYear(OceanIOStep):
+    def run(self):
+        ds_year = []
+        for month in range(1, 13):
+            ds = self.open_model_dataset(f'monthly_{month:02d}.nc',
+                                         self.config)
+            _, z_interface = get_z_mid_and_interface(ds)
+            ohc = []
+            for z_top, z_bot in elevation_ranges:
+                weights = elevation_range_weights(z_interface, k_min, k_max,
+                                                  z_top, z_bot)
+                column = heat_content(ds.temperature, weights, rho0, cp0)
+                ohc.append((area_cell * column).sum('nCells'))
+            ds_year.append(...)
+        write_netcdf(xr.concat(ds_year, dim='Time'), 'ohc.nc')
+```
+
+and a range-keyed `time_series` step concatenates the per-year files for the
+requested years and plots them.  The task's `configure()` creates one per-year
+step for each year in the configured range with
+`get_or_create_shared_step()`, so a year analyzed by an earlier range is reused
+rather than recomputed.
+
+Reading a month at a time within the year step is deliberate.  A global
+three-dimensional temperature field at 30 km resolution and 80 levels is
+roughly 150 MB per month, so a forty-year record is several tens of gigabytes;
+a month at a time bounds memory regardless of how long the record is.  Only
+`temperature`, `zInterface`, and the vertical-index fields are read.
+
+The plot has two panels: absolute heat content in units of 10²² J, and the
+anomaly relative to the first month, with one line per elevation range.  The
+concatenated time series is written to `ocean_heat_content_time_series.nc`.
+
+The per-year steps are the most expensive part of the suite.  If they prove too
+slow, there are two independent moves available: run them concurrently once
+Polaris's task parallelism lands, which needs no changes here because they are
+already independent non-MPI steps; or compute the vertical integrals in Omega
+in situ, which reduces the whole product to a concatenation.  If mixed-layer
+depth is also computed offline, its per-year steps make the same pass over the
+same monthly files and could be merged with these; they are kept separate
+because a merged step would couple two products for a saving that only matters
+if the pass proves expensive.
+
+### Implementation: moc-plot
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The `moc/plot` step reads Omega's global MOC output over the climatology years,
+averages over time weighted by the length of each reduction period, and plots
+the result as filled contours with overlaid contour lines against the interface
+elevations Omega provides.
+
+The plotting primitive is added to `polaris/viz/` as a general
+latitude-elevation contour plot, rather than being written inline in the step,
+since regional overturning, zonal means, and meridional heat transport plots
+will all want it in a later phase:
+
+```python
+def plot_lat_elevation_field(da, lat, z, out_filename, config,
+                             colormap_section, contour_interval=None, ...):
+```
+
+Elevation on the vertical axis puts the sea surface at the top without
+inverting the axis, consistent with the sign convention used everywhere else in
+this design.
+
+The step is guarded so that a missing MOC file, or MOC output without interface
+elevations, produces a clear message naming the expected file and the Omega
+config option that produces it, rather than a traceback --- the MOC capability
+is new in Omega and users will encounter simulations that predate it.
+
+### Implementation: commit sequence
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+1. This design document and the umbrella document
+   {ref}`design-ocean-analysis`.
+2. `polaris/ocean/vertical/elevation.py` --- elevation specifications,
+   elevation slicing, and elevation-range weights --- with unit tests.
+3. `polaris/ocean/heat_content.py` with unit tests.
+4. The `omega_analysis` scaffolding: the `polaris/tasks/ocean/analysis/`
+   package, `analysis.cfg`, `sim_files.py`, the range-keyed step subdirectories
+   and output staging shared by every step, the four tasks with their
+   `configure()` methods, and the `omega_analysis` suite, with steps that do
+   nothing yet.  This is the commit where the repeated-analysis structure is
+   established, so it should land before anything that depends on it.
+5. The `Climatology` step (`ncclimo`).
+6. The `ClimatologyMaps` step, including velocity reconstruction.
+7. The ocean heat content `maps` step.
+8. The `global_stats` `time_series` step, including factoring the shared
+   plotting function out of `StatsAnalysis`.
+9. The per-year and range-keyed ocean heat content time series steps.
+10. The `moc` `plot` step and the `plot_lat_elevation_field` primitive.
+11. The offline per-year `mixed_layer_depth` steps, only if Omega's in-situ
+    diagnostic will not be ready in time.
+12. User's Guide documentation: a page under `docs/users_guide/ocean/tasks/`
+    describing the analysis suite and its config options, and an entry in
+    `docs/users_guide/ocean/suites.md`.
+
+Commits 2, 3, and 5 through 11 are independently reviewable and each leaves the
+suite in a working state for the products delivered so far.
+
+## Testing
+
+### Testing and Validation: analysis-suite and data-products
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Unit tests under `tests/ocean/` cover the parts that do not need a simulation:
+
+- expansion of file-name templates over a year range, including the error
+  message when years are missing;
+- parsing of the elevation and elevation-range config syntax, including invalid
+  input and the `top`, `bottom`, and `k<n>` keywords;
+- that every plotting step registers a netCDF output for each PNG output, which
+  keeps the data-products requirement from quietly regressing.
+
+### Testing and Validation: repeated-analysis
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The step tree each task builds is a pure function of its config options, so
+most of this can be tested without running anything.  Unit tests construct a
+task, set config options, call `configure()`, and inspect the resulting steps:
+
+- the range-keyed steps land at subdirectories named for the configured range,
+  and changing the range changes those subdirectories;
+- one per-year step is created for each year in the configured range, at a
+  subdirectory named for the year;
+- widening the range produces the same per-year steps for the years the two
+  ranges share --- literally the same objects, via
+  `get_or_create_shared_step()` --- plus new ones for the added years;
+- the climatology and time series ranges are independent, so changing one does
+  not disturb the other's steps.
+
+Two behaviors need an actual run, tested with a stubbed step that records that
+it ran:
+
+- re-running with an unchanged range does no work;
+- after analyzing a second range, the first range's staged results are still
+  present, which is the requirement that a new range must not clobber an old
+  one.
+
+Finally, a check that the range recorded in a netCDF file's attributes matches
+the range in its path, which is what would catch a plot labeled with the wrong
+range if the step tree and the metadata ever drifted apart.
+
+### Testing and Validation: climatology
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+A small synthetic monthly-mean data set --- a handful of cells, a few levels,
+three years of months with known values, written with Omega names and CF time
+metadata --- is written to a temporary directory, `ncclimo` is run on it, and
+the resulting `ANN`, `DJF`, and monthly climatologies are compared against
+day-weighted means computed directly in the test.  This validates our `ncclimo`
+invocation, including the `-a sdd` convention and the claim that `ncclimo` can
+read Omega-style files without `-P mpaso`, rather than validating `ncclimo`
+itself.
+
+The test is skipped if `ncclimo` is not on the path.
+
+### Testing and Validation: climatology-maps
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Unit tests on `extract_elevation_slice` with synthetic columns having known
+layer geometry, `minLevelCell`, and `maxLevelCell`:
+
+- `top` and `bottom` return the values at `minLevelCell` and `maxLevelCell`,
+  including for a column with `minLevelCell > 0` (an ice-shelf cavity) and a
+  column with `maxLevelCell` less than the number of levels;
+- a fixed index returns that index and is masked where the index is outside the
+  valid range;
+- interpolation to an elevation exactly at a layer midpoint returns that
+  layer's value exactly;
+- interpolation to an elevation midway between two midpoints returns the
+  average of the two values;
+- an elevation above the topmost midpoint returns the topmost value, and an
+  elevation below the seafloor is masked;
+- a linear-in-$z$ field is recovered exactly at arbitrary elevations.
+
+The last of these is the strongest test: it catches index-off-by-one and
+weight-inversion errors that the others can miss.
+
+### Testing and Validation: mixed-layer depth
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+If the offline fallback is implemented, unit tests on synthetic profiles:
+
+- a two-layer profile with a density jump exactly at an interface returns that
+  interface elevation;
+- a linearly stratified profile returns the elevation at which the density
+  threshold is crossed, matching an analytic answer, which exercises the
+  interpolation between bounding layers;
+- a fully mixed column returns the seafloor elevation rather than an
+  extrapolated value or `NaN`;
+- the computation agrees with a direct `gsw` evaluation at the reference
+  elevation, so that a mistake in the reference pressure is caught.
+
+### Testing and Validation: ocean-heat-content
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+Unit tests on `elevation_range_weights` and `heat_content`:
+
+- for a range aligned with layer interfaces, the weights are exactly the layer
+  thicknesses in the range and zero outside;
+- for a range boundary in the interior of a layer, the weight of that layer is
+  the exact partial thickness;
+- for a constant temperature $\Theta_0$ over a range $[z_{bot}, z_{top}]$
+  entirely within the water column, the heat content is exactly
+  $\rho_0 c_p^0 \Theta_0 (z_{top} - z_{bot})$;
+- for a range extending below the seafloor, the result is truncated at the
+  seafloor;
+- the whole-ocean range equals the sum of a set of ranges that partition it,
+  which is a useful invariant that also exercises the `bottom` keyword;
+- for a column entirely above $z_{top}$, the result is zero rather than `NaN`,
+  since a `NaN` here would poison the global sum.
+
+### Testing and Validation: time series and MOC
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+The time series and MOC steps are mostly file handling and plotting, and are
+covered by:
+
+- a unit test that the per-year heat content files are reused rather than
+  recomputed when they already exist, and that adding a year extends the series
+  correctly;
+- a unit test on the construction of `GlobalStats` variable names from
+  Polaris-standard field names and the configured statistics;
+- a unit test that a configured field or statistic missing from the dataset is
+  skipped rather than raising, that a field with no surviving statistics is
+  dropped, and that a dataset with none of the configured variables does
+  raise --- this is the behavior most likely to regress into an exception the
+  first time a simulation writes an unexpected subset;
+- a unit test that the MOC time average weights reduction periods correctly on
+  a synthetic data set with unequal period lengths.
+
+### Testing and Validation: end-to-end
+
+Date last modified: 2026/08/11
+
+Contributors: Xylar Asay-Davis, Claude
+
+End-to-end validation is against Omega, staged as Omega capabilities land.
+None of it belongs in the `pr` or `nightly` suites, since it requires a
+completed simulation as input and its cost is dominated by that simulation.
+
+1. **As each Omega capability lands**, the corresponding product is run against
+   real Omega output at low resolution and inspected.  `GlobalStats` output
+   exists today, so the global-stats time series can be validated first; the
+   MOC plot follows when the MOC analysis group is available; the climatology,
+   map, and heat content products follow when monthly means are available.
+   Staging the validation this way is what keeps the September 15 date
+   credible, since it front-loads discovery of mismatches between what the
+   design assumes and what Omega actually writes.
+2. **A short Omega run as a smoke test.**  Once Omega can write monthly means,
+   the QU240 `realistic_global` task is configured to write two years of
+   monthly means, `GlobalStats`, and MOC output, and the whole suite is run on
+   it.  This confirms that the suite runs end to end and produces every
+   expected file.  It is fast enough that it could later be added to a suite if
+   we decide the coverage is worth the cost, but that is a separate decision.
+
+We do not validate by running this analysis on MPAS-Ocean output.  MPAS-Ocean
+differs from Omega in variable and dimension names, in time metadata, and in
+which analysis member produces its monthly means, so an MPAS-Ocean test would
+exercise code paths we do not ship and would give false confidence about the
+paths we do.  Confidence in the numerics comes instead from the unit tests
+above, which check the kernels against analytic answers rather than against
+another model's output.
+
+Where a diagnostic's *magnitude* needs a sanity check --- is the heat content
+in the right ballpark, is the MOC of a plausible strength --- published
+MPAS-Analysis results for E3SM simulations are a reasonable reference to
+eyeball against.  That is a science judgment made by the person reviewing the
+plots, not an automated test.
+
+## Open questions
+
+*These are the decisions that should be settled before implementation starts.
+They are collected here rather than buried in the sections above.*
+
+1. **Mixed-layer depth.**  Can Omega deliver an in-situ, density-threshold
+   mixed-layer depth diagnostic, averaged monthly, by September 15?  If not, we
+   ship the offline fallback with its caveats.  This needs a team discussion
+   rather than a decision in this document, and it affects both the Omega
+   schedule and commit 11 above.
+2. **`ncclimo` and Omega output.**  Whether `ncclimo` can read Omega
+   monthly-mean files without the MPAS-specific processing type needs to be
+   confirmed against real output as soon as Omega can produce it.  This is on
+   the critical path.
+3. **Omega MOC output conventions.**  The variable, dimension, and coordinate
+   names, and whether the mean interface elevations are written alongside the
+   streamfunction, need to be confirmed against the MOC implementation.  This
+   should be straightforward to settle once the vertical-coordinate question
+   above is resolved and the Omega MOC analysis is rerun.
+4. **The default `GlobalStats` field and statistic list.**  Which quantities a
+   reader most wants to see drift in is a judgment call and is still open.  How
+   the list behaves is settled: it lives in Polaris's config file, and entries
+   the simulation did not write are skipped rather than raising.
+
+Two questions from earlier drafts are now settled and are recorded here so that
+they are not reopened by accident:
+
+- **Constants for heat content:** Phase 1 uses the PCD values, since adding
+  $c_p^0$ to the PCD cannot be completed by September 15.  Switching to the
+  TEOS-10 constant is a deferred item in {ref}`design-ocean-analysis`.
+- **Task granularity for ocean heat content:** one task, two steps.

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1713,10 +1713,12 @@ sub-range inside it reads nothing at all the second time.  A partially written
 cache in the step's own directory is itself a valid starting point on a retry,
 which is most of what restartability asks for.
 
-Because the remaining months are independent, they are spread over a process
-pool inside the step rather than over steps.  This follows principle 3 in
-{ref}`design-ocean-analysis`, and it means the analysis gets its concurrency
-from a capability that exists today rather than from task parallelism.
+The remaining months are independent, so the concurrency here belongs in a
+process pool inside the step rather than in more steps --- principle 3 in
+{ref}`design-ocean-analysis`, and a capability that exists today rather than
+one waiting on task parallelism.  Phase 1 does not take it: the months are
+computed one after another, as *One step per accumulator in Phase 1* below
+says, and the pool is deferred with the rest of the concurrency work.
 
 #### Replotting
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1788,15 +1788,17 @@ its own manifest fragments.
 # web-servable if you want to share the results.
 output_path =
 
-# The width in pixels of the thumbnail generated for each plot.  Thumbnails
-# are what make a few hundred plots browsable, and their total size is what
-# decides whether a gallery page loads over a throttled link, so this is the
-# first thing to reduce if pages are slow to appear.
-thumbnail_width = 320
+# The maximum width and height in pixels of the thumbnail generated for each
+# plot.  A thumbnail is scaled to fit inside this box, so that a portrait plot
+# and a landscape one cost about the same and sit in the same grid.
+# Thumbnails are what make a few hundred plots browsable, and their total size
+# is what decides whether a gallery page loads over a throttled link, so this
+# is the first thing to reduce if pages are slow to appear.
+thumbnail_size = 320, 240
 
-# The image format for thumbnails, jpeg or webp.  webp is roughly a quarter
-# smaller at the same quality and every current browser reads it; jpeg is the
-# safer default.
+# The image format for thumbnails, jpeg or webp.  webp is between a third and
+# a half smaller at the same quality and every current browser reads it; jpeg
+# is the safer default.
 thumbnail_format = jpeg
 
 # The compression quality of thumbnails, from 1 to 100.  Above about 80 the
@@ -1825,6 +1827,14 @@ Three rules keep this from growing into a format that needs a specification.
 published name and the thumbnail are added by the collector when it publishes,
 so a step never has to know the staging tree's layout, and a change to that
 layout is a change to one step.
+
+**A product is declared once.**  The steps already call
+`OceanIOStep.add_produced_file()` to register each plot and netCDF as they are
+written, because a step that plots what a simulation wrote does not know at
+setup which plots it will make.  Describing a product to the manifest is the
+same event, so it happens in the same call rather than in a second one a step
+can forget --- which is what would otherwise make a product real to Polaris's
+output checking but invisible to the gallery.
 
 **Only `group` and `gallery` shape the site.**  Every other facet is caption
 material today and filter material later.  This is the hinge that makes the
@@ -1897,23 +1907,34 @@ hundred.
 #### Thumbnails
 
 Each thumbnail is made from the published PNG with `pillow`: the image is
-flattened onto white, since the plots are written with an alpha channel and
-neither JPEG nor a gallery wants transparency, scaled to `thumbnail_width`
-preserving aspect ratio, and written in `thumbnail_format` at
-`thumbnail_quality`.
+flattened onto white, scaled to fit inside `thumbnail_size` preserving aspect
+ratio, and written in `thumbnail_format` at `thumbnail_quality`.  The flatten
+is not defensive --- the plots really are written RGBA, and without it JPEG
+renders the transparent background black.
+
+**Thumbnails are bounded in both dimensions, not in width alone**, and the two
+products that exist show why.  A climatology map is 4000x2250, so at 320 px
+wide it is 320x180 and 12.2 kB.  A `global_stats` figure stacks its statistics
+vertically and is 2383x3941, so the same width rule makes it 320x519 --- taller
+than it is wide, three times the pixels of the map, 23.3 kB, and destructive to
+any uniform grid it is placed in.  Bounded to 320x240 instead it is 148x240 and
+**6.7 kB**.  Constraining width alone quietly charges the most for exactly the
+plots that need a thumbnail least.
 
 Making them here rather than in the plotting steps is deliberate.  It keeps the
 plotting steps ignorant of presentation, it keeps the policy in one place where
 changing it re-renders everything consistently, and it means a thumbnail can be
 regenerated from what was published without re-running any analysis.
 
-The measured cost, on the three-panel MPAS-Analysis figure used for the
-comparison below, is 20 ms per image to decode, scale, and encode.  A default
-Phase 1 analysis is on the order of a hundred products, so the whole pass is a
-few seconds.  Memory is one image at a time.  The loop is embarrassingly
-parallel and is an obvious candidate for principle 3's in-step pool if the
-product count ever grows enough to matter; Phase 1 runs it serially with
-`cpus_per_task = 1`.
+The measured cost is **156 ms per image** to decode, flatten, scale, and
+encode, on the real output of the two steps that exist.  That is far more than
+a trivial pass because the source PNGs are large --- a climatology map is
+4000x2250 and 1.3 to 2.1 MB on disk --- and it is dominated by decoding them.
+A hundred products is therefore around fifteen seconds, and a thousand would be
+minutes.  Memory is one image at a time.  The loop is embarrassingly parallel
+and is the clearest candidate in this design for principle 3's in-step pool;
+Phase 1 runs it serially with `cpus_per_task = 1`, which is defensible at the
+Phase 1 product count and would not stay so.
 
 #### The generated site
 
@@ -1958,23 +1979,38 @@ is about **75 MB in 1641 requests** before the page settles.  Its thumbnails
 are 480 px wide and lightly compressed.  This is the behavior that stalls on a
 throttled link.
 
-Against a single global map panel of that figure --- a stand-in for the
-single-panel maps this suite produces, since no Polaris analysis has been
-published yet --- a thumbnail at the defaults above is **about 13 kB** as JPEG
-at 320 px and quality 75, or about 10 kB as WebP.  This should be confirmed on
-real output rather than trusted; the point it is making, that the reference's
-thumbnails are several times larger than they need to be, is not sensitive to
-the exact figure.  With the default field and season lists a climatology-map
-gallery holds roughly fifteen products, so a gallery page is a ~10 kB document
-plus ~200 kB of thumbnails, of which lazy loading fetches only the visible rows
---- on the order of **100 kB** before the page is usable.  The landing page
-carries one thumbnail per gallery, so it is of the same order.
+Ours is measured on the real output of the two steps that produce plots today
+--- the QU240 climatology-map and `global_stats` mock-ups --- at the defaults
+above:
+
+| | full PNG | thumbnail, JPEG | thumbnail, WebP |
+| --- | --- | --- | --- |
+| climatology map (4000x2250) | 1.3-2.1 MB | 12.2 kB | 8.5 kB |
+| `global_stats` (2383x3941) | 0.33-0.56 MB | 6.7 kB | 3.6 kB |
+
+A thumbnail is therefore **one to two hundred times smaller** than the plot it
+stands for, and about a quarter the size of the reference's.  With the default
+field and season lists a climatology-map gallery holds roughly fifteen
+products, so a gallery page is a ~10 kB document plus ~180 kB of thumbnails, of
+which lazy loading fetches only the visible rows --- on the order of **50 kB**
+before the page is usable.  The landing page carries one thumbnail per gallery
+and is of the same order.
 
 The three levers act independently, which is why all three are used: small
-thumbnails cut the bytes per image by a factor of three or four against the
-reference, gallery pages cut the images per page by two orders of magnitude,
-and lazy loading cuts what is fetched before the page settles to the handful
-that are visible.  A single page never asks for a full PNG.
+thumbnails cut the bytes per image by a factor of four against the reference,
+gallery pages cut the images per page by two orders of magnitude, and lazy
+loading cuts what is fetched before the page settles to the handful that are
+visible.  A single page never asks for a full PNG.
+
+One number here is worth noticing for a different reason.  The full plots are
+1.3 to 2.1 MB each, because they are written at 4000x2250, so *clicking* a
+thumbnail costs about as much as an entire gallery page.  That is acceptable
+--- it is one image, deliberately requested --- but it means the plot size and
+resolution the steps write at are themselves a lever on what browsing costs,
+and one this design does not currently touch.  If full images prove painful to
+open over the portal, the answer is a mid-size image between the thumbnail and
+the full plot, which is the same generated-derivative machinery with a second
+size.
 
 What is *not* known is whether the LCRC portal throttles bytes or requests.
 Everything above helps with either, but the remedies differ if requests are the

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1138,11 +1138,22 @@ which already maps the vertical geometry this design depends on:
   zInterface: GeomZInterface
 ```
 
-Fields that are new to Omega and have no MPAS-Ocean counterpart --- a
-mixed-layer depth diagnostic, for instance --- get a Polaris-standard name and
-an entry in that mapping as they become available.  No analysis step branches
-on `config.get('ocean', 'model')` to choose a field or dimension name; if a
-step needs to do so, that is a signal the mapping file is missing an entry.
+The keys in that file are Polaris-standard names, which are MPAS-Ocean names
+wherever MPAS-Ocean has the field.  Fields that are new to Omega --- a
+mixed-layer depth diagnostic, for instance --- have no MPAS-Ocean name to
+borrow, so we choose a Polaris-standard name in the same style and add an entry
+mapping it to the Omega name as those names are fixed.  The entry is still
+needed: translation is a rename on read, so a field with no entry arrives under
+its Omega name and analysis code would have to know Omega's spelling.  What is
+not needed is a *counterpart* in MPAS-Ocean.
+
+The one field this design deliberately does not translate is
+`PseudoThickness`, for the reasons given under the conventions.
+
+With those two things in place, no analysis step branches on
+`config.get('ocean', 'model')` to choose a field or dimension name, except
+`get_layer_mass`, which exists precisely to be that one branch.  Anywhere else,
+a branch on the model is a signal that the mapping file is missing an entry.
 
 #### Locating input files
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -154,7 +154,9 @@ in config options, algorithms, and output are elevations $z$ in meters with
 $z = 0$ at the resting sea surface and $z$ increasing upward, so that positions
 within the ocean are negative.  A map "at 100 m below the surface" is requested
 as `-100.0`, and the ocean heat content range conventionally called "0 to
-700 m" is written `0.0:-700.0`.  This matches `zMid` and `zInterface` as the
+700 m" is written `top:-700.0` --- `top` being the free surface of each column,
+which is what "0 m" means in that phrase, rather than the resting sea surface
+at $z = 0$.  This matches `zMid` and `zInterface` as the
 models write them and avoids sign flips scattered through the code.  Where the
 text uses the word "depth" it is describing a quantity that is positive down,
 such as `bottomDepth`, and says so.
@@ -799,7 +801,8 @@ in the kernel.*
 
 Ocean heat content per unit area is a *mass*-weighted integral of conservative
 temperature.  Over an elevation range $[z_{bot}, z_{top}]$ with
-$z_{bot} < z_{top} \le 0$,
+$z_{bot} < z_{top}$, where either boundary may be a fixed elevation, the free
+surface, or the seafloor,
 
 $$
 Q(z_{bot}, z_{top}) = c_p^0 \int_{z_{bot}}^{z_{top}} \rho \, \Theta \, dz
@@ -883,9 +886,17 @@ The $w_k$ expression handles all of the cases the requirement calls for without
 special casing: a range boundary in the interior of a layer contributes a
 partial thickness; a range extending below the seafloor is truncated because
 $z^{int}_{k_{max}+1} = -H$; a `bottom` boundary is expressed as
-$z_{bot} = -\infty$; and a column whose seafloor lies above $z_{top}$
-contributes zero.  For the conventional `0:bottom` range, every valid layer is
-whole and the geometric coordinate drops out of the answer entirely.
+$z_{bot} = -\infty$; a `top` boundary as $z_{top} = +\infty$, which resolves
+per column to the free surface $z^{int}_{k_{min}}$; and a column whose seafloor
+lies above $z_{top}$ contributes zero.
+
+Expressing the upper boundary as `top` rather than as $0.0$ matters more than
+it looks.  A range written `0.0:-700.0` would exclude the water between the
+resting sea surface and the free surface, and would exclude a different amount
+of it in each column and in each season.  `top` is what "0 to 700 m" means
+everywhere it is reported, and it makes the whole-column range `top:bottom`
+cover every valid layer, so that every layer is whole and the geometric
+coordinate drops out of that answer entirely.
 
 The globally integrated heat content used for the time series is the
 area-weighted sum
@@ -1179,7 +1190,7 @@ mixed_layer_depth_threshold = 0.03
 # <top>:<bottom> in m, positive up.  "bottom" means the seafloor.  These are
 # geometric elevations, matching the convention used by MPAS-Analysis and by
 # observational heat content products; the integral itself is mass-weighted.
-elevation_ranges = 0.0:-700.0, -700.0:-2000.0, -2000.0:bottom, 0.0:bottom
+elevation_ranges = top:-700.0, -700.0:-2000.0, -2000.0:bottom, top:bottom
 
 # The specific heat capacity used to convert conservative temperature to heat
 # content.  By default, this comes from the Physical Constants Dictionary.
@@ -1536,7 +1547,7 @@ and to diff between two analyses:
 └── plots/
     ├── climatology_maps_temperature_ANN_-100m_0021-0040.png
     ├── climatology_maps_temperature_ANN_-100m_0021-0040.nc
-    ├── climatology_maps_heat_content_ANN_0m-700m_0021-0040.png
+    ├── climatology_maps_heat_content_ANN_top_to_-700m_0021-0040.png
     ├── heat_content_series_0001-0060.png
     └── …
 ```
@@ -1795,8 +1806,9 @@ its reduction is an elevation range rather than an elevation, and both of those
 are cases the loop already handles.
 
 Output names are `<field>_<season>_<reduction_label>.png` with reduction labels
-`top`, `bottom`, `-100m`, `k10`, and `0m-700m`, so that the set of files in the
-step directory is self-describing.
+`top`, `bottom`, `-100m`, `k10`, and `top_to_-700m`, so that the set of files
+in the step directory is self-describing.  Range labels use `_to_` rather than
+a hyphen because the elevations are themselves negative.
 
 The plots are independent, so a step with many of them spreads them over a
 process pool rather than over steps.  Building the `mosaic` descriptor is the
@@ -1882,7 +1894,8 @@ The result is written to netCDF in J m⁻² and plotted in GJ m⁻² --- a range
 $0$ to $-700$ m at a typical 10 °C is about 29 GJ m⁻², which is a readable
 number.  Output names follow the same convention as the rest of the maps,
 `heat_content_<season>_<range_label>.png`, for example
-`heat_content_ANN_0m-700m.png` and `heat_content_ANN_-2000m-bottom.png`.  Plot
+`heat_content_ANN_top_to_-700m.png` and
+`heat_content_ANN_-2000m_to_bottom.png`.  Plot
 titles state the elevation range and the season explicitly, and the netCDF
 carries the range as attributes, so that a plot cannot be mistaken for a
 different range.

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -588,15 +588,16 @@ climatology --- this design produces:
 | --- | --- |
 | `ncclimo` climatology | 1 |
 | Climatology maps, one per field group | 6 |
-| Heat content series: shards plus merge | 9 |
-| Offline mixed-layer depth, shards plus its climatology (fallback only) | 9 |
+| Heat content series accumulator | 1 |
+| Offline mixed-layer depth, accumulator plus its climatology (fallback only) | 2 |
 | Global stats, MOC | 2 |
-| **Total** | **27** |
+| **Total** | **12** |
 
 The count is **independent of the length of the record**, which is the property
-worth having.  The accumulator shard count is a config option, so the largest
-term in that table is set by how much concurrency the machine can use rather
-than by how long the simulation ran.  An earlier draft, with one shared step per simulation year, gave
+worth having.  It grows with the number of field groups and products, and --- in
+a later phase, when accumulators are split for a scheduler --- with how much
+concurrency the machine can use.  Neither is something the length of a
+simulation can run away with.  An earlier draft, with one shared step per simulation year, gave
 about 130 steps for the same analysis and grew linearly, so a century-long
 record would have given about 230.  That was never going to break Polaris --- a
 few hundred steps is ordinary, and the existing `ocean` component builds
@@ -604,18 +605,20 @@ several hundred across all its tasks --- but the count grew with something the
 user has no control over, which is the wrong shape even when the numbers are
 small.
 
-Step *size* is the other half, and it is now comfortable at both ends.  On a
-first run each heat content shard reads its slice of the record, which is
-minutes at 30 km for an eighth of a multi-decade record; on a re-run over an
-overlapping range it reads only the new months in its slice.  A climatology map
-step plots the seasons and reductions of one field group, which is seconds to
-minutes per plot at production resolution.  Neither is close to the regime
+Step *size* is the other half.  On a first run the heat content accumulator
+reads the whole record, which at 6to18 km over several decades is hours; on a
+re-run over an overlapping range it reads only the new months.  A climatology
+map step plots the seasons and reductions of one field group, which is seconds
+to minutes per plot at production resolution.  Neither is close to the regime
 where a step's overhead --- a work directory, a pickle, a config copy, a log
 file --- would be a meaningful fraction of its runtime.
 
-Nor is any single step now a large fraction of the suite, which is principle
-9's other target: the most expensive product is split into shards that the
-scheduler can place independently.
+Principle 9's other target, that no step be a large fraction of the suite, is
+knowingly missed: the heat content accumulator is the bulk of a first run.  That
+is acceptable only because Phase 1 is serial, so there is nothing the imbalance
+could have been traded against.  It is the first thing to fix when there is a
+scheduler, and it is fixed by splitting the accumulator, which costs nothing in
+reuse.
 
 The count grows with the number of field groups and, in later phases, with
 whatever new products are added --- not with the record, the seasons, the
@@ -1045,11 +1048,9 @@ ocean/analysis/
 │   ├── ssh/ mixed_layer_depth/
 │   └── heat_content/
 ├── mixed_layer_depth/0021-0040/              (only if computed offline)
-│   ├── 0021-0023/ … 0038-0040/               (accumulator shards)
+│   ├── monthly/                              (accumulator)
 │   └── climatology/                          (second ncclimo call)
 ├── heat_content_series/0001-0060/
-│   ├── 0001-0008/ … 0053-0060/               (accumulator shards)
-│   └── merge/
 ├── global_stats/0001-0060/
 └── moc/0021-0040/
 ```
@@ -1428,9 +1429,9 @@ never share a directory.
 #### Reuse comes from seeded accumulators
 
 The expensive range-independent work --- vertically integrated heat content,
-and mixed-layer depth if it is computed offline --- is a set of steps per
-product, keyed by the range like everything else, which inherit what earlier
-runs already computed.
+and mixed-layer depth if it is computed offline --- is one step per product,
+keyed by the range like everything else, which inherits what earlier runs
+already computed.
 
 `polaris/tasks/ocean/analysis/accumulate.py` provides the shared machinery, so
 that each product supplies only its kernel and its cache layout:
@@ -1449,61 +1450,28 @@ class Accumulator(OceanIOStep):
         have = inherited_months(self.seeds)
         self.logger.info(f'inheriting {len(have)} months, '
                          f'computing {len(needed - have)}')
-        compute(sorted(needed - have), pool_size=self.cpus_per_task)
+        for month in sorted(needed - have):
+            self.compute_month(month)
         publish(have, needed)
 ```
 
-#### An accumulator is several steps, not one
+#### One step per accumulator in Phase 1
 
-A single accumulator step would be the largest piece of work in the suite and
-would be invisible to the scheduler: however many cores its pool used, it would
-run on one node.  That is the ceiling principle 3 in
-{ref}`design-ocean-analysis` exists to avoid, so the requested range is split
-into a configurable number of **shards**, each an independent accumulator over
-its slice, followed by a cheap `merge` step:
+Each accumulator is a single step, and its months are processed one after
+another.  Phase 1 runs serially: there is no scheduler to feed by the deadline,
+so splitting a product into more steps would add directories, a merge step and
+a config option while nothing ran any sooner.
 
-```none
-heat_content_series/0001-0060/
-├── 0001-0008/ … 0053-0060/   (shards: reduce these years)
-└── merge/                    (concatenate, plot, publish)
-```
-
-```ini
-[ocean_analysis]
-
-# The number of steps an accumulator is split into, so that the scheduler has
-# independent pieces to balance.  Raise it when analyzing a long record in a
-# large allocation.  Clamped to the number of months to be processed, so that a
-# short record does not produce trivial steps.
-accumulator_steps = 8
-```
-
-Three properties of this split are worth stating, because they are what make it
-a knob rather than a commitment.
-
-**Sharding costs nothing in reuse.**  A shard asks which months it needs and
-which of them some earlier run already produced; neither question refers to how
-that earlier run was divided.  The shard count can therefore differ between two
-analyses of the same record and everything is still inherited.  This is exactly
-what a chunk keyed by its path could not do, and it is why the count is free to
-be a tuning parameter.
-
-**The count comes from config, not from the data or the allocation.**  Deriving
-it from the length of the record would put the step budget back on a growth
-curve.  Deriving it from the allocation is not possible even in principle here:
-the step tree is fixed by `polaris setup`, while the allocation is whatever job
-later runs `polaris serial`.  A config option is the honest form, it is recorded
-in the config file for provenance, and it is what a user would change when
-moving from a workstation to a batch job.
-
-**Shards split the requested range, not the missing work.**  Splitting the
-missing months instead would balance better on an incremental run, but setup
-would have to read the filesystem to decide how many steps exist and what each
-covers, so two setups with identical config could produce different step trees.
-Determinism is worth more than balance here, and the imbalance only appears on
-the incremental run --- the case where there is little work to balance.  On a
-first run, where all the cost is, equal slices of the range are equal slices of
-the work.
+The design this leaves on the table is recorded in principle 3 of
+{ref}`design-ocean-analysis`, and it is worth knowing that taking it later
+costs nothing here.  Splitting an accumulator into several steps that each
+cover a slice of the request is safe *because inheritance is decided by
+content*: a shard asks which months it needs and which of them some earlier run
+already produced, and neither question refers to how that earlier run was
+divided.  So the split can be introduced when there is a scheduler to use it,
+and every month cached before then is still inherited.  That is the property a
+chunk keyed by its path could never have had, and it is why deferring this is a
+deferral rather than a debt.
 
 Four things about this are worth stating explicitly, because they are what make
 it acceptable to have software hunting for data on disk.
@@ -1905,8 +1873,8 @@ Velocity reconstruction uses the weights on the mesh via
 the step reports that clearly and skips the zonal and meridional velocity maps
 rather than failing the whole step.
 
-If `compute_mixed_layer_depth` is set, the task adds a sharded accumulator
-structured exactly like the heat content one: its kernel computes a month of
+If `compute_mixed_layer_depth` is set, the task adds an accumulator structured
+exactly like the heat content one: its kernel computes a month of
 mixed-layer depth with `gsw` as described in the algorithm design.  Its cache
 is one gridded file per month, so inherited months are symlinked forward rather
 than copied or rewritten --- and, per principle 8 in
@@ -1916,8 +1884,8 @@ than copied or rewritten --- and, per principle 8 in
 
 That consumer is `ncclimo`, run a second time over the accumulator's monthly
 files.  It is a second instance of the same `Climatology` step class, at
-`mixed_layer_depth/<range>/climatology`, taking the shards' outputs as inputs
-and a variable list of one.
+`mixed_layer_depth/<range>/climatology`, taking the accumulator's monthly files
+as inputs and a variable list of one.
 
 Doing the seasonal averaging with `ncclimo` rather than ourselves keeps a
 single implementation of what a season is.  The seasonally discontinuous
@@ -1936,10 +1904,10 @@ product Polaris computes rather than reads.
 The scheduling consequence is worth being explicit about, since a serial chain
 behind an expensive step is what principle 3 warns against.  It is confined to
 this product: the main climatology reads model output only and does not wait on
-the accumulator, so every other map step is free to run beside it.  Only the
-mixed-layer depth maps sit behind the chain of shards, second climatology, and
-maps --- and only in the fallback case, which exists precisely because we would
-rather Omega computed this diagnostic in situ.
+the accumulator, so nothing else is held up by it.  Only the mixed-layer depth
+maps sit behind the chain of accumulator, second climatology, and maps --- and
+only in the fallback case, which exists precisely because we would rather Omega
+computed this diagnostic in situ.
 
 Its outputs carry an attribute recording that they were computed offline from
 monthly means, and the step adds a note to the plot titles, so that a reader
@@ -2033,12 +2001,11 @@ Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
-This product is a set of `HeatContentShard` accumulator steps and a
-`HeatContentMerge` step, all under the requested range.  The shard kernel
-reduces one month to a handful of numbers:
+This product is one accumulator step, `HeatContentSeries`, keyed by the
+requested range.  Its kernel reduces one month to a handful of numbers:
 
 ```python
-class HeatContentShard(Accumulator):
+class HeatContentSeries(Accumulator):
     def compute_month(self, filename):
         ds = self.open_model_dataset(self.path(filename), self.config)
         _, z_interface = get_z_mid_and_interface(ds)
@@ -2053,21 +2020,14 @@ class HeatContentShard(Accumulator):
 ```
 
 The accumulator machinery described under `repeated-analysis` handles the rest:
-inheriting the months an earlier range already reduced, spreading the remaining
-months of this shard's slice over a process pool, and writing the cache.
+inheriting the months an earlier range already reduced, reducing the remaining
+months one at a time, and writing the cache.
 
-Each shard's cache is a single netCDF with an unlimited `Time` dimension,
-appended to as months are added, because its consumer reads the whole slice.
-This is principle 8 in {ref}`design-ocean-analysis`: the form follows the
-consumer.  Forty years of four elevation ranges is a few tens of kilobytes in
-total, so there is nothing here worth chunking further.
-
-`HeatContentMerge` concatenates the shards' caches along `Time`, writes
-`ocean_heat_content_time_series.nc`, plots, and records the products in its
-manifest fragment.  It is cheap by construction: everything expensive happened
-in the shards, and merging a few tens of kilobytes costs nothing.  Splitting it
-out is not the compute-versus-plot split that principle 10 warns against --- it
-is the join that a fan-out requires.
+The cache is a single netCDF with an unlimited `Time` dimension, appended to as
+months are added, because its consumer is the plotting in this same step, which
+reads the whole series.  This is principle 8 in {ref}`design-ocean-analysis`:
+the form follows the consumer.  Forty years of four elevation ranges is a few
+tens of kilobytes, so there is nothing here worth chunking.
 
 Reading a month at a time is deliberate.  A global three-dimensional
 temperature field at 30 km resolution and 80 levels is roughly 150 MB per
@@ -2080,15 +2040,20 @@ The plot has two panels: absolute heat content in units of 10²² J, and the
 anomaly relative to the first month, with one line per elevation range.  The
 concatenated time series is written to `ocean_heat_content_time_series.nc`.
 
-These shards are the most expensive part of the suite on a first run, and
-nearly free on every run after it.  Raising `accumulator_steps` is the first
-response to a slow first run, since the shards are independent and non-MPI.
-Beyond that, the move available is to compute the vertical integrals in Omega
-in situ, which reduces the whole product to a concatenation.  If mixed-layer
-depth is also computed offline, its shards make the same pass over the same
-monthly files and the two could share one pass; they are kept separate because
-merging them would couple two products for a saving that only matters on a
-first run.
+This accumulator is the most expensive part of the suite on a first run, and
+nearly free on every run after it.  At 6to18 km over several decades a first run
+is hours, which is acceptable for a product that is then incremental forever
+after, and it is bounded rather than unbounded because only one month is held
+at a time.
+
+Two moves are available if that proves intolerable, in the order we would reach
+for them: reduce the months concurrently, either across steps or within one,
+which is what principle 3 describes and Phase 1 deliberately leaves out; or
+compute the vertical integrals in Omega in situ, which reduces the whole
+product to a concatenation.  If mixed-layer depth is also computed offline, its
+accumulator makes the same pass over the same monthly files and the two could
+share one pass; they are kept separate because merging them would couple two
+products for a saving that only matters on a first run.
 
 ### Implementation: moc-plot
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -763,12 +763,6 @@ climatology period, rather than being computed from the climatology.  Computing
 it from the seasonal or annual climatology would be a second, much larger
 approximation on top of the one described next.
 
-That order --- compute per month, average afterwards --- is why this product
-does its own seasonal averaging rather than handing monthly files to `ncclimo`.
-The averaging is the last step either way; doing it ourselves keeps `ncclimo`
-on model output alone and keeps the climatology from waiting on a full-record
-pass.
-
 What this fallback does *not* capture, and what should be said on the plots and
 in the netCDF metadata:
 
@@ -1670,19 +1664,13 @@ Notes on the arguments:
 - `-a sdd` selects the seasonally discontinuous December convention discussed
   in the algorithm design.
 - `-v` restricts the climatology to the union of the fields requested for maps,
-  the fields needed for heat content (`temperature` and the model's mass-like
-  thickness), the fields needed for velocity reconstruction (`normalVelocity`,
-  when zonal and meridional velocity are requested and not written by the
-  model), and the vertical geometry (`zMid`, `zInterface`).  Building this list
-  is the reason `Climatology` needs to know which steps depend on it; the list
-  is assembled from config options at runtime rather than passed in by each
-  task, so that the step stays neutral with respect to which tasks pulled it
-  in.
-
-  Every name on that list is a field the model wrote.  Fields Polaris computes
-  offline --- mixed-layer depth in the fallback case --- form their own
-  seasonal means and never appear here, which is what keeps this mapping back
-  to Omega names well defined.
+  the fields needed for heat content (`temperature`), the fields needed for
+  velocity reconstruction (`normalVelocity`, when zonal and meridional velocity
+  are requested and not written by the model), and the vertical geometry
+  (`zMid`, `zInterface`).  Building this list is the reason `Climatology` needs
+  to know which steps depend on it; the list is assembled from config options
+  at runtime rather than passed in by each task, so that the step stays neutral
+  with respect to which tasks pulled it in.
 
   Note that `-v` takes the names as they appear *in the files*, which are Omega
   names, so the step maps its Polaris-standard list back through
@@ -1826,37 +1814,15 @@ Velocity reconstruction uses the weights on the mesh via
 the step reports that clearly and skips the zonal and meridional velocity maps
 rather than failing the whole step.
 
-If `compute_mixed_layer_depth` is set, the task adds a sharded accumulator
-structured exactly like the heat content one: its kernel computes a month of
-mixed-layer depth with `gsw` as described in the algorithm design, and its
-cache is one gridded file per month, so that inherited months are symlinked
-forward rather than copied or rewritten.
-
-**Its `merge` step forms the seasonal means itself; `ncclimo` is not involved.**
-An earlier draft handed the monthly files to `ncclimo` along with the model
-output, on the grounds that a derived monthly field is just another monthly
-field.  That was wrong on three counts:
-
-- it made the climatology --- and therefore every map step behind it --- wait
-  on a full-record pass, which is the worst possible shape under principle 3;
-- it required a Polaris-computed field to appear in `ncclimo`'s `-v` list,
-  which the step builds by mapping Polaris names back to *Omega* names.  A
-  field Omega never wrote has no Omega name to map back to;
-- it was the only thing forcing this cache's format, per principle 8, when the
-  format should follow from how the data are actually used.
-
-Averaging monthly values into seasons is a small, testable function, and the
-step reuses the same season definitions and length-of-month weighting that
-`ncclimo` is configured with, including the seasonally discontinuous December
-convention.  The regression test checks that an annual mean equals the
-appropriately weighted mean of the twelve monthly means, which is what keeps
-the two paths from drifting apart.
-
-With this, `ncclimo` consumes only model output, and the mixed-layer depth
-product is self-contained: monthly means in, seasonal maps out, independent of
-the climatology and free to run beside it.
-
-Its outputs carry an attribute recording that they were computed offline from
+If `compute_mixed_layer_depth` is set, the task adds an accumulator structured
+exactly like the heat content one: its kernel computes a month of mixed-layer
+depth with `gsw` as described in the algorithm design.  Because its consumer is
+`ncclimo`, which reads monthly files, its cache is one file per month rather
+than a single series --- principle 8 in {ref}`design-ocean-analysis` --- and
+inherited months are symlinked forward rather than copied.  The climatology
+step then averages those into the seasonal and annual means that are plotted.
+Its
+outputs carry an attribute recording that they were computed offline from
 monthly means, and the step adds a note to the plot titles, so that a reader
 cannot mistake them for an in-situ diagnostic.
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -586,13 +586,15 @@ climatology --- this design produces:
 | --- | --- |
 | `ncclimo` climatology | 1 |
 | Climatology maps, one per field group | 6 |
-| Offline mixed-layer depth accumulator (fallback only) | 1 |
-| Heat content series accumulator | 1 |
+| Heat content series: shards plus merge | 9 |
+| Offline mixed-layer depth, shards plus merge (fallback only) | 9 |
 | Global stats, MOC | 2 |
-| **Total** | **11** |
+| **Total** | **27** |
 
 The count is **independent of the length of the record**, which is the property
-worth having.  An earlier draft, with one shared step per simulation year, gave
+worth having.  The accumulator shard count is a config option, so the largest
+term in that table is set by how much concurrency the machine can use rather
+than by how long the simulation ran.  An earlier draft, with one shared step per simulation year, gave
 about 130 steps for the same analysis and grew linearly, so a century-long
 record would have given about 230.  That was never going to break Polaris --- a
 few hundred steps is ordinary, and the existing `ocean` component builds
@@ -601,12 +603,17 @@ user has no control over, which is the wrong shape even when the numbers are
 small.
 
 Step *size* is the other half, and it is now comfortable at both ends.  On a
-first run the heat content accumulator reads the whole record, which is minutes
-to hours at 30 km; on a re-run over an overlapping range it reads only the new
-months.  A climatology map step plots the seasons and reductions of one field
-group, which is seconds to minutes per plot at production resolution.  Neither
-is close to the regime where a step's overhead --- a work directory, a pickle,
-a config copy, a log file --- would be a meaningful fraction of its runtime.
+first run each heat content shard reads its slice of the record, which is
+minutes at 30 km for an eighth of a multi-decade record; on a re-run over an
+overlapping range it reads only the new months in its slice.  A climatology map
+step plots the seasons and reductions of one field group, which is seconds to
+minutes per plot at production resolution.  Neither is close to the regime
+where a step's overhead --- a work directory, a pickle, a config copy, a log
+file --- would be a meaningful fraction of its runtime.
+
+Nor is any single step now a large fraction of the suite, which is principle
+9's other target: the most expensive product is split into shards that the
+scheduler can place independently.
 
 The count grows with the number of field groups and, in later phases, with
 whatever new products are added --- not with the record, the seasons, the
@@ -1018,8 +1025,12 @@ ocean/analysis/
 │   ├── temperature/ salinity/ velocity/      (one step per field group)
 │   ├── ssh/ mixed_layer_depth/
 │   └── heat_content/
-├── mixed_layer_depth_monthly/0021-0040/      (only if computed offline)
+├── mixed_layer_depth/0021-0040/              (only if computed offline)
+│   ├── 0021-0023/ … 0038-0040/               (accumulator shards)
+│   └── merge/
 ├── heat_content_series/0001-0060/
+│   ├── 0001-0008/ … 0053-0060/               (accumulator shards)
+│   └── merge/
 ├── global_stats/0001-0060/
 └── moc/0021-0040/
 ```
@@ -1333,9 +1344,9 @@ never share a directory.
 #### Reuse comes from seeded accumulators
 
 The expensive range-independent work --- vertically integrated heat content,
-and mixed-layer depth if it is computed offline --- is one step per product,
-keyed by the range like everything else, which inherits what earlier runs
-already computed.
+and mixed-layer depth if it is computed offline --- is a set of steps per
+product, keyed by the range like everything else, which inherit what earlier
+runs already computed.
 
 `polaris/tasks/ocean/analysis/accumulate.py` provides the shared machinery, so
 that each product supplies only its kernel and its cache layout:
@@ -1346,7 +1357,7 @@ class Accumulator(OceanIOStep):
         # find cache files under sibling range directories of this product,
         # keep those from completed steps whose provenance stamp matches,
         # and add each as an input file
-        self.seeds = discover_seeds(self.work_dir, self.stamp())
+        self.seeds = discover_seeds(self.product_dir, self.stamp())
 
     def run(self):
         needed = months_in_range(self.start_year, self.end_year)
@@ -1356,6 +1367,58 @@ class Accumulator(OceanIOStep):
         compute(sorted(needed - have), pool_size=self.cpus_per_task)
         publish(have, needed)
 ```
+
+#### An accumulator is several steps, not one
+
+A single accumulator step would be the largest piece of work in the suite and
+would be invisible to the scheduler: however many cores its pool used, it would
+run on one node.  That is the ceiling principle 3 in
+{ref}`design-ocean-analysis` exists to avoid, so the requested range is split
+into a configurable number of **shards**, each an independent accumulator over
+its slice, followed by a cheap `merge` step:
+
+```none
+heat_content_series/0001-0060/
+├── 0001-0008/ … 0053-0060/   (shards: reduce these years)
+└── merge/                    (concatenate, plot, publish)
+```
+
+```ini
+[ocean_analysis]
+
+# The number of steps an accumulator is split into, so that the scheduler has
+# independent pieces to balance.  Raise it when analyzing a long record in a
+# large allocation.  Clamped to the number of months to be processed, so that a
+# short record does not produce trivial steps.
+accumulator_steps = 8
+```
+
+Three properties of this split are worth stating, because they are what make it
+a knob rather than a commitment.
+
+**Sharding costs nothing in reuse.**  A shard asks which months it needs and
+which of them some earlier run already produced; neither question refers to how
+that earlier run was divided.  The shard count can therefore differ between two
+analyses of the same record and everything is still inherited.  This is exactly
+what a chunk keyed by its path could not do, and it is why the count is free to
+be a tuning parameter.
+
+**The count comes from config, not from the data or the allocation.**  Deriving
+it from the length of the record would put the step budget back on a growth
+curve.  Deriving it from the allocation is not possible even in principle here:
+the step tree is fixed by `polaris setup`, while the allocation is whatever job
+later runs `polaris serial`.  A config option is the honest form, it is recorded
+in the config file for provenance, and it is what a user would change when
+moving from a workstation to a batch job.
+
+**Shards split the requested range, not the missing work.**  Splitting the
+missing months instead would balance better on an incremental run, but setup
+would have to read the filesystem to decide how many steps exist and what each
+covers, so two setups with identical config could produce different step trees.
+Determinism is worth more than balance here, and the imbalance only appears on
+the incremental run --- the case where there is little work to balance.  On a
+first run, where all the cost is, equal slices of the range are equal slices of
+the work.
 
 Four things about this are worth stating explicitly, because they are what make
 it acceptable to have software hunting for data on disk.
@@ -1830,11 +1893,12 @@ Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
-This product is a single accumulator step, `HeatContentSeries`, keyed by the
-requested range.  Its kernel reduces one month to a handful of numbers:
+This product is a set of `HeatContentShard` accumulator steps and a
+`HeatContentMerge` step, all under the requested range.  The shard kernel
+reduces one month to a handful of numbers:
 
 ```python
-class HeatContentSeries(Accumulator):
+class HeatContentShard(Accumulator):
     def compute_month(self, filename):
         ds = self.open_model_dataset(filename, self.config)
         _, z_interface = get_z_mid_and_interface(ds)
@@ -1850,13 +1914,20 @@ class HeatContentSeries(Accumulator):
 
 The accumulator machinery described under `repeated-analysis` handles the rest:
 inheriting the months an earlier range already reduced, spreading the remaining
-months over a process pool, and writing the cache.
+months of this shard's slice over a process pool, and writing the cache.
 
-The cache is a single netCDF with an unlimited `Time` dimension, appended to as
-months are added, because its consumer is the plotting in this same step, which
-reads the whole series.  This is principle 8 in {ref}`design-ocean-analysis`:
-the form follows the consumer.  Forty years of four elevation ranges is a few
-tens of kilobytes, so there is nothing here worth chunking.
+Each shard's cache is a single netCDF with an unlimited `Time` dimension,
+appended to as months are added, because its consumer reads the whole slice.
+This is principle 8 in {ref}`design-ocean-analysis`: the form follows the
+consumer.  Forty years of four elevation ranges is a few tens of kilobytes in
+total, so there is nothing here worth chunking further.
+
+`HeatContentMerge` concatenates the shards' caches along `Time`, writes
+`ocean_heat_content_time_series.nc`, plots, and records the products in its
+manifest fragment.  It is cheap by construction: everything expensive happened
+in the shards, and merging a few tens of kilobytes costs nothing.  Splitting it
+out is not the compute-versus-plot split that principle 10 warns against --- it
+is the join that a fan-out requires.
 
 Reading a month at a time is deliberate.  A global three-dimensional
 temperature field at 30 km resolution and 80 levels is roughly 150 MB per
@@ -1869,13 +1940,15 @@ The plot has two panels: absolute heat content in units of 10²² J, and the
 anomaly relative to the first month, with one line per elevation range.  The
 concatenated time series is written to `ocean_heat_content_time_series.nc`.
 
-This accumulator is the most expensive part of the suite on a first run, and
-nearly free on every run after it.  If a first run proves too slow, the move
-available is to compute the vertical integrals in Omega in situ, which reduces
-the whole product to a concatenation.  If mixed-layer depth is also computed
-offline, its accumulator makes the same pass over the same monthly files and
-the two could share one pass; they are kept separate because merging them would
-couple two products for a saving that only matters on a first run.
+These shards are the most expensive part of the suite on a first run, and
+nearly free on every run after it.  Raising `accumulator_steps` is the first
+response to a slow first run, since the shards are independent and non-MPI.
+Beyond that, the move available is to compute the vertical integrals in Omega
+in situ, which reduces the whole product to a concatenation.  If mixed-layer
+depth is also computed offline, its shards make the same pass over the same
+monthly files and the two could share one pass; they are kept separate because
+merging them would couple two products for a saving that only matters on a
+first run.
 
 ### Implementation: moc-plot
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -2187,6 +2187,10 @@ Baseline comparison against a previous run of the same suite is available as it
 is for any Polaris task, and is the natural way to catch an unintended change
 in a diagnostic's values.
 
+This task is also where the task-parallel conformance checks described under
+`analysis-suite` are run, since it is the only place a whole analysis suite
+exists cheaply enough to exercise every step.
+
 #### Dependency on Omega
 
 This task cannot run until Omega can write monthly means of full model fields.
@@ -2243,7 +2247,7 @@ suite in a working state for the products delivered so far.
 
 ### Testing and Validation: analysis-suite and data-products
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -2255,6 +2259,34 @@ Unit tests under `tests/ocean/` cover the parts that do not need a simulation:
   input and the `top`, `bottom`, and `k<n>` keywords;
 - that every plotting step registers a netCDF output for each PNG output, which
   keeps the data-products requirement from quietly regressing.
+
+#### Conformance with the task-parallel groundrules
+
+[Task-Parallel-Safe Analysis Steps](task_parallel_analysis_steps.md) observes
+that rules which are only written down are not adopted, and that most of these
+can be checked mechanically.  The analysis steps are the first body of code
+written to them, so they should be the first to run the checks.
+
+Applied to every step in the suite:
+
+- **Working-directory independence.**  Run the step with the process working
+  directory set somewhere unrelated and confirm the results are identical.
+  This is the check that would have caught the bare relative filenames this
+  design carried until recently, which is a fair indication of how easily the
+  rule is broken by writing ordinary-looking code.
+- **No process-global state mutation.**  Snapshot the globals a step is
+  forbidden to touch --- the working directory, `mpas_tools.io.default_format`
+  and `default_engine`, `plt.rcParams` --- before and after `run()`, and
+  compare.
+- **Isolation.**  Compare the set of files the step wrote against its declared
+  outputs and its own work directory, which catches both undeclared outputs and
+  writes into a shared location.
+- **Bounded launching.**  Confirm the step starts no more processes than
+  `cpus_per_task`.
+
+These run against the coarse-resolution regression test, where a whole suite is
+cheap enough to exercise, rather than against synthetic steps --- the point is
+to check the steps we ship, not a model of them.
 
 ### Testing and Validation: repeated-analysis
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1720,9 +1720,12 @@ Contributors: Xylar Asay-Davis, Claude
 This is Omega work and is implemented in the Omega repository, not in Polaris.
 What Polaris needs to do:
 
-- nothing for the monthly-mean file names: they come from the `History` stream
-  of the simulation's own Omega configuration, so a change to the stream is
-  picked up without a Polaris change;
+- name the stream the monthly means are written to.  The file names come from
+  the simulation's own Omega configuration, so a change to the stream's file
+  name, frequency or directory needs no Polaris change --- but which stream to
+  read is Polaris's to say, and the expectation is that monthly means will get
+  a stream of their own rather than staying in `History`, which is where the
+  mock-up has them.  That is a one-line change here when the stream exists;
 - add any new Omega fields, including a mixed-layer depth diagnostic, to
   `polaris/ocean/model/mpaso_to_omega.yaml` once their Omega names are fixed;
 - add an Omega YAML fragment that turns on monthly-mean output of the required
@@ -1752,6 +1755,13 @@ one month per file, carrying `Temperature`, `Salinity`, `PseudoThickness`,
 `NormalVelocity`, on dimensions `time`, `NCells`, `NVertLayers`,
 `NVertLayersP1` and `NEdges`, with `time` in `seconds since 0000-12-01` on a
 `noleap` calendar and `time_bnds` giving each month's bounds.
+
+These files are reached by pointing `simulation_path` at a directory whose
+`output/` is a symlink to `monthly_means/`, since the run's own Omega
+configuration names `output/` and the mock-up is not what Omega will actually
+write.  That is a fixture, deliberately, and not something the analysis has
+code for: the mock-up exists to be developed against and then discarded, and
+the monthly means are expected to arrive in their own stream in any case.
 
 Every product in this design except mixed-layer depth and the reconstructed
 velocity components can be developed and tested against these files today.

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1958,9 +1958,13 @@ is about **75 MB in 1641 requests** before the page settles.  Its thumbnails
 are 480 px wide and lightly compressed.  This is the behavior that stalls on a
 throttled link.
 
-Measured against a Polaris single-panel global map reduced to the defaults
-above, a thumbnail is **about 13 kB** as JPEG at 320 px and quality 75, or
-about 10 kB as WebP.  With the default field and season lists a climatology-map
+Against a single global map panel of that figure --- a stand-in for the
+single-panel maps this suite produces, since no Polaris analysis has been
+published yet --- a thumbnail at the defaults above is **about 13 kB** as JPEG
+at 320 px and quality 75, or about 10 kB as WebP.  This should be confirmed on
+real output rather than trusted; the point it is making, that the reference's
+thumbnails are several times larger than they need to be, is not sensitive to
+the exact figure.  With the default field and season lists a climatology-map
 gallery holds roughly fifteen products, so a gallery page is a ~10 kB document
 plus ~200 kB of thumbnails, of which lazy loading fetches only the visible rows
 --- on the order of **100 kB** before the page is usable.  The landing page

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1494,8 +1494,8 @@ silence, as would a changed elevation range or a changed constant.
 half-written cache left by an interrupted run.
 
 **Reuse is reported.**  Each run logs how many months it inherited and from
-where, and the provenance travels into the output netCDF.  Two config options
-provide an explicit mode for anyone who wants determinism instead of
+where, and the provenance travels into the output netCDF.  One config option
+provides an explicit mode for anyone who wants determinism instead of
 discovery:
 
 ```ini
@@ -1505,9 +1505,6 @@ discovery:
 # directory.  Set to False to recompute everything from the monthly means.
 reuse_previous = True
 
-# An additional directory to search for inheritable results, for the case
-# where an earlier analysis has been moved or copied.  Empty by default.
-reuse_search_path =
 ```
 
 The pattern applies wherever we own the reduction kernel.  It does not apply to
@@ -1555,20 +1552,24 @@ identify it:
 ```
 
 **A `publish` step collects them.**  One cheap step per suite reads every
-fragment, symlinks each product into the staging tree, and writes an
-`index.html` over the result.  It works from the fragments rather than from
-directory structure, which is what lets the work be re-chunked later without
-disturbing output paths, links, or the gallery --- principle 2.  A product
-whose fragment is present but whose file is missing is reported rather than
-silently omitted.
+fragment, symlinks each product into the staging tree, and writes the merged
+manifest.  It works from the fragments rather than from directory structure,
+which is what lets the work be re-chunked later without disturbing output
+paths, links, or a gallery --- principle 2.  A product whose fragment is
+present but whose file is missing is reported rather than silently omitted.
 
-**The staging tree is shallow, with descriptive filenames.**  A gallery is
-generated, not navigated, and a shallow tree is easier to archive, to serve,
-and to diff between two analyses:
+**Generating an index over that tree is not in Phase 1.**  A flat directory of
+PNGs and netCDF is enough for the Ocean Team to work from, and the gallery is
+Phase 2 in {ref}`design-ocean-analysis`.  What Phase 1 owes it is the merged
+manifest, which is everything a gallery generator needs and is the reason it
+can be added later without touching a single step.
+
+**The staging tree is shallow, with descriptive filenames.**  A shallow tree is
+easier to archive, to serve, and to diff between two analyses, and it is what a
+generated index wants underneath it when one arrives:
 
 ```none
 <output_path>/
-├── index.html
 ├── manifest.json                                   (the merged manifest)
 └── plots/
     ├── climatology_maps_temperature_ANN_-100m_0021-0040.png

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -2182,13 +2182,20 @@ This task is also where the task-parallel conformance checks described under
 `analysis-suite` should run when they are built, since it is the only place a
 whole analysis suite exists cheaply enough to exercise every step.
 
-#### Dependency on Omega
+#### Dependency on Omega, and when this lands
 
 This task cannot run until Omega can write monthly means of full model fields.
 Until then it is set up but its forward step is expected to produce nothing the
 analysis can read, which the analysis steps report as missing fields rather
 than as failures --- the same degradation described under
 `omega-monthly-means`.  It should not go into any shared suite until it passes.
+
+That dependency also places it **after the September 15 deliverable** rather
+than within it.  By the time Omega can write what this task needs, the
+deliverable itself is due, and the products a scientist is waiting on come
+first.  This is a schedule judgment rather than a statement about its value: a
+capability that nothing we run exercises is a capability that regresses
+quietly, so this is the first thing to build once the products are out.
 
 ### Implementation: commit sequence
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1285,6 +1285,31 @@ Input files are symlinked into each step's work directory in `setup()` using
 `Step.add_input_file`, which gives the usual Polaris provenance and dependency
 checking without copying data.
 
+#### Every path is explicit
+
+Polaris changes the process working directory into each step's work directory
+before running it, so a step may open a bare filename and get the right file.
+Analysis steps do not rely on that, per
+[Task-Parallel-Safe Analysis Steps](task_parallel_analysis_steps.md): a step
+that depends on the process working directory cannot run beside another step in
+one process and cannot be sent to a worker on another node at all.
+
+Declaring inputs and outputs by relative name stays exactly as it is --- setup
+already resolves those against the step's work directory.  The rule is about
+the body of `run()`, and it is met with one helper on the step:
+
+```python
+def path(self, filename):
+    """Resolve a filename against this step's work directory."""
+    return os.path.join(self.work_dir, filename)
+```
+
+Every `open`, `open_model_dataset`, `write_netcdf` and output filename in the
+pseudocode below goes through it.  The pseudocode is written that way rather
+than being cleaned up later, because this is precisely the habit that is cheap
+to adopt while the code is being written and expensive to retrofit once there
+are dozens of steps.
+
 ### Implementation: data-products
 
 Date last modified: 2026/08/25
@@ -1375,7 +1400,8 @@ class Accumulator(OceanIOStep):
     def setup(self):
         # find cache files under sibling range directories of this product,
         # keep those from completed steps whose provenance stamp matches,
-        # and add each as an input file
+        # and add each as an input file.  product_dir is an absolute path
+        # resolved at setup, not a path relative to the process cwd
         self.seeds = discover_seeds(self.product_dir, self.stamp())
 
     def run(self):
@@ -1771,7 +1797,8 @@ reductions requested for them:
 
 ```python
 for season in plot_seasons:
-    ds = self.open_model_dataset(climo_filename(season), self.config)
+    ds = self.open_model_dataset(self.path(climo_filename(season)),
+                                 self.config)
     z_mid, z_interface = get_z_mid_and_interface(ds)
     layer_mass = get_layer_mass(ds, self.config)
     for field in self.field_group.fields:
@@ -1780,13 +1807,15 @@ for season in plot_seasons:
             da_map = apply_vertical_reduction(
                 da, reduction, z_mid, z_interface, layer_mass,
                 k_min, k_max)
-            write_netcdf(da_map, out_filename)
+            basename = f'{field}_{season}_{reduction.label}'
+            write_netcdf(da_map, self.path(f'{basename}.nc'))
             self.manifest.add(da_map, field=field, season=season,
-                              reduction=reduction, filename=out_filename)
+                              reduction=reduction, filename=f'{basename}.nc')
             plot_global_mpas_field(
-                da=da_map, out_filename=..., config=self.config,
+                da=da_map, out_filename=self.path(f'{basename}.png'),
+                config=self.config,
                 colormap_section=f'ocean_analysis_map_{field}',
-                mesh_filename='mesh.nc', ...)
+                mesh_filename=self.path('mesh.nc'), ...)
 ```
 
 Heat content needs no branch here.  Its field is derived rather than read, and
@@ -1949,7 +1978,7 @@ reduces one month to a handful of numbers:
 ```python
 class HeatContentShard(Accumulator):
     def compute_month(self, filename):
-        ds = self.open_model_dataset(filename, self.config)
+        ds = self.open_model_dataset(self.path(filename), self.config)
         _, z_interface = get_z_mid_and_interface(ds)
         layer_mass = get_layer_mass(ds, self.config)
         ohc = []

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1335,13 +1335,10 @@ one process and cannot be sent to a worker on another node at all.
 
 Declaring inputs and outputs by relative name stays exactly as it is --- setup
 already resolves those against the step's work directory.  The rule is about
-the body of `run()`, and it is met with one helper on the step:
-
-```python
-def path(self, filename):
-    """Resolve a filename against this step's work directory."""
-    return os.path.join(self.work_dir, filename)
-```
+the body of `run()`, and the framework now provides what it needs:
+`Step.work_path()`, which joins path components onto the step's own work
+directory and returns an absolute path, raising rather than guessing if the
+work directory is not set.
 
 Every `open`, `open_model_dataset`, `write_netcdf` and output filename in the
 pseudocode below goes through it.  The pseudocode is written that way rather
@@ -1892,7 +1889,7 @@ reductions requested for them:
 
 ```python
 for season in plot_seasons:
-    ds = self.open_model_dataset(self.path(climo_filename(season)),
+    ds = self.open_model_dataset(self.work_path(climo_filename(season)),
                                  self.config)
     z_mid, z_interface = get_z_mid_and_interface(ds)
     layer_mass = get_layer_mass(ds, self.config)
@@ -1903,14 +1900,14 @@ for season in plot_seasons:
                 da, reduction, z_mid, z_interface, layer_mass,
                 k_min, k_max)
             basename = f'{field}_{season}_{reduction.label}'
-            write_netcdf(da_map, self.path(f'{basename}.nc'))
+            write_netcdf(da_map, self.work_path(f'{basename}.nc'))
             self.manifest.add(da_map, field=field, season=season,
                               reduction=reduction, filename=f'{basename}.nc')
             plot_global_mpas_field(
-                da=da_map, out_filename=self.path(f'{basename}.png'),
+                da=da_map, out_filename=self.work_path(f'{basename}.png'),
                 config=self.config,
                 colormap_section=f'ocean_analysis_map_{field}',
-                mesh_filename=self.path('mesh.nc'), ...)
+                mesh_filename=self.work_path('mesh.nc'), ...)
 ```
 
 Heat content needs no branch here.  Its field is derived rather than read, and
@@ -2081,7 +2078,7 @@ requested range.  Its kernel reduces one month to a handful of numbers:
 ```python
 class HeatContentSeries(Accumulator):
     def compute_month(self, filename):
-        ds = self.open_model_dataset(self.path(filename), self.config)
+        ds = self.open_model_dataset(self.work_path(filename), self.config)
         _, z_interface = get_z_mid_and_interface(ds)
         layer_mass = get_layer_mass(ds, self.config)
         ohc = []

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1862,6 +1862,29 @@ later without disturbing output paths, links, or the gallery --- principle 2.
 A product whose fragment is present but whose file is missing is reported
 rather than silently omitted.
 
+It runs after everything it reads because it is wired to.  The `publish` step
+declares every step that writes a fragment as a dependency, through
+`Step.add_dependency()`.  That method exists for exactly this case: what the
+step consumes is not known at setup, since the fragments name themselves from
+facets that config options decide.  Ordering by dependency rather than by
+position in the suite is what keeps the step correct when the work is
+re-chunked, which principle 2 promises it can be.
+
+Those dependencies cross task boundaries --- the `publish` step belongs to
+its own task and depends on the steps of every other analysis task.  Polaris
+allows this, and the cost is small and worth stating: each dependency pickles
+itself after it runs, and the `publish` step's directory gains one symlink per
+dependency under `dependencies/`.  Neither changes how steps are listed or
+run.
+
+One consequence needs deciding before the step is written.  A dependency's
+pickle is an input file of the step that depends on it, so a `publish` step
+that lists every analysis step cannot run until all of them have.  Running the
+whole suite is fine, and running a single product task is fine because
+`publish` is not in it.  What is not yet settled is the case in between ---
+asking for the gallery after only some products have been computed, which is
+what a developer iterating on one plot would want.
+
 Because it is the only step that knows how results are presented, everything in
 the two sections below can change without a single plotting step changing.
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1583,12 +1583,9 @@ def get_z_mid_and_interface(ds):
     """Return zMid and zInterface, raising a clear error if absent."""
 
 
-def parse_elevation_spec(spec):
-    """Parse 'top', 'bottom', 'k<n>' or an elevation in m."""
-
-
 def parse_vertical_reduction(spec):
-    """Parse an elevation spec or a '<top>:<bottom>' range into a reduction."""
+    """Parse 'top', 'bottom', 'k<n>', an elevation in m, or a '<top>:<bottom>'
+    elevation range, into a vertical reduction."""
 
 
 def apply_vertical_reduction(da, reduction, z_mid, z_interface, layer_mass,
@@ -1968,12 +1965,12 @@ The test is skipped if `ncclimo` is not on the path.
 
 ### Testing and Validation: climatology-maps
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
-Unit tests on `extract_elevation_slice` with synthetic columns having known
-layer geometry, `minLevelCell`, and `maxLevelCell`:
+Unit tests on `apply_vertical_reduction`, in its slicing cases, with synthetic
+columns having known layer geometry, `minLevelCell`, and `maxLevelCell`:
 
 - `top` and `bottom` return the values at `minLevelCell` and `maxLevelCell`,
   including for a column with `minLevelCell > 0` (an ice-shelf cavity) and a

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -195,13 +195,18 @@ climatology computation shall be shared between the tasks that need it.
 
 ### Requirement: data-products
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
 Every plot the suite produces shall be accompanied by a netCDF file containing
 exactly the data that were plotted, so that the values can be inspected,
 compared against other tools, or re-plotted without recomputation.
+
+Every plot and its data shall also be described in a machine-readable manifest
+naming the facets that identify it --- at minimum the field, the season, the
+vertical reduction, and the date range --- so that a reader or an index can
+find a product without knowing how the work was divided into steps.
 
 Intermediate products that are expensive to compute --- climatologies and
 reduced monthly ocean heat content in particular --- shall be written to
@@ -213,17 +218,19 @@ silent.
 
 ### Requirement: repeated-analysis
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
 Polaris shall support analyzing the same simulation repeatedly with different
 climatology and time-series date ranges.
 
-Results shall be staged in a single, range-keyed location that a reader can
-navigate without knowing anything about Polaris work directories, and that a
-web interface can serve when one is added.  Analyzing a new range shall not
-overwrite or remove the results of a range analyzed earlier.
+Results shall be published to a single location that a reader can browse
+without knowing anything about Polaris work directories, and that a web
+interface can serve when one is added.  That location shall carry an index over
+the results rather than requiring the reader to navigate directories.
+Analyzing a new range shall not overwrite or remove the results of a range
+analyzed earlier.
 
 Re-running the analysis with a changed range shall recompute the products that
 depend on that range.  It shall not be necessary to delete the work directory
@@ -234,7 +241,10 @@ Re-running with a changed range shall reuse the intermediate results that do
 not depend on the range.  Extending a time series from twenty years to forty
 shall cost twenty years of work, not forty.
 
-Re-running with an unchanged range shall recompute nothing.
+Re-running with an unchanged range shall recompute nothing by default, and it
+shall be possible to ask for the plots to be redrawn --- after a change to
+colormaps or other styling --- without recomputing the intermediate results
+behind them.
 
 ### Requirement: omega-monthly-means
 
@@ -1204,15 +1214,21 @@ checking without copying data.
 
 ### Implementation: data-products
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
 Each plotting step writes, alongside each PNG, a netCDF file with the same base
 name containing the plotted field, its coordinates, units, and the config
 options --- including the date range --- that produced it as global attributes.
-Both go in the step's range-keyed subdirectory and are symlinked into the
-staging tree, as described under `repeated-analysis`.
+Both go in the step's own subdirectory, are described in the step's manifest
+fragment, and are published into the staging tree by symlink, as described
+under `repeated-analysis`.
+
+The manifest is what carries the facets that identify a product --- field,
+season, vertical reduction, date range, and later region and observational
+reference.  Encoding those in the path instead would mean a directory level per
+facet, and a path has one dimension where the metadata has six.
 
 The expensive intermediates are:
 
@@ -1227,7 +1243,7 @@ provenance stamp that makes them safe to inherit across runs.
 
 ### Implementation: repeated-analysis
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1352,43 +1368,92 @@ pool inside the step rather than over steps.  This follows principle 3 in
 {ref}`design-ocean-analysis`, and it means the analysis gets its concurrency
 from a capability that exists today rather than from task parallelism.
 
-#### Staging results
+#### Publishing results
 
-The step directories are already range-keyed, but they are scattered across
-four products several levels down in a work directory.  Plots and their netCDF
-files are therefore also symlinked into a staging tree whose root is a config
-option, so that there is one place to browse and, later, one tree for a web
-interface to serve:
+The work tree is built for predictability, not for browsing, so results are
+published into a separate staging tree whose root is a config option.  This is
+principle 1 in {ref}`design-ocean-analysis`: two trees, two audiences.
 
 ```ini
 [ocean_analysis]
 
-# Where to stage plots and their netCDF files for browsing.  Defaults to
+# Where to publish plots and their netCDF files for browsing.  Defaults to
 # <work_dir>/analysis_output.  Point this somewhere web-servable if you want
 # to share the results.
 output_path =
 ```
 
-The tree is organized product first, then range, because the climatology range
-and the time series range are independent and a range-first tree would have to
-repeat products under two different range directories:
+**Every step writes a manifest fragment.**  Alongside its outputs, each step
+writes `manifest.json` describing every product it made and the facets that
+identify it:
+
+```json
+{"products": [
+  {"png": "temperature_ANN_-100m.png",
+   "nc": "temperature_ANN_-100m.nc",
+   "group": "climatology_maps", "field": "temperature",
+   "season": "ANN", "reduction": "-100m",
+   "start_year": 21, "end_year": 40,
+   "title": "Potential temperature at 100 m, ANN, years 21-40"}]}
+```
+
+**A `publish` step collects them.**  One cheap step per suite reads every
+fragment, symlinks each product into the staging tree, and writes an
+`index.html` over the result.  It works from the fragments rather than from
+directory structure, which is what lets the work be re-chunked later without
+disturbing output paths, links, or the gallery --- principle 2.  A product
+whose fragment is present but whose file is missing is reported rather than
+silently omitted.
+
+**The staging tree is shallow, with descriptive filenames.**  A gallery is
+generated, not navigated, and a shallow tree is easier to archive, to serve,
+and to diff between two analyses:
 
 ```none
 <output_path>/
-├── climatology_maps/0021-0040/
-├── ocean_heat_content/maps/0021-0040/
-├── ocean_heat_content/time_series/0001-0060/
-├── global_stats/0001-0060/
-└── moc/0021-0040/
+├── index.html
+├── manifest.json                                   (the merged manifest)
+└── plots/
+    ├── climatology_maps_temperature_ANN_-100m_0021-0040.png
+    ├── climatology_maps_temperature_ANN_-100m_0021-0040.nc
+    ├── climatology_maps_heat_content_ANN_0m-700m_0021-0040.png
+    ├── heat_content_series_0001-0060.png
+    └── …
 ```
 
-Range keys are the zero-padded start and end years, matching the convention
-`ncclimo` already uses in its file names.
+The filename is the facets in a fixed order, so it sorts usefully, greps
+usefully, and cannot collide between two ranges.  Range keys are the
+zero-padded start and end years, matching the convention `ncclimo` already uses
+in its file names.  This follows MPAS-Analysis, where the experience with a
+flat plot directory plus a generated gallery has been good.
 
-Writing into the step directory and symlinking, rather than writing directly
-into the staging tree, keeps every file owned by the step that produced it, so
-Polaris's output checking and provenance continue to work and the staging tree
-is a view rather than a second source of truth.
+**Products are published by symlink** from the step that owns them, so each
+file has exactly one owner, Polaris's output checking continues to work, and
+the staging tree is a view rather than a second source of truth.  Results from
+different ranges coexist because the range is in the filename.
+
+#### Replotting
+
+Re-running with an unchanged range recomputes nothing, which is what the
+requirement asks for and is usually what a user wants.  It is not what they
+want after changing a colormap.  A config option forces the plotting steps to
+run again:
+
+```ini
+[ocean_analysis]
+
+# Re-run the plotting steps even when their range is unchanged, to pick up
+# changes to colormaps and other plot styling.  Intermediate results --
+# climatologies and accumulator caches -- are still reused.
+replot = False
+```
+
+When it is set, `configure()` removes the completion markers of the steps that
+produce plots, and only those, so replotting costs the plotting and nothing
+else.  This is why plotting does not need to be split into its own step, per
+principle 10: for a map, plotting *is* the expensive part, so a separate step
+would buy nothing that this option does not.  MPAS-Analysis replots
+unconditionally, which is rarely what is wanted; the default here is not to.
 
 #### Caveats
 
@@ -1793,7 +1858,7 @@ is new in Omega and users will encounter simulations that predate it.
 
 ### Implementation: commit sequence
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1803,26 +1868,34 @@ Contributors: Xylar Asay-Davis, Claude
    elevation slicing, and elevation-range weights --- with unit tests.
 3. `polaris/ocean/heat_content.py` with unit tests.
 4. The `omega_analysis` scaffolding: the `polaris/tasks/ocean/analysis/`
-   package, `analysis.cfg`, `sim_files.py`, the range-keyed step subdirectories
-   and output staging shared by every step, the four tasks with their
-   `configure()` methods, and the `omega_analysis` suite, with steps that do
-   nothing yet.  This is the commit where the repeated-analysis structure is
-   established, so it should land before anything that depends on it.
-5. The `Climatology` step (`ncclimo`).
-6. The `ClimatologyMaps` step, including velocity reconstruction.
-7. The ocean heat content `maps` step.
-8. The `global_stats` `time_series` step, including factoring the shared
+   package, `analysis.cfg`, `sim_files.py`, the range-keyed step
+   subdirectories, the tasks with their `configure()` methods, and the
+   `omega_analysis` suite, with steps that do nothing yet.  This is the commit
+   where the repeated-analysis structure is established, so it should land
+   before anything that depends on it.
+5. The manifest writer and the `publish` step, including the generated index.
+   Early, so that every step added afterwards writes its manifest fragment as
+   a matter of course rather than being retrofitted.
+6. The `Climatology` step (`ncclimo`).
+7. The `ClimatologyMaps` step and the vertical reduction it is built on,
+   covering the read-and-slice field groups, including velocity
+   reconstruction.
+8. The `heat_content` field group of `ClimatologyMaps`.
+9. The `global_stats` time series step, including factoring the shared
    plotting function out of `StatsAnalysis`.
-9. The `Accumulator` base class and the ocean heat content time series step
-   built on it.
-10. The `moc` `plot` step and the `plot_lat_elevation_field` primitive.
-11. The offline `mixed_layer_depth` accumulator, only if Omega's in-situ
+10. The `Accumulator` base class --- seed discovery, provenance stamping, and
+    the process pool --- with unit tests, since this is the piece whose
+    failure modes are silent.
+11. The `heat_content_series` step built on it.
+12. The `moc` step and the `plot_lat_elevation_field` primitive.
+13. The offline `mixed_layer_depth` accumulator, only if Omega's in-situ
     diagnostic will not be ready in time.
-12. User's Guide documentation: a page under `docs/users_guide/ocean/tasks/`
+14. The `replot` option.
+15. User's Guide documentation: a page under `docs/users_guide/ocean/tasks/`
     describing the analysis suite and its config options, and an entry in
     `docs/users_guide/ocean/suites.md`.
 
-Commits 2, 3, and 5 through 11 are independently reviewable and each leaves the
+Commits 2, 3, and 6 through 14 are independently reviewable and each leaves the
 suite in a working state for the products delivered so far.
 
 ## Testing

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1821,7 +1821,14 @@ product it made and the facets that identify it:
    "title": "Potential temperature at 100 m, ANN, years 21-40"}]}
 ```
 
-Three rules keep this from growing into a format that needs a specification.
+These rules keep this from growing into a format that needs a specification.
+
+**Every step writes one, even when it made nothing.**  A step that produced no
+products --- `moc` against a simulation that wrote no overturning output, say
+--- writes a fragment with an empty product list rather than no fragment at
+all.  That is what lets the `publish` step declare each fragment as an input
+and have the framework check it, instead of tolerating absence and discovering
+late that a step it expected never wrote anything.
 
 **A step fills the facets; the collector fills everything else.**  The
 published name and the thumbnail are added by the collector when it publishes,
@@ -1903,12 +1910,13 @@ Neither mechanism reorders anything: steps run in the order the suite lists
 them, so `publish` goes last.  What the declarations buy is that running it
 too early fails, and says why.
 
-One question is left open deliberately.  If every analysis step must write a
-fragment, then a step that made no products writes an empty one, and a suite
-run with some products skipped fails on a missing input.  If fragments are
-instead optional, `publish` reports what it did not find and publishes the
-rest, which is what a developer iterating on a single plot wants.  Which of
-those two is right should be settled when the step is written.
+Making the fragment mandatory is what lets it be declared, and the alternative
+buys less than it appears to.  Optional fragments would let `publish` report
+what it did not find and carry on, which sounds like what a developer
+iterating on a single plot wants --- but a step that did not run leaves no
+pickle either, and `publish` fails on that first.  The only case optionality
+would actually cover is a step that ran and made nothing, and writing an empty
+fragment covers it at no cost.
 
 Because it is the only step that knows how results are presented, everything in
 the two sections below can change without a single plotting step changing.

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -273,9 +273,13 @@ fields.  The monthly-mean output shall:
 - include the **geometric vertical coordinate**, `GeomZMid` and
   `GeomZInterface`, so that Polaris does not have to reconstruct it (see the
   vertical-geometry algorithm design for why it cannot);
-- carry CF-compliant time metadata, with a time coordinate and time bounds that
-  identify the averaging period, so that standard tools can identify the month
-  each average represents;
+- carry CF-compliant time metadata: a `time` coordinate with `units`,
+  `calendar` and a `bounds` attribute, and a **`time_bnds` variable holding the
+  start and end of the averaging period**.  This is not a formality --- it is
+  the specific thing `ncclimo` needs in order to read Omega output at all, and
+  it has to hold the right values, not merely be present.  See the
+  implementation section, where this is now confirmed against real output
+  rather than assumed;
 - use a file-name convention that encodes the year and month, or that groups
   whole years into one file, and that is stable across a simulation.
 
@@ -1667,14 +1671,16 @@ requested fields for every season.
 
 ### Implementation: omega-monthly-means
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
 This is Omega work and is implemented in the Omega repository, not in Polaris.
 What Polaris needs to do:
 
-- add config options for the monthly-mean file-name template, as above;
+- add config options for the monthly-mean file-name template, as above ---
+  though the templates normally come from the simulation's Omega configuration
+  rather than from the user, so these are overrides;
 - add any new Omega fields, including a mixed-layer depth diagnostic, to
   `polaris/ocean/model/mpaso_to_omega.yaml` once their Omega names are fixed;
 - add an Omega YAML fragment that turns on monthly-mean output of the required
@@ -1682,15 +1688,49 @@ What Polaris needs to do:
   analysis, in the same way `analysis_members.cfg` and `forward.yaml` configure
   `GlobalStats` today.
 
-Development of the Polaris side proceeds against Omega output as each Omega
-capability lands, rather than against MPAS-Ocean output.  MPAS-Ocean would be a
-misleading development target: its variable and dimension names differ, its
-time metadata is not CF compliant, and its monthly means come from a different
-analysis member with different conventions, so code that works against
-MPAS-Ocean output tells us little about whether it will work against Omega's.
-Before Omega can write monthly means at all, development is limited to the
-shared kernels, which are exercised by unit tests on synthetic data and do not
-need model output of either kind.
+#### A mock-up already exists to develop against
+
+Development proceeds against Omega output rather than MPAS-Ocean output.
+MPAS-Ocean would be a misleading target: its variable and dimension names
+differ, its time metadata is not CF compliant, and its monthly means come from
+a different analysis member with different conventions, so code that works
+against it tells us little about whether it will work against Omega's.
+
+That would have limited early work to the shared kernels, but no longer does.
+A one-year QU240 Omega simulation has been run for this purpose on the
+`mockup-realistic-global-analysis-run` branch, and a mock-up set of
+monthly-averaged files derived from it is staged at
+
+```none
+<test_dir>/qu240-one-year-analysis-mockup/monthly_means/ocn.hist.0001-01.nc … 0001-12.nc
+```
+
+one month per file, carrying `Temperature`, `Salinity`, `PseudoThickness`,
+`GeomZMid`, `GeomZInterface`, `SshCell`, `SpecVol`, `KineticEnergyCell` and
+`NormalVelocity`, on dimensions `time`, `NCells`, `NVertLayers`,
+`NVertLayersP1` and `NEdges`, with `time` in `seconds since 0000-12-01` on a
+`noleap` calendar and `time_bnds` giving each month's bounds.
+
+Every product in this design except mixed-layer depth and the reconstructed
+velocity components can be developed and tested against these files today.
+They are what the order of work assumes: the steps are built against real Omega
+output from the start rather than against synthetic data with a later
+integration step.
+
+#### `ncclimo` reads Omega output --- confirmed
+
+The open question about whether `ncclimo` could read Omega monthly means
+without the MPAS-specific `-P mpaso` processing type is **settled, and the
+answer is yes** --- provided `time_bnds` is present and holds the expected
+values.  That was established against the mock-up files above, and it is why
+the requirement now names `time_bnds` specifically rather than asking for
+"time bounds" in general.
+
+This was the item on the critical path, so it is worth being clear about what
+was and was not shown: that `ncclimo` accepts the files and produces
+climatologies, at QU240, from a mock-up.  It has not been exercised at high
+resolution, over multiple years, or against output Omega's own monthly
+reduction wrote rather than a mock-up of it.
 
 The steps are written so that they degrade gracefully: a step whose input
 fields are not yet available reports which fields are missing from which file
@@ -2521,10 +2561,13 @@ They are collected here rather than buried in the sections above.*
    ship the offline fallback with its caveats.  This needs a team discussion
    rather than a decision in this document, and it affects both the Omega
    schedule and work item 14 above.
-2. **`ncclimo` and Omega output.**  Whether `ncclimo` can read Omega
-   monthly-mean files without the MPAS-specific processing type needs to be
-   confirmed against real output as soon as Omega can produce it.  This is on
-   the critical path.
+2. *(Settled.)*  **`ncclimo` and Omega output.**  `ncclimo` reads Omega
+   monthly-mean files without the MPAS-specific `-P mpaso` processing type,
+   provided `time_bnds` is present with the expected values.  Confirmed against
+   the QU240 mock-up described under `omega-monthly-means`.  Recorded here
+   because it was the item on the critical path; what remains is to repeat it
+   at high resolution and against Omega's own monthly reduction rather than a
+   mock-up of it.
 3. **Omega MOC output conventions.**  The variable, dimension, and coordinate
    names, and whether the mean interface elevations are written alongside the
    streamfunction, need to be confirmed against the MOC implementation.  This

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1310,6 +1310,46 @@ than being cleaned up later, because this is precisely the habit that is cheap
 to adopt while the code is being written and expensive to retrofit once there
 are dozens of steps.
 
+Temporary files go in the step's work directory for the same reason, never in
+`/tmp` or the base work directory: each step already has a directory of its
+own, so writing there is enough to guarantee that two concurrent steps cannot
+choose the same temporary path.
+
+#### Declared resources
+
+Every analysis step declares what it needs, so that a scheduler can decide how
+many may run at once.  Two quantities matter and they behave differently.
+
+**Cores** are declared as `cpus_per_task` with `ntasks = 1`, since nothing here
+is MPI.  The number is whatever internal parallelism the step will actually
+start --- twelve for the climatology, matching `ncclimo`'s background
+processes, and the pool size for a shard or a map step.  Any pool a step
+creates is sized from this number rather than from `os.cpu_count()`, which is
+the whole content of the bounded-process-launching rule: a step that sizes its
+pool to the machine oversubscribes the node the moment a second step runs
+beside it.
+
+**Memory** is the quantity that distinguishes analysis from most existing
+Polaris steps, because at high resolution a step can need a large fraction of a
+node and a scheduler packing by cores alone will oversubscribe it.  What each
+step's footprint is set by is known:
+
+- an accumulator shard holds one month of three-dimensional input per pool
+  worker, so its footprint is the pool size times a month --- which is why
+  reading a month at a time, rather than a year, is a resource decision and not
+  only a convenience;
+- a map step holds one season of the climatology for its field group, plus the
+  `mosaic` descriptor for the mesh;
+- the climatology step's footprint is `ncclimo`'s, not ours;
+- the merge and publish steps hold kilobytes.
+
+The *numbers* are deliberately not guessed here.  Sensible values need
+measurement at production resolution, which is being gathered separately for
+exactly this purpose, and a guessed default that is too large wastes a node
+while one that is too small fails late.  What this design commits to is that
+each step declares the quantity, and that the declaration is derived from the
+list above rather than from a spot measurement of one configuration.
+
 ### Implementation: data-products
 
 Date last modified: 2026/08/25

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1860,6 +1860,15 @@ same event, so it happens in the same call rather than in a second one a step
 can forget --- which is what would otherwise make a product real to Polaris's
 output checking but invisible to the gallery.
 
+**A product is a figure.**  Its netCDF is an attribute of it --- the data that
+were plotted --- and not a product in its own right, so a file with no figure
+has no entry today.  The intermediates are outside this entirely: a
+climatology or an accumulator cache is written for reuse, not for publication,
+and the step that makes one says so with `makes_products = False`.  Whether
+archiving needs a wider notion than publication does is raised under *pruning
+and archiving* in {ref}`design-ocean-analysis`; it is not settled, and Phase 1
+does not depend on the answer.
+
 **Only `group` and `gallery` shape the site.**  Every other facet is caption
 material today and filter material later.  This is the hinge that makes the
 extensibility requirement cheap: adding a `region` facet adds a key to the

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -84,8 +84,9 @@ automatically when a dataset is opened with
 `polaris/ocean/model/mpaso_to_omega.yaml`.  Analysis steps therefore never
 branch on the model to get a field name, and config options that name fields
 use the MPAS-Ocean names.  Where a field is new to Omega and has no MPAS-Ocean
-counterpart, a Polaris-standard name in the same style is chosen and mapped to
-the Omega name, so that the translation on read still applies.
+counterpart --- and is not expected to gain one --- it keeps its Omega name, and
+there is no entry to add: a mapping exists to reconcile two spellings of the
+same quantity, not to assign names.
 
 **Pseudo-thickness is not translated.**  There is one deliberate exception to
 the rule above, and it matters enough to state up front.
@@ -1212,22 +1213,35 @@ which already maps the vertical geometry this design depends on:
   zInterface: GeomZInterface
 ```
 
-The keys in that file are Polaris-standard names, which are MPAS-Ocean names
-wherever MPAS-Ocean has the field.  Fields that are new to Omega --- a
-mixed-layer depth diagnostic, for instance --- have no MPAS-Ocean name to
-borrow, so we choose a Polaris-standard name in the same style and add an entry
-mapping it to the Omega name as those names are fixed.  The entry is still
-needed: translation is a rename on read, so a field with no entry arrives under
-its Omega name and analysis code would have to know Omega's spelling.  What is
-not needed is a *counterpart* in MPAS-Ocean.
+**The mapping reconciles two spellings; it is not a naming authority.**  An
+entry exists when both models write the same quantity under different names,
+and only then.  Three cases follow from that, and they cover everything this
+design needs:
 
-The one field this design deliberately does not translate is
-`PseudoThickness`, for the reasons given under the conventions.
+- **Both models have the field.**  It is mapped, and analysis uses the
+  MPAS-Ocean name --- `temperature`, `zMid`, `areaCell`.
+- **Only Omega has the field.**  A mixed-layer depth diagnostic, for instance.
+  There is nothing to reconcile, so there is no entry and analysis uses the
+  Omega name as written.  Inventing an MPAS-Ocean-styled synonym would put a
+  name in the codebase that no model ever writes, and the entry recording it
+  would be a rename in appearance only.
+- **Both models have a similar name for different quantities.**
+  `layerThickness` and `PseudoThickness` are the case in point.  There is no
+  entry, deliberately, for the reasons given under the conventions.
 
-With those two things in place, no analysis step branches on
-`config.get('ocean', 'model')` to choose a field or dimension name, except
-`get_layer_mass`, which exists precisely to be that one branch.  Anywhere else,
-a branch on the model is a signal that the mapping file is missing an entry.
+The practical consequence of the middle case is that Omega's spelling appears
+in analysis code and in config section names for fields Omega alone provides,
+which is a small inconsistency of style and an accurate one: those fields come
+from Omega and from nowhere else.  If such a field later gains an MPAS-Ocean
+counterpart, or Omega renames it, that is the point at which an entry earns its
+keep --- and adding one then is a one-line change, so there is nothing to be
+gained by adding it in advance.
+
+No analysis step branches on `config.get('ocean', 'model')` to choose a field
+or dimension name, except `get_layer_mass`, which exists precisely to be that
+one branch.  Anywhere else, a branch on the model means either that the mapping
+is missing an entry, or that a field one model does not have is being read
+unconditionally.
 
 #### Locating input files
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1280,6 +1280,22 @@ norm_args = {'vmin': -2., 'vmax': 32.}
 Sections for the fields we expect to plot ship with defaults; fields without a
 section fall back to the defaults in `polaris.viz.get_viz_defaults`.
 
+The section name is not the field name pasted onto a prefix.  Field names are
+the models' own and are therefore camel case, while Polaris config sections are
+lower case with underscores everywhere else in the codebase, and the sections
+this design adds are no exception.  A field's section is
+`ocean_analysis_map_<field, in lower case with underscores>`, so
+`velocityZonal` gets `[ocean_analysis_map_velocity_zonal]` and
+`mixedLayerDepth` gets `[ocean_analysis_map_mixed_layer_depth]`.
+
+That conversion is mechanical, so no step spells a section out.  A small helper
+module, `polaris/tasks/ocean/analysis/config_sections.py`, provides
+`camel_to_snake(name)` and `map_section(field)`, and every caller goes through
+`map_section`, so exactly one place knows the prefix and the spelling rule.  It
+is a leaf module with no Polaris imports, for the same reason `sim_files.py` is
+one: it can be unit tested on its own, and any step can use it without pulling
+in a step.
+
 #### Field and dimension naming
 
 Per the conventions stated in the summary, config options name fields using
@@ -1310,9 +1326,12 @@ design needs:
   entry, deliberately, for the reasons given under the conventions.
 
 The practical consequence of the middle case is that Omega's spelling appears
-in analysis code and in config section names for fields Omega alone provides,
-which is a small inconsistency of style and an accurate one: those fields come
-from Omega and from nowhere else.  If such a field later gains an MPAS-Ocean
+in analysis code, and in the values of config options that name fields, for
+fields Omega alone provides, which is a small inconsistency of style and an
+accurate one: those fields come from Omega and from nowhere else.  Config
+section names are the exception, because they are Polaris' own rather than
+either model's: `map_section` converts the field name, so no model's spelling
+reaches a section header.  If such a field later gains an MPAS-Ocean
 counterpart, or Omega renames it, that is the point at which an entry earns its
 keep --- and adding one then is a one-line change, so there is nothing to be
 gained by adding it in advance.
@@ -1993,7 +2012,7 @@ for season in plot_seasons:
             plot_global_mpas_field(
                 da=da_map, out_filename=self.work_path(f'{basename}.png'),
                 config=self.config,
-                colormap_section=f'ocean_analysis_map_{field}',
+                colormap_section=map_section(field),
                 mesh_filename=self.work_path('mesh.nc'), ...)
 ```
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -235,7 +235,7 @@ Re-running with an unchanged range shall recompute nothing.
 
 ### Requirement: omega-monthly-means
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -246,9 +246,14 @@ Omega shall be able to write monthly means of a configurable list of model
 fields.  The monthly-mean output shall:
 
 - cover, at minimum, the fields needed by this analysis: conservative
-  temperature, absolute salinity, pseudo-thickness, sea surface height, normal
-  velocity (or reconstructed zonal and meridional velocity), and mixed-layer
-  depth;
+  temperature, absolute salinity, pseudo-thickness, sea surface height,
+  reconstructed zonal and meridional velocity at cell centers, and mixed-layer
+  depth.  Reconstructed velocities are preferred over `normalVelocity` as the
+  default monthly output because two cell-centered fields are smaller than one
+  edge field --- there are roughly three edges per cell --- and because
+  `normalVelocity` is not itself plotted by anything in this analysis.  Polaris
+  can reconstruct offline from `normalVelocity` if that is what a simulation
+  wrote, at the cost of carrying and reading the larger field;
 - include the **geometric vertical coordinate**, `GeomZMid` and
   `GeomZInterface`, so that Polaris does not have to reconstruct it (see the
   vertical-geometry algorithm design for why it cannot);
@@ -591,17 +596,25 @@ out-of-column cases.
 
 #### Reconstructed velocities
 
-Omega writes `normalVelocity` on edges.  Zonal and meridional velocity at cell
-centers are obtained by the least-squares reconstruction designed in
+The map steps plot zonal and meridional velocity at cell centers.  If the
+monthly means contain them, they are used directly.  If they contain
+`normalVelocity` on edges instead, the step reconstructs them with the
+least-squares reconstruction designed in
 [Vector Reconstruction](vector_reconstruction.md), whose weights are stored on
 the mesh.
 
-Reconstruction is a linear operator on the edge field, so reconstructing from a
-climatology of normal velocity gives exactly the climatology of the
-reconstructed velocity.  There is therefore no accuracy argument for doing the
-reconstruction in the model, and doing it offline avoids adding a dependency on
-Omega work.  If Omega later writes reconstructed velocities directly, the step
-uses them in preference.
+Both paths give the same answer.  Reconstruction is a linear operator on the
+edge field, so reconstructing from a climatology of normal velocity gives
+exactly the climatology of the reconstructed velocity; there is no accuracy
+argument for preferring one over the other, and having the offline path means
+this product does not block on Omega work.
+
+The preference is about output volume rather than accuracy, which is why the
+`omega-monthly-means` requirement asks for reconstructed velocities as the
+default monthly output: two cell-centered fields are about two thirds the size
+of one edge field, and nothing else in this analysis reads `normalVelocity`.
+Offline reconstruction is the fallback for simulations that wrote the edge
+field, not the intended steady state.
 
 ### Algorithm Design: mixed-layer depth (fallback only)
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -2750,52 +2750,62 @@ work carrying its code, its unit tests, and its User's Guide documentation,
 leaving the suite working for the products delivered so far.  Design changes
 are not among them, since those land on the design branch.
 
-The order is by deliverable priority rather than by dependency depth, which is
-why the vertical machinery comes late.  Slicing by layer index needs no
-vertical geometry at all, and heat content over the whole column needs only
-`minLevelCell` and `maxLevelCell`, so both a map and a heat content drift curve
-can be on screen well before elevation interpolation exists.  The standard
-$0$--$700$ m, $700$--$2000$ m and $2000$ m--seafloor ranges then enrich a
-product that already works rather than gating it.
+The order is by dependency rather than by deliverable priority, so that each
+branch is reviewed against the one below it and lands a capability whole.  An
+earlier version ordered by priority, which put the vertical machinery last: a
+map sliced by layer index and a whole-column heat content drift curve need no
+vertical geometry, so both could be on screen before elevation interpolation
+existed, with the standard $0$--$700$ m, $700$--$2000$ m and $2000$
+m--seafloor ranges enriching them later.
+
+That ordering was right for delivery and wrong for review.  It had the
+climatology maps document elevations as asked for and reported as skipped, and
+heat content introduce the vocabulary for elevation ranges while producing
+only the whole column --- prose and API that a later branch then had to
+retract.  Once a product's fragments are published, a partial product set is
+also a visibly incomplete gallery rather than a quiet absence.  The vertical
+reduction is a dependency-light leaf module, unit tested against synthetic
+columns and importing nothing from :py:class:`polaris.Step`, so it costs
+little to land first and saves every branch above it from shipping a
+limitation it will have to un-say.
 
 1. This design document and the umbrella document
    {ref}`design-ocean-analysis`.
-2. The `omega_analysis` scaffolding: the `polaris/tasks/ocean/analysis/`
+2. `polaris/ocean/vertical/elevation.py` --- the full vertical reduction:
+   slicing at a layer index, the sea surface, the seafloor or an elevation,
+   and the weights for an elevation range --- with unit tests.  It depends on
+   nothing else here, and everything vertically reduced above it depends on
+   it.
+3. The `omega_analysis` scaffolding: the `polaris/tasks/ocean/analysis/`
    package, `analysis.cfg`, `sim_files.py` including the reader for the
    simulation's Omega configuration, the range-keyed step subdirectories, the
    tasks with their `configure()` methods, and the `omega_analysis` suite, with
    steps that do nothing yet.  This is where the repeated-analysis structure is
    established, so it lands before anything that depends on it.
-3. The `global_stats` time series step, including factoring the shared plotting
-   function out of `StatsAnalysis`.  It depends on nothing above it, reads
-   Omega's `GlobalStats` output directly, and needs no vertical geometry, so it
-   is the earliest point at which the suite produces a plot a scientist wants.
-4. The `Climatology` step (`ncclimo`).  Early because it carries the most
+4. Publication: the manifest writer, the `publish` step that collects and
+   renders thumbnails, and the generated gallery over the staging tree, as
+   designed under `publication`.  It comes before the products because the
+   manifest writer is a dependency of every plotting step and because every
+   step that makes products must leave a fragment for the `publish` step to
+   declare as an input.
+5. The `global_stats` time series step, including factoring the shared plotting
+   function out of `StatsAnalysis`.  It reads Omega's `GlobalStats` output
+   directly and needs no vertical geometry, so it is the earliest point at
+   which the suite produces a plot a scientist wants.  It also brings
+   `OceanIOStep.add_produced_file()`, which every plotting step above uses.
+6. The `Climatology` step (`ncclimo`).  Early because it carries the most
    external risk in the design: it shells out to NCO and depends on Omega's
    time metadata being read correctly by a tool we do not control.  Everything
    map-shaped is blocked on it, so we want to find out.
-5. The `ClimatologyMaps` step, restricted to fields with no vertical dimension
-   and to slicing by layer index.  The first maps on disk, and no vertical
-   geometry needed.
-6. Publication: the manifest writer, the `publish` step that collects and
-   renders thumbnails, and the generated gallery over the staging tree, as
-   designed under `publication`.  Its position in this list is a priority
-   rather than a dependency: it is cut from item 2 and not from the products,
-   because the manifest writer is a dependency of every plotting step.  The
-   product branches above it therefore rebase onto it, each gaining one commit
-   that emits its own fragments.
-7. `polaris/ocean/heat_content.py` and whole-column mass weights, with unit
-   tests.
-8. The `heat_content` field group of `ClimatologyMaps`, whole column only.
-9. The `Accumulator` base class --- seed discovery and provenance stamping ---
-   with unit tests, since this is the piece whose failure modes are silent.
-10. The `heat_content_series` step built on it, whole column only.  Heat content
-    drift is what a coupled run is judged on, which is why it precedes the
-    vertical machinery rather than following it.
-11. `polaris/ocean/vertical/elevation.py` --- the full vertical reduction:
-    interpolation to an elevation, the sea surface, the seafloor, and elevation
-    ranges --- with unit tests.  This enriches items 5, 8 and 10, each of which
-    already works without it.
+7. The `ClimatologyMaps` step.  The first maps on disk, at any elevation the
+   vertical reduction supports rather than at layer indices only.
+8. `polaris/ocean/heat_content.py` and the mass weights, with unit tests.
+9. The `heat_content` field group of `ClimatologyMaps`, over the whole column
+   and over the standard elevation ranges.
+10. The `Accumulator` base class --- seed discovery and provenance stamping ---
+    with unit tests, since this is the piece whose failure modes are silent.
+11. The `heat_content_series` step built on it.  Heat content drift is what a
+    coupled run is judged on.
 12. The `moc` step and the `plot_lat_elevation_field` primitive.
 13. The `replot` option.
 14. The offline `mixed_layer_depth` accumulator and its climatology, only if

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -2999,6 +2999,12 @@ columns having known layer geometry, `minLevelCell`, and `maxLevelCell`:
   average of the two values;
 - an elevation above the topmost midpoint returns the topmost value, and an
   elevation below the seafloor is masked;
+- a column with a single valid layer returns that layer's value, rather than
+  interpolating it against a layer below the seafloor;
+- an elevation below the second midpoint of a cavity column returns the right
+  layer.  This is the case that distinguishes a bounding-layer search that
+  adds $k_{min}$ back from one that does not, and every column with
+  $k_{min} = 0$ passes either way;
 - a linear-in-$z$ field is recovered exactly at arbitrary elevations.
 
 The last of these is the strongest test: it catches index-off-by-one and

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -761,6 +761,12 @@ climatology period, rather than being computed from the climatology.  Computing
 it from the seasonal or annual climatology would be a second, much larger
 approximation on top of the one described next.
 
+That order --- compute per month, average afterwards --- is why this product
+does its own seasonal averaging rather than handing monthly files to `ncclimo`.
+The averaging is the last step either way; doing it ourselves keeps `ncclimo`
+on model output alone and keeps the climatology from waiting on a full-record
+pass.
+
 What this fallback does *not* capture, and what should be said on the plots and
 in the netCDF metadata:
 
@@ -1645,13 +1651,19 @@ Notes on the arguments:
 - `-a sdd` selects the seasonally discontinuous December convention discussed
   in the algorithm design.
 - `-v` restricts the climatology to the union of the fields requested for maps,
-  the fields needed for heat content (`temperature`), the fields needed for
-  velocity reconstruction (`normalVelocity`, when zonal and meridional velocity
-  are requested and not written by the model), and the vertical geometry
-  (`zMid`, `zInterface`).  Building this list is the reason `Climatology` needs
-  to know which steps depend on it; the list is assembled from config options
-  at runtime rather than passed in by each task, so that the step stays neutral
-  with respect to which tasks pulled it in.
+  the fields needed for heat content (`temperature` and the model's mass-like
+  thickness), the fields needed for velocity reconstruction (`normalVelocity`,
+  when zonal and meridional velocity are requested and not written by the
+  model), and the vertical geometry (`zMid`, `zInterface`).  Building this list
+  is the reason `Climatology` needs to know which steps depend on it; the list
+  is assembled from config options at runtime rather than passed in by each
+  task, so that the step stays neutral with respect to which tasks pulled it
+  in.
+
+  Every name on that list is a field the model wrote.  Fields Polaris computes
+  offline --- mixed-layer depth in the fallback case --- form their own
+  seasonal means and never appear here, which is what keeps this mapping back
+  to Omega names well defined.
 
   Note that `-v` takes the names as they appear *in the files*, which are Omega
   names, so the step maps its Polaris-standard list back through
@@ -1794,15 +1806,37 @@ Velocity reconstruction uses the weights on the mesh via
 the step reports that clearly and skips the zonal and meridional velocity maps
 rather than failing the whole step.
 
-If `compute_mixed_layer_depth` is set, the task adds an accumulator structured
-exactly like the heat content one: its kernel computes a month of mixed-layer
-depth with `gsw` as described in the algorithm design.  Because its consumer is
-`ncclimo`, which reads monthly files, its cache is one file per month rather
-than a single series --- principle 8 in {ref}`design-ocean-analysis` --- and
-inherited months are symlinked forward rather than copied.  The climatology
-step then averages those into the seasonal and annual means that are plotted.
-Its
-outputs carry an attribute recording that they were computed offline from
+If `compute_mixed_layer_depth` is set, the task adds a sharded accumulator
+structured exactly like the heat content one: its kernel computes a month of
+mixed-layer depth with `gsw` as described in the algorithm design, and its
+cache is one gridded file per month, so that inherited months are symlinked
+forward rather than copied or rewritten.
+
+**Its `merge` step forms the seasonal means itself; `ncclimo` is not involved.**
+An earlier draft handed the monthly files to `ncclimo` along with the model
+output, on the grounds that a derived monthly field is just another monthly
+field.  That was wrong on three counts:
+
+- it made the climatology --- and therefore every map step behind it --- wait
+  on a full-record pass, which is the worst possible shape under principle 3;
+- it required a Polaris-computed field to appear in `ncclimo`'s `-v` list,
+  which the step builds by mapping Polaris names back to *Omega* names.  A
+  field Omega never wrote has no Omega name to map back to;
+- it was the only thing forcing this cache's format, per principle 8, when the
+  format should follow from how the data are actually used.
+
+Averaging monthly values into seasons is a small, testable function, and the
+step reuses the same season definitions and length-of-month weighting that
+`ncclimo` is configured with, including the seasonally discontinuous December
+convention.  The regression test checks that an annual mean equals the
+appropriately weighted mean of the twelve monthly means, which is what keeps
+the two paths from drifting apart.
+
+With this, `ncclimo` consumes only model output, and the mixed-layer depth
+product is self-contained: monthly means in, seasonal maps out, independent of
+the climatology and free to run beside it.
+
+Its outputs carry an attribute recording that they were computed offline from
 monthly means, and the step adds a note to the plot titles, so that a reader
 cannot mistake them for an in-situ diagnostic.
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -74,17 +74,79 @@ describes.  Both are Polaris-wide conventions rather than choices made here.
 
 **Names are MPAS-Ocean names.**  MPAS-Ocean variable and dimension names are
 Polaris's internal standard.  Analysis code refers to `temperature`,
-`salinity`, `layerThickness`, `zMid`, `zInterface`, `minLevelCell`,
-`maxLevelCell`, `bottomDepth`, and `areaCell`, and to the dimensions `nCells`,
-`nEdges`, `nVertLevels`, `nVertLevelsP1`, and `Time`, regardless of which model
-produced the data.  Omega's names --- `Temperature`, `PseudoThickness`,
-`GeomZMid`, `GeomZInterface`, `NCells`, `NVertLayers`, and so on --- are
-translated to the Polaris standard automatically when a dataset is opened with
+`salinity`, `zMid`, `zInterface`, `minLevelCell`, `maxLevelCell`,
+`bottomDepth`, and `areaCell`, and to the dimensions `nCells`, `nEdges`,
+`nVertLevels`, `nVertLevelsP1`, and `Time`, regardless of which model produced
+the data.  Omega's names --- `Temperature`, `GeomZMid`, `GeomZInterface`,
+`NCells`, `NVertLayers`, and so on --- are translated to the Polaris standard
+automatically when a dataset is opened with
 `OceanIOStep.open_model_dataset`, using the mapping in
 `polaris/ocean/model/mpaso_to_omega.yaml`.  Analysis steps therefore never
 branch on the model to get a field name, and config options that name fields
 use the MPAS-Ocean names.  Where a field is new to Omega and has no MPAS-Ocean
-counterpart, a Polaris-standard name is chosen and added to that mapping.
+counterpart, a Polaris-standard name in the same style is chosen and mapped to
+the Omega name, so that the translation on read still applies.
+
+**Pseudo-thickness is not translated.**  There is one deliberate exception to
+the rule above, and it matters enough to state up front.
+
+Omega is non-Boussinesq and prognoses **pseudo-height**, $\tilde{z}$, a
+normalized pressure with units of meters, defined in
+[Omega's governing equations](https://github.com/E3SM-Project/Omega/blob/develop/components/omega/doc/design/OmegaV1GoverningEqns.md)
+as
+
+$$
+\tilde{z} = -\frac{p}{\rho_0 g},
+\qquad\text{so that}\qquad
+d\tilde{z} = \frac{\rho}{\rho_0} \, dz
+$$
+
+with $\rho_0$ a constant reference density used purely as a normalization ---
+its presence does not make the model Boussinesq.  `PseudoThickness` is
+$\tilde{h} = \Delta \tilde{z}$, in meters, and $\tilde{h} \approx h$ only to
+the extent that $\rho \approx \rho_0$.  Two consequences follow, and analysis
+code needs both:
+
+- **Reference density times pseudo-thickness equals full density times
+  geometric thickness**,
+
+  $$
+  \rho_0 \tilde{h} = \rho h = \frac{\Delta p}{g},
+  $$
+
+  which is the **mass per unit area** of the layer, exactly, by hydrostatic
+  balance.  It needs no equation of state.
+- The **geometric** thickness is the derived quantity:
+  $h = \rho_0 \, \alpha \, \tilde{h}$, where $\alpha = 1/\rho$ is specific
+  volume, so recovering it requires the equation of state.  This is the
+  relation Omega uses to build `GeomZInterface` and `GeomZMid`.
+
+MPAS-Ocean's `layerThickness` is the other way around: it is the geometric
+thickness $h$, and because MPAS-Ocean is Boussinesq, $\rho_0 h$ is *its* mass
+per unit area.  The two variables therefore coincide in what they mean for a
+mass-weighted integral and differ in what they mean for a geometric one, so
+renaming one to the other would hide exactly the distinction that matters.
+`polaris/ocean/model/mpaso_to_omega.yaml` already declines to map them; this
+design records why.
+
+Analysis therefore never asks for "the thickness".  It asks for one of two
+things by name:
+
+- **Geometric positions and thicknesses** come from `zInterface` and `zMid`,
+  which both models write (Omega as `GeomZInterface` and `GeomZMid`) and which
+  are translated as usual.  A geometric layer thickness, where one is needed,
+  is a difference of interface elevations, not a separate variable --- which is
+  also the only way to get it offline, since $\alpha$ is not written.
+- **Mass per unit area** comes from the model's own mass-like thickness
+  variable --- `PseudoThickness` for Omega, `layerThickness` for MPAS-Ocean ---
+  read under its native name and multiplied by $\rho_0$.  A single helper,
+  `polaris.ocean.model.get_layer_mass`, returns $\rho_0 \tilde{h}$ for Omega
+  and $\rho_0 h$ for MPAS-Ocean, so this is the one place in the analysis code
+  that knows which model wrote the file.
+
+This is what makes the heat content integral below a mass integral rather than
+a volume integral scaled by a reference density, and it is the same convention
+used for evaluating conservation in Omega.
 
 **The vertical coordinate is elevation, positive up.**  All vertical positions
 in config options, algorithms, and output are elevations $z$ in meters with
@@ -444,7 +506,7 @@ already encodes the range in its output file names
 
 ### Algorithm Design: climatology-maps
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -458,17 +520,27 @@ $z^{int}_{k}$, for each column.  These are read directly from `zMid` and
 
 Polaris cannot reconstruct them from the monthly means of the other fields.
 Omega builds the geometric coordinate by accumulating upward from
-$-\mathrm{BottomGeomDepth}$ using $\mathrm{SpecVol} \times
-\mathrm{PseudoThickness}$, and it does so the same way regardless of which
-vertical coordinate the simulation uses --- the choice of z-star, p-star, or
-sigma determines how `PseudoThickness` is initialized and how it evolves, not
-how geometric elevation is computed from it.  Reconstructing $z$ offline
-therefore requires specific volume, which means evaluating the TEOS-10 equation
-of state on the monthly-mean state.  That is not the monthly mean of
-$\mathrm{SpecVol} \times \mathrm{PseudoThickness}$, so the reconstruction would
-introduce an error that has nothing to do with the diagnostic being computed.
-Having Omega write the geometric coordinate removes the problem entirely, since
-the monthly mean of $z$ is exactly the mean layer geometry we want.
+$-\mathrm{BottomGeomDepth}$ using layer thicknesses
+$h = \rho_0 \, \mathrm{SpecVol} \times \mathrm{PseudoThickness}$, and it does
+so the same way regardless of which vertical coordinate the simulation uses ---
+the choice of z-star, p-star, or sigma determines how `PseudoThickness` is
+initialized and how it evolves, not how geometric elevation is computed from
+it.  Reconstructing $z$ offline therefore requires specific volume, which means
+evaluating the TEOS-10 equation of state on the monthly-mean state.  That is
+not the monthly mean of $\mathrm{SpecVol} \times \mathrm{PseudoThickness}$, so
+the reconstruction would introduce an error that has nothing to do with the
+diagnostic being computed.  Having Omega write the geometric coordinate removes
+the problem entirely, since the monthly mean of $z$ is exactly the mean layer
+geometry we want.
+
+Note the direction of the dependence, which is the reason for the conventions
+stated at the top of this document: geometric thickness is *derived* from
+pseudo-thickness and specific volume, and it is the derived quantity that
+cannot be recovered offline.  Mass per unit area, $\rho_0 \tilde{h} = \rho h$,
+needs no equation of state at all.  That is why the heat content integral is
+written in terms of it and why only quantities that genuinely need the
+geometry --- elevation slices, and the partial layers at a heat content range
+boundary --- read `zMid` and `zInterface`.
 
 Because the input to the map steps is a climatology, the $z^{mid}_{k}$ they use
 is the climatological-mean layer geometry.  This does mean that a $-100$ m map

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1925,14 +1925,19 @@ drawn one after another.  Building the `mosaic` descriptor is the expensive
 part of plotting a global mesh, so it is constructed once per step and shared,
 which is where most of the available saving is anyway.
 
-Two dependencies on the framework follow from
-[Task-Parallel-Safe Analysis Steps](task_parallel_analysis_steps.md) and are
-recorded here rather than worked around.  `polaris.viz` assigns
-`plt.rcParams['savefig.dpi']`, which is process-global state and is being made
-scope-safe separately; these steps use whatever scoped form it takes.  And
-plotting in a pool means no reliance on the `pyplot` current-figure state,
-which is likewise global --- each plot creates and closes its own figure
-explicitly.
+Both framework dependencies this used to have are now met.  `polaris.viz` no
+longer assigns `plt.rcParams` from inside a step: `mplstyle_context()` scopes
+the style and DPI to a `with` block, and the spherical and planar plotting
+functions use matplotlib's object-oriented `Figure` API rather than the
+`pyplot` current-figure state.  Both landed with the task-parallel groundrules.
+These steps therefore need no workaround and no special pleading --- they call
+`polaris.viz` as it now is.
+
+Step authors should follow
+[the task parallelism page](../developers_guide/framework/task_parallelism.md)
+in the Developer's Guide, which is the practical form of the rules; the design
+behind them is
+[Task-Parallel-Safe Analysis Steps](task_parallel_analysis_steps.md).
 
 Maps are plotted on the native mesh with the existing
 `polaris.viz.plot_global_mpas_field`, which is `mosaic`-based and needs no

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -475,7 +475,7 @@ Two conventions matter and are worth stating explicitly:
 
 ### Algorithm Design: repeated-analysis
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -499,6 +499,53 @@ content is the same quantity no matter which range asked for it, so it is
 computed once and reused forever.  Everything that is range-keyed is then
 either cheap to redo from those per-year products, or is the climatology
 itself.
+
+These year-keyed and range-keyed steps are **shared steps** in the sense of
+[Shared steps](shared_steps.md), created with
+`Component.get_or_create_shared_step()` at a subdirectory computed from the
+year or range.  Nothing in this design needs a caching layer of its own: reuse
+across repeated analyses is the existing rule that a shared step at a given
+subdirectory is created once and is skipped when its completion marker is
+already there.  The implementation section works through the details.
+
+#### How many steps is too many?
+
+Decomposing by year buys reuse and concurrency at the cost of step count, and
+it is worth having a number in mind before the design commits to per-year
+granularity.  For a typical decadal-to-multidecadal analysis --- a 60-year
+record with a 20-year climatology --- the suite contains roughly:
+
+| Steps | Count |
+| --- | --- |
+| Per-year ocean heat content | 60 |
+| Per-year offline mixed-layer depth (fallback only) | 60 |
+| `ncclimo` climatology | 1 |
+| Range-keyed plotting and time-series steps | ~6 |
+| **Total** | **~130** |
+
+For comparison, the existing `ocean` component builds several hundred steps
+across all of its tasks, and `polaris setup` handles that in seconds, so ~130
+steps in a single suite is not a regime we have reason to expect trouble in.
+The number scales linearly with the length of the record, so a century-long
+record with both per-year products would be ~230 steps, which is still not
+alarming.
+
+The thresholds worth naming, so that we notice if we approach them: a few
+hundred steps is ordinary; at around a thousand, `polaris setup` time and the
+size of the suite pickle become worth measuring before proceeding; well beyond
+that, the per-step overhead --- a work directory, a pickle, a config copy, a
+log file --- starts to dominate the actual computation, which for a single year
+of heat content is only seconds of work on a few GB of input.
+
+Two levers exist if we get there, and neither requires reworking the design.
+The first is to merge the per-year products: the heat content and mixed-layer
+depth year steps make the same pass over the same twelve files, so one step
+producing both halves the count.  They are kept separate here because merging
+couples two products for a saving that only matters at scale.  The second is to
+coarsen the key from a year to a decade, which divides the count by ten at the
+cost of making reuse coarser --- extending a record from 60 to 65 years would
+redo a decade rather than five years.  We should reach for merging first, since
+it costs nothing in reuse.
 
 The climatology is the one expensive computation that genuinely depends on the
 range, and it is recomputed for each new range.  In principle a climatology

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1118,7 +1118,15 @@ proposed starting point:
 ```ini
 [ocean_analysis]
 
-# The absolute path to the directory containing the simulation's output
+# The absolute path to the simulation's Omega configuration file.  Polaris
+# reads the mesh, the output streams and their file-name templates from it, so
+# that they do not have to be restated below.  Leave empty and fill in the
+# templates by hand for MPAS-Ocean, or for a run whose config file is not
+# available.
+omega_config_filename =
+
+# The absolute path to the directory containing the simulation's output.
+# Defaults to the output directory the Omega config names.
 simulation_path =
 
 # A short name for the simulation, used in plot titles and file names
@@ -1128,7 +1136,8 @@ simulation_name = omega
 # product and date range.  Defaults to <work_dir>/analysis_output.
 output_path =
 
-# The horizontal mesh file, absolute or relative to simulation_path
+# The horizontal mesh file, absolute or relative to simulation_path.  Defaults
+# to the mesh the Omega config names.
 mesh_filename =
 
 # The vertical-coordinate file (Omega only), absolute or relative to
@@ -1137,10 +1146,11 @@ vert_coord_filename =
 
 # File-name templates for the simulation output the analysis reads, relative
 # to simulation_path.  $Y and $M are replaced by the four-digit year and
-# two-digit month.
-monthly_mean_template = ocean.hist.MonthlyMean.$Y-$M.nc
-global_stats_template = ocean.hist.GlobalStats_1MonthTimeStats.$Y.nc
-moc_template = ocean.hist.Moc_1MonthTimeStats.$Y.nc
+# two-digit month.  Each defaults to the template of the corresponding Omega
+# output stream; set one only to override what the config file says.
+monthly_mean_template =
+global_stats_template =
+moc_template =
 
 
 [ocean_analysis_climatology]
@@ -1279,6 +1289,24 @@ file-name templates over a year range into lists of files and checks that they
 exist, reporting the missing years clearly.  It is shared by every step that
 reads simulation output.  This is deliberately a separate module rather than a
 method on a step, so that it can be unit tested and reused.
+
+Where the templates come from is the point.  The user's normal input is
+`omega_config_filename`, the path to the simulation's own Omega configuration,
+and the same module reads the output streams from it: each stream gives a
+file-name template, a reduction period and a directory, which is enough to
+identify the monthly means, the `GlobalStats` output and the MOC output without
+the user restating any of it.  The mesh file is read from the same place.
+
+The explicit templates remain as overrides, and are the only way in for
+MPAS-Ocean output or a run whose configuration file is not to hand.  An option
+the user sets always wins over what the config file says, and the step logs
+which source each path came from, so that a surprising file list can be
+diagnosed without guessing.
+
+Reading Omega's configuration is done defensively --- a missing or unfamiliar
+stream is reported as such, naming the option to set by hand instead --- since
+its schema is Omega's to change and this is the one place Polaris depends on
+its shape rather than on its output.
 
 Input files are symlinked into each step's work directory in `setup()` using
 `Step.add_input_file`, which gives the usual Polaris provenance and dependency

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1880,9 +1880,19 @@ in the step directory is self-describing.  Range labels use `_to_` rather than
 a hyphen because the elevations are themselves negative.
 
 The plots are independent, so a step with many of them spreads them over a
-process pool rather than over steps.  Building the `mosaic` descriptor is the
-expensive part of plotting a global mesh, so it is constructed once per step
-and shared.
+process pool rather than over steps.  The pool is sized from `cpus_per_task`,
+never from the machine, per the bounded-process-launching rule.  Building the
+`mosaic` descriptor is the expensive part of plotting a global mesh, so it is
+constructed once per step and shared.
+
+Two dependencies on the framework follow from
+[Task-Parallel-Safe Analysis Steps](task_parallel_analysis_steps.md) and are
+recorded here rather than worked around.  `polaris.viz` assigns
+`plt.rcParams['savefig.dpi']`, which is process-global state and is being made
+scope-safe separately; these steps use whatever scoped form it takes.  And
+plotting in a pool means no reliance on the `pyplot` current-figure state,
+which is likewise global --- each plot creates and closes its own figure
+explicitly.
 
 Maps are plotted on the native mesh with the existing
 `polaris.viz.plot_global_mpas_field`, which is `mosaic`-based and needs no

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -28,13 +28,13 @@ completed Omega simulation through a user-supplied config file and produces:
    (MOC)** from the MOC diagnostic that Omega computes in situ.
 
 Every plot is accompanied by a netCDF file containing the data plotted, and the
-expensive intermediate products (climatologies, per-year heat content) are
-written to netCDF as well.
+expensive intermediate products (climatologies, reduced monthly heat content)
+are written to netCDF as well.
 
 The same simulation can be analyzed repeatedly over different date ranges.
 Results accumulate in a range-keyed staging tree that a web interface can serve
-later, and re-analyzing a new range reuses the per-year intermediates from
-earlier ranges instead of recomputing them.
+later, and re-analyzing a new range inherits the reduced monthly values
+earlier ranges already computed instead of recomputing them.
 
 MPAS-Analysis is the scientific reference for what each of these diagnostics
 means, but the implementation is written from scratch with Polaris and Omega in
@@ -204,9 +204,12 @@ exactly the data that were plotted, so that the values can be inspected,
 compared against other tools, or re-plotted without recomputation.
 
 Intermediate products that are expensive to compute --- climatologies and
-per-year ocean heat content in particular --- shall be written to netCDF, and a
-step that finds a complete intermediate product from a previous run shall be
-able to reuse it rather than recomputing it.
+reduced monthly ocean heat content in particular --- shall be written to
+netCDF, and a step that finds an intermediate product from a previous run shall
+be able to reuse it rather than recomputing it.  Reuse shall be conditional on
+the product having been computed for the same simulation, by the same kernel,
+under the config options that govern it, and shall be reported rather than
+silent.
 
 ### Requirement: repeated-analysis
 
@@ -400,9 +403,9 @@ drift and for the planetary energy budget while the absolute value is dominated
 by the mean state.
 
 The computation shall stream over the monthly files rather than loading the
-full record into memory, and shall write per-year intermediate results so that
+full record into memory, and shall cache the reduced monthly values so that
 extending the time series with additional simulation years does not require
-recomputing the years already processed.
+reprocessing the years already covered.
 
 ### Requirement: moc-plot
 
@@ -485,28 +488,41 @@ what does not:
 | Product | Depends on the range? | Cost |
 | --- | --- | --- |
 | Monthly means (model output) | no | read-only input |
-| Per-year ocean heat content integrals | no, keyed by year | expensive |
-| Per-year offline mixed-layer depth | no, keyed by year | expensive |
+| Reduced monthly ocean heat content | no, keyed by month | expensive |
+| Offline monthly mixed-layer depth | no, keyed by month | expensive |
 | `ncclimo` climatologies | yes | expensive |
 | Climatology and heat content maps | yes | cheap, from the climatology |
 | Global stats time series | yes | cheap |
 | MOC time average | yes | cheap |
 
-The rule that follows: **every expensive computation is decomposed into a
-per-year product keyed by the year, not by the range**, and is given its own
-step at a year-keyed subdirectory.  A given year's vertically integrated heat
-content is the same quantity no matter which range asked for it, so it is
-computed once and reused forever.  Everything that is range-keyed is then
-either cheap to redo from those per-year products, or is the climatology
-itself.
+The rows in the middle are the ones that matter.  A given month's vertically
+integrated heat content is the same quantity no matter which range asked for
+it, so it should be computed once and reused forever, while everything else is
+either cheap to redo from those monthly values or is the climatology itself.
 
-These year-keyed and range-keyed steps are **shared steps** in the sense of
+Every step is keyed by what the user asked for --- a date range --- and the
+expensive range-independent work is made incremental *inside* a step by the
+**seeded accumulator** of principle 6 in {ref}`design-ocean-analysis`.  The
+accumulator finds the cache files left by earlier runs of the same product,
+inherits the months they cover, computes only the rest, and writes a complete
+cache for its own range.
+
+An earlier draft of this design instead gave every simulation year its own
+shared step at a year-keyed subdirectory, so that reuse fell out of Polaris's
+completion markers with no machinery of our own.  That was appealing but wrong
+on two counts.  It paid a step's overhead --- a directory, a pickle, a config
+copy, a log file --- for a chunk no user ever asked for, and it turned the
+directory tree into a bucket named after a mechanism.  Worse, the completion
+marker was then the *only* validity check: change the heat content kernel or a
+constant and every one of those directories would still report itself complete.
+The accumulator is cheaper and, with the provenance stamp described below,
+safer.
+
+The steps that remain are **shared steps** in the sense of
 [Shared steps](shared_steps.md), created with
 `Component.get_or_create_shared_step()` at a subdirectory computed from the
-year or range.  Nothing in this design needs a caching layer of its own: reuse
-across repeated analyses is the existing rule that a shared step at a given
-subdirectory is created once and is skipped when its completion marker is
-already there.  The implementation section works through the details.
+range, so that the climatology for a range is built once no matter how many
+products read it.  The implementation section works through the details.
 
 #### How many steps is too many?
 
@@ -1183,13 +1199,12 @@ The expensive intermediates are:
 
 - the `ncclimo` output in `ocean/analysis/climatology/<range>/`, already a set
   of netCDF files;
-- the per-year heat content file written by each
-  `ocean/analysis/years/ocean_heat_content/<year>` step;
-- the equivalent per-year mixed-layer depth files, if it is computed offline.
+- the monthly heat content cache written by the heat content accumulator;
+- the equivalent monthly mixed-layer depth cache, if it is computed offline.
 
-Because each of these is the output of a shared step keyed by year or by range,
-reuse across repeated analyses is Polaris's ordinary step-completion behavior
-rather than a caching layer of our own.
+The climatology is a range-keyed output of a shared step, so its reuse is
+Polaris's ordinary step-completion behavior.  The accumulator caches carry the
+provenance stamp that makes them safe to inherit across runs.
 
 ### Implementation: repeated-analysis
 
@@ -1237,27 +1252,86 @@ in its work directory.  It also makes it structurally impossible to get a plot
 labeled with one range whose contents came from another, since the two ranges
 never share a directory.
 
-#### Reuse comes from per-year shared steps
+#### Reuse comes from seeded accumulators
 
-The expensive per-year work --- vertically integrated heat content, and
-mixed-layer depth if it is computed offline --- is one shared step per
-simulation year, at `years/ocean_heat_content/0021` and so on, created with
-`get_or_create_shared_step()`.  Each reads that year's twelve monthly-mean
-files and writes one small netCDF.
+The expensive range-independent work --- vertically integrated heat content,
+and mixed-layer depth if it is computed offline --- is one step per product,
+keyed by the range like everything else, which inherits what earlier runs
+already computed.
 
-Because these steps are keyed by year rather than by range, a later analysis
-over a different range asks for the same step for any year the two ranges have
-in common, finds it already complete, and skips it.  Extending a time series
-from twenty years to forty creates twenty new steps and reuses twenty existing
-ones, which is exactly the cost the requirement asks for --- and again with no
-mechanism beyond shared steps and the completion marker.
+`polaris/tasks/ocean/analysis/accumulate.py` provides the shared machinery, so
+that each product supplies only its kernel and its cache layout:
 
-A per-year step is also a well-sized unit of work: roughly 1.8 GB of monthly
-means read, one small file written.  Making these steps rather than a loop
-inside a single step has a second payoff, which is that they are embarrassingly
-parallel and become eligible for concurrent execution as soon as Polaris's task
-parallelism lands.  See the task-parallelism requirement in
-{ref}`design-ocean-analysis`.
+```python
+class Accumulator(OceanIOStep):
+    def setup(self):
+        # find cache files under sibling range directories of this product,
+        # keep those from completed steps whose provenance stamp matches,
+        # and add each as an input file
+        self.seeds = discover_seeds(self.work_dir, self.stamp())
+
+    def run(self):
+        needed = months_in_range(self.start_year, self.end_year)
+        have = inherited_months(self.seeds)
+        self.logger.info(f'inheriting {len(have)} months, '
+                         f'computing {len(needed - have)}')
+        compute(sorted(needed - have), pool_size=self.cpus_per_task)
+        publish(have, needed)
+```
+
+Four things about this are worth stating explicitly, because they are what make
+it acceptable to have software hunting for data on disk.
+
+**The search scope is what construction guarantees, and nothing wider.**  Only
+sibling directories of the same product are candidates: the same step class,
+with the same outputs, differing only in the range.  Nothing outside the
+product's own directory is searched, and no other work directory is ever
+consulted.
+
+**Admissibility comes from content, not from location.**  Each cache record
+carries a provenance stamp --- the identity of the simulation, the config
+options that govern the product, and a version integer for the kernel --- and a
+record whose stamp does not match is recomputed rather than inherited.  This
+matters because the path guarantees less than it looks like: task
+subdirectories do not encode which simulation was analyzed, so the same work
+directory pointed at a second simulation would otherwise cross-contaminate in
+silence, as would a changed elevation range or a changed constant.
+
+**Only completed steps are candidates.**  A sibling directory without
+`polaris_step_complete.log` is skipped, which also disposes of the
+half-written cache left by an interrupted run.
+
+**Reuse is reported.**  Each run logs how many months it inherited and from
+where, and the provenance travels into the output netCDF.  Two config options
+provide an explicit mode for anyone who wants determinism instead of
+discovery:
+
+```ini
+[ocean_analysis]
+
+# Inherit results from earlier analyses of the same simulation in this work
+# directory.  Set to False to recompute everything from the monthly means.
+reuse_previous = True
+
+# An additional directory to search for inheritable results, for the case
+# where an earlier analysis has been moved or copied.  Empty by default.
+reuse_search_path =
+```
+
+The pattern applies wherever we own the reduction kernel.  It does not apply to
+the climatology, because `ncclimo` has no incremental mode; a climatology is
+recomputed in full for each new range.
+
+Extending a time series from twenty years to forty therefore reads twenty years
+of monthly means, not forty.  Running a forty-year range and then a twenty-year
+sub-range inside it reads nothing at all the second time.  A partially written
+cache in the step's own directory is itself a valid starting point on a retry,
+which is most of what restartability asks for.
+
+Because the remaining months are independent, they are spread over a process
+pool inside the step rather than over steps.  This follows principle 3 in
+{ref}`design-ocean-analysis`, and it means the analysis gets its concurrency
+from a capability that exists today rather than from task parallelism.
 
 #### Staging results
 
@@ -1503,11 +1577,14 @@ Velocity reconstruction uses the weights on the mesh via
 the step reports that clearly and skips the zonal and meridional velocity maps
 rather than failing the whole step.
 
-If `compute_mixed_layer_depth` is set, the task adds a shared per-year step for
-each year of the climatology, structured exactly like the per-year heat content
-steps: each computes monthly mixed-layer depth with `gsw` as described in the
-algorithm design and writes one file for its year.  A range-keyed step then
-averages those into the seasonal and annual means that `maps` plots.  Its
+If `compute_mixed_layer_depth` is set, the task adds an accumulator structured
+exactly like the heat content one: its kernel computes a month of mixed-layer
+depth with `gsw` as described in the algorithm design.  Because its consumer is
+`ncclimo`, which reads monthly files, its cache is one file per month rather
+than a single series --- principle 8 in {ref}`design-ocean-analysis` --- and
+inherited months are symlinked forward rather than copied.  The climatology
+step then averages those into the seasonal and annual means that are plotted.
+Its
 outputs carry an attribute recording that they were computed offline from
 monthly means, and the step adds a note to the plot titles, so that a reader
 cannot mistake them for an in-situ diagnostic.
@@ -1585,54 +1662,52 @@ Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
-This product is two kinds of step.  A shared `OceanHeatContentYear` step per
-simulation year does the expensive work for that year:
+This product is a single accumulator step, `HeatContentSeries`, keyed by the
+requested range.  Its kernel reduces one month to a handful of numbers:
 
 ```python
-class OceanHeatContentYear(OceanIOStep):
-    def run(self):
-        ds_year = []
-        for month in range(1, 13):
-            ds = self.open_model_dataset(f'monthly_{month:02d}.nc',
-                                         self.config)
-            _, z_interface = get_z_mid_and_interface(ds)
-            layer_mass = get_layer_mass(ds, self.config)
-            ohc = []
-            for z_top, z_bot in elevation_ranges:
-                weights = elevation_range_weights(z_interface, layer_mass,
-                                                  k_min, k_max, z_top, z_bot)
-                column = heat_content(ds.temperature, weights, cp0)
-                ohc.append((area_cell * column).sum('nCells'))
-            ds_year.append(...)
-        write_netcdf(xr.concat(ds_year, dim='Time'), 'ohc.nc')
+class HeatContentSeries(Accumulator):
+    def compute_month(self, filename):
+        ds = self.open_model_dataset(filename, self.config)
+        _, z_interface = get_z_mid_and_interface(ds)
+        layer_mass = get_layer_mass(ds, self.config)
+        ohc = []
+        for z_top, z_bot in elevation_ranges:
+            weights = elevation_range_weights(z_interface, layer_mass,
+                                              k_min, k_max, z_top, z_bot)
+            column = heat_content(ds.temperature, weights, cp0)
+            ohc.append((area_cell * column).sum('nCells'))
+        return xr.merge(ohc)
 ```
 
-and a range-keyed `time_series` step concatenates the per-year files for the
-requested years and plots them.  The task's `configure()` creates one per-year
-step for each year in the configured range with
-`get_or_create_shared_step()`, so a year analyzed by an earlier range is reused
-rather than recomputed.
+The accumulator machinery described under `repeated-analysis` handles the rest:
+inheriting the months an earlier range already reduced, spreading the remaining
+months over a process pool, and writing the cache.
 
-Reading a month at a time within the year step is deliberate.  A global
-three-dimensional temperature field at 30 km resolution and 80 levels is
-roughly 150 MB per month, so a forty-year record is several tens of gigabytes;
-a month at a time bounds memory regardless of how long the record is.  Only
-`temperature`, the model's mass-like thickness variable, `zInterface`, and the
-vertical-index fields are read.
+The cache is a single netCDF with an unlimited `Time` dimension, appended to as
+months are added, because its consumer is the plotting in this same step, which
+reads the whole series.  This is principle 8 in {ref}`design-ocean-analysis`:
+the form follows the consumer.  Forty years of four elevation ranges is a few
+tens of kilobytes, so there is nothing here worth chunking.
+
+Reading a month at a time is deliberate.  A global three-dimensional
+temperature field at 30 km resolution and 80 levels is roughly 150 MB per
+month, so a forty-year record is several tens of gigabytes; a month at a time
+bounds memory regardless of how long the record is, and it is also what makes
+the unit of caching a month.  Only `temperature`, the model's mass-like
+thickness variable, `zInterface`, and the vertical-index fields are read.
 
 The plot has two panels: absolute heat content in units of 10²² J, and the
 anomaly relative to the first month, with one line per elevation range.  The
 concatenated time series is written to `ocean_heat_content_time_series.nc`.
 
-The per-year steps are the most expensive part of the suite.  If they prove too
-slow, there are two independent moves available: run them concurrently once
-Polaris's task parallelism lands, which needs no changes here because they are
-already independent non-MPI steps; or compute the vertical integrals in Omega
-in situ, which reduces the whole product to a concatenation.  If mixed-layer
-depth is also computed offline, its per-year steps make the same pass over the
-same monthly files and could be merged with these; they are kept separate
-because a merged step would couple two products for a saving that only matters
-if the pass proves expensive.
+This accumulator is the most expensive part of the suite on a first run, and
+nearly free on every run after it.  If a first run proves too slow, the move
+available is to compute the vertical integrals in Omega in situ, which reduces
+the whole product to a concatenation.  If mixed-layer depth is also computed
+offline, its accumulator makes the same pass over the same monthly files and
+the two could share one pass; they are kept separate because merging them would
+couple two products for a saving that only matters on a first run.
 
 ### Implementation: moc-plot
 
@@ -1686,9 +1761,10 @@ Contributors: Xylar Asay-Davis, Claude
 7. The ocean heat content `maps` step.
 8. The `global_stats` `time_series` step, including factoring the shared
    plotting function out of `StatsAnalysis`.
-9. The per-year and range-keyed ocean heat content time series steps.
+9. The `Accumulator` base class and the ocean heat content time series step
+   built on it.
 10. The `moc` `plot` step and the `plot_lat_elevation_field` primitive.
-11. The offline per-year `mixed_layer_depth` steps, only if Omega's in-situ
+11. The offline `mixed_layer_depth` accumulator, only if Omega's in-situ
     diagnostic will not be ready in time.
 12. User's Guide documentation: a page under `docs/users_guide/ocean/tasks/`
     describing the analysis suite and its config options, and an entry in
@@ -1726,11 +1802,13 @@ task, set config options, call `configure()`, and inspect the resulting steps:
 
 - the range-keyed steps land at subdirectories named for the configured range,
   and changing the range changes those subdirectories;
-- one per-year step is created for each year in the configured range, at a
-  subdirectory named for the year;
-- widening the range produces the same per-year steps for the years the two
-  ranges share --- literally the same objects, via
-  `get_or_create_shared_step()` --- plus new ones for the added years;
+- an accumulator set up over a range that overlaps an earlier one discovers
+  that earlier cache, declares it as an input, and reports the months it
+  inherited;
+- an accumulator whose provenance stamp does not match a candidate cache ---
+  a different simulation, a changed elevation range, a bumped kernel version
+  --- ignores it and recomputes;
+- a candidate directory without a completion marker is never inherited from;
 - the climatology and time series ranges are independent, so changing one does
   not disturb the other's steps.
 
@@ -1847,9 +1925,10 @@ Contributors: Xylar Asay-Davis, Claude
 The time series and MOC steps are mostly file handling and plotting, and are
 covered by:
 
-- a unit test that the per-year heat content files are reused rather than
-  recomputed when they already exist, and that adding a year extends the series
-  correctly;
+- a unit test that months already present in an inherited cache are reused
+  rather than recomputed, and that adding a year extends the series correctly;
+- a unit test that a cache written with one provenance stamp is not inherited
+  by a step asking under another;
 - a unit test on the construction of `GlobalStats` variable names from
   Polaris-standard field names and the configured statistics;
 - a unit test that a configured field or statistic missing from the dataset is

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1849,6 +1849,20 @@ all.  That is what lets the `publish` step declare each fragment as an input
 and have the framework check it, instead of tolerating absence and discovering
 late that a step it expected never wrote anything.
 
+**The base class writes it, not the step.**  `AnalysisStep.runtime_setup()`
+writes the empty fragment before the step runs, and describing a product
+rewrites it, so there is no call at the end of `run()` for a step author to
+remember.  That matters because the step that would forget is a step that made
+nothing, which is exactly the case the empty fragment exists for.  The
+fragment is also a declared output, so a step that leaves none names itself
+rather than surfacing as a missing input of `publish`.
+
+`makes_products` decides who writes one.  It is the same attribute `publish`
+uses to decide what to depend on, but the two questions are asked separately
+and nothing in the base class is gallery-aware --- which is what leaves room
+for a step to write a fragment without being a gallery step, as an archiver
+would want; see *pruning and archiving* in {ref}`design-ocean-analysis`.
+
 **A step fills the facets; the collector fills everything else.**  The
 published name and the thumbnail are added by the collector when it publishes,
 so a step never has to know the staging tree's layout, and a change to that

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -2179,8 +2179,8 @@ is for any Polaris task, and is the natural way to catch an unintended change
 in a diagnostic's values.
 
 This task is also where the task-parallel conformance checks described under
-`analysis-suite` are run, since it is the only place a whole analysis suite
-exists cheaply enough to exercise every step.
+`analysis-suite` should run when they are built, since it is the only place a
+whole analysis suite exists cheaply enough to exercise every step.
 
 #### Dependency on Omega
 
@@ -2258,7 +2258,14 @@ that rules which are only written down are not adopted, and that most of these
 can be checked mechanically.  The analysis steps are the first body of code
 written to them, so they should be the first to run the checks.
 
-Applied to every step in the suite:
+**The checks themselves are not in Phase 1.**  They need harness support that
+does not exist, and nothing they protect can go wrong until steps actually run
+concurrently, which is Phase 2.  What Phase 1 does is *follow* the rules ---
+explicit paths, declared resources, temporary files in the work directory,
+logging through the step's logger, and no mutation of process globals --- since
+that costs nothing while the code is being written and is what would be
+expensive to retrofit.  The checks are listed here so that the first phase that
+needs them knows what to build:
 
 - **Working-directory independence.**  Run the step with the process working
   directory set somewhere unrelated and confirm the results are identical.
@@ -2275,9 +2282,9 @@ Applied to every step in the suite:
 - **Bounded launching.**  Confirm the step starts no more processes than
   `cpus_per_task`.
 
-These run against the coarse-resolution regression test, where a whole suite is
-cheap enough to exercise, rather than against synthetic steps --- the point is
-to check the steps we ship, not a model of them.
+They should run against the coarse-resolution regression test, where a whole
+suite is cheap enough to exercise, rather than against synthetic steps --- the
+point is to check the steps we ship, not a model of them.
 
 ### Testing and Validation: repeated-analysis
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1751,7 +1751,19 @@ Notes on the arguments:
   soon as Omega can write monthly means because it is on the critical path.
 - `-p`/`-j` set the parallel mode and thread count.  `ncclimo` in `bck` mode
   runs up to twelve background processes, one per month, so the step requests
-  `cpus_per_task = 12` and `ntasks = 1`.
+  `cpus_per_task = 12` and `ntasks = 1`.  This is the worked example of bounded
+  process launching from
+  [Task-Parallel-Safe Analysis Steps](task_parallel_analysis_steps.md): the
+  step declares what it will start, and `-j` is set from `cpus_per_task` rather
+  than from the size of the machine, so a second step running beside it does
+  not find the node oversubscribed.
+- `ncclimo`'s scratch space is pointed at the step's own work directory rather
+  than being left to `TMPDIR`, so that two climatologies running at once ---
+  the model one and the mixed-layer depth one --- cannot collide on a temporary
+  path.
+- `ncclimo` is launched through Polaris's subprocess helper with the step's
+  logger, so its output is captured into the step's log rather than
+  interleaving on shared streams with whatever else is running.
 
 The output file names produced by `ncclimo` follow the pattern
 `<caseid>_<season>_<YYYYMM>_<YYYYMM>_climo.nc`.  Rather than reconstructing

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -264,12 +264,12 @@ fields.  The monthly-mean output shall:
 - cover, at minimum, the fields needed by this analysis: conservative
   temperature, absolute salinity, pseudo-thickness, sea surface height,
   reconstructed zonal and meridional velocity at cell centers, and mixed-layer
-  depth.  Reconstructed velocities are preferred over `normalVelocity` as the
-  default monthly output because two cell-centered fields are smaller than one
-  edge field --- there are roughly three edges per cell --- and because
-  `normalVelocity` is not itself plotted by anything in this analysis.  Polaris
-  can reconstruct offline from `normalVelocity` if that is what a simulation
-  wrote, at the cost of carrying and reading the larger field;
+  depth.  Reconstructed velocities are **required** rather than preferred: the
+  machinery to write them exists in Omega, two cell-centered fields are about
+  two thirds the size of one edge field, and `normalVelocity` is not itself
+  plotted by anything here, so there is no reason for a simulation to write the
+  larger field and no reason for Polaris to carry a reconstruction it would
+  never use;
 - include the **geometric vertical coordinate**, `GeomZMid` and
   `GeomZInterface`, so that Polaris does not have to reconstruct it (see the
   vertical-geometry algorithm design for why it cannot);
@@ -720,27 +720,25 @@ with `z_mid` set to `NaN` outside the valid range so invalid layers do not
 contribute, followed by a clip into `[k_min, k_max - 1]` and a mask for the
 out-of-column cases.
 
-#### Reconstructed velocities
+#### Velocity
 
-The map steps plot zonal and meridional velocity at cell centers.  If the
-monthly means contain them, they are used directly.  If they contain
-`normalVelocity` on edges instead, the step reconstructs them with the
-least-squares reconstruction designed in
-[Vector Reconstruction](vector_reconstruction.md), whose weights are stored on
-the mesh.
+The map steps plot zonal and meridional velocity at cell centers, read directly
+from the monthly means.  Polaris does not reconstruct them, and Phase 1 has no
+offline reconstruction path at all.
 
-Both paths give the same answer.  Reconstruction is a linear operator on the
-edge field, so reconstructing from a climatology of normal velocity gives
-exactly the climatology of the reconstructed velocity; there is no accuracy
-argument for preferring one over the other, and having the offline path means
-this product does not block on Omega work.
+An earlier draft had one, reconstructing from `normalVelocity` on edges with
+the least-squares weights designed in
+[Vector Reconstruction](vector_reconstruction.md), so that this product would
+not block on Omega work.  It is not needed: Omega already has what it needs to
+write reconstructed velocities, so they are a required output rather than a
+preferred one, and a fallback for a case that will not arise is code we would
+write, test and maintain for nothing.
 
-The preference is about output volume rather than accuracy, which is why the
-`omega-monthly-means` requirement asks for reconstructed velocities as the
-default monthly output: two cell-centered fields are about two thirds the size
-of one edge field, and nothing else in this analysis reads `normalVelocity`.
-Offline reconstruction is the fallback for simulations that wrote the edge
-field, not the intended steady state.
+The accuracy question that would otherwise decide this does not arise either.
+Reconstruction is linear, so reconstructing from a climatology of normal
+velocity gives exactly the climatology of the reconstructed velocity --- doing
+it in the model costs nothing in accuracy, and it saves writing and reading an
+edge field nothing else here wants.
 
 ### Algorithm Design: mixed-layer depth (fallback only)
 
@@ -1698,10 +1696,10 @@ Notes on the arguments:
 - `-a sdd` selects the seasonally discontinuous December convention discussed
   in the algorithm design.
 - `-v` restricts the climatology to the union of the fields requested for maps,
-  the fields needed for heat content (`temperature`), the fields needed for
-  velocity reconstruction (`normalVelocity`, when zonal and meridional velocity
-  are requested and not written by the model), and the vertical geometry
-  (`zMid`, `zInterface`).  Building this list is the reason `Climatology` needs
+  the fields needed for heat content (`temperature` and the model's mass-like
+  thickness), and the vertical geometry (`zMid`, `zInterface`).  Every name on
+  that list is a field the model wrote, which is what keeps the mapping back to
+  Omega names below well defined.  Building this list is the reason `Climatology` needs
   to know which steps depend on it; the list is assembled from config options
   at runtime rather than passed in by each task, so that the step stays neutral
   with respect to which tasks pulled it in.
@@ -1822,7 +1820,7 @@ for season in plot_seasons:
     z_mid, z_interface = get_z_mid_and_interface(ds)
     layer_mass = get_layer_mass(ds, self.config)
     for field in self.field_group.fields:
-        da = self._get_field(ds, field)   # reconstructs velocities if needed
+        da = self._get_field(ds, field)
         for reduction in self._reductions(da):
             da_map = apply_vertical_reduction(
                 da, reduction, z_mid, z_interface, layer_mass,
@@ -1868,9 +1866,8 @@ remapping.  Native-mesh plotting is not a temporary expedient: it is where
 observational comparison is headed too, with observations remapped onto the
 MPAS mesh rather than the model remapped onto a comparison grid.
 
-Velocity reconstruction uses the weights on the mesh via
-`polaris.mesh.reconstruct`.  If the mesh does not carry reconstruction weights,
-the step reports that clearly and skips the zonal and meridional velocity maps
+A field the simulation did not write --- zonal velocity from a run configured
+without it, for instance --- is reported clearly and its maps are skipped,
 rather than failing the whole step.
 
 If `compute_mixed_layer_depth` is set, the task adds an accumulator structured

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -789,12 +789,29 @@ The search for $k_1$ is vectorized over columns as the count of valid layer
 midpoints at or above $z$, which avoids a Python loop over cells:
 
 ```python
-k1 = (z_mid >= z).sum(dim='nVertLevels') - 1
+k1 = k_min + (z_mid >= z).sum(dim='nVertLevels') - 1
 ```
 
 with `z_mid` set to `NaN` outside the valid range so invalid layers do not
 contribute, followed by a clip into `[k_min, k_max - 1]` and a mask for the
 out-of-column cases.
+
+The $k_{min}$ term is easy to drop and worth keeping in view.  Because
+`z_mid` is `NaN` above the valid range as well as below it, the count is of
+*valid* midpoints at or above $z$, which is $k_1 - k_{min} + 1$ rather than
+$k_1 + 1$.  Without the term the index lands $k_{min}$ layers too high, which
+is invisible wherever $k_{min} = 0$ and wrong in every ice-shelf cavity: for
+$k_{min} = 3$, $k_{max} = 5$ and a $z$ below every valid midpoint, the count
+is 3, so the index clips to $k_{min}$ and clamps to $f_3$ where the rule above
+says $f_{k_{max}} = f_5$.
+
+Two details of the implementation follow from the rules above rather than
+adding to them.  The two clamping cases come out of clipping the weight $w$
+into $[0, 1]$ after the index is clipped, which reproduces them exactly
+without a branch.  A column with a single valid layer, $k_{min} = k_{max}$,
+does need its own branch: the clip range `[k_min, k_max - 1]` is empty, and
+the answer is $f_{k_{min}}$ rather than an interpolation against a layer below
+the seafloor.
 
 #### Velocity
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -313,21 +313,26 @@ the full contents of the monthly-mean files.
 
 ### Requirement: climatology-maps
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
 Polaris shall produce global maps of climatological fields on the native MPAS
 mesh, for each requested field and each requested season.
 
-For fields that have a vertical dimension, the user shall be able to request
-maps at any combination of:
+A field with a vertical dimension has to be reduced to a horizontal map before
+it can be plotted, and there is more than one useful way to do that.  Polaris
+shall provide a general **vertical reduction** for this purpose, of which the
+user shall be able to request any combination:
 
 - **the sea surface** --- the topmost valid layer of each column;
 - **a fixed geometric elevation** --- a given elevation $z$ (positive up, so
   negative within the ocean), obtained by linear interpolation in the vertical;
 - **a fixed layer index** --- a given vertical index, common to all columns;
-- **the seafloor** --- the bottommost valid layer of each column.
+- **the seafloor** --- the bottommost valid layer of each column;
+- **an integral over an elevation range** --- the mass-weighted integral of the
+  field between two elevations, which is how ocean heat content maps are
+  produced.
 
 The "topmost" and "bottommost" valid layers shall respect `minLevelCell` and
 `maxLevelCell`, so that columns under ice-shelf cavities and columns with
@@ -344,13 +349,19 @@ Polaris shall reconstruct them from the normal velocity on edges.
 
 ### Requirement: ocean-heat-content-maps
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
 Polaris shall compute ocean heat content integrated over elevation ranges from
 a climatology of conservative temperature, and shall produce a global map for
 each elevation range and each requested season.
+
+This is the elevation-range case of the vertical reduction required above, and
+is delivered as a field of the climatology maps rather than as a product of its
+own.  A heat content map is a climatology map of a field that happens to be
+derived, and separating the two would mean two code paths, two step trees, and
+two config conventions for the same operation.
 
 The elevation ranges shall be set by config options.  The defaults shall be the
 whole ocean, the surface to $-700$ m, $-700$ m to $-2000$ m, and $-2000$ m to
@@ -1506,8 +1517,20 @@ def parse_elevation_spec(spec):
     """Parse 'top', 'bottom', 'k<n>' or an elevation in m."""
 
 
-def extract_elevation_slice(da, spec, z_mid, min_level_cell, max_level_cell):
-    """Extract a horizontal slice at the requested elevation."""
+def parse_vertical_reduction(spec):
+    """Parse an elevation spec or a '<top>:<bottom>' range into a reduction."""
+
+
+def apply_vertical_reduction(da, reduction, z_mid, z_interface, layer_mass,
+                             min_level_cell, max_level_cell):
+    """Reduce a field with a vertical dimension to a horizontal map.
+
+    Slicing at an elevation, a layer index, the surface or the seafloor, and
+    integrating over an elevation range, are the cases of one operation: every
+    one of them turns ``nVertLevels`` into nothing.  Keeping them behind a
+    single entry point is what lets ocean heat content be a field of the
+    climatology maps rather than a product of its own.
+    """
 
 
 def elevation_range_weights(z_interface, layer_mass, min_level_cell,
@@ -1536,41 +1559,62 @@ layer mass rather than computing it, so that the one place that knows how each
 model spells its mass-like thickness stays
 `polaris.ocean.model.get_layer_mass`.
 
-The `ClimatologyMaps` step then loops over seasons, fields, and elevations:
+#### Chunking: one step per field group
+
+There is one `ClimatologyMaps` step per **field group**, not per field and not
+one for all of them.  Per principle 4 in {ref}`design-ocean-analysis`, the
+field list is an axis a user edits between runs --- adding a field should cost
+that field and not the others --- while seasons and elevations are bounded and
+rarely change, so they are loops inside the step.
+
+The unit is a group rather than a variable because things computed together
+belong together: zonal and meridional velocity share one vector reconstruction,
+and heat content over several elevation ranges shares one set of layer weights.
+Splitting those would repeat the expensive part.  The Phase 1 groups are
+`temperature`, `salinity`, `velocity`, `ssh`, `mixed_layer_depth`, and
+`heat_content`.
+
+Each step loops over seasons, the fields in its group, and the vertical
+reductions requested for them:
 
 ```python
 for season in plot_seasons:
     ds = self.open_model_dataset(climo_filename(season), self.config)
-    z_mid, _ = get_z_mid_and_interface(ds)
-    for field in fields:
+    z_mid, z_interface = get_z_mid_and_interface(ds)
+    layer_mass = get_layer_mass(ds, self.config)
+    for field in self.field_group.fields:
         da = self._get_field(ds, field)   # reconstructs velocities if needed
-        if 'nVertLevels' in da.dims:
-            specs = [parse_elevation_spec(spec) for spec in elevations]
-        else:
-            specs = [None]
-        for spec in specs:
-            da_slice = (da if spec is None else
-                        extract_elevation_slice(da, spec, z_mid,
-                                                k_min, k_max))
-            write_netcdf(da_slice, out_filename)
+        for reduction in self._reductions(da):
+            da_map = apply_vertical_reduction(
+                da, reduction, z_mid, z_interface, layer_mass,
+                k_min, k_max)
+            write_netcdf(da_map, out_filename)
+            self.manifest.add(da_map, field=field, season=season,
+                              reduction=reduction, filename=out_filename)
             plot_global_mpas_field(
-                da=da_slice, out_filename=..., config=self.config,
+                da=da_map, out_filename=..., config=self.config,
                 colormap_section=f'ocean_analysis_map_{field}',
                 mesh_filename='mesh.nc', ...)
 ```
 
-Output names are `<field>_<season>_<elevation_label>.png` with elevation labels
-`top`, `bottom`, `-100m`, and `k10`, so that the set of files in the step
-directory is self-describing.
+Heat content needs no branch here.  Its field is derived rather than read, and
+its reduction is an elevation range rather than an elevation, and both of those
+are cases the loop already handles.
+
+Output names are `<field>_<season>_<reduction_label>.png` with reduction labels
+`top`, `bottom`, `-100m`, `k10`, and `0m-700m`, so that the set of files in the
+step directory is self-describing.
+
+The plots are independent, so a step with many of them spreads them over a
+process pool rather than over steps.  Building the `mosaic` descriptor is the
+expensive part of plotting a global mesh, so it is constructed once per step
+and shared.
 
 Maps are plotted on the native mesh with the existing
 `polaris.viz.plot_global_mpas_field`, which is `mosaic`-based and needs no
 remapping.  Native-mesh plotting is not a temporary expedient: it is where
 observational comparison is headed too, with observations remapped onto the
 MPAS mesh rather than the model remapped onto a comparison grid.
-
-The `mosaic` descriptor is constructed once and reused across all plots, since
-building it is the expensive part of plotting a global mesh.
 
 Velocity reconstruction uses the weights on the mesh via
 `polaris.mesh.reconstruct`.  If the mesh does not carry reconstruction weights,
@@ -1595,24 +1639,27 @@ Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
-The `maps` step of the `ocean_heat_content` task reads the same climatology
-files, computes
+Heat content maps are the `heat_content` field group of `ClimatologyMaps`, not
+a step of their own.  The group differs from the others in two small ways, both
+of which the loop above already accommodates:
 
-```python
-layer_mass = get_layer_mass(ds, self.config)
-weights = elevation_range_weights(z_interface, layer_mass, k_min, k_max,
-                                  z_top, z_bot)
-ohc = heat_content(ds.temperature, weights, cp0)
-```
+- its field is derived rather than read, by
+  `heat_content(ds.temperature, weights, cp0)` where `weights` comes from
+  `elevation_range_weights`;
+- its vertical reductions are the configured elevation ranges rather than the
+  configured elevations.
 
-for each configured elevation range and each plotted season, writes the result
-to netCDF in J m⁻² and plots it in GJ m⁻² (a range of $0$ to $-700$ m at a
-typical 10 °C is about 29 GJ m⁻², which is a readable number).
+Because the layer weights depend only on the range and not on the season, they
+are computed once per season and reused across ranges within it.
 
-Output names are `ohc_<season>_<z_top>_<z_bot>.png`, for example
-`ohc_ANN_0m_-700m.png` and `ohc_ANN_-2000m_bottom.png`.  Plot titles state the
-elevation range and the season explicitly, and the netCDF carries the range as
-attributes, so that a plot cannot be mistaken for a different range.
+The result is written to netCDF in J m⁻² and plotted in GJ m⁻² --- a range of
+$0$ to $-700$ m at a typical 10 °C is about 29 GJ m⁻², which is a readable
+number.  Output names follow the same convention as the rest of the maps,
+`heat_content_<season>_<range_label>.png`, for example
+`heat_content_ANN_0m-700m.png` and `heat_content_ANN_-2000m-bottom.png`.  Plot
+titles state the elevation range and the season explicitly, and the netCDF
+carries the range as attributes, so that a plot cannot be mistaken for a
+different range.
 
 ### Implementation: global-stats-time-series
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1369,6 +1369,17 @@ Input files are symlinked into each step's work directory in `setup()` using
 `Step.add_input_file`, which gives the usual Polaris provenance and dependency
 checking without copying data.
 
+**Where that reporting goes is not settled, and today's answer is temporary.**
+It is written to stdout during `setup()`, because a step has no logger until
+the run harness attaches one, and it earns its place while the reader is new:
+it is how a wrong file list gets diagnosed at the moment.  It cannot stay
+there.  Polaris deliberately writes almost nothing during setup, so that what
+the user sees is the suite being set up rather than the internals of individual
+steps, and ten analysis steps each reporting their inputs dilutes exactly that.
+Before the deliverable, this moves into each step's own log at run time, where
+`self.logger` exists and where a reader looking into one step's behavior will
+go for it, leaving setup with only what it already prints.
+
 #### Every path is explicit
 
 Polaris changes the process working directory into each step's work directory

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1759,8 +1759,19 @@ of which the loop above already accommodates:
 - its vertical reductions are the configured elevation ranges rather than the
   configured elevations.
 
-Because the layer weights depend only on the range and not on the season, they
-are computed once per season and reused across ranges within it.
+The layer weights $\tilde{w}_k$ do depend on the range, so they are not shared
+between ranges --- but everything expensive is.  The climatology of $\Theta$,
+of `PseudoThickness` and of `zInterface` is read once per season, and each
+range is then a masked weighted sum over levels, which is negligible beside the
+read.  Adding an elevation range therefore costs almost nothing, which is why
+the ranges are a loop inside this step rather than an axis of decomposition.
+
+This is also why the heat content maps have no dependency on the heat content
+accumulator: they are computed from the climatology, like every other map,
+while the accumulator exists only for the time series, where the per-month
+values *are* the product.  The asymmetry is not an inconsistency --- it is the
+difference between wanting a seasonal mean, which the climatology already is,
+and wanting a time axis, which only a pass over every month can give.
 
 The result is written to netCDF in J m⁻² and plotted in GJ m⁻² --- a range of
 $0$ to $-700$ m at a typical 10 °C is about 29 GJ m⁻², which is a readable

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -733,10 +733,25 @@ offline reconstruction path at all.
 An earlier draft had one, reconstructing from `normalVelocity` on edges with
 the least-squares weights designed in
 [Vector Reconstruction](vector_reconstruction.md), so that this product would
-not block on Omega work.  It is not needed: Omega already has what it needs to
-write reconstructed velocities, so they are a required output rather than a
-preferred one, and a fallback for a case that will not arise is code we would
-write, test and maintain for nothing.
+not block on Omega work.  It is not needed: the Omega side is in progress in
+[Omega #525](https://github.com/E3SM-Project/Omega/pull/525), which adds
+velocity-component reconstruction for I/O, so reconstructed velocities become a
+required output rather than a preferred one, and a fallback for a case that
+will not arise is code we would write, test and maintain for nothing.
+
+That work is still a draft, so this is the one place the design depends on
+something not yet landed upstream.  The consequence is contained: until it
+does, the mock-up files carry `NormalVelocity` and no components, so the
+velocity maps are the one product that reports missing fields and skips, in the
+way described under `omega-monthly-means`.  Nothing else waits on it.  Writing
+the offline path against that gap would cost more than the wait, and would
+leave us maintaining two ways to obtain the same field.
+
+Polaris's reconstruction itself is not going away and is being fixed
+independently --- [Polaris #721](https://github.com/E3SM-Project/polaris/pull/721)
+corrects vector reconstruction on planar meshes, found while doing the Omega
+work.  It stays available for tasks that need it; this analysis simply does not
+read edge velocities.
 
 The accuracy question that would otherwise decide this does not arise either.
 Reconstruction is linear, so reconstructing from a climatology of normal

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -535,44 +535,44 @@ The steps that remain are **shared steps** in the sense of
 range, so that the climatology for a range is built once no matter how many
 products read it.  The implementation section works through the details.
 
-#### How many steps is too many?
+#### How many steps, and how much do they do?
 
-Decomposing by year buys reuse and concurrency at the cost of step count, and
-it is worth having a number in mind before the design commits to per-year
-granularity.  For a typical decadal-to-multidecadal analysis --- a 60-year
-record with a 20-year climatology --- the suite contains roughly:
+Principle 9 in {ref}`design-ocean-analysis` asks for step counts in the low
+hundreds and for steps that do at least tens of seconds of work at production
+resolution.  For a typical analysis --- a 60-year record with a 20-year
+climatology --- this design produces:
 
 | Steps | Count |
 | --- | --- |
-| Per-year ocean heat content | 60 |
-| Per-year offline mixed-layer depth (fallback only) | 60 |
 | `ncclimo` climatology | 1 |
-| Range-keyed plotting and time-series steps | ~6 |
-| **Total** | **~130** |
+| Climatology maps, one per field group | 6 |
+| Offline mixed-layer depth accumulator (fallback only) | 1 |
+| Heat content series accumulator | 1 |
+| Global stats, MOC | 2 |
+| **Total** | **11** |
 
-For comparison, the existing `ocean` component builds several hundred steps
-across all of its tasks, and `polaris setup` handles that in seconds, so ~130
-steps in a single suite is not a regime we have reason to expect trouble in.
-The number scales linearly with the length of the record, so a century-long
-record with both per-year products would be ~230 steps, which is still not
-alarming.
+The count is **independent of the length of the record**, which is the property
+worth having.  An earlier draft, with one shared step per simulation year, gave
+about 130 steps for the same analysis and grew linearly, so a century-long
+record would have given about 230.  That was never going to break Polaris --- a
+few hundred steps is ordinary, and the existing `ocean` component builds
+several hundred across all its tasks --- but the count grew with something the
+user has no control over, which is the wrong shape even when the numbers are
+small.
 
-The thresholds worth naming, so that we notice if we approach them: a few
-hundred steps is ordinary; at around a thousand, `polaris setup` time and the
-size of the suite pickle become worth measuring before proceeding; well beyond
-that, the per-step overhead --- a work directory, a pickle, a config copy, a
-log file --- starts to dominate the actual computation, which for a single year
-of heat content is only seconds of work on a few GB of input.
+Step *size* is the other half, and it is now comfortable at both ends.  On a
+first run the heat content accumulator reads the whole record, which is minutes
+to hours at 30 km; on a re-run over an overlapping range it reads only the new
+months.  A climatology map step plots the seasons and reductions of one field
+group, which is seconds to minutes per plot at production resolution.  Neither
+is close to the regime where a step's overhead --- a work directory, a pickle,
+a config copy, a log file --- would be a meaningful fraction of its runtime.
 
-Two levers exist if we get there, and neither requires reworking the design.
-The first is to merge the per-year products: the heat content and mixed-layer
-depth year steps make the same pass over the same twelve files, so one step
-producing both halves the count.  They are kept separate here because merging
-couples two products for a saving that only matters at scale.  The second is to
-coarsen the key from a year to a decade, which divides the count by ten at the
-cost of making reuse coarser --- extending a record from 60 to 65 years would
-redo a decade rather than five years.  We should reach for merging first, since
-it costs nothing in reuse.
+The count grows with the number of field groups and, in later phases, with
+whatever new products are added --- not with the record, the seasons, the
+elevations, or the regions.  That is what principle 4 is protecting: the
+dimensions that multiply are loops inside steps, so adding regional analysis
+multiplies the *plots* without multiplying the *steps*.
 
 The climatology is the one expensive computation that genuinely depends on the
 range, and it is recomputed for each new range.  In principle a climatology
@@ -973,45 +973,53 @@ work-directory layout is:
 
 ```none
 ocean/analysis/
-├── climatology/
-│   └── 0021-0040/                (shared step: ncclimo, per range)
-├── years/                        (shared per-year steps, range-independent)
-│   ├── ocean_heat_content/0021/ … 0060/
-│   └── mixed_layer_depth/0021/ … 0060/   (only if computed offline)
-├── climatology_maps/             (task)
-│   └── maps/0021-0040/           (step, per range)
-├── ocean_heat_content/           (task)
-│   ├── maps/0021-0040/           (step, from the climatology)
-│   └── time_series/0001-0060/    (step, from the per-year steps)
-├── global_stats/                 (task)
-│   └── time_series/0001-0060/    (step)
-└── moc/                          (task)
-    └── plot/0021-0040/           (step)
+├── climatology/0021-0040/                    (shared: ncclimo)
+├── climatology_maps/0021-0040/
+│   ├── temperature/ salinity/ velocity/      (one step per field group)
+│   ├── ssh/ mixed_layer_depth/
+│   └── heat_content/
+├── mixed_layer_depth_monthly/0021-0040/      (only if computed offline)
+├── heat_content_series/0001-0060/
+├── global_stats/0001-0060/
+└── moc/0021-0040/
 ```
 
-Step subdirectories are keyed by the date range they cover, and the expensive
-per-year work lives in shared steps keyed by year rather than by range.  The
-`repeated-analysis` implementation below explains why, and why this structure
-is what makes re-running with a new range work.
+The layout follows one rule --- **`<product>/<period>/[<field group>]`** ---
+and the third level exists only for the one product that is chunked.  This is
+the work tree, so it is built for predictability and for finding a step's log,
+not for browsing; browsing is the staging tree's job.  See principles 1 and 5
+in {ref}`design-ocean-analysis`.
 
-The `climatology` and `years` steps are shared steps in the sense of
-[Shared steps](shared_steps.md): the climatology for a given range is used by
-`climatology_maps/maps` and by `ocean_heat_content/maps`, and both sit at
-`ocean/analysis`, the highest level at or below which all of the tasks that use
-them live.  Each runs once no matter how many of the tasks are run.
+Two levels from an earlier draft are gone, and it is worth saying why, since
+the reasoning generalizes:
 
-Ocean heat content is one task with two steps rather than two tasks: the maps
-and the time series share the elevation ranges and the heat content kernel, and
-are one product from the reader's point of view even though they read different
-inputs.  Running only one of them is still possible with `polaris serial
---steps`.
+- **`years/`**, which held one shared step per simulation year, is gone because
+  those steps are gone --- the expensive per-year work is now a seeded
+  accumulator inside a single step.  Renaming the level would not have helped:
+  a directory whose best name describes how the work was chunked is a level
+  that should not exist.
+- **`maps/`, `time_series/`, and `plot/`**, the single-step levels between a
+  product and its period, are gone because a level with one child and a name
+  that repeats its parent earns nothing and costs a level of depth on every
+  path.
+
+Every step is a shared step in the sense of [Shared steps](shared_steps.md),
+created at `ocean/analysis`, the highest level at or below which all of the
+tasks that use them live.  This matters most for the climatology, which every
+field group of `climatology_maps` reads and which therefore runs once no matter
+how many of them are run.
+
+Tasks are a thin grouping over these steps and no longer introduce directory
+levels of their own: `climatology_maps` is one task with a step per field
+group, and `heat_content_series`, `global_stats`, and `moc` are one task with
+one step each.  Running a subset is `polaris serial --steps`.
 
 The suite is `polaris/suites/ocean/omega_analysis.txt`, named to match the
 existing `omega_pr` and `omega_nightly` suites:
 
 ```none
 ocean/analysis/climatology_maps
-ocean/analysis/ocean_heat_content
+ocean/analysis/heat_content_series
 ocean/analysis/global_stats
 ocean/analysis/moc
 ```
@@ -1251,8 +1259,8 @@ resolutions.
 #### Re-running comes from range-keyed step subdirectories
 
 Every range-dependent step lives at a subdirectory named for the range it
-covers: `climatology/0021-0040`, `climatology_maps/maps/0021-0040`,
-`global_stats/time_series/0001-0060`.  A setup with a new range therefore
+covers: `climatology/0021-0040`, `climatology_maps/0021-0040/temperature`,
+`global_stats/0001-0060`.  A setup with a new range therefore
 creates *new steps in new directories*, which have never run and so are not
 complete, and they run.  A setup with the same range lands on the same
 directories, which are complete, and nothing is recomputed.
@@ -1391,15 +1399,12 @@ outputs, and completion markers --- so re-running an earlier range means
 re-running setup with that range's config, after which everything it needs is
 already complete except whatever it is being asked to redo.
 
-Analyzing many ranges accumulates step directories and climatology files.  This
-is deliberate, since it is what makes re-analyzing an earlier range nearly
-free, but it is worth knowing about on a filesystem with a quota.
-
-Per-year steps also mean a suite with a forty-year time series contains forty
-extra steps per per-year product.  That is a larger step count than existing
-Polaris tasks produce, though not by orders of magnitude, and it is worth a
-look at setup time on a long record before committing to per-year rather than,
-say, per-decade granularity.
+Analyzing many ranges accumulates step directories, climatology files, and
+accumulator caches.  This is deliberate, since it is what makes re-analyzing an
+earlier range nearly free, but it is worth knowing about on a filesystem with a
+quota.  The climatology files dominate: an accumulator cache for a reduced
+series is kilobytes, while a full set of `ncclimo` output is a copy of the
+requested fields for every season.
 
 ### Implementation: omega-monthly-means
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -2205,49 +2205,71 @@ first.  This is a schedule judgment rather than a statement about its value: a
 capability that nothing we run exercises is a capability that regresses
 quietly, so this is the first thing to build once the products are out.
 
-### Implementation: commit sequence
+### Implementation: order of work
 
 Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
+Each entry below is a coherent, independently reviewable piece of work, not a
+single commit --- most will take several --- and each leaves the suite working
+for the products delivered so far.
+
+The order is by deliverable priority rather than by dependency depth, which is
+why the vertical machinery comes late.  Slicing by layer index needs no
+vertical geometry at all, and heat content over the whole column needs only
+`minLevelCell` and `maxLevelCell`, so both a map and a heat content drift curve
+can be on screen well before elevation interpolation exists.  The standard
+$0$--$700$ m, $700$--$2000$ m and $2000$ m--seafloor ranges then enrich a
+product that already works rather than gating it.
+
 1. This design document and the umbrella document
    {ref}`design-ocean-analysis`.
-2. `polaris/ocean/vertical/elevation.py` --- elevation specifications,
-   elevation slicing, and elevation-range weights --- with unit tests.
-3. `polaris/ocean/heat_content.py` with unit tests.
-4. The `omega_analysis` scaffolding: the `polaris/tasks/ocean/analysis/`
-   package, `analysis.cfg`, `sim_files.py`, the range-keyed step
-   subdirectories, the tasks with their `configure()` methods, and the
-   `omega_analysis` suite, with steps that do nothing yet.  This is the commit
-   where the repeated-analysis structure is established, so it should land
-   before anything that depends on it.
-5. The manifest writer and the `publish` step, including the generated index.
-   Early, so that every step added afterwards writes its manifest fragment as
-   a matter of course rather than being retrofitted.
-6. The `Climatology` step (`ncclimo`).
-7. The `ClimatologyMaps` step and the vertical reduction it is built on,
-   covering the read-and-slice field groups, including velocity
-   reconstruction.
-8. The `heat_content` field group of `ClimatologyMaps`.
-9. The `global_stats` time series step, including factoring the shared
-   plotting function out of `StatsAnalysis`.
-10. The `Accumulator` base class --- seed discovery, provenance stamping, and
-    the process pool --- with unit tests, since this is the piece whose
-    failure modes are silent.
-11. The `heat_content_series` step built on it.
+2. The `omega_analysis` scaffolding: the `polaris/tasks/ocean/analysis/`
+   package, `analysis.cfg`, `sim_files.py` including the reader for the
+   simulation's Omega configuration, the range-keyed step subdirectories, the
+   tasks with their `configure()` methods, and the `omega_analysis` suite, with
+   steps that do nothing yet.  This is where the repeated-analysis structure is
+   established, so it lands before anything that depends on it.
+3. The `global_stats` time series step, including factoring the shared plotting
+   function out of `StatsAnalysis`.  It depends on nothing above it, reads
+   Omega's `GlobalStats` output directly, and needs no vertical geometry, so it
+   is the earliest point at which the suite produces a plot a scientist wants.
+4. The `Climatology` step (`ncclimo`).  Early because it carries the most
+   external risk in the design: it shells out to NCO and depends on Omega's
+   time metadata being read correctly by a tool we do not control.  Everything
+   map-shaped is blocked on it, so we want to find out.
+5. The `ClimatologyMaps` step, restricted to fields with no vertical dimension
+   and to slicing by layer index.  The first maps on disk, and no vertical
+   geometry needed.
+6. The manifest writer and the `publish` step.  Here rather than earlier so
+   that it is built against products that exist, and here rather than later so
+   that only one step needs its manifest fragment retrofitted.
+7. `polaris/ocean/heat_content.py` and whole-column mass weights, with unit
+   tests.
+8. The `heat_content` field group of `ClimatologyMaps`, whole column only.
+9. The `Accumulator` base class --- seed discovery and provenance stamping ---
+   with unit tests, since this is the piece whose failure modes are silent.
+10. The `heat_content_series` step built on it, whole column only.  Heat content
+    drift is what a coupled run is judged on, which is why it precedes the
+    vertical machinery rather than following it.
+11. `polaris/ocean/vertical/elevation.py` --- the full vertical reduction:
+    interpolation to an elevation, the sea surface, the seafloor, and elevation
+    ranges --- with unit tests.  This enriches items 5, 8 and 10, each of which
+    already works without it.
 12. The `moc` step and the `plot_lat_elevation_field` primitive.
-13. The offline `mixed_layer_depth` accumulator, only if Omega's in-situ
-    diagnostic will not be ready in time.
-14. The `replot` option.
-15. The `analysis_test` task and the `omega_analysis_test` suite, once Omega
-    can write monthly means.
-16. User's Guide documentation: a page under `docs/users_guide/ocean/tasks/`
+13. The `replot` option.
+14. The offline `mixed_layer_depth` accumulator and its climatology, only if
+    Omega's in-situ diagnostic will not be ready in time.
+15. User's Guide documentation: a page under `docs/users_guide/ocean/tasks/`
     describing the analysis suite and its config options, and an entry in
     `docs/users_guide/ocean/suites.md`.
 
-Commits 2, 3, and 6 through 14 are independently reviewable and each leaves the
-suite in a working state for the products delivered so far.
+Deferred past this deliverable, and designed in
+{ref}`design-ocean-analysis` rather than here: splitting accumulators into
+several steps, process pools inside steps, the generated gallery over the
+staging tree, the mechanical conformance checks, and the `analysis_test` task
+and its suite.
 
 ## Testing
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1937,21 +1937,26 @@ def parse_vertical_reduction(spec):
     elevation range, into a vertical reduction."""
 
 
-def apply_vertical_reduction(da, reduction, z_mid, z_interface, layer_mass,
+def apply_vertical_reduction(da, reduction, z_mid, z_interface,
                              min_level_cell, max_level_cell):
-    """Reduce a field with a vertical dimension to a horizontal map.
+    """Slice a field with a vertical dimension into a horizontal map.
 
-    Slicing at an elevation, a layer index, the surface or the seafloor, and
-    integrating over an elevation range, are the cases of one operation: every
-    one of them turns ``nVertLevels`` into nothing.  Keeping them behind a
-    single entry point is what lets ocean heat content be a field of the
-    climatology maps rather than a product of its own.
+    Slicing at an elevation, a layer index, the surface or the seafloor are
+    the cases of one operation: every one of them picks one layer of each
+    column, whatever the field means.
     """
 
 
 def elevation_range_weights(z_interface, layer_mass, min_level_cell,
                             max_level_cell, z_top, z_bot):
     """Return the per-layer mass per unit area within an elevation range.
+
+    An elevation range also turns ``nVertLevels`` into nothing, but it is a
+    weighted integral rather than a slice, and what the weighted sum of a
+    field *means* is a property of the diagnostic rather than of the vertical
+    coordinate.  So this module supplies the weights and the diagnostic
+    supplies the sum, which is what lets one heat content kernel serve both
+    the maps and the time series.
 
     The geometric overlap thickness w_k is computed from ``z_interface`` and
     used only as a fraction of the layer, which is then applied to
@@ -2000,11 +2005,13 @@ for season in plot_seasons:
     z_mid, z_interface = get_z_mid_and_interface(ds)
     layer_mass = get_layer_mass(ds, self.config)
     for field in self.field_group.fields:
-        da = self._get_field(ds, field)
+        if field == 'heat_content':
+            self._plot_heat_content(ds, season, layer_mass, k_min, k_max)
+            continue
+        da = ds[field]
         for reduction in self._reductions(da):
             da_map = apply_vertical_reduction(
-                da, reduction, z_mid, z_interface, layer_mass,
-                k_min, k_max)
+                da, reduction, z_mid, z_interface, k_min, k_max)
             basename = f'{field}_{season}_{reduction.label}'
             write_netcdf(da_map, self.work_path(f'{basename}.nc'))
             self.manifest.add(da_map, field=field, season=season,
@@ -2016,9 +2023,13 @@ for season in plot_seasons:
                 mesh_filename=self.work_path('mesh.nc'), ...)
 ```
 
-Heat content needs no branch here.  Its field is derived rather than read, and
-its reduction is an elevation range rather than an elevation, and both of those
-are cases the loop already handles.
+Heat content is the one branch in this loop.  Its field is derived rather
+than read, and its reduction is an elevation range rather than an elevation,
+and a range is weighted rather than sliced, so it takes the weights from
+`elevation_range_weights` and the sum from the heat content kernel instead of
+going through `apply_vertical_reduction`.  Everything around it --- the
+season loop, the netCDF beside each plot, the shared `mosaic` descriptor,
+the naming --- is the same.
 
 Output names are `<field>_<season>_<reduction_label>.png` with reduction labels
 `top`, `bottom`, `-100m`, `k10`, and `top_to_-700m`, so that the set of files
@@ -2107,9 +2118,11 @@ of which the loop above already accommodates:
 
 - its field is derived rather than read, by
   `heat_content(ds.temperature, weights, cp0)` where `weights` comes from
-  `elevation_range_weights`;
+  `elevation_range_weights`, so the derivation happens inside the reduction
+  loop rather than before it, since the weights depend on the range;
 - its vertical reductions are the configured elevation ranges rather than the
-  configured elevations.
+  configured elevations, and they are read from `[ocean_analysis_ohc]` rather
+  than from `[ocean_analysis_climatology]`.
 
 The layer weights $\tilde{w}_k$ do depend on the range, so they are not shared
 between ranges --- but everything expensive is.  The climatology of $\Theta$,

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -649,7 +649,7 @@ follow-up after September 15 if the fallback is what ships.
 
 ### Algorithm Design: ocean-heat-content
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -657,16 +657,56 @@ Contributors: Xylar Asay-Davis, Claude
 series; the two differ in what they integrate over and in what they read, not
 in the kernel.*
 
-Ocean heat content per unit area, integrated over an elevation range
-$[z_{bot}, z_{top}]$ with $z_{bot} < z_{top} \le 0$, is
+Ocean heat content per unit area is a *mass*-weighted integral of conservative
+temperature.  Over an elevation range $[z_{bot}, z_{top}]$ with
+$z_{bot} < z_{top} \le 0$,
 
 $$
-Q(z_{bot}, z_{top}) = \rho_0 c_p^0 \int_{z_{bot}}^{z_{top}} \Theta \, dz
-            \approx \rho_0 c_p^0 \sum_k \Theta_k \, w_k
+Q(z_{bot}, z_{top}) = c_p^0 \int_{z_{bot}}^{z_{top}} \rho \, \Theta \, dz
+                    = \rho_0 c_p^0 \int_{\tilde{z}_{bot}}^{\tilde{z}_{top}}
+                      \Theta \, d\tilde{z}
+                    \approx \rho_0 c_p^0 \sum_k \Theta_k \, \tilde{w}_k
 $$
 
-where $\Theta$ is conservative temperature and $w_k$ is the thickness of the
-overlap between layer $k$ and the requested range:
+where $\Theta$ is conservative temperature, $\rho$ is in-situ density, and
+$\tilde{w}_k$ is the pseudo-thickness of the overlap between layer $k$ and the
+requested range.
+
+The middle step is the change of variable $\rho \, dz = \rho_0 \, d\tilde{z}$
+from the conventions, and it is an identity, not an approximation: a
+mass-weighted integral in $z$ is a plain integral in $\tilde{z}$ scaled by
+$\rho_0$.  The final step is the layer quadrature, so the only error is the
+usual one of treating $\Theta$ as uniform within a layer.
+
+In particular, the reference density in the discrete sum is **not** a
+Boussinesq approximation.  Since $\rho_0 \tilde{h}_k = \rho_k h_k$ is the mass
+per unit area of layer $k$ exactly --- for Omega by the definition of
+pseudo-height, for MPAS-Ocean because it is Boussinesq --- a range covering
+whole layers gives the mass-weighted integral with no reference-density error
+at all.  This is the substantive difference from the MPAS-Analysis
+formulation, which weights $\Theta$ by a *geometric* thickness and multiplies
+by a reference density, and so carries an in-situ-versus-reference density
+error of a few tenths of a percent.
+
+The geometric coordinate enters only through the partial layers at the range
+boundaries, because the range is specified in $z$ while the integral is in
+$\tilde{z}$.
+
+That the range is specified in geometric elevation is a deliberate choice
+rather than an oversight.  "Ocean heat content, 0 to 700 m" means 700
+*geometric* meters in MPAS-Analysis, in the observational products this
+diagnostic is compared against, and in the literature, and the same is true of
+a map "at 100 m".  Specifying ranges in pseudo-depth instead would be more
+natural for a mass-conserving model --- a fixed $\tilde{z}$ range is a fixed
+pressure range and therefore exactly a fixed mass per unit area, which is a
+cleaner control volume for a heat budget --- and it would remove the geometric
+coordinate from this algorithm entirely.  We do not do it, because it would
+silently redefine a number everyone else reports geometrically, for a
+difference that is a fraction of a percent in the upper ocean and one to two
+percent at abyssal depths.  Config options are documented as geometric
+elevations, and the conversion happens here, in one place.
+
+Let
 
 $$
 w_k = \max\left(0, \;
@@ -674,13 +714,38 @@ w_k = \max\left(0, \;
       \max\left(z^{int}_{k+1}, z_{bot}\right)\right)
 $$
 
-for layers within `[minLevelCell, maxLevelCell]` and $w_k = 0$ elsewhere.  This
-expression handles all of the cases the requirement calls for without special
-casing: a range boundary in the interior of a layer contributes a partial
-thickness; a range extending below the seafloor is truncated because
+be the geometric thickness of the overlap, for layers within
+`[minLevelCell, maxLevelCell]` and $w_k = 0$ elsewhere, and let
+$h_k = z^{int}_{k} - z^{int}_{k+1}$ be the layer's geometric thickness.  Then
+
+$$
+\tilde{w}_k = \frac{w_k}{h_k} \, \tilde{h}_k
+$$
+
+is the pseudo-thickness of the overlap, and $\tilde{w}_k = \tilde{h}_k$
+whenever the layer lies entirely within the range.
+
+Splitting a layer by a geometric fraction rather than by a pseudo-height
+fraction is exact with respect to the model's own discretization, not a further
+approximation: within a layer Omega uses a single specific volume
+$\alpha_{i,k}$, so $h = \rho_0 \alpha \tilde{h}$ makes $z$ linear in
+$\tilde{z}$ across the layer and the two fractions are equal.  For MPAS-Ocean
+the question does not arise, since `layerThickness` is the geometric thickness
+and $\tilde{w}_k$ reduces to $w_k$.
+
+Where these weights are formed from a *climatology* rather than from a single
+month, the ratio $w_k/h_k$ is a ratio of monthly means rather than a mean of
+ratios.  This is second order --- it affects only the two boundary layers of a
+range, and only through the seasonal cycle of layer thickness --- and it is one
+face of the covariance term discussed below.
+
+The $w_k$ expression handles all of the cases the requirement calls for without
+special casing: a range boundary in the interior of a layer contributes a
+partial thickness; a range extending below the seafloor is truncated because
 $z^{int}_{k_{max}+1} = -H$; a `bottom` boundary is expressed as
 $z_{bot} = -\infty$; and a column whose seafloor lies above $z_{top}$
-contributes zero.
+contributes zero.  For the conventional `0:bottom` range, every valid layer is
+whole and the geometric coordinate drops out of the answer entirely.
 
 The globally integrated heat content used for the time series is the
 area-weighted sum
@@ -706,38 +771,55 @@ MPAS-Analysis uses.  The specific heat capacity differs from the TEOS-10
 constant by 0.1%, which is small compared to other uncertainties but is a
 systematic offset in any comparison.
 
-**Decision:** Phase 1 uses the PCD values.  $c_p^0$ is not in the PCD today,
-and adding a constant to it is not something we can complete by September 15,
-so using the PCD is what keeps Polaris consistent with the constants the rest
-of E3SM is using in the meantime.  Both constants are exposed as config options
-so that a user can experiment with the TEOS-10 value without a code change.
+**Decision:** Phase 1 uses the PCD value for $c_p^0$.  The TEOS-10 constant is
+not in the PCD today, and adding a constant to it is not something we can
+complete by September 15, so using the PCD is what keeps Polaris consistent
+with the constants the rest of E3SM is using in the meantime.  It is exposed as
+a config option so that a user can experiment with the TEOS-10 value without a
+code change.
 
 In the long run we do want $c_p^0$: because Omega carries conservative
-temperature, $\rho_0 c_p^0 \Theta$ is the definition of heat content rather
-than an approximation to it.  Adding $c_p^0$ to the PCD and switching to it is
-recorded as a deferred item in {ref}`design-ocean-analysis`.
+temperature, $c_p^0 \Theta$ is potential enthalpy per unit mass by definition,
+so the mass-weighted integral above is the heat content rather than an
+approximation to it.  Adding $c_p^0$ to the PCD and switching to it is recorded
+as a deferred item in {ref}`design-ocean-analysis`.
 
-A constant reference density is used rather than in-situ density.  This is the
-MPAS-Analysis convention and keeps the diagnostic comparable; the difference is
-a few tenths of a percent and is nearly uniform, so it affects the absolute
-heat content much more than the anomaly, which is the quantity of interest.
+**$\rho_0$ is not a free parameter.**  Unlike $c_p^0$, the reference density in
+the discrete sum is not a modeling choice we are making --- it is the constant
+that *defines* pseudo-height in Omega, and the Boussinesq reference density in
+MPAS-Ocean.  Using any other value would make $\rho_0 \tilde{h}$ something
+other than the layer's mass per unit area.  It must therefore be the same
+$\rho_0$ the model used, and it is not exposed as a config option.  Polaris already takes that value from the PCD's
+`seawater_density_reference` when it builds Omega's p-star vertical coordinate
+in `polaris/ocean/vertical/pstar.py`, so the analysis reads it from the same
+place; if Omega's `RhoSw` ever diverges from the PCD value, that is a bug in
+Polaris's vertical coordinate before it is a bug in this diagnostic.
+
+The practical consequence of the mass-weighted form, noted above, is that the
+in-situ-versus-reference density error in the MPAS-Analysis formulation ---
+a few tenths of a percent, nearly uniform, so it biased the absolute heat
+content much more than the anomaly --- is gone at no cost, since the model
+already writes the mass-like thickness we need.
 
 #### Heat content from a climatology versus from monthly means
 
 The heat content maps are computed from the climatology of $\Theta$ and of the
-layer geometry, per the requirement.  Because heat content is a product of
+layer thicknesses, per the requirement.  Because heat content is a product of
 those two, this omits the covariance term:
 
 $$
-\overline{\Theta h} = \overline{\Theta}\,\overline{h} +
-                      \overline{\Theta' h'}
+\overline{\Theta \tilde{h}} = \overline{\Theta}\,\overline{\tilde{h}} +
+                      \overline{\Theta' \tilde{h}'}
 $$
 
 The neglected term is small for heat content over fixed elevation ranges ---
 the range boundaries are fixed in $z$, so the covariance enters only through
 the partial layers at the boundaries and through the free surface --- but it is
 not identically zero, particularly in regions with a large seasonal cycle in
-sea surface height and layer thickness.
+sea surface height and layer thickness.  Note that this means the climatology
+must include both `PseudoThickness` and the geometric interfaces: the former
+sets the mass weight, the latter sets the partial-layer fraction at the range
+boundaries.
 
 The heat content time series does not have this issue, because it integrates
 each monthly mean separately and averages afterward.
@@ -792,7 +874,7 @@ open questions.
 
 ### Implementation: analysis-suite
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -934,13 +1016,14 @@ mixed_layer_depth_threshold = 0.03
 [ocean_analysis_ohc]
 
 # The elevation ranges over which heat content is integrated, given as
-# <top>:<bottom> in m, positive up.  "bottom" means the seafloor.
+# <top>:<bottom> in m, positive up.  "bottom" means the seafloor.  These are
+# geometric elevations, matching the convention used by MPAS-Analysis and by
+# observational heat content products; the integral itself is mass-weighted.
 elevation_ranges = 0.0:-700.0, -700.0:-2000.0, -2000.0:bottom, 0.0:bottom
 
-# The reference density and specific heat capacity used to convert
-# conservative temperature to heat content.  By default, these come from the
-# Physical Constants Dictionary.
-#seawater_density = 1026.0
+# The specific heat capacity used to convert conservative temperature to heat
+# content.  By default, this comes from the Physical Constants Dictionary.
+# The reference density is not a config option; see the algorithm design.
 #seawater_specific_heat_capacity = 3996.0
 
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -2520,7 +2520,7 @@ They are collected here rather than buried in the sections above.*
    mixed-layer depth diagnostic, averaged monthly, by September 15?  If not, we
    ship the offline fallback with its caveats.  This needs a team discussion
    rather than a decision in this document, and it affects both the Omega
-   schedule and commit 11 above.
+   schedule and work item 14 above.
 2. **`ncclimo` and Omega output.**  Whether `ncclimo` can read Omega
    monthly-mean files without the MPAS-specific processing type needs to be
    confirmed against real output as soon as Omega can produce it.  This is on

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -450,6 +450,35 @@ Polaris shall not compute the MOC itself.  The overturning streamfunction
 requires the full three-dimensional velocity field at every time step to be
 computed correctly, and Omega computes it in situ for exactly that reason.
 
+### Requirement: regression-test
+
+Date last modified: 2026/08/25
+
+Contributors: Xylar Asay-Davis, Claude
+
+Polaris shall provide a regression test that runs a short Omega simulation and
+then analyzes its output, so that the analysis capability is exercised
+end-to-end by something we run ourselves.
+
+Everything else in this document consumes output from a simulation Polaris did
+not run, on a machine where that simulation happens to live.  That is the point
+of the capability, and it is also why nothing in it would otherwise be covered
+by a suite: a regression that broke the climatology, the vertical reduction, or
+the accumulator would be found by a person analyzing a coupled run, which is
+the most expensive place to find it.
+
+The test shall run a coarse-resolution Omega forward run configured to write
+the monthly-mean output this analysis reads, and shall then run the analysis
+products against it.  It shall be a suite of its own rather than an addition to
+`omega_pr` or `omega_nightly`, since it costs a forward run and it is blocked
+on Omega capabilities that the PR suite must not be blocked on.  Adding it to
+`omega_nightly` once it is stable and its cost is known is the expected
+follow-up.
+
+The test verifies that the products are produced and are self-consistent, not
+that they are scientifically meaningful: a simulation short enough to run in a
+test is too short for the diagnostics to say anything.
+
 ## Algorithm Design
 
 ### Algorithm Design: climatology
@@ -1853,6 +1882,81 @@ elevations, produces a clear message naming the expected file and the Omega
 config option that produces it, rather than a traceback --- the MOC capability
 is new in Omega and users will encounter simulations that predate it.
 
+### Implementation: regression-test
+
+Date last modified: 2026/08/25
+
+Contributors: Xylar Asay-Davis, Claude
+
+The task is `ocean/analysis_test/QU240`, in
+`polaris/tasks/ocean/analysis_test/`, and the suite is
+`polaris/suites/ocean/omega_analysis_test.txt` containing only it.
+
+#### What it runs
+
+An init chain and a forward run at QU240, reusing the existing
+`realistic_global` QU240 machinery rather than adding another mesh, with an
+Omega YAML fragment that turns on monthly-mean output of the fields this
+analysis reads.  That fragment is the same one described under
+`omega-monthly-means`, which is what makes this test worth having: it exercises
+the Omega-side configuration, not just the Polaris-side code.
+
+**One simulated year**, which is the shortest run that exercises the whole
+chain.  `ncclimo` needs whole years to form seasonal and annual climatologies,
+so a one- or two-month run would cover the accumulator and the maps but would
+skip the climatology entirely --- and the climatology is the step with the
+most external surface area, since it shells out to NCO and depends on Omega's
+time metadata being read correctly by a tool we do not control.  A year at
+QU240 is a small forward run, and the analysis over it is seconds.
+
+The analysis products then run over years 1 to 1: the climatology, the
+climatology maps for each field group, the heat content series, the global
+stats time series, and the MOC plot if the simulation wrote MOC output.
+
+#### How the analysis steps are pointed at it
+
+The analysis steps read a simulation through the file-name templates in
+`[ocean_analysis]`, so the task sets those templates to the forward step's
+output and creates its own instances of the same step classes at
+`ocean/analysis_test/QU240/`.  No step class learns anything about being under
+test.
+
+The one addition is ordering: the forward step's monthly-mean outputs are
+declared as inputs of the analysis steps, so Polaris runs them in the right
+order and reports a missing file as a missing dependency rather than as a
+mystery.
+
+#### What it checks
+
+Beyond running without error, the step that closes the task checks the
+properties that do not depend on the simulation being long enough to be
+meaningful:
+
+- every product named in the merged manifest exists, and every published
+  symlink resolves;
+- each plot has its netCDF companion, and the netCDF carries the date range
+  the plot is labeled with;
+- the global heat content time series has twelve months, is finite, and is
+  positive for every elevation range;
+- the annual-mean climatology of a field equals the mean of its twelve monthly
+  climatologies to round-off, which exercises `ncclimo`'s weighting and our
+  reading of it;
+- a map at the sea surface equals the top valid layer of the same field, which
+  exercises the vertical reduction against the climatology rather than against
+  synthetic data.
+
+Baseline comparison against a previous run of the same suite is available as it
+is for any Polaris task, and is the natural way to catch an unintended change
+in a diagnostic's values.
+
+#### Dependency on Omega
+
+This task cannot run until Omega can write monthly means of full model fields.
+Until then it is set up but its forward step is expected to produce nothing the
+analysis can read, which the analysis steps report as missing fields rather
+than as failures --- the same degradation described under
+`omega-monthly-means`.  It should not go into any shared suite until it passes.
+
 ### Implementation: commit sequence
 
 Date last modified: 2026/08/25
@@ -1888,7 +1992,9 @@ Contributors: Xylar Asay-Davis, Claude
 13. The offline `mixed_layer_depth` accumulator, only if Omega's in-situ
     diagnostic will not be ready in time.
 14. The `replot` option.
-15. User's Guide documentation: a page under `docs/users_guide/ocean/tasks/`
+15. The `analysis_test` task and the `omega_analysis_test` suite, once Omega
+    can write monthly means.
+16. User's Guide documentation: a page under `docs/users_guide/ocean/tasks/`
     describing the analysis suite and its config options, and an entry in
     `docs/users_guide/ocean/suites.md`.
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1322,23 +1322,23 @@ Every analysis step declares what it needs, so that a scheduler can decide how
 many may run at once.  Two quantities matter and they behave differently.
 
 **Cores** are declared as `cpus_per_task` with `ntasks = 1`, since nothing here
-is MPI.  The number is whatever internal parallelism the step will actually
-start --- twelve for the climatology, matching `ncclimo`'s background
-processes, and the pool size for a shard or a map step.  Any pool a step
-creates is sized from this number rather than from `os.cpu_count()`, which is
-the whole content of the bounded-process-launching rule: a step that sizes its
-pool to the machine oversubscribes the node the moment a second step runs
-beside it.
+is MPI.  The number is whatever parallelism the step will actually start, which
+in Phase 1 is one for every step except the climatology, where it is twelve to
+match `ncclimo`'s background processes.  Should a step later gain an internal
+pool, its size comes from this number and never from `os.cpu_count()`: that is
+the whole content of the bounded-process-launching rule, since a step sized to
+the machine oversubscribes the node the moment a second step runs beside it.
 
 **Memory** is the quantity that distinguishes analysis from most existing
 Polaris steps, because at high resolution a step can need a large fraction of a
 node and a scheduler packing by cores alone will oversubscribe it.  What each
 step's footprint is set by is known:
 
-- an accumulator shard holds one month of three-dimensional input per pool
-  worker, so its footprint is the pool size times a month --- which is why
-  reading a month at a time, rather than a year, is a resource decision and not
-  only a convenience;
+- an accumulator holds one month of three-dimensional input at a time, which is
+  what keeps its footprint independent of the length of the record --- reading
+  a month at a time rather than a year is a resource decision and not only a
+  convenience, and it is what lets several decades at 6to18 km be analyzed at
+  all;
 - a map step holds one season of the climatology for its field group, plus the
   `mosaic` descriptor for the mesh;
 - the climatology step's footprint is `ncclimo`'s, not ours;
@@ -1848,10 +1848,10 @@ in the step directory is self-describing.  Range labels use `_to_` rather than
 a hyphen because the elevations are themselves negative.
 
 The plots are independent, so a step with many of them spreads them over a
-process pool rather than over steps.  The pool is sized from `cpus_per_task`,
-never from the machine, per the bounded-process-launching rule.  Building the
-`mosaic` descriptor is the expensive part of plotting a global mesh, so it is
-constructed once per step and shared.
+process pool rather than over steps, but Phase 1 does not take it: plots are
+drawn one after another.  Building the `mosaic` descriptor is the expensive
+part of plotting a global mesh, so it is constructed once per step and shared,
+which is where most of the available saving is anyway.
 
 Two dependencies on the framework follow from
 [Task-Parallel-Safe Analysis Steps](task_parallel_analysis_steps.md) and are

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -167,6 +167,27 @@ models write them and avoids sign flips scattered through the code.  Where the
 text uses the word "depth" it is describing a quantity that is positive down,
 such as `bottomDepth`, and says so.
 
+**Attributes are the CF ones.**  Omega writes each variable attribute twice:
+once in its own capitalized spelling --- `Units`, `Name`, `StdName`,
+`Description`, `ValidMin`, `ValidMax` --- and once in the CF spelling ---
+`units`, `name`, `standard_name`, `long_name`, `valid_min`, `valid_max`.
+Analysis reads **only** the CF form and ignores the capitalized one entirely.
+
+This is not a stylistic preference.  The CF attributes are the ones every tool
+in the stack already understands: `xarray` ingests them, uses `units` and
+`calendar` to decode times, and writes them back out.  The capitalized
+duplicates are understood by nothing, so code that reads them works on files
+Omega wrote and fails on every other file --- including one that has merely
+been through `xarray`, which moves `units` into `.encoding` on decoding while
+leaving `Units` sitting in `.attrs`.  A dependence on the capitalized form is
+therefore invisible until it is tested against a file we wrote ourselves,
+which is exactly when it is most expensive to find.
+
+`polaris.ocean.model.time.get_days_since_start` has such a dependence today,
+in `ds['Time'].Units`.  It predates this design and is used across the ocean
+component, so fixing it is framework work rather than analysis work, but no
+new analysis code should follow it.
+
 ## Requirements
 
 ### Requirement: analysis-suite
@@ -2097,7 +2118,7 @@ different range.
 
 ### Implementation: global-stats-time-series
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/27
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -2132,10 +2153,24 @@ used by both the existing `StatsAnalysis` step and the new one.  This keeps the
 `realistic_global` task's behavior unchanged while avoiding a second copy of
 the plotting logic.
 
-The time axis is converted to simulation years from the CF time coordinate.
-`polaris.ocean.model.time.get_days_since_start` provides the days-since-start
-conversion already used elsewhere; the new code divides by the length of the
-year in the file's calendar.
+The time axis is the simulation year, derived from the decoded CF time
+coordinate as the calendar year plus the fraction of the year elapsed, using
+the calendar the file declares.
+
+It is worth being explicit about why this is not
+`polaris.ocean.model.time.get_days_since_start` divided by the length of a
+year, which an earlier draft of this design proposed.  That helper returns
+days since the *file's reference date*, which is whatever `units` happens to
+say --- `seconds since 0000-12-01` in the QU240 mock-up.  Dividing that by a
+year length gives a number that coincides with the simulation year only when
+the reference date happens to sit at the start of year zero, so a series over
+years 21--40 would be labelled correctly by luck rather than by construction.
+
+Taking the year from the decoded date instead has no such dependence, and it
+makes the axis agree with the two other places the same year appears: the `$Y`
+in the file names the analysis expanded to find these files, and the range key
+in the step's own directory.  Those three have to mean the same year, and this
+is what makes them.
 
 ### Implementation: ocean-heat-content-time-series
 

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1343,7 +1343,7 @@ season, which is robust to `ncclimo` naming changes.
 
 ### Implementation: climatology-maps
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1365,21 +1365,31 @@ def extract_elevation_slice(da, spec, z_mid, min_level_cell, max_level_cell):
     """Extract a horizontal slice at the requested elevation."""
 
 
-def elevation_range_weights(z_interface, min_level_cell, max_level_cell,
-                            z_top, z_bot):
-    """Return the per-layer overlap thickness w_k for an elevation range."""
+def elevation_range_weights(z_interface, layer_mass, min_level_cell,
+                            max_level_cell, z_top, z_bot):
+    """Return the per-layer mass per unit area within an elevation range.
+
+    The geometric overlap thickness w_k is computed from ``z_interface`` and
+    used only as a fraction of the layer, which is then applied to
+    ``layer_mass``.  Passing a layer mass of ``z_interface`` differences
+    recovers the purely geometric weights, which is what the elevation-slice
+    utilities want.
+    """
 ```
 
 `polaris/ocean/heat_content.py`:
 
 ```python
-def heat_content(temperature, weights, density, specific_heat):
+def heat_content(temperature, weights, specific_heat):
     """Vertically integrated heat content per unit area [J m-2]."""
 ```
 
 `elevation_range_weights` lives with the other elevation utilities rather than
 with heat content because it is a property of the vertical coordinate, and it
-will be reused by any future vertically integrated diagnostic.
+will be reused by any future vertically integrated diagnostic.  It takes the
+layer mass rather than computing it, so that the one place that knows how each
+model spells its mass-like thickness stays
+`polaris.ocean.model.get_layer_mass`.
 
 The `ClimatologyMaps` step then loops over seasons, fields, and elevations:
 
@@ -1433,7 +1443,7 @@ cannot mistake them for an in-situ diagnostic.
 
 ### Implementation: ocean-heat-content-maps
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1441,8 +1451,10 @@ The `maps` step of the `ocean_heat_content` task reads the same climatology
 files, computes
 
 ```python
-weights = elevation_range_weights(z_interface, k_min, k_max, z_top, z_bot)
-ohc = heat_content(ds.temperature, weights, rho0, cp0)
+layer_mass = get_layer_mass(ds, self.config)
+weights = elevation_range_weights(z_interface, layer_mass, k_min, k_max,
+                                  z_top, z_bot)
+ohc = heat_content(ds.temperature, weights, cp0)
 ```
 
 for each configured elevation range and each plotted season, writes the result
@@ -1498,7 +1510,7 @@ year in the file's calendar.
 
 ### Implementation: ocean-heat-content-time-series
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
@@ -1513,11 +1525,12 @@ class OceanHeatContentYear(OceanIOStep):
             ds = self.open_model_dataset(f'monthly_{month:02d}.nc',
                                          self.config)
             _, z_interface = get_z_mid_and_interface(ds)
+            layer_mass = get_layer_mass(ds, self.config)
             ohc = []
             for z_top, z_bot in elevation_ranges:
-                weights = elevation_range_weights(z_interface, k_min, k_max,
-                                                  z_top, z_bot)
-                column = heat_content(ds.temperature, weights, rho0, cp0)
+                weights = elevation_range_weights(z_interface, layer_mass,
+                                                  k_min, k_max, z_top, z_bot)
+                column = heat_content(ds.temperature, weights, cp0)
                 ohc.append((area_cell * column).sum('nCells'))
             ds_year.append(...)
         write_netcdf(xr.concat(ds_year, dim='Time'), 'ohc.nc')
@@ -1533,7 +1546,8 @@ Reading a month at a time within the year step is deliberate.  A global
 three-dimensional temperature field at 30 km resolution and 80 levels is
 roughly 150 MB per month, so a forty-year record is several tens of gigabytes;
 a month at a time bounds memory regardless of how long the record is.  Only
-`temperature`, `zInterface`, and the vertical-index fields are read.
+`temperature`, the model's mass-like thickness variable, `zInterface`, and the
+vertical-index fields are read.
 
 The plot has two panels: absolute heat content in units of 10²² J, and the
 anomaly relative to the first month, with one line per elevation range.  The
@@ -1723,19 +1737,29 @@ If the offline fallback is implemented, unit tests on synthetic profiles:
 
 ### Testing and Validation: ocean-heat-content
 
-Date last modified: 2026/08/11
+Date last modified: 2026/08/25
 
 Contributors: Xylar Asay-Davis, Claude
 
-Unit tests on `elevation_range_weights` and `heat_content`:
+Unit tests on `elevation_range_weights` and `heat_content` are written in
+pseudo-height, since that is the coordinate the
+integral is actually taken in, and every synthetic column is built with
+$\tilde{h} \ne h$ so that a formulation that confused the two would fail rather
+than coincidentally pass:
 
 - for a range aligned with layer interfaces, the weights are exactly the layer
-  thicknesses in the range and zero outside;
-- for a range boundary in the interior of a layer, the weight of that layer is
-  the exact partial thickness;
-- for a constant temperature $\Theta_0$ over a range $[z_{bot}, z_{top}]$
-  entirely within the water column, the heat content is exactly
-  $\rho_0 c_p^0 \Theta_0 (z_{top} - z_{bot})$;
+  masses $\rho_0 \tilde{h}_k$ in the range and zero outside;
+- for such a range, a constant temperature $\Theta_0$ gives heat content
+  exactly $\rho_0 c_p^0 \Theta_0 \Delta\tilde{z}$, where $\Delta\tilde{z}$ is
+  the pseudo-thickness of the range --- *not* its geometric thickness;
+- the whole-column result equals $c_p^0 \sum_k \Theta_k \rho_0 \tilde{h}_k$ and
+  is unchanged if the geometric interfaces are perturbed while pseudo-thickness
+  is held fixed, which is the property that distinguishes the mass-weighted
+  form from the geometric one;
+- for a range boundary in the interior of a layer --- the one place geometry
+  legitimately enters --- the weight of that layer is its mass scaled by the
+  exact geometric fraction $w_k/h_k$, and a range boundary swept across a layer
+  gives a result that varies linearly between the two whole-layer answers;
 - for a range extending below the seafloor, the result is truncated at the
   seafloor;
 - the whole-ocean range equals the sum of a set of ranges that partition it,

--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1308,6 +1308,14 @@ stream is reported as such, naming the option to set by hand instead --- since
 its schema is Omega's to change and this is the one place Polaris depends on
 its shape rather than on its output.
 
+The pattern is MPAS-Analysis's, which locates MPAS-Ocean and MPAS-Seaice output
+by reading their streams files rather than asking the user where each file
+lives.  Only the file being read differs.  Worth knowing when the Omega reader
+is written, because the failure modes MPAS-Analysis hit there --- a stream
+present but empty, a template whose expansion matches nothing, a relative path
+resolved against the wrong directory --- are the ones to report clearly rather
+than discover in a traceback.
+
 Input files are symlinked into each step's work directory in `setup()` using
 `Step.add_input_file`, which gives the usual Polaris provenance and dependency
 checking without copying data.


### PR DESCRIPTION
# Design docs for ocean analysis in Polaris

Two design documents, no code. They are the design the six implementation branches below them are written against, and they are still expected to change as we discuss them.

`ocean_analysis.md` is the umbrella document: the long-term direction for analyzing Omega and MPAS-Ocean simulations in Polaris, why this is written from scratch rather than ported from MPAS-Analysis, where the line falls between what Omega computes in situ and what Polaris computes offline, the organizing principles the implementation follows, and a phased roadmap. It also carries the requirements that outlive Phase 1 — presentation and provenance, pruning and archiving, concurrency, and workflow integration — and the list of items Phase 1 knowingly defers.

`ocean_analysis_initial.md` designs the concrete near-term deliverable: the analysis capabilities the E3SM Ocean Team has committed to providing for Omega's initial coupled runs by September 15, 2026. Climatology maps, ocean heat content as maps and as a time series, global statistics time series, a MOC plot, and the publication layer that turns them into a browsable gallery, all produced by a Polaris suite pointed at a completed simulation.

## Where review is most useful

The requirements, and the open questions collected at the end of the second document — those are where the decisions we still need to make as a team are gathered. Two in particular are worth an opinion: whether the gallery's presentation layer is the right shape given that the LCRC portal throttles, and what a product means for archiving as opposed to publication, which the design now raises but deliberately does not settle.

## This is one of seven PRs, reviewed in order

The work is a chain in dependency order. GitHub cannot base a cross-fork PR on another fork branch, so every one of these is based on `main` and its diff contains everything below it. Reviewing them in order is what keeps each diff small — review only the commits this branch adds.

| order | PR | branch | what it adds |
| --- | --- | --- | --- |
| 1 | #706 | `add-analysis-designs` | the two design documents |
| 2 | #735 | `add-omega-analysis-elevation` | the vertical reduction kernel |
| 3 | #726 | `add-omega-analysis-scaffolding` | the suite, tasks and step structure |
| 4 | #736 | `add-omega-analysis-publisher` | manifests, the staging tree, the gallery |
| 5 | #729 | `add-omega-analysis-global-stats` | global statistics time series |
| 6 | #730 | `add-omega-analysis-climatology-maps` | the ncclimo climatology and its maps |
| 7 | #737 | `add-omega-analysis-heat-content` | ocean heat content, maps and time series |

A gallery generated by the whole chain against the QU240 mock-up is published here, which is the quickest way to see what the suite produces: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/xasaydavis/omega_analysis_qu240_mockup_20260830/

Checklist
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
