### PR TITLE
Geostrophic test fix

### DIFF
--- a/polaris/tasks/ocean/geostrophic/forward.yaml
+++ b/polaris/tasks/ocean/geostrophic/forward.yaml
@@ -57,6 +57,8 @@ mpas-ocean:
 Omega:
   Tendencies:
     TracerVertAdvTendencyEnable: false
+    BottomDragTendency:
+      Enable: false
   IOStreams:
     History:
       Filename: output.nc

--- a/polaris/tasks/ocean/geostrophic/viz.py
+++ b/polaris/tasks/ocean/geostrophic/viz.py
@@ -46,7 +46,7 @@ class Viz(OceanIOStep):
         super().__init__(component=component, name=name, subdir=subdir)
         self.add_input_file(
             filename='mesh.nc',
-            work_dir_target=f'{base_mesh.path}/base_mesh.nc',
+            work_dir_target=f'{init.path}/culled_mesh.nc',
         )
         self.add_input_file(
             filename='initial_state.nc',
@@ -76,7 +76,12 @@ class Viz(OceanIOStep):
             v='geostrophic_viz_vel',
         )
 
-        ds_init = self.open_model_dataset('initial_state.nc', config)
+        ds_init = self.open_model_dataset(
+            'initial_state.nc',
+            config,
+            mesh_filename='mesh.nc',
+            reconstruct_variables=['normalVelocity'],
+        )
         ds_vert_coord = self.open_vert_coord_dataset(ds_init)
         bottom_depth = ds_vert_coord.bottomDepth
         ds_init = self._process_ds(ds_init, bottom_depth, time_index=0)
@@ -94,7 +99,12 @@ class Viz(OceanIOStep):
                 plot_land=False,
             )
 
-        ds_out = self.open_model_dataset('output.nc', config)
+        ds_out = self.open_model_dataset(
+            'output.nc',
+            config,
+            mesh_filename='mesh.nc',
+            reconstruct_variables=['normalVelocity'],
+        )
         ds_out = self._process_ds(ds_out, bottom_depth, time_index=-1)
         ds_out.to_netcdf('remapped_final.nc')
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR fixes the fail in the geostrophic test related to conflicting bottom drag and vertical mixing tendencies for a single layer case.

Also address viz issue with reconstructing the normal velocity.

Fixes #708.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
