### PR TITLE
update omega meshes for cron testing

### DIFF
--- a/cron-scripts/machines/config_frontier.sh
+++ b/cron-scripts/machines/config_frontier.sh
@@ -11,10 +11,8 @@ declare -A COMPILER_MAP
 # Add archs
 COMPILER_MAP["craygnu-mphipcc"]="HIP"
 COMPILER_MAP["craycray-mphipcc"]="HIP"
-COMPILER_MAP["crayamd-mphipcc"]="HIP"
 COMPILER_MAP["craygnu"]="SERIAL"
 COMPILER_MAP["craycray"]="SERIAL"
-COMPILER_MAP["crayamd"]="SERIAL"
 
 export COMPILER_MAP_DEF=$(declare -p COMPILER_MAP)
 export JOB_SCHEDULER=SLURM

--- a/cron-scripts/tasks/omega_cdash/job_chrysalis_omega_cdash.sbatch
+++ b/cron-scripts/tasks/omega_cdash/job_chrysalis_omega_cdash.sbatch
@@ -3,6 +3,18 @@
 #SBATCH  --qos=high
 #SBATCH  --time 02:00:00
 
-source /etc/bashrc
+if [ -f /etc/bashrc ]; then
+    source /etc/bashrc
+fi
 
-exec bash $(dirname "$0")/run_omega_cdash.sh
+TARGET_SCRIPT="$RUNSCRIPT_DIR/run_omega_cdash.sh"
+
+if [ -f "$TARGET_SCRIPT" ]; then
+    echo "Running script from: $TARGET_SCRIPT"
+    exec bash "$TARGET_SCRIPT"
+else
+    echo "Error: $TARGET_SCRIPT not found."
+    echo "Current directory: $(pwd)"
+    echo "RUNSCRIPT_DIR: $RUNSCRIPT_DIR"
+    exit 1
+fi

--- a/cron-scripts/tasks/omega_cdash/job_frontier_omega_cdash.sbatch
+++ b/cron-scripts/tasks/omega_cdash/job_frontier_omega_cdash.sbatch
@@ -14,10 +14,7 @@ export http_proxy=http://proxy.ccs.ornl.gov:3128/
 export https_proxy=http://proxy.ccs.ornl.gov:3128/
 export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
 
-#SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-
 # Check if the target script exists before executing
-#TARGET_SCRIPT="$SCRIPT_DIR/run_omega_cdash.sh"
 TARGET_SCRIPT="$RUNSCRIPT_DIR/run_omega_cdash.sh"
 
 if [ -f "$TARGET_SCRIPT" ]; then

--- a/cron-scripts/tasks/omega_cdash/job_pm-cpu_omega_cdash.sbatch
+++ b/cron-scripts/tasks/omega_cdash/job_pm-cpu_omega_cdash.sbatch
@@ -14,8 +14,6 @@ fi
 
 source /opt/cray/pe/lmod/8.7.60/init/sh
 
-#SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-
 # Check if the target script exists before executing
 TARGET_SCRIPT="$RUNSCRIPT_DIR/run_omega_cdash.sh"
 

--- a/cron-scripts/tasks/omega_cdash/job_pm-gpu_omega_cdash.sbatch
+++ b/cron-scripts/tasks/omega_cdash/job_pm-gpu_omega_cdash.sbatch
@@ -15,10 +15,7 @@ fi
 
 source /opt/cray/pe/lmod/8.7.60/init/sh
 
-#SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-
 # Check if the target script exists before executing
-#TARGET_SCRIPT="$SCRIPT_DIR/run_omega_cdash.sh"
 TARGET_SCRIPT="$RUNSCRIPT_DIR/run_omega_cdash.sh"
 
 if [ -f "$TARGET_SCRIPT" ]; then

--- a/cron-scripts/tasks/omega_cdash/launch_omega_cdash.sh
+++ b/cron-scripts/tasks/omega_cdash/launch_omega_cdash.sh
@@ -35,20 +35,9 @@ fi
 echo "Updating submodules..."
 git submodule update --init --recursive externals/ekat externals/scorpio cime components/omega/external
 
-if [[ ! -f ${TESTROOT}/OmegaMesh.nc ]]; then
-    wget -O ${TESTROOT}/OmegaMesh.nc https://web.lcrc.anl.gov/public/e3sm/inputdata/ocn/mpas-o/oQU240/ocean.QU.240km.151209.nc
-fi
-
-if [[ ! -f ${TESTROOT}/OmegaSphereMesh.nc ]]; then
-    wget -O ${TESTROOT}/OmegaSphereMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/polaris_cache/global_convergence/icos/cosine_bell/Icos480/init/initial_state.230220.nc
-fi
-
-if [[ ! -f ${TESTROOT}/OmegaPlanarMesh.nc ]]; then
-    wget -O ${TESTROOT}/OmegaPlanarMesh.nc https://gist.github.com/mwarusz/f8caf260398dbe140d2102ec46a41268/raw/e3c29afbadc835797604369114321d93fd69886d/PlanarPeriodic48x48.nc
-fi
-
-  # --export=RUNSCRIPT_DIR="${HERE}",CRONJOB_MACHINE="${CRONJOB_MACHINE}",E3SM_COMPILERS="${E3SM_COMPILERS}",CRONJOB_DATE="${E3SM_COMPILERS}",TESTROOT="${TESTROOT}",OMEGA_ROOT="${OMEGA_ROOT}"
-  #--export=RUNSCRIPT_DIR,CRONJOB_MACHINE,E3SM_COMPILERS,CRONJOB_DATE,TESTROOT,OMEGA_ROOT \
+wget -O ${TESTROOT}/OmegaMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/ocean.QU.240km.omega_vars.260807.nc
+wget -O ${TESTROOT}/OmegaSphereMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/cosine_bell_icos480.omega_vars.260807.nc
+wget -O ${TESTROOT}/OmegaPlanarMesh.nc https://web.lcrc.anl.gov/public/e3sm/polaris/ocean/omega_ctest/PlanarPeriodic48x48.omega_vars.260720.nc
 
 export RUNSCRIPT_DIR="${HERE}"
 export CRONJOB_MACHINE


### PR DESCRIPTION
This PR updates the test meshes to the latest versions for Omega tests.

In addition, it removes the compiler configurations for AMD compilers on Frontier, whose support has been discontinued.

Temporary fixes: #707 

Checklist
* [X] `Testing` comment in the PR documents testing used to verify the changes (https://my.cdash.org/index.php?project=omega&date=2026-08-15)