### PR TITLE
Benchmarking with agents

### DIFF
--- a/.github/instructions/benchmark.instructions.md
+++ b/.github/instructions/benchmark.instructions.md
@@ -16,7 +16,11 @@ These rules are specific to the benchmarking driver in
 - Do not add `--model`, `--branch`, `-p`, `-w`, `-b`, `-f`, `--build` or
   `--clean_build` to `setup_command`; the driver appends them.
 - Do add `--suite_name` to a `polaris setup` command; the driver requires
-  it so that the benchmark is not named `custom`.
+  it.  The suite name identifies the benchmark: it names the baseline
+  directory, the run directory and the job script.  So when setting up a
+  second benchmark of the same two branches, give it a different suite
+  name and change nothing else — that alone keeps the two apart.  Do not
+  reach for a separate `work_base` to avoid a collision.
 - When only polaris differs between the two sides, suggest
   `component_path` so that the model is built once and shared rather than
   built twice.  Neither `--rebuild` nor `--clean-build` is needed for a

--- a/.github/instructions/benchmark.instructions.md
+++ b/.github/instructions/benchmark.instructions.md
@@ -20,12 +20,18 @@ These rules are specific to the benchmarking driver in
 
 - When a side uses `source = existing`, never run `git fetch`,
   `checkout`, `submodule update`, `reset`, `clean`, `rm` or any other
-  mutating command against the adopted worktree yourself.  Polaris'
-  own build does write into it, so do not tell the user the worktree is
-  left untouched.
+  mutating command against the adopted worktree yourself.  Polaris' own
+  build does write into it when one is requested, so do not tell the user
+  the worktree is left untouched unless nothing is being built.
 - If an adopted worktree is dirty or is missing an initialized
   submodule, stop and ask the user to resolve it.  Do not pass
-  `--allow-dirty` without the user explicitly asking for it.
+  `--allow-dirty` without the user explicitly asking for it.  Report what
+  actually made it dirty: a submodule built in place does not count, so
+  the cause is polaris-level changes, edited tracked source in the
+  submodule the model is built from, or a submodule at a commit other
+  than the pinned one.
+- A task that runs no model needs `model = none`, not an initialized
+  submodule.  Check that before asking the user to clone one.
 
 ## Guardrails
 

--- a/.github/instructions/benchmark.instructions.md
+++ b/.github/instructions/benchmark.instructions.md
@@ -33,9 +33,11 @@ These rules are specific to the benchmarking driver in
   submodule, stop and ask the user to resolve it.  Do not pass
   `--allow-dirty` without the user explicitly asking for it.  Report what
   actually made it dirty: a submodule built in place does not count, so
-  the cause is polaris-level changes, edited tracked source in the
-  submodule the model is built from, or a submodule at a commit other
-  than the pinned one.
+  the cause is an uncommitted change to a tracked file, an untracked file
+  inside the `polaris` package, edited tracked source in the submodule the
+  model is built from, or a submodule at a commit other than the pinned
+  one.  Untracked notes and scratch files outside `polaris` are tolerated
+  and reported, so they are never the cause.
 - A task that runs no model needs `model = none`, not an initialized
   submodule.  Check that before asking the user to clone one.
 

--- a/.github/instructions/benchmark.instructions.md
+++ b/.github/instructions/benchmark.instructions.md
@@ -15,6 +15,8 @@ These rules are specific to the benchmarking driver in
   overrides.  Do not hard-code paths in the driver modules.
 - Do not add `--model`, `--branch`, `-p`, `-w`, `-b`, `-f`, `--build` or
   `--clean_build` to `setup_command`; the driver appends them.
+- Do add `--suite_name` to a `polaris setup` command; the driver requires
+  it so that the benchmark is not named `custom`.
 
 ## Adopted worktrees
 

--- a/.github/instructions/benchmark.instructions.md
+++ b/.github/instructions/benchmark.instructions.md
@@ -1,0 +1,45 @@
+---
+applyTo: "utils/benchmark/**"
+---
+
+# Benchmark Workflow Instructions
+
+These rules are specific to the benchmarking driver in
+`utils/benchmark`.  Repository-wide rules in `AGENTS.md` still apply.
+
+## Running a benchmark
+
+- Always run with `--dry-run` first and show the resolved commit hashes
+  and planned commands to the user before running for real.
+- Prefer editing a copy of `example.cfg` or using the command-line
+  overrides.  Do not hard-code paths in the driver modules.
+- Do not add `--model`, `--branch`, `-p`, `-w`, `-b`, `-f`, `--build` or
+  `--clean_build` to `setup_command`; the driver appends them.
+
+## Adopted worktrees
+
+- When a side uses `source = existing`, the adopted worktree is
+  read-only.  Never run `git fetch`, `checkout`, `submodule update`,
+  `reset`, `clean`, `rm` or any other mutating command against it.
+- If an adopted worktree is dirty or is missing an initialized
+  submodule, stop and ask the user to resolve it.  Do not pass
+  `--allow-dirty` without the user explicitly asking for it.
+
+## Guardrails
+
+- Do not weaken or bypass the guardrails in `_check_guardrails` or
+  `gitrepo.adopt` to make a run succeed.
+- `--allow-multiple-changes`, `--allow-env-mismatch` and `--allow-dirty`
+  each make results harder to interpret.  Only pass them when the user
+  has asked for it, and say so in the summary.
+
+## Environment
+
+- The load script must already exist in the worktree.  If it does not,
+  stop and tell the user to run `./deploy.py` themselves, per
+  `AGENTS.md`.  Never run `./deploy.py`.
+
+## Stop conditions
+
+- On a build or run failure, collect the log path, report it, and stop.
+  Do not retry with different flags unless the user asks.

--- a/.github/instructions/benchmark.instructions.md
+++ b/.github/instructions/benchmark.instructions.md
@@ -18,9 +18,11 @@ These rules are specific to the benchmarking driver in
 
 ## Adopted worktrees
 
-- When a side uses `source = existing`, the adopted worktree is
-  read-only.  Never run `git fetch`, `checkout`, `submodule update`,
-  `reset`, `clean`, `rm` or any other mutating command against it.
+- When a side uses `source = existing`, never run `git fetch`,
+  `checkout`, `submodule update`, `reset`, `clean`, `rm` or any other
+  mutating command against the adopted worktree yourself.  Polaris'
+  own build does write into it, so do not tell the user the worktree is
+  left untouched.
 - If an adopted worktree is dirty or is missing an initialized
   submodule, stop and ask the user to resolve it.  Do not pass
   `--allow-dirty` without the user explicitly asking for it.

--- a/.github/instructions/benchmark.instructions.md
+++ b/.github/instructions/benchmark.instructions.md
@@ -17,6 +17,10 @@ These rules are specific to the benchmarking driver in
   `--clean_build` to `setup_command`; the driver appends them.
 - Do add `--suite_name` to a `polaris setup` command; the driver requires
   it so that the benchmark is not named `custom`.
+- When only polaris differs between the two sides, suggest
+  `component_path` so that the model is built once and shared rather than
+  built twice.  Neither `--rebuild` nor `--clean-build` is needed for a
+  first build, and `--clean-build` is refused with a `component_path`.
 
 ## Adopted worktrees
 

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -78,6 +78,28 @@ every guardrail and prints the exact commands.  It creates no worktrees
 and builds and runs nothing, but resolving a fork does add a remote to
 `primary_path` and fetch into it.
 
+## Before your first run
+
+Four things have to be true of the source trees before the driver will do
+anything, and none of them are done for you.  Each is a guardrail below,
+but settling them up front is quicker than meeting them one dry run at a
+time:
+
+1. **A load script exists.**  `load_*.sh` is git-ignored and written by
+   `./deploy.py`, which is always a developer action.  Run it once in
+   each worktree, or set `load_script` to the absolute path of one
+   existing script so that a single deployment serves both sides.
+2. **`model` matches what the suite runs.**  `model = none` needs no
+   submodule and no build; see the note under Guardrails on how to tell.
+3. **The submodule the model is built from is initialized**, on the side
+   that builds — both sides normally, the baseline only when a
+   `component_path` is shared:
+   `git -C <worktree> submodule update --init e3sm_submodules/Omega`.
+4. **Adopted worktrees are clean.**  An untracked scratch file is enough
+   to stop the run, since the benchmark could not then be reproduced from
+   the recorded hashes.  Commit it, move it aside, or decide up front to
+   pass `--allow-dirty`.
+
 Every fork and ref can also be given on the command line, which is
 convenient for scripted or agent-driven use:
 

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -183,6 +183,11 @@ Polaris builds the model only when it does not already find one at `-p`,
 so the side that is set up first builds it there and the other finds it
 and skips.  No build flag is needed.
 
+That side is the baseline, so `--branch` points at the baseline's
+submodule for both sides.  The test side is never built from, and so does
+not need the submodule initialized at all: a provisioned test worktree
+skips cloning it, and an adopted one is not asked for it.
+
 The driver refuses a `component_path` when the two sides pin different
 commits of the submodule the model is built from, since one side would
 then run the other's model, and it refuses `--clean-build`, which would

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -35,11 +35,13 @@ initialized, the driver stops and prints the command for the developer to
 run.  This makes it cheap to benchmark the branch you are already working
 in without a second copy.
 
-Polaris' own build is a separate matter: it builds the component from
-`--branch`, which for MPAS-Ocean is an in-source `make` in the branch
-directory, and both build templates run
-`git submodule update --init --recursive` there.  An adopted worktree is
-therefore built in place, not left untouched.
+Polaris' own build is a separate matter.  It builds only when asked
+(`--rebuild` or `--clean-build`); `[build] build` defaults to `False`.
+When it does build, it builds the component from `--branch`, which for
+MPAS-Ocean is an in-source `make` in the branch directory, and both build
+templates run `git submodule update --init --recursive` there.  An adopted
+worktree is therefore built in place rather than left untouched whenever a
+build is requested.
 
 Because the `[baseline]` and `[test]` sections take exactly the same
 options, the same driver benchmarks a polaris change, an Omega change or

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -57,9 +57,12 @@ sides.
    ```
 
 2. Edit `benchmark.cfg` to set `work_base`, `load_script`, `setup_command`
-   and the `[baseline]` and `[test]` sections.  A `polaris setup` command
-   has to name its suite with `--suite_name`, since polaris would
-   otherwise call it `custom`.
+   and the `[baseline]` and `[test]` sections.  Give the benchmark a suite
+   name: `polaris suite` takes it from `-t`, and a `polaris setup` command
+   has to supply it with `--suite_name`, which the driver requires.  The
+   suite name is what makes one benchmark distinct from another — it names
+   the baseline directory, the run directory and the job script — so
+   benchmarking one branch two ways means two suite names.
 
 3. Resolve the plan without building anything:
 
@@ -165,7 +168,7 @@ for each of them.  Getting it wrong is loud rather than silent: a
   worktrees/<ref>-<sha7>/            provisioned polaris worktrees
   baselines/<suite>_<model>_opts-<key>_polaris-<sha7>[_<repo>-<sha7>]/
                                      reusable baseline work dirs
-  runs/<date>-polaris-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
+  runs/<date>-<suite>-polaris-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
                                      one benchmark run
     benchmark.log
     manifest.json
@@ -179,6 +182,12 @@ tasks and most suites outgrow.  Set `wall_time` in the `[benchmark]`
 section to change it for both sides at once; the driver merges it with
 `polaris_config_file` into `polaris_benchmark.cfg` in the run directory,
 because `polaris setup` takes only one config file.
+
+A run directory is keyed on the suite, so that benchmarking one branch two
+ways on one day gives two run directories rather than one that overwrites
+the other.  It carries no `opts-<key>`: that hash keeps a *baseline* from
+being reused when it is not comparable, and a run directory is not a
+cache.
 
 A baseline work directory is keyed on the suite, the model, the polaris
 commit, the commit of the submodule the model is built from, and a short

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -156,6 +156,30 @@ A baseline is marked complete when it finishes, and a later benchmark with
 the same name **reuses** it instead of rerunning, which is what makes
 iterating on a test branch cheap.
 
+## Sharing one build between the two sides
+
+Each side is given `build_baseline` or `build_test` inside the run
+directory as its `-p`, so it builds its own copy of the model.  When only
+polaris differs between the two sides, that builds the same Omega or
+MPAS-Ocean source twice.  Setting `component_path` in the `[benchmark]`
+section points both sides at one directory:
+
+```ini
+[benchmark]
+component_path = ${work_base}/build_omega
+```
+
+Polaris builds the model only when it does not already find one at `-p`,
+so the side that is set up first builds it there and the other finds it
+and skips.  No build flag is needed.
+
+The driver refuses a `component_path` when the two sides pin different
+commits of the submodule the model is built from, since one side would
+then run the other's model, and it refuses `--clean-build`, which would
+delete a directory the benchmark does not own.  The path is part of the
+key the cached baseline is named from, but what was built there is the
+developer's to keep in step with the recorded hashes.
+
 Validation results themselves are written by polaris under `case_outputs/`
 in the test work directory; collecting and reporting them is deliberately
 not part of the driver.

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -1,0 +1,202 @@
+(dev-benchmarking)=
+
+# Benchmarking a branch against a baseline
+
+Polaris can compare a run against a baseline work directory with the `-b`
+flag (see {ref}`dev-validation`).  Doing that by hand means resolving two
+source trees, initializing submodules, sourcing the right load script,
+setting up and building each side, and finally wiring the baseline work
+directory into the test setup.  The driver in `utils/benchmark` automates
+that bookkeeping so that the only thing left to do is interpret polaris'
+own validation output.
+
+The driver is designed to be run either by a developer or by an AI coding
+agent.  Every run is recorded in a `manifest.json` with the resolved commit
+hashes of polaris and of each submodule, so a benchmark can be reproduced
+later.
+
+## Concepts
+
+A benchmark has two *sides*:
+
+- the **baseline**, which is usually a released or `main` state, and
+- the **test**, which is the branch under evaluation.
+
+Each side is resolved with one of two `source` modes:
+
+| `source` | Behavior |
+| --- | --- |
+| `worktree` (default) | Resolve a fork and ref to a commit, create a detached `git worktree` under `work_base`, initialize submodules, and optionally override the fork/ref of a single submodule. |
+| `existing` | Adopt a polaris worktree that already exists, exactly as it is found. |
+
+An adopted worktree is **strictly read-only**.  The driver never runs
+`fetch`, `checkout`, `submodule update`, `reset` or `clean` against it.  If
+a required submodule is not initialized, the driver stops and prints the
+command for the developer to run.  This makes it cheap to benchmark the
+branch you are already working in, reusing its existing build.
+
+Because the `[baseline]` and `[test]` sections take exactly the same
+options, the same driver benchmarks a polaris change, an Omega change, an
+E3SM change or a MALI change; the only difference is which refs differ
+between the two sides.
+
+## Quick start
+
+1. Copy the example config to the root of a polaris branch:
+
+   ```bash
+   cp utils/benchmark/example.cfg benchmark.cfg
+   ```
+
+2. Edit `benchmark.cfg` to set `work_base`, `load_script`, `setup_command`
+   and the `[baseline]` and `[test]` sections.
+
+3. Resolve the plan without building anything:
+
+   ```bash
+   ./utils/benchmark/benchmark.py -f benchmark.cfg --dry-run
+   ```
+
+4. When the plan looks right, run it:
+
+   ```bash
+   ./utils/benchmark/benchmark.py -f benchmark.cfg
+   ```
+
+Always start with `--dry-run`.  It resolves every commit hash, applies
+every guardrail and prints the exact commands, but touches nothing.
+
+Every fork and ref can also be given on the command line, which is
+convenient for scripted or agent-driven use:
+
+```bash
+./utils/benchmark/benchmark.py -f benchmark.cfg \
+    --test-polaris-fork cbegeman \
+    --test-polaris-ref add-surface-forcing-to-vmix
+```
+
+Full option tables are in `utils/benchmark/README.md`.
+
+## Guardrails
+
+The driver refuses to run, *before* anything is built, if:
+
+- the two sides resolve to the same worktree or to identical commits
+  everywhere, so there would be nothing to compare;
+- they differ in more than one of polaris, Omega, E3SM and MALI, so a
+  difference could not be attributed to a single change
+  (`--allow-multiple-changes`);
+- they use different load scripts, implying a different machine, compiler
+  or MPI library (`--allow-env-mismatch`);
+- they use different `model` values;
+- an adopted worktree has uncommitted or untracked changes, so the run
+  could not be reproduced from the recorded hashes (`--allow-dirty`, which
+  records the run as `reproducible: false` and never caches its baseline);
+- an adopted worktree is missing the submodule needed for `model`, or its
+  load script does not exist.  Creating the environment with `./deploy.py`
+  is always a developer action.
+
+Each override makes the result harder to interpret, so it should be used
+deliberately and noted when reporting results.
+
+## Output layout
+
+```
+<work_base>/
+  worktrees/<ref>-<sha7>/            provisioned polaris worktrees
+  baselines/<suite>_<model>_<shas>/  reusable baseline work dirs
+  runs/<date>-<base sha7>-<test sha7>/
+    benchmark.log
+    manifest.json
+    build_baseline/  build_test/
+    test/
+```
+
+A baseline work directory is keyed on the suite, model and every commit
+hash, and is marked complete when it finishes.  A later benchmark with the
+same key reuses it rather than rerunning it, which is what makes iterating
+on a test branch inexpensive.
+
+Validation results themselves are written by polaris under `case_outputs/`
+in the test work directory; collecting and reporting them is deliberately
+not part of the driver.
+
+## Why this matters for agent-driven workflows
+
+Orchestrating a baseline comparison by hand is dominated by the *number of
+tool calls* an agent has to make and by the size of the output each one
+returns — build logs in particular.  Because an agent resends its
+accumulated context on every turn, that cost grows roughly quadratically
+with the number of steps.
+
+Consolidating the whole workflow into a single, guardrailed driver replaces
+roughly twenty exploratory shell turns with a `--dry-run` and a run, and
+replaces raw build-log output with a compact resolved plan and a
+`manifest.json`.  In the estimate recorded with this driver, that reduces
+the cumulative context of a single baseline comparison by close to an order
+of magnitude, and it removes the retry loops that dominate the cost when a
+build or setup step fails.
+
+The agent-facing rules live in `.github/instructions/benchmark.instructions.md`
+and apply automatically to work under `utils/benchmark`.
+
+## Example prompts for an AI agent
+
+The driver is meant to be handed to an agent as a *single* tool, rather
+than having the agent reinvent the git and build steps.  The prompts below
+are examples that work well in practice.  In each case the agent should
+come back with the resolved commit hashes from `--dry-run` and wait for
+your approval before running for real.
+
+### Benchmark the branch you are working in
+
+The most common case: you have a branch checked out with a working build,
+and you want to compare it to `main`.
+
+> Benchmark my current worktree against `E3SM-Project/main` using
+> `utils/benchmark`.  Adopt this worktree as the test side with
+> `--test-existing` so my existing build is reused, and provision the
+> baseline from `main`.  Use the `ocean/single_column` suite with
+> `--model omega`.  Run `--dry-run` first and show me the resolved
+> hashes before running for real.
+
+### Compare two polaris branches
+
+> Set up a benchmark config in `utils/benchmark` that compares
+> `E3SM-Project/main` as the baseline against `cbegeman/add-surface-forcing-to-vmix`
+> as the test side, for the `ocean/single_column/vmix` task on Chrysalis
+> with GNU.  Start from `example.cfg`, don't hard-code paths, and show me
+> the `--dry-run` plan.
+
+### Benchmark an Omega submodule change
+
+Here polaris is held fixed on both sides and only the Omega submodule
+differs, which is exactly what the "only one repository may differ"
+guardrail is designed to enforce:
+
+> Using `utils/benchmark`, benchmark an Omega change: keep `polaris_ref`
+> the same on both sides and override only the test side's Omega with
+> `--test-omega-fork cbegeman --test-omega-ref my-omega-feature`.  Confirm
+> from the dry run that polaris and the other submodules resolve to
+> identical hashes.
+
+### Iterate after pushing a fix
+
+Because a completed baseline is keyed on the commit hashes and reused, the
+follow-up run only builds and runs the test side:
+
+> I pushed a fix to `cbegeman/add-surface-forcing-to-vmix`.  Re-run the
+> same benchmark with `--rebuild` on the test side and tell me whether the
+> baseline work directory was reused or rebuilt.
+
+### Interpret the results
+
+> The benchmark finished.  Read `manifest.json` and the validation output
+> under `case_outputs/` in the test work directory, and summarize which
+> variables differ from the baseline and by how much.  Include the
+> baseline and test commit hashes in the summary.
+
+### Diagnose a failure
+
+> The benchmark failed.  Report the failing step and the path to its log,
+> show me the last 50 lines, and stop — don't retry with different flags.

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -106,7 +106,8 @@ deliberately and noted when reporting results.
   worktrees/<ref>-<sha7>/            provisioned polaris worktrees
   baselines/<suite>_<model>_<key>_<shas>/
                                      reusable baseline work dirs
-  runs/<date>-<base sha7>-<test sha7>/
+  runs/<date>-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
+                                     one benchmark run
     benchmark.log
     manifest.json
     build_baseline/  build_test/

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -104,9 +104,11 @@ The driver refuses to run, *before* anything is built, if:
 - an adopted worktree has uncommitted or untracked changes, so the run
   could not be reproduced from the recorded hashes (`--allow-dirty`, which
   records the run as `reproducible: false` and never caches its baseline).
-  A submodule built in place does *not* count; edited tracked source in
-  the submodule the model is built from, or a submodule checked out at a
-  commit other than the pinned one, does;
+  A submodule built in place does *not* count; edited source in the
+  submodule the model is built from, or a submodule checked out at a
+  commit other than the pinned one, does.  Untracked files in that
+  submodule are ignored only for `mpas-ocean`, whose in-source `make`
+  leaves them behind, and not for the out-of-source Omega build;
 - an adopted worktree is missing the submodule needed for `model`, or its
   load script does not exist.  Creating the environment with `./deploy.py`
   is always a developer action.  A task or suite that runs no model

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -123,9 +123,16 @@ deliberately and noted when reporting results.
                                      one benchmark run
     benchmark.log
     manifest.json
+    polaris_benchmark.cfg            written only when wall_time is set
     build_baseline/  build_test/
     test/
 ```
+
+Polaris' job scripts default to a one-hour wall-clock time, which many
+tasks and most suites outgrow.  Set `wall_time` in the `[benchmark]`
+section to change it for both sides at once; the driver merges it with
+`polaris_config_file` into `polaris_benchmark.cfg` in the run directory,
+because `polaris setup` takes only one config file.
 
 A baseline work directory is keyed on the suite, the model, every commit
 hash and a short `<key>` hashed from the setup command, the polaris config

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -57,7 +57,9 @@ sides.
    ```
 
 2. Edit `benchmark.cfg` to set `work_base`, `load_script`, `setup_command`
-   and the `[baseline]` and `[test]` sections.
+   and the `[baseline]` and `[test]` sections.  A `polaris setup` command
+   has to name its suite with `--suite_name`, since polaris would
+   otherwise call it `custom`.
 
 3. Resolve the plan without building anything:
 

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -36,9 +36,9 @@ command for the developer to run.  This makes it cheap to benchmark the
 branch you are already working in, reusing its existing build.
 
 Because the `[baseline]` and `[test]` sections take exactly the same
-options, the same driver benchmarks a polaris change, an Omega change, an
-E3SM change or a MALI change; the only difference is which refs differ
-between the two sides.
+options, the same driver benchmarks a polaris change, an Omega change or
+an E3SM change; the only difference is which refs differ between the two
+sides.
 
 ## Quick start
 
@@ -83,7 +83,7 @@ The driver refuses to run, *before* anything is built, if:
 
 - the two sides resolve to the same worktree or to identical commits
   everywhere, so there would be nothing to compare;
-- they differ in more than one of polaris, Omega, E3SM and MALI, so a
+- they differ in more than one of polaris, Omega and E3SM, so a
   difference could not be attributed to a single change
   (`--allow-multiple-changes`);
 - they use different load scripts, implying a different machine, compiler

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -204,6 +204,18 @@ A baseline is marked complete when it finishes, and a later benchmark with
 the same name **reuses** it instead of rerunning, which is what makes
 iterating on a test branch cheap.
 
+Completeness is read from one of two files.  The driver writes
+`.polaris_benchmark_complete` when it runs polaris in place and sees it
+return.  When the run was submitted, the driver exits as soon as `sbatch`
+accepts the job and never learns the outcome, so it falls back to the
+`<suite>_output_for_pr.md` that polaris writes at the end of its own run —
+just before the pass/fail exit, so it means the run finished rather than
+that it passed.  That is a deliberate coupling to a polaris output file:
+removing or renaming it would stop benchmark baselines from being reused.
+It fails safe, since an unrecognized baseline is run again rather than
+trusted, and the driver reports when it re-runs a baseline directory that
+already exists.
+
 ## Sharing one build between the two sides
 
 Each side is given `build_baseline` or `build_test` inside the run

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -29,11 +29,17 @@ Each side is resolved with one of two `source` modes:
 | `worktree` (default) | Resolve a fork and ref to a commit, create a detached `git worktree` under `work_base`, initialize submodules, and optionally override the fork/ref of a single submodule. |
 | `existing` | Adopt a polaris worktree that already exists, exactly as it is found. |
 
-An adopted worktree is **strictly read-only**.  The driver never runs
-`fetch`, `checkout`, `submodule update`, `reset` or `clean` against it.  If
-a required submodule is not initialized, the driver stops and prints the
-command for the developer to run.  This makes it cheap to benchmark the
-branch you are already working in, reusing its existing build.
+The driver never runs `fetch`, `checkout`, `submodule update`, `reset` or
+`clean` against an adopted worktree.  If a required submodule is not
+initialized, the driver stops and prints the command for the developer to
+run.  This makes it cheap to benchmark the branch you are already working
+in without a second copy.
+
+Polaris' own build is a separate matter: it builds the component from
+`--branch`, which for MPAS-Ocean is an in-source `make` in the branch
+directory, and both build templates run
+`git submodule update --init --recursive` there.  An adopted worktree is
+therefore built in place, not left untouched.
 
 Because the `[baseline]` and `[test]` sections take exactly the same
 options, the same driver benchmarks a polaris change, an Omega change or

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -119,6 +119,16 @@ The driver refuses to run, *before* anything is built, if:
 Each override makes the result harder to interpret, so it should be used
 deliberately and noted when reporting results.
 
+To tell which `model` a suite needs, read its tasks rather than its name.
+`e3sm/init`, `mesh` and `seaice` never run a model; within `ocean`, what
+decides it is whether any step is an `OceanModelStep`, which is what
+`Ocean.configure()` tests before it goes looking for a build.  The suite
+file `polaris/suites/ocean/<suite>.txt` lists one task path per line, and
+`grep -rl OceanModelStep polaris/tasks/ocean/<task>` answers the question
+for each of them.  Getting it wrong is loud rather than silent: a
+`model = none` benchmark of a suite that does run the model stops during
+`polaris setup`, unable to detect an ocean model.
+
 ## Output layout
 
 ```

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -104,7 +104,8 @@ deliberately and noted when reporting results.
 ```
 <work_base>/
   worktrees/<ref>-<sha7>/            provisioned polaris worktrees
-  baselines/<suite>_<model>_<shas>/  reusable baseline work dirs
+  baselines/<suite>_<model>_<key>_<shas>/
+                                     reusable baseline work dirs
   runs/<date>-<base sha7>-<test sha7>/
     benchmark.log
     manifest.json
@@ -112,8 +113,9 @@ deliberately and noted when reporting results.
     test/
 ```
 
-A baseline work directory is keyed on the suite, model and every commit
-hash, and is marked complete when it finishes.  A later benchmark with the
+A baseline work directory is keyed on the suite, the model, every commit
+hash and a short `<key>` hashed from the setup command, the polaris config
+file and the load script, and is marked complete when it finishes.  A later benchmark with the
 same key reuses it rather than rerunning it, which is what makes iterating
 on a test branch inexpensive.
 

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -122,9 +122,9 @@ deliberately and noted when reporting results.
 ```
 <work_base>/
   worktrees/<ref>-<sha7>/            provisioned polaris worktrees
-  baselines/<suite>_<model>_<key>_<shas>/
+  baselines/<suite>_<model>_opts-<key>_polaris-<sha7>[_<repo>-<sha7>]/
                                      reusable baseline work dirs
-  runs/<date>-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
+  runs/<date>-polaris-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
                                      one benchmark run
     benchmark.log
     manifest.json
@@ -139,11 +139,20 @@ section to change it for both sides at once; the driver merges it with
 `polaris_config_file` into `polaris_benchmark.cfg` in the run directory,
 because `polaris setup` takes only one config file.
 
-A baseline work directory is keyed on the suite, the model, every commit
-hash and a short `<key>` hashed from the setup command, the polaris config
-file and the load script, and is marked complete when it finishes.  A later benchmark with the
-same key reuses it rather than rerunning it, which is what makes iterating
-on a test branch inexpensive.
+A baseline work directory is keyed on the suite, the model, the polaris
+commit, the commit of the submodule the model is built from, and a short
+`opts-<key>` hashed from the setup command, the polaris config file and
+the load script.  Every hash is labelled, so the directory reads without
+knowing the order.
+
+A submodule that is never built cannot change the results, so its hash is
+left out; with `model = none` the polaris commit is the only one.  The
+manifest still records every hash, and the one-variable guardrail still
+compares all of them.
+
+A baseline is marked complete when it finishes, and a later benchmark with
+the same name **reuses** it instead of rerunning, which is what makes
+iterating on a test branch cheap.
 
 Validation results themselves are written by polaris under `case_outputs/`
 in the test work directory; collecting and reporting them is deliberately

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -64,7 +64,9 @@ sides.
    ```
 
 Always start with `--dry-run`.  It resolves every commit hash, applies
-every guardrail and prints the exact commands, but touches nothing.
+every guardrail and prints the exact commands.  It creates no worktrees
+and builds and runs nothing, but resolving a fork does add a remote to
+`primary_path` and fetch into it.
 
 Every fork and ref can also be given on the command line, which is
 convenient for scripted or agent-driven use:

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -96,13 +96,16 @@ The driver refuses to run, *before* anything is built, if:
   (`--allow-multiple-changes`);
 - they use different load scripts, implying a different machine, compiler
   or MPI library (`--allow-env-mismatch`);
-- they use different `model` values;
+- they use different `model` values (`mpas-ocean`, `omega` or `none`);
 - an adopted worktree has uncommitted or untracked changes, so the run
   could not be reproduced from the recorded hashes (`--allow-dirty`, which
   records the run as `reproducible: false` and never caches its baseline);
 - an adopted worktree is missing the submodule needed for `model`, or its
   load script does not exist.  Creating the environment with `./deploy.py`
-  is always a developer action.
+  is always a developer action.  A task or suite that runs no model
+  (anything under `e3sm/init`, `mesh` or `seaice`, and some `ocean` tasks)
+  should use `model = none`, which builds nothing and so needs no
+  submodule on either side.
 
 Each override makes the result harder to interpret, so it should be used
 deliberately and noted when reporting results.

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -78,6 +78,17 @@ every guardrail and prints the exact commands.  It creates no worktrees
 and builds and runs nothing, but resolving a fork does add a remote to
 `primary_path` and fetch into it.
 
+Every fork and ref can also be given on the command line, which is
+convenient for scripted or agent-driven use:
+
+```bash
+./utils/benchmark/benchmark.py -f benchmark.cfg \
+    --test-polaris-fork cbegeman \
+    --test-polaris-ref add-surface-forcing-to-vmix
+```
+
+Full option tables are in `utils/benchmark/README.md`.
+
 ## Before your first run
 
 Four things have to be true of the source trees before the driver will do
@@ -95,21 +106,11 @@ time:
    that builds — both sides normally, the baseline only when a
    `component_path` is shared:
    `git -C <worktree> submodule update --init e3sm_submodules/Omega`.
-4. **Adopted worktrees are clean.**  An untracked scratch file is enough
-   to stop the run, since the benchmark could not then be reproduced from
-   the recorded hashes.  Commit it, move it aside, or decide up front to
-   pass `--allow-dirty`.
-
-Every fork and ref can also be given on the command line, which is
-convenient for scripted or agent-driven use:
-
-```bash
-./utils/benchmark/benchmark.py -f benchmark.cfg \
-    --test-polaris-fork cbegeman \
-    --test-polaris-ref add-surface-forcing-to-vmix
-```
-
-Full option tables are in `utils/benchmark/README.md`.
+4. **Adopted worktrees have nothing uncommitted.**  Notes and scratch
+   files at the root are fine and are simply recorded, but an uncommitted
+   change to a tracked file, or an untracked file inside `polaris`, stops
+   the run.  Commit it, move it aside, or decide up front to pass
+   `--allow-dirty`.
 
 ## Guardrails
 
@@ -123,12 +124,18 @@ The driver refuses to run, *before* anything is built, if:
 - they use different load scripts, implying a different machine, compiler
   or MPI library (`--allow-env-mismatch`);
 - they use different `model` values (`mpas-ocean`, `omega` or `none`);
-- an adopted worktree has uncommitted or untracked changes, so the run
+- an adopted worktree has changes that are not in a commit, so the run
   could not be reproduced from the recorded hashes (`--allow-dirty`, which
   records the run as `reproducible: false` and never caches its baseline).
-  A submodule built in place does *not* count; edited source in the
-  submodule the model is built from, or a submodule checked out at a
-  commit other than the pinned one, does.  Untracked files in that
+  An untracked file outside the `polaris` package does *not* count: notes,
+  plan documents and scratch output at the root of a worktree in use are
+  never imported, registered or read by a task, so they are listed and
+  recorded as `untracked` while the run stays reproducible and caches its
+  baseline as usual.  Inside `polaris` an untracked file does count, since
+  a new module is importable and a new task directory is discovered
+  without any tracked file changing.  A submodule built in place does
+  *not* count; edited source in the submodule the model is built from, or
+  a submodule checked out at a commit other than the pinned one, does.  Untracked files in that
   submodule are ignored only for `mpas-ocean`, whose in-source `make`
   leaves them behind, and not for the out-of-source Omega build;
 - an adopted worktree is missing the submodule needed for `model`, or its

--- a/docs/developers_guide/benchmarking.md
+++ b/docs/developers_guide/benchmarking.md
@@ -101,7 +101,10 @@ The driver refuses to run, *before* anything is built, if:
 - they use different `model` values (`mpas-ocean`, `omega` or `none`);
 - an adopted worktree has uncommitted or untracked changes, so the run
   could not be reproduced from the recorded hashes (`--allow-dirty`, which
-  records the run as `reproducible: false` and never caches its baseline);
+  records the run as `reproducible: false` and never caches its baseline).
+  A submodule built in place does *not* count; edited tracked source in
+  the submodule the model is built from, or a submodule checked out at a
+  commit other than the pinned one, does;
 - an adopted worktree is missing the submodule needed for `model`, or its
   load script does not exist.  Creating the environment with `./deploy.py`
   is always a developer action.  A task or suite that runs no model

--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -223,9 +223,9 @@ For some output files, you may wish to run checks of certain properties such as
 conservation of mass or energy. Currently, only conservation checks for the
 ocean are available.
 
-To run property checks, add a list of properties
-the keyword argument `verify_properties` to the
-:py:meth:`polaris.Step.add_output_file()` method.  As an example:
+To run property checks, pass a list of properties as the keyword argument
+`check_properties` to the {py:meth}`polaris.Step.add_output_file()` method.
+As an example:
 
 ```python
 from polaris import Step
@@ -239,7 +239,7 @@ class Forward(OceanModelStep):
             filename='mesh.nc', target='../init/culled_mesh.nc'
         )
         self.add_output_file('output.nc',
-                             verify_properties=['mass conservation'])
+                             check_properties=['mass conservation'])
 ```
 
 ## Conservation checks
@@ -265,31 +265,8 @@ energy_conservation_tolerance = 1e-8
 As shown in the previous example, we have added a mesh file with the name
 'mesh.nc' because conservation checks require the area of cells.
 
-Each call to {py:meth}`polaris.Step.add_output_file()` adds a single
-conservation comparison, defined by the keyword arguments
-`check_properties_baseline` (either `'init'` for the initial condition or a
-time index in the output file) and `check_properties_time_index_end` (the
-time index in the output file at the end of the comparison).  To check
-conservation over more than one time interval of the same output file, call
-{py:meth}`polaris.Step.add_property_check()` once per interval:
-
-```python
-self.add_output_file('output.nc')
-# between the initial condition and the first time step
-self.add_property_check('output.nc', ['mass conservation'],
-                        baseline='init', time_index_end=0)
-# between the last two time steps
-self.add_property_check('output.nc', ['mass conservation'],
-                        baseline=-2, time_index_end=-1)
-```
-
-The surface forcing fluxes are accumulated over the duration of each
-comparison and used as the expected change in the corresponding budget.
-
-The results of the checks are written to `property_check_passed.log` (which
-lists the properties that passed) or `property_check_failed.log` (which lists
-the properties that failed along with the relative error and the relative
-error tolerance) in the step's work directory.  The full details of every
-check are also written to `property_check_results.json` and stored in the
-step's `property_check_results` attribute, so that other steps can summarize
-them.
+The results of the checks are written to the step's work directory: either
+`property_check_passed.log`, which lists each property that passed along
+with its relative error, or `property_check_failed.log`, which lists each
+property that failed along with its relative error and the tolerance it
+exceeded.  A step writes one or the other, never both.

--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -6,6 +6,11 @@ Tasks should typically include validation of variables and/or timers.
 This validation is a critical part of running suites and comparing them
 to baselines.
 
+To set up and run both sides of a baseline comparison automatically --
+resolving two source trees, initializing submodules, building each side and
+passing the baseline work directory on with `-b` -- see
+{ref}`dev-benchmarking`.
+
 ## Validating variables against a baseline
 
 The easiest type of validation you can add is against a baseline if one is
@@ -259,3 +264,32 @@ energy_conservation_tolerance = 1e-8
 
 As shown in the previous example, we have added a mesh file with the name
 'mesh.nc' because conservation checks require the area of cells.
+
+Each call to {py:meth}`polaris.Step.add_output_file()` adds a single
+conservation comparison, defined by the keyword arguments
+`check_properties_baseline` (either `'init'` for the initial condition or a
+time index in the output file) and `check_properties_time_index_end` (the
+time index in the output file at the end of the comparison).  To check
+conservation over more than one time interval of the same output file, call
+{py:meth}`polaris.Step.add_property_check()` once per interval:
+
+```python
+self.add_output_file('output.nc')
+# between the initial condition and the first time step
+self.add_property_check('output.nc', ['mass conservation'],
+                        baseline='init', time_index_end=0)
+# between the last two time steps
+self.add_property_check('output.nc', ['mass conservation'],
+                        baseline=-2, time_index_end=-1)
+```
+
+The surface forcing fluxes are accumulated over the duration of each
+comparison and used as the expected change in the corresponding budget.
+
+The results of the checks are written to `property_check_passed.log` (which
+lists the properties that passed) or `property_check_failed.log` (which lists
+the properties that failed along with the relative error and the relative
+error tolerance) in the step's work directory.  The full details of every
+check are also written to `property_check_results.json` and stored in the
+step's `property_check_results` attribute, so that other steps can summarize
+them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ developers_guide/ocean/index
 developers_guide/seaice/index
 developers_guide/framework/index
 developers_guide/machines/index
+developers_guide/benchmarking
 developers_guide/troubleshooting
 developers_guide/docs
 developers_guide/building_docs

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -744,6 +744,20 @@ def _write_output_for_pull_request(
 
     suite : dict
         The unpickled suite dictionary containing tasks and base work dir.
+
+    Notes
+    -----
+    The benchmarking driver in ``utils/benchmark`` uses the file this
+    writes as its signal that a run finished, which is how it can reuse a
+    baseline whose job it submitted and then stopped watching.  It is
+    written from ``run_tasks()`` just before the pass/fail exit, so it is
+    there whether the run passed or failed, which is what makes it usable
+    for that.
+
+    So renaming or removing this file would stop benchmark baselines from
+    being reused.  Nothing breaks -- an unrecognized baseline is simply
+    run again -- but it would get slower quietly, so please update
+    ``POLARIS_RUN_OUTPUT`` in ``utils/benchmark/benchmark.py`` to match.
     """
     work_dir = suite.get('work_dir', os.getcwd())
     provenance_path = os.path.join(work_dir, 'provenance')

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -392,6 +392,21 @@ baseline *pins*, and keeping the build at that hash is yours to manage.
 
 ## Notes
 
+- A baseline is reused when its work directory looks complete.  Two
+  things can say so: the `.polaris_benchmark_complete` marker the driver
+  writes when it ran polaris in place and saw it return, or the
+  `<suite>_output_for_pr.md` that polaris writes at the end of its own
+  run.  The second is what makes reuse work for `submit = True`, where
+  the driver exits as soon as `sbatch` accepts the job and never learns
+  the outcome.
+
+  Polaris writes that file immediately before the pass/fail exit, so it
+  means the run *finished*, not that it passed — which is the right test,
+  for the same reason the test job depends on `afterany`.  Renaming or
+  removing it in polaris would quietly stop baselines from being reused;
+  it fails safe, since an unrecognized baseline is simply run again, but
+  the driver says so when it re-runs a baseline directory that already
+  exists, so the regression is visible rather than silent.
 - When `submit = True`, the test job is submitted with
   `--dependency=afterany:<baseline job id>`, so the pair can be launched
   in one go.  It is `afterany` rather than `afterok` because a polaris

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -115,6 +115,10 @@ scripted or agent-driven use:
     --test-existing /path/to/my/polaris/worktree
 ```
 
+For example prompts to hand to an AI agent, see the "Example prompts for an
+AI agent" section of the developer's guide page on benchmarking
+(`docs/developers_guide/benchmarking.md`).
+
 ## Guardrails
 
 The driver refuses to run, before anything is built, if:

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -84,8 +84,10 @@ builds and runs nothing, but resolving a fork does add a remote to
 | `submit` | Submit the job script instead of running in place. |
 | `polaris_config_file` | Optional config file passed on with `-f`. |
 
-`${USER}`, `${HOME}` and `${SCRATCH}` are substituted from the
-environment anywhere in the config file, when they are set.
+Any environment variable can be substituted as `${NAME}` anywhere in the
+config file.  A name that a config option already defines wins, and one
+that is neither an option nor set in the environment is an error, so a
+typo is reported rather than silently expanding to nothing.
 
 `--model`, `--branch`, `-p`, `-w`, `-b`, `-f` and the build flags are
 appended automatically and **must not** appear in `setup_command`; the

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -188,8 +188,13 @@ The driver refuses to run, before anything is built, if:
 built in place is not dirty: build products are regenerable from the
 recorded hashes, and building in place is the normal state of a polaris
 worktree.  A submodule checked out at a commit other than the pinned one
-*is* dirty, as is edited tracked source in the submodule the model is
-built from.
+*is* dirty, as is edited source in the submodule the model is built from.
+
+Untracked files in that submodule are ignored only for `mpas-ocean`,
+whose in-source `make` leaves them behind.  Omega is built out of source,
+so an untracked file there is source rather than a build product, and its
+CMakeLists globs `*.cpp`, so a new one would be compiled in without any
+tracked file changing.
 - An adopted worktree is missing the submodule needed for `model`, or its
   load script does not exist.  Creating the environment with `./deploy.py`
   is a developer action and is never done for you.  A benchmark that

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -91,8 +91,7 @@ driver raises an error if they do.
 | `polaris_ref` | A branch, tag or commit hash. |
 | `omega_fork`, `omega_ref` | Override the Omega submodule. |
 | `e3sm_fork`, `e3sm_ref` | Override the E3SM-Project submodule. |
-| `mali_fork`, `mali_ref` | Override the MALI-Dev submodule. |
-| `model` | The polaris `--model` value: `mpas-ocean`, `omega` or `mali`. |
+| `model` | The polaris `--model` value: `mpas-ocean` or `omega`. |
 
 A fork given as a bare owner is expanded to a URL matching the style
 (ssh or https) of the existing `origin` remote.  Fork and ref options are
@@ -128,7 +127,7 @@ The driver refuses to run, before anything is built, if:
 
 - The two sides resolve to the **same** worktree or to identical commits
   everywhere, so there would be nothing to compare.
-- They differ in **more than one** of polaris, Omega, E3SM and MALI, so a
+- They differ in **more than one** of polaris, Omega and E3SM, so a
   difference could not be attributed to a single change.
   Override with `--allow-multiple-changes`.
 - They use **different load scripts**, implying a different machine,

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -82,7 +82,18 @@ builds and runs nothing, but resolving a fork does add a remote to
 | `setup_command` | A `polaris setup` or `polaris suite` command. |
 | `run_command` | Usually `polaris serial`; used when `submit = False`. |
 | `submit` | Submit the job script instead of running in place. |
+| `wall_time` | Optional wall-clock time for both sides' job scripts. |
 | `polaris_config_file` | Optional config file passed on with `-f`. |
+
+Both of the last two shape what polaris is given with `-f`.  `wall_time`
+sets `[job] wall_time`, which otherwise defaults to `1:00:00`; since
+`polaris setup` takes a single config file, the driver merges it with
+`polaris_config_file` into `polaris_benchmark.cfg` in the run directory
+and passes that on.  A `wall_time` here wins over one in
+`polaris_config_file`, and both sides always get the same file.
+
+Changing `wall_time` does **not** invalidate a cached baseline, since it
+cannot change results.  Changing `polaris_config_file` does.
 
 Any environment variable can be substituted as `${NAME}` anywhere in the
 config file.  A name that a config option already defines wins, and one
@@ -183,6 +194,7 @@ The driver refuses to run, before anything is built, if:
                                      one benchmark run
     benchmark.log
     manifest.json
+    polaris_benchmark.cfg            written only when wall_time is set
     build_baseline/  build_test/
     test/
 ```

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -393,8 +393,17 @@ baseline *pins*, and keeping the build at that hash is yours to manage.
 ## Notes
 
 - When `submit = True`, the test job is submitted with
-  `--dependency=afterok:<baseline job id>`, so the pair can be launched in
-  one go.  Because completion is asynchronous, work directories are not
+  `--dependency=afterany:<baseline job id>`, so the pair can be launched
+  in one go.  It is `afterany` rather than `afterok` because a polaris
+  suite exits non-zero when *any* task in it fails.  A baseline should
+  not have failures, and one that does is worth investigating — but a
+  single failed task does not invalidate the others, whose baseline
+  output is on disk and is exactly what the test side needs.  Under
+  `afterok`, one failure cost the entire comparison and left no way
+  forward but to run both sides again.  The job is also submitted with
+  `--kill-on-invalid-dep=yes`, so that a dependency that genuinely
+  cannot be satisfied removes the job rather than stranding it as
+  `DependencyNeverSatisfied`.  Because completion is asynchronous, work directories are not
   marked complete (and so not reused) in this mode.
 - A load script is **never created for you**; `./deploy.py` is a developer
   action.  A freshly provisioned worktree therefore has no load script of

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -178,6 +178,13 @@ The driver refuses to run, before anything is built, if:
   with `--allow-dirty`; the run is recorded as `reproducible: false`, its
   directory is prefixed with `dirty-`, and its baseline is never cached
   or reused.
+
+`--allow-dirty` is about source that is not in a commit.  A submodule
+built in place is not dirty: build products are regenerable from the
+recorded hashes, and building in place is the normal state of a polaris
+worktree.  A submodule checked out at a commit other than the pinned one
+*is* dirty, as is edited tracked source in the submodule the model is
+built from.
 - An adopted worktree is missing the submodule needed for `model`, or its
   load script does not exist.  Creating the environment with `./deploy.py`
   is a developer action and is never done for you.  A benchmark that

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -82,6 +82,7 @@ builds and runs nothing, but resolving a fork does add a remote to
 | `setup_command` | A `polaris setup` or `polaris suite` command.  A `polaris setup` command must name its suite with `--suite_name`. |
 | `run_command` | Usually `polaris serial`; used when `submit = False`. |
 | `submit` | Submit the job script instead of running in place. |
+| `component_path` | Optional build directory shared by both sides, passed on with `-p`. |
 | `wall_time` | Optional wall-clock time for both sides' job scripts. |
 | `polaris_config_file` | Optional config file passed on with `-f`. |
 
@@ -251,9 +252,37 @@ Neither flag is needed for a first build.  `[build] build` defaults to
 find the model at `-p`.  Use `--rebuild` to force a build over one that
 is already there, and `--clean-build` to throw that one away first.
 
-Note that `-p` is inside the run directory, so a build is shared only by
-benchmarks that land in the same run directory, and never with an adopted
-worktree's own build.
+## Sharing one build between the two sides
+
+By default `-p` is `build_baseline` or `build_test` inside the run
+directory, so each side builds its own copy and a run on a new day builds
+both again from scratch.
+
+When only polaris differs, that is two builds of the same source.  Set
+`component_path` in `[benchmark]` to a directory both sides should use
+instead:
+
+```ini
+[benchmark]
+component_path = ${work_base}/build_omega
+```
+
+Since polaris builds only what it cannot find at `-p`, the side that is
+set up first builds the model there and the other one finds it and skips.
+Nothing else has to be passed: no `--rebuild`, and no build flag at all.
+
+The driver refuses a `component_path` when the two sides pin **different**
+commits of the submodule the model is built from, since one side would
+then run the other's model — with `submit = True` both sides are set up
+before either runs, so whichever built last would win for both.  It also
+refuses `--clean-build`, which would delete a directory the benchmark
+does not own and then build it twice over; clean it yourself instead.
+
+`component_path` is part of the key the cached baseline is named from, so
+pointing it somewhere else starts a new baseline rather than reusing one
+built against a different executable.  The driver cannot check what was
+actually built there: the baseline directory names the submodule hash the
+baseline *pins*, and keeping the build at that hash is yours to manage.
 
 ## Notes
 

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -74,6 +74,9 @@ guardrail and prints the exact commands, but touches nothing.
 | `submit` | Submit the job script instead of running in place. |
 | `polaris_config_file` | Optional config file passed on with `-f`. |
 
+`${USER}`, `${HOME}` and `${SCRATCH}` are substituted from the
+environment anywhere in the config file, when they are set.
+
 `--model`, `--branch`, `-p`, `-w`, `-b`, `-f` and the build flags are
 appended automatically and **must not** appear in `setup_command`; the
 driver raises an error if they do.

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -150,7 +150,8 @@ The driver refuses to run, before anything is built, if:
   worktrees/<ref>-<sha7>/            provisioned polaris worktrees
   baselines/<suite>_<model>_<key>_<shas>/
                                      reusable baseline work dirs
-  runs/<date>-<base sha7>-<test sha7>/
+  runs/<date>-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
+                                     one benchmark run
     benchmark.log
     manifest.json
     build_baseline/  build_test/

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -68,7 +68,7 @@ guardrail and prints the exact commands, but touches nothing.
 | --- | --- |
 | `work_base` | Base directory for all benchmark output. |
 | `primary_path` | The polaris clone worktrees are made from and forks are fetched into.  Defaults to the config file's directory.  Only ever fetched from. |
-| `load_script` | Name of the load script to source *within each worktree*. |
+| `load_script` | Name of the load script to source within each worktree, or an absolute path to a single shared one. |
 | `setup_command` | A `polaris setup` or `polaris suite` command. |
 | `run_command` | Usually `polaris serial`; used when `submit = False`. |
 | `submit` | Submit the job script instead of running in place. |
@@ -183,8 +183,14 @@ usually the point of adopting an existing worktree.
   `--dependency=afterok:<baseline job id>`, so the pair can be launched in
   one go.  Because completion is asynchronous, work directories are not
   marked complete (and so not reused) in this mode.
-- `NO_POLARIS_REINSTALL=true` is exported before sourcing a load script, so
-  one deployment can serve several worktrees.
+- A load script is **never created for you**; `./deploy.py` is a developer
+  action.  A freshly provisioned worktree therefore has no load script of
+  its own, since `load_*.sh` is git-ignored.  Either run `./deploy.py` in
+  the provisioned worktree once, or set `load_script` to the *absolute*
+  path of an existing load script.  In the latter case
+  `NO_POLARIS_REINSTALL=true`, which is exported before the load script is
+  sourced, lets one deployment serve several worktrees.  A `--dry-run`
+  says so when it cannot yet check a load script.
 - Collecting results and generating a report are deliberately **not** part
   of this driver yet; polaris writes its own validation output under
   `case_outputs/` in the test work directory.

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -295,6 +295,13 @@ Since polaris builds only what it cannot find at `-p`, the side that is
 set up first builds the model there and the other one finds it and skips.
 Nothing else has to be passed: no `--rebuild`, and no build flag at all.
 
+The baseline is that side, so `--branch` points at the **baseline's**
+submodule for both.  The test side is therefore never built from and does
+not need `e3sm_submodules/Omega` or `e3sm_submodules/E3SM-Project`
+initialized at all — a provisioned test worktree does not clone it, and
+an adopted one is not asked for it.  That is usually several GB of source
+that nothing would read.
+
 The driver refuses a `component_path` when the two sides pin **different**
 commits of the submodule the model is built from, since one side would
 then run the other's model — with `submit = True` both sides are set up

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -148,7 +148,8 @@ The driver refuses to run, before anything is built, if:
 ```
 <work_base>/
   worktrees/<ref>-<sha7>/            provisioned polaris worktrees
-  baselines/<suite>_<model>_<shas>/  reusable baseline work dirs
+  baselines/<suite>_<model>_<key>_<shas>/
+                                     reusable baseline work dirs
   runs/<date>-<base sha7>-<test sha7>/
     benchmark.log
     manifest.json
@@ -156,8 +157,12 @@ The driver refuses to run, before anything is built, if:
     test/
 ```
 
-A baseline work directory is keyed on the suite, model and every commit
-hash, and is marked complete when it finishes.  A later benchmark with the
+A baseline work directory is keyed on the suite, the model, every commit
+hash and a short `<key>` hashed from the setup command, the polaris config
+file and the load script.  The last of these matters because
+`polaris setup` always reports the suite name `custom`, so without it two
+different tasks would share a baseline.  A baseline is marked complete
+when it finishes.  A later benchmark with the
 same key **reuses** it instead of rerunning, which is what makes iterating
 on a test branch cheap.
 

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -146,6 +146,30 @@ nothing to build.
 
 Both sides must use the same `model`, `none` included.
 
+#### Telling which one you need
+
+The component usually settles it: `e3sm/init`, `mesh` and `seaice` run no
+model, so those are always `none`.  Only `ocean` is mixed.
+
+What decides it there is whether any step is an `OceanModelStep`, which is
+what `Ocean.configure()` tests before it looks for a build.  So read the
+tasks rather than the suite name: `polaris/suites/ocean/<suite>.txt` lists
+one task path per line, and
+
+```bash
+grep -rl OceanModelStep polaris/tasks/ocean/<task>
+```
+
+says whether that task forward-runs the model.  A suite named for a PR or
+nightly test almost certainly does; a task that only builds a mesh, remaps
+a field or checks convergence against an analytic solution may well not.
+
+Guessing wrong is cheap and loud, not silent.  `model = none` on a suite
+that does run the model fails during `polaris setup` with *"Could not
+detect ocean model; neither MPAS-Ocean nor Omega appear to be
+available"*.  The opposite mistake costs a build that is never used, and
+the driver asks for a submodule you did not need.
+
 ## Command-line overrides
 
 Every fork and ref can be set on the command line, which is convenient for

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -79,7 +79,7 @@ builds and runs nothing, but resolving a fork does add a remote to
 | `work_base` | Base directory for all benchmark output. |
 | `primary_path` | The polaris clone worktrees are made from and forks are fetched into.  Defaults to the config file's directory.  Only ever fetched from. |
 | `load_script` | Name of the load script to source within each worktree, or an absolute path to a single shared one. |
-| `setup_command` | A `polaris setup` or `polaris suite` command. |
+| `setup_command` | A `polaris setup` or `polaris suite` command.  A `polaris setup` command must name its suite with `--suite_name`. |
 | `run_command` | Usually `polaris serial`; used when `submit = False`. |
 | `submit` | Submit the job script instead of running in place. |
 | `wall_time` | Optional wall-clock time for both sides' job scripts. |
@@ -104,6 +104,11 @@ typo is reported rather than silently expanding to nothing.
 appended automatically and **must not** appear in `setup_command`; the
 driver raises an error if they do.  `--model` and `--branch` are left off
 entirely when `model = none`.
+
+`--suite_name` is the exception: it is *required* in a `polaris setup`
+command.  Polaris would otherwise call the suite `custom`, so every
+benchmark set up that way would share one baseline directory and one job
+script name.  `polaris suite` takes its name from `-t` instead.
 
 ### `[baseline]` and `[test]`
 
@@ -208,9 +213,9 @@ built from.
 
 A baseline work directory is keyed on the suite, the model, every commit
 hash and a short `<key>` hashed from the setup command, the polaris config
-file and the load script.  The last of these matters because
-`polaris setup` always reports the suite name `custom`, so without it two
-different tasks would share a baseline.  A baseline is marked complete
+file and the load script.  The last two matter because they change the
+results; the suite name comes from `-t` for a suite and from
+`--suite_name` for `polaris setup`.  A baseline is marked complete
 when it finishes.  A later benchmark with the
 same key **reuses** it instead of rerunning, which is what makes iterating
 on a test branch cheap.

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -244,13 +244,16 @@ which repositories differ.
 | `--clean-build` | Start from a clean build directory on both sides. |
 | `--rebuild` | Force a build even if the component is already built. |
 
-Polaris does **not** build unless it is asked to: `[build] build` defaults
-to `False` in `polaris/default.cfg`, and the driver only passes `--build`
-or `--clean_build` when one of these flags is given.  So a first run of a
-`mpas-ocean` or `omega` benchmark needs `--rebuild` (or a component
-already present at `-p`).  Note that `-p` is inside the run directory, so
-a build is shared only by benchmarks that land in the same run directory,
-and never with an adopted worktree's own build.
+Neither flag is needed for a first build.  `[build] build` defaults to
+`False` in `polaris/default.cfg` and the driver passes `--build` or
+`--clean_build` only when one of these flags is given, but
+`Ocean.configure()` turns the option on by itself whenever it does not
+find the model at `-p`.  Use `--rebuild` to force a build over one that
+is already there, and `--clean-build` to throw that one away first.
+
+Note that `-p` is inside the run directory, so a build is shared only by
+benchmarks that land in the same run directory, and never with an adopted
+worktree's own build.
 
 ## Notes
 

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -25,11 +25,19 @@ Each side is resolved in one of two ways:
 | `worktree` (default) | Resolve a fork and ref to a commit, create a detached `git worktree` under `work_base`, initialize submodules, and optionally check out a different fork/ref for one submodule. |
 | `existing` | Adopt a polaris worktree that already exists, exactly as it is found. |
 
-An adopted worktree is treated as **strictly read-only**.  The driver never
-runs `fetch`, `checkout`, `submodule update`, `reset` or `clean` against it.
-If a required submodule is not initialized, the driver stops and tells you
-the command to run yourself.  This lets you benchmark the branch you are
-already working in, with its existing build, without a second copy.
+The **driver** never runs `fetch`, `checkout`, `submodule update`, `reset`
+or `clean` against an adopted worktree.  If a required submodule is not
+initialized, the driver stops and tells you the command to run yourself.
+This lets you benchmark the branch you are already working in without a
+second copy.
+
+That is not the same as the worktree being left untouched.  Polaris builds
+the component from `--branch`, and for MPAS-Ocean that is an in-source
+`make` in the branch directory; both build templates also run
+`git submodule update --init --recursive` there.  Since polaris turns the
+build on by itself whenever the component is not found at `-p`, expect an
+adopted worktree to be built in place the first time each run directory is
+created.
 
 Both sections take exactly the same options, so *which* repository is being
 benchmarked is just a matter of which refs differ between them.
@@ -181,8 +189,10 @@ which repositories differ.
 | `--clean-build` | Start from a clean build directory on both sides. |
 | `--rebuild` | Force a build even if the component is already built. |
 
-By default neither is passed, so an existing build is reused — which is
-usually the point of adopting an existing worktree.
+Neither is normally needed: polaris sets the build option itself when the
+component is not found at `-p`.  Note that `-p` is inside the run
+directory, so a build is shared only by benchmarks that land in the same
+run directory, and never with an adopted worktree's own build.
 
 ## Notes
 

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -135,10 +135,38 @@ appended automatically and **must not** appear in `setup_command`; the
 driver raises an error if they do.  `--model` and `--branch` are left off
 entirely when `model = none`.
 
-`--suite_name` is the exception: it is *required* in a `polaris setup`
-command.  Polaris would otherwise call the suite `custom`, so every
-benchmark set up that way would share one baseline directory and one job
-script name.  `polaris suite` takes its name from `-t` instead.
+### The suite name identifies the benchmark
+
+**The suite name is what makes one benchmark distinct from another.**  It
+names the cached baseline directory, the run directory and the job script,
+so two benchmarks with the same suite name are, as far as the driver is
+concerned, the same benchmark:
+
+```
+baselines/<suite>_<model>_opts-<key>_polaris-<sha7>[_<repo>-<sha7>]/
+runs/<date>-<suite>-polaris-<sha7>-<sha7>[-<repo>-<sha7>-<sha7>]/
+job_script.<suite>.sh
+```
+
+Two benchmarks of the *same* pair of commits are therefore told apart by
+their suite names.  Benchmarking one branch two ways — one suite that
+runs the model and one task that does not, say — needs two different suite
+names and nothing else.  The `opts-<key>` on the baseline is a hash of the
+setup command, the config file, the load script and any shared
+`component_path`.  It is not something you choose; it is there so that a
+cached baseline is never reused by a benchmark it is not comparable with,
+which is why it appears on the baseline and not on the run directory.
+
+Where the name comes from depends on the command:
+
+| command | the name is |
+| --- | --- |
+| `polaris suite` | the value of `-t`, e.g. `-t omega_pr` → `omega_pr` |
+| `polaris setup` | the value of `--suite_name`, which is **required** |
+
+`--suite_name` is the one flag the driver requires rather than forbids.
+Polaris would otherwise call the suite `custom`, so every benchmark set up
+that way would collide with every other.
 
 ### `[baseline]` and `[test]`
 
@@ -273,7 +301,7 @@ tracked file changing.
   worktrees/<ref>-<sha7>/            provisioned polaris worktrees
   baselines/<suite>_<model>_opts-<key>_polaris-<sha7>[_<repo>-<sha7>]/
                                      reusable baseline work dirs
-  runs/<date>-polaris-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
+  runs/<date>-<suite>-polaris-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
                                      one benchmark run
     benchmark.log
     manifest.json
@@ -281,6 +309,12 @@ tracked file changing.
     build_baseline/  build_test/
     test/
 ```
+
+A run directory is keyed on the suite, so that two benchmarks of the
+*same* pair of commits on the same day do not share one.  Every repository
+that differs follows.  It carries no `opts-<key>`: that hash is there to
+stop a *baseline* being reused when it is not comparable, and a run
+directory is not a cache.
 
 A baseline work directory is keyed on the suite, the model, the polaris
 commit, the commit of the submodule the model is built from, and a short

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -31,13 +31,13 @@ initialized, the driver stops and tells you the command to run yourself.
 This lets you benchmark the branch you are already working in without a
 second copy.
 
-That is not the same as the worktree being left untouched.  Polaris builds
-the component from `--branch`, and for MPAS-Ocean that is an in-source
-`make` in the branch directory; both build templates also run
-`git submodule update --init --recursive` there.  Since polaris turns the
-build on by itself whenever the component is not found at `-p`, expect an
-adopted worktree to be built in place the first time each run directory is
-created.
+That is not the same as the worktree being left untouched, *if* a build is
+requested.  Polaris builds the component from `--branch`, and for
+MPAS-Ocean that is an in-source `make` in the branch directory; both build
+templates also run `git submodule update --init --recursive` there.  So
+`--rebuild` or `--clean-build` on an adopted worktree writes into it.
+Without those flags, and always with `model = none`, nothing is built and
+the worktree really is only read.
 
 Both sections take exactly the same options, so *which* repository is being
 benchmarked is just a matter of which refs differ between them.
@@ -209,10 +209,13 @@ which repositories differ.
 | `--clean-build` | Start from a clean build directory on both sides. |
 | `--rebuild` | Force a build even if the component is already built. |
 
-Neither is normally needed: polaris sets the build option itself when the
-component is not found at `-p`.  Note that `-p` is inside the run
-directory, so a build is shared only by benchmarks that land in the same
-run directory, and never with an adopted worktree's own build.
+Polaris does **not** build unless it is asked to: `[build] build` defaults
+to `False` in `polaris/default.cfg`, and the driver only passes `--build`
+or `--clean_build` when one of these flags is given.  So a first run of a
+`mpas-ocean` or `omega` benchmark needs `--rebuild` (or a component
+already present at `-p`).  Note that `-p` is inside the run directory, so
+a build is shared only by benchmarks that land in the same run directory,
+and never with an adopted worktree's own build.
 
 ## Notes
 

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -58,7 +58,9 @@ benchmarked is just a matter of which refs differ between them.
    ```
 
 Always start with `--dry-run`.  It resolves every commit hash, applies every
-guardrail and prints the exact commands, but touches nothing.
+guardrail and prints the exact commands.  It creates no worktrees and
+builds and runs nothing, but resolving a fork does add a remote to
+`primary_path` and fetch into it.
 
 ## Configuration options
 

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -1,0 +1,183 @@
+# Benchmarking a branch against a baseline
+
+The `utils/benchmark` directory contains a driver that benchmarks a
+**polaris**, **Omega** or **E3SM** branch against a baseline using a polaris
+task or suite.  It is designed to be run either by a developer or by an AI
+agent, and to produce a run that can be reproduced from the recorded commit
+hashes.
+
+The idea is simple:
+
+1. Resolve two *sides* of the benchmark, a **baseline** and a **test**.
+2. Set up the same task or suite for each.
+3. Give the test side the baseline work directory with `-b`, so that
+   polaris' own validation compares the two (see {ref}`dev-validation`).
+
+Because the comparison is done by polaris itself, this driver only has to
+get the source trees, the environment and the paths right.
+
+## The two source modes
+
+Each side is resolved in one of two ways:
+
+| `source` | Behavior |
+| --- | --- |
+| `worktree` (default) | Resolve a fork and ref to a commit, create a detached `git worktree` under `work_base`, initialize submodules, and optionally check out a different fork/ref for one submodule. |
+| `existing` | Adopt a polaris worktree that already exists, exactly as it is found. |
+
+An adopted worktree is treated as **strictly read-only**.  The driver never
+runs `fetch`, `checkout`, `submodule update`, `reset` or `clean` against it.
+If a required submodule is not initialized, the driver stops and tells you
+the command to run yourself.  This lets you benchmark the branch you are
+already working in, with its existing build, without a second copy.
+
+Both sections take exactly the same options, so *which* repository is being
+benchmarked is just a matter of which refs differ between them.
+
+## Quick start
+
+1. Copy the example config to the root of a polaris branch:
+
+   ```bash
+   cp utils/benchmark/example.cfg benchmark.cfg
+   ```
+
+2. Edit `benchmark.cfg` to set `work_base`, `load_script`, `setup_command`
+   and the `[baseline]` and `[test]` sections.
+
+3. Resolve everything and see the plan without building anything:
+
+   ```bash
+   ./utils/benchmark/benchmark.py -f benchmark.cfg --dry-run
+   ```
+
+4. When the plan looks right, run it:
+
+   ```bash
+   ./utils/benchmark/benchmark.py -f benchmark.cfg
+   ```
+
+Always start with `--dry-run`.  It resolves every commit hash, applies every
+guardrail and prints the exact commands, but touches nothing.
+
+## Configuration options
+
+### `[benchmark]`
+
+| Option | Description |
+| --- | --- |
+| `work_base` | Base directory for all benchmark output. |
+| `primary_path` | The polaris clone worktrees are made from and forks are fetched into.  Defaults to the config file's directory.  Only ever fetched from. |
+| `load_script` | Name of the load script to source *within each worktree*. |
+| `setup_command` | A `polaris setup` or `polaris suite` command. |
+| `run_command` | Usually `polaris serial`; used when `submit = False`. |
+| `submit` | Submit the job script instead of running in place. |
+| `polaris_config_file` | Optional config file passed on with `-f`. |
+
+`--model`, `--branch`, `-p`, `-w`, `-b`, `-f` and the build flags are
+appended automatically and **must not** appear in `setup_command`; the
+driver raises an error if they do.
+
+### `[baseline]` and `[test]`
+
+| Option | Description |
+| --- | --- |
+| `source` | `worktree` or `existing`. |
+| `path` | The existing worktree, when `source = existing`. |
+| `polaris_fork` | A GitHub owner (e.g. `E3SM-Project`) or a full remote URL. |
+| `polaris_ref` | A branch, tag or commit hash. |
+| `omega_fork`, `omega_ref` | Override the Omega submodule. |
+| `e3sm_fork`, `e3sm_ref` | Override the E3SM-Project submodule. |
+| `mali_fork`, `mali_ref` | Override the MALI-Dev submodule. |
+| `model` | The polaris `--model` value: `mpas-ocean`, `omega` or `mali`. |
+
+A fork given as a bare owner is expanded to a URL matching the style
+(ssh or https) of the existing `origin` remote.  Fork and ref options are
+forbidden when `source = existing`, since the checkout's own fork and ref
+are *recorded* rather than requested.
+
+Any submodule not given a ref stays at the hash pinned by `polaris_ref`.
+
+## Command-line overrides
+
+Every fork and ref can be set on the command line, which is convenient for
+scripted or agent-driven use:
+
+```bash
+./utils/benchmark/benchmark.py -f benchmark.cfg \
+    --test-polaris-fork cbegeman \
+    --test-polaris-ref add-surface-forcing-to-vmix
+
+./utils/benchmark/benchmark.py -f benchmark.cfg \
+    --test-omega-fork cbegeman --test-omega-ref my-omega-feature
+
+./utils/benchmark/benchmark.py -f benchmark.cfg \
+    --test-existing /path/to/my/polaris/worktree
+```
+
+## Guardrails
+
+The driver refuses to run, before anything is built, if:
+
+- The two sides resolve to the **same** worktree or to identical commits
+  everywhere, so there would be nothing to compare.
+- They differ in **more than one** of polaris, Omega, E3SM and MALI, so a
+  difference could not be attributed to a single change.
+  Override with `--allow-multiple-changes`.
+- They use **different load scripts**, implying a different machine,
+  compiler or MPI library.  Override with `--allow-env-mismatch`.
+- They use different `model` values.
+- An **adopted** worktree has uncommitted or untracked changes, since the
+  run could not then be reproduced from the recorded hashes.  Override
+  with `--allow-dirty`; the run is recorded as `reproducible: false`, its
+  directory is prefixed with `dirty-`, and its baseline is never cached
+  or reused.
+- An adopted worktree is missing the submodule needed for `model`, or its
+  load script does not exist.  Creating the environment with `./deploy.py`
+  is a developer action and is never done for you.
+
+## Output layout
+
+```
+<work_base>/
+  worktrees/<ref>-<sha7>/            provisioned polaris worktrees
+  baselines/<suite>_<model>_<shas>/  reusable baseline work dirs
+  runs/<date>-<base sha7>-<test sha7>/
+    benchmark.log
+    manifest.json
+    build_baseline/  build_test/
+    test/
+```
+
+A baseline work directory is keyed on the suite, model and every commit
+hash, and is marked complete when it finishes.  A later benchmark with the
+same key **reuses** it instead of rerunning, which is what makes iterating
+on a test branch cheap.
+
+`manifest.json` records both sides in full — mode, path, fork, ref, commit
+hashes, pinned versus actual submodule hashes, any overrides, the dirty
+flag and the load script — along with the commands, the directories and
+which repositories differ.
+
+## Other flags
+
+| Flag | Description |
+| --- | --- |
+| `--dry-run` | Resolve and print, but do not build or run. |
+| `--clean-build` | Start from a clean build directory on both sides. |
+| `--rebuild` | Force a build even if the component is already built. |
+
+By default neither is passed, so an existing build is reused — which is
+usually the point of adopting an existing worktree.
+
+## Notes
+
+- When `submit = True`, the test job is submitted with
+  `--dependency=afterok:<baseline job id>`, so the pair can be launched in
+  one go.  Because completion is asynchronous, work directories are not
+  marked complete (and so not reused) in this mode.
+- `NO_POLARIS_REINSTALL=true` is exported before sourcing a load script, so
+  one deployment can serve several worktrees.
+- Collecting results and generating a report are deliberately **not** part
+  of this driver yet; polaris writes its own validation output under
+  `case_outputs/` in the test work directory.

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -92,10 +92,12 @@ but they are quicker to settle up front than one dry run at a time:
 
    With a shared `component_path` it is the baseline only, and the test
    side needs nothing.
-4. **Adopted worktrees are clean.**  An untracked scratch file is enough
-   to stop the run, since the benchmark could not then be reproduced from
-   the recorded hashes.  Commit it, move it aside, or decide up front to
-   pass `--allow-dirty`.
+4. **Adopted worktrees have nothing uncommitted.**  Notes and scratch
+   files at the root are fine and are simply recorded, but an uncommitted
+   change to a tracked file, or an untracked file inside `polaris`, stops
+   the run: the benchmark could not then be reproduced from the recorded
+   hashes.  Commit it, move it aside, or decide up front to pass
+   `--allow-dirty`.
 
 ## Configuration options
 
@@ -230,11 +232,23 @@ The driver refuses to run, before anything is built, if:
 - They use **different load scripts**, implying a different machine,
   compiler or MPI library.  Override with `--allow-env-mismatch`.
 - They use different `model` values.
-- An **adopted** worktree has uncommitted or untracked changes, since the
+- An **adopted** worktree has changes that are not in a commit, since the
   run could not then be reproduced from the recorded hashes.  Override
   with `--allow-dirty`; the run is recorded as `reproducible: false`, its
   directory is prefixed with `dirty-`, and its baseline is never cached
   or reused.
+
+An untracked file **outside** the `polaris` package does not count.  A
+worktree in use normally carries notes, plan documents and scratch output
+at its root, and nothing a task runs imports, registers or reads them, so
+they cannot change a result.  They are listed in the summary and recorded
+in the manifest as `untracked`, but the run stays reproducible, keeps its
+undecorated directory name and caches its baseline as usual.
+
+Inside `polaris` an untracked file *can* change a result: a new module is
+importable and a new task directory is discovered, both without any
+tracked file changing.  Those are dirty, as is any uncommitted change to
+a tracked file anywhere.
 
 `--allow-dirty` is about source that is not in a commit.  A submodule
 built in place is not dirty: build products are regenerable from the

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -418,8 +418,10 @@ baseline *pins*, and keeping the build at that hash is yours to manage.
   forward but to run both sides again.  The job is also submitted with
   `--kill-on-invalid-dep=yes`, so that a dependency that genuinely
   cannot be satisfied removes the job rather than stranding it as
-  `DependencyNeverSatisfied`.  Because completion is asynchronous, work directories are not
-  marked complete (and so not reused) in this mode.
+  `DependencyNeverSatisfied`.  Because the driver exits as soon as
+  `sbatch` accepts the job, it never sees the run return and so never
+  writes the marker itself; a submitted baseline is recognized as
+  complete from polaris' own end-of-run file instead, as above.
 - A load script is **never created for you**; `./deploy.py` is a developer
   action.  A freshly provisioned worktree therefore has no load script of
   its own, since `load_*.sh` is git-ignored.  Either run `./deploy.py` in

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -70,6 +70,33 @@ guardrail and prints the exact commands.  It creates no worktrees and
 builds and runs nothing, but resolving a fork does add a remote to
 `primary_path` and fetch into it.
 
+## Before your first run
+
+Four things have to be true of the source trees before the driver will do
+anything, and none of them are done for you.  Each is a guardrail below,
+but they are quicker to settle up front than one dry run at a time:
+
+1. **A load script exists.**  `load_*.sh` is git-ignored and is written
+   by `./deploy.py`, which is a developer action.  Either run it once in
+   each worktree, or set `load_script` to the *absolute* path of one
+   existing script so that a single deployment serves both sides.
+2. **`model` matches what the suite runs**, per
+   [Choosing `model`](#choosing-model) below.  `model = none` needs no
+   submodule and no build.
+3. **The submodule the model is built from is initialized**, on the side
+   that builds.  Without a `component_path` that is both sides:
+
+   ```bash
+   git -C <worktree> submodule update --init e3sm_submodules/Omega
+   ```
+
+   With a shared `component_path` it is the baseline only, and the test
+   side needs nothing.
+4. **Adopted worktrees are clean.**  An untracked scratch file is enough
+   to stop the run, since the benchmark could not then be reproduced from
+   the recorded hashes.  Commit it, move it aside, or decide up front to
+   pass `--allow-dirty`.
+
 ## Configuration options
 
 ### `[benchmark]`

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -200,9 +200,9 @@ built from.
 ```
 <work_base>/
   worktrees/<ref>-<sha7>/            provisioned polaris worktrees
-  baselines/<suite>_<model>_<key>_<shas>/
+  baselines/<suite>_<model>_opts-<key>_polaris-<sha7>[_<repo>-<sha7>]/
                                      reusable baseline work dirs
-  runs/<date>-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
+  runs/<date>-polaris-<base sha7>-<test sha7>[-<repo>-<sha7>-<sha7>]/
                                      one benchmark run
     benchmark.log
     manifest.json
@@ -211,14 +211,20 @@ built from.
     test/
 ```
 
-A baseline work directory is keyed on the suite, the model, every commit
-hash and a short `<key>` hashed from the setup command, the polaris config
-file and the load script.  The last two matter because they change the
-results; the suite name comes from `-t` for a suite and from
-`--suite_name` for `polaris setup`.  A baseline is marked complete
-when it finishes.  A later benchmark with the
-same key **reuses** it instead of rerunning, which is what makes iterating
-on a test branch cheap.
+A baseline work directory is keyed on the suite, the model, the polaris
+commit, the commit of the submodule the model is built from, and a short
+`opts-<key>` hashed from the setup command, the polaris config file and
+the load script.  Every hash is labelled, so the directory reads without
+knowing the order.
+
+A submodule that is never built cannot change the results, so its hash is
+left out; with `model = none` the polaris commit is the only one.  The
+manifest still records every hash, and the one-variable guardrail still
+compares all of them.
+
+A baseline is marked complete when it finishes, and a later benchmark with
+the same name **reuses** it instead of rerunning, which is what makes
+iterating on a test branch cheap.
 
 `manifest.json` records both sides in full — mode, path, fork, ref, commit
 hashes, pinned versus actual submodule hashes, any overrides, the dirty

--- a/utils/benchmark/README.md
+++ b/utils/benchmark/README.md
@@ -91,7 +91,8 @@ typo is reported rather than silently expanding to nothing.
 
 `--model`, `--branch`, `-p`, `-w`, `-b`, `-f` and the build flags are
 appended automatically and **must not** appear in `setup_command`; the
-driver raises an error if they do.
+driver raises an error if they do.  `--model` and `--branch` are left off
+entirely when `model = none`.
 
 ### `[baseline]` and `[test]`
 
@@ -103,7 +104,7 @@ driver raises an error if they do.
 | `polaris_ref` | A branch, tag or commit hash. |
 | `omega_fork`, `omega_ref` | Override the Omega submodule. |
 | `e3sm_fork`, `e3sm_ref` | Override the E3SM-Project submodule. |
-| `model` | The polaris `--model` value: `mpas-ocean` or `omega`. |
+| `model` | The polaris `--model` value: `mpas-ocean` or `omega`, or `none` for a task or suite that runs no model. |
 
 A fork given as a bare owner is expanded to a URL matching the style
 (ssh or https) of the existing `origin` remote.  Fork and ref options are
@@ -111,6 +112,22 @@ forbidden when `source = existing`, since the checkout's own fork and ref
 are *recorded* rather than requested.
 
 Any submodule not given a ref stays at the hash pinned by `polaris_ref`.
+
+### Choosing `model`
+
+`model` says which component polaris builds, not which component the task
+belongs to.  A `model` of `mpas-ocean` or `omega` means the driver passes
+`--model` and `--branch` on to `polaris setup`, and requires the matching
+submodule to be initialized on that side.
+
+Many tasks build nothing at all: everything under `e3sm/init`, `mesh` and
+`seaice` is pure Python, and so are some `ocean` tasks.  Use `model = none`
+for those.  The driver then omits `--model` and `--branch`, and neither
+side needs `e3sm_submodules/Omega` or `e3sm_submodules/E3SM-Project` to be
+initialized.  `--clean-build` and `--rebuild` are refused, since there is
+nothing to build.
+
+Both sides must use the same `model`, `none` included.
 
 ## Command-line overrides
 
@@ -152,7 +169,8 @@ The driver refuses to run, before anything is built, if:
   or reused.
 - An adopted worktree is missing the submodule needed for `model`, or its
   load script does not exist.  Creating the environment with `./deploy.py`
-  is a developer action and is never done for you.
+  is a developer action and is never done for you.  A benchmark that
+  builds nothing should use `model = none`, which needs no submodule.
 
 ## Output layout
 

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -90,6 +90,8 @@ def benchmark(config, config_path, args):
         work_base,
         load_script_name,
     )
+    # with one shared build, only the baseline is ever the side polaris
+    # builds from, so the test side needs no model source of its own
     test = _resolve_side(
         'test',
         config,
@@ -98,7 +100,10 @@ def benchmark(config, config_path, args):
         primary_path,
         work_base,
         load_script_name,
+        needs_model_source=shared_component_path is None,
     )
+    if shared_component_path is not None:
+        test.component_source = baseline.component_branch_path or ''
 
     _check_guardrails(
         baseline, test, load_script_name, args, shared_component_path
@@ -358,6 +363,7 @@ def _resolve_side(
     primary_path,
     work_base,
     load_script_name,
+    needs_model_source=True,
 ):
     """Provision or adopt one side of the benchmark."""
     section = config[name]
@@ -382,6 +388,7 @@ def _resolve_side(
             model=model,
             load_script_name=load_script_name,
             allow_dirty=args.allow_dirty,
+            needs_model_source=needs_model_source,
         )
 
     if source == 'existing':
@@ -392,6 +399,7 @@ def _resolve_side(
             model=model,
             load_script_name=load_script_name,
             allow_dirty=args.allow_dirty,
+            needs_model_source=needs_model_source,
         )
 
     if source != 'worktree':
@@ -424,6 +432,7 @@ def _resolve_side(
         load_script_name=load_script_name,
         submodule_specs=submodule_specs,
         dry_run=args.dry_run,
+        needs_model_source=needs_model_source,
     )
 
 
@@ -784,8 +793,19 @@ def _print_summary(manifest):
         print(f'  path:    {side["path"]}')
         print(f'  polaris: {side["polaris_ref"]} {side["polaris_sha"][:7]}')
         print(f'  model:   {side["model"]}')
-        for key, sha in sorted(side['submodule_shas'].items()):
-            print(f'  {key}: {sha[:7]}')
+        # an uninitialized submodule is still pinned by the polaris
+        # commit, and that pin is what the guardrail compares, so report
+        # it rather than leaving the side looking as though it differs
+        for key in sorted(
+            set(side['submodule_shas']) | set(side['pinned_shas'])
+        ):
+            sha = side['submodule_shas'].get(key, '')
+            suffix = ''
+            if not sha:
+                sha = side['pinned_shas'].get(key, '')
+                suffix = ' (pinned, not checked out)'
+            if sha:
+                print(f'  {key}: {sha[:7]}{suffix}')
     for name in ['baseline', 'test']:
         side = manifest[name]
         if not side['load_script_ready']:
@@ -800,9 +820,11 @@ def _print_summary(manifest):
         print('')
         print(
             f'Both sides share one build at\n  '
-            f'{manifest["component_path"]}\nPolaris builds the model only '
-            f'when it does not find one there, so the first side set up '
-            f'builds it and the second reuses it.'
+            f'{manifest["component_path"]}\nbuilt from\n  '
+            f'{manifest["baseline"]["component_branch_path"]}\nPolaris '
+            f'builds the model only when it does not find one there, so '
+            f'the first side set up builds it and the second reuses it.  '
+            f'The test worktree needs no submodule of its own.'
         )
     print('')
     print(f'differing:    {", ".join(manifest["differing_repos"])}')

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -20,6 +20,7 @@ import configparser
 import hashlib
 import json
 import os
+import re
 import sys
 from datetime import datetime
 
@@ -484,9 +485,22 @@ def _run_baseline(
 
 
 def _get_run_dir(work_base, baseline, test):
-    """Get the deterministic run directory for this pair of sides."""
+    """
+    Get the deterministic run directory for this pair of sides.
+
+    Every repository that differs appears in the name.  Benchmarking a
+    submodule change holds polaris fixed on both sides, so the polaris
+    hashes alone would be the same for every such benchmark run on a
+    given day.
+    """
     date = datetime.now().strftime('%Y%m%d')
-    name = f'{date}-{baseline.polaris_sha[:7]}-{test.polaris_sha[:7]}'
+    parts = [date, baseline.polaris_sha[:7], test.polaris_sha[:7]]
+    for key in gitrepo.SUBMODULE_PATHS:
+        baseline_sha = baseline.submodule_shas.get(key, '')
+        test_sha = test.submodule_shas.get(key, '')
+        if baseline_sha != test_sha:
+            parts.append(f'{key}-{baseline_sha[:7]}-{test_sha[:7]}')
+    name = _slugify('-'.join(parts))
     if baseline.dirty or test.dirty:
         name = f'dirty-{name}'
     return os.path.join(work_base, 'runs', name)
@@ -530,6 +544,11 @@ def _setup_key(setup_command, polaris_config, baseline):
             parts.append(handle.read())
     text = '\n'.join(parts)
     return hashlib.sha256(text.encode('utf-8')).hexdigest()[:7]
+
+
+def _slugify(name):
+    """Get a filesystem-safe version of a run directory name."""
+    return re.sub(r'[^A-Za-z0-9_.-]', '-', name)
 
 
 def _is_complete(work_dir):

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -584,7 +584,10 @@ def _get_run_dir(work_base, baseline, test):
     given day.
     """
     date = datetime.now().strftime('%Y%m%d')
-    parts = [date, baseline.polaris_sha[:7], test.polaris_sha[:7]]
+    parts = [
+        date,
+        f'polaris-{baseline.polaris_sha[:7]}-{test.polaris_sha[:7]}',
+    ]
     baseline_shas = baseline.compare_shas
     test_shas = test.compare_shas
     for key in gitrepo.SUBMODULE_PATHS:
@@ -604,15 +607,28 @@ def _get_baseline_dir(work_base, baseline, setup_command, polaris_config):
 
     The name covers everything a baseline depends on, so that a baseline
     is only ever reused by a benchmark it is actually comparable with.
+    That is polaris plus the submodule the model is built from: a
+    submodule that is never built cannot change the results, so bumping
+    the hash polaris pins for it should not throw a baseline away.  The
+    manifest still records every hash, and the one-variable guardrail
+    still compares all of them.
+
+    Every hash is labelled with what it names, since the reader would
+    otherwise have to know the order they are written in.
 
     A dirty baseline is never cached or reused, since it cannot be
     reproduced from the recorded commit hashes.
     """
-    suite = polaris_run.get_suite_name(setup_command)
     shas = baseline.compare_shas
-    parts = [suite, baseline.model]
-    parts.append(_setup_key(setup_command, polaris_config, baseline))
-    parts.extend(sha[:7] for sha in shas.values() if sha)
+    parts = [
+        polaris_run.get_suite_name(setup_command),
+        baseline.model,
+        f'opts-{_setup_key(setup_command, polaris_config, baseline)}',
+        f'polaris-{shas["polaris"][:7]}',
+    ]
+    key = gitrepo.MODEL_SUBMODULES.get(baseline.model)
+    if key is not None and shas[key]:
+        parts.append(f'{key}-{shas[key][:7]}')
     name = '_'.join(parts)
     if baseline.dirty:
         name = f'dirty_{name}_{datetime.now().strftime("%Y%m%d%H%M%S")}'

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -21,6 +21,7 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 from datetime import datetime
 
@@ -208,6 +209,21 @@ def main():
     except (ValueError, configparser.Error) as exc:
         print('')
         print(f'Error: {exc}')
+        sys.exit(1)
+    except subprocess.CalledProcessError as exc:
+        # a bare CalledProcessError says only that a command failed, which
+        # is the least useful half of what is known.  The command itself
+        # reported why on standard error, so say that instead of leaving
+        # the developer to rerun it by hand to find out.
+        print('')
+        print(f'Error: a command failed with exit status {exc.returncode}:')
+        print(f'  {exc.cmd}')
+        for label, stream in [('stderr', exc.stderr), ('stdout', exc.output)]:
+            text = (stream or '').strip()
+            if text:
+                print('')
+                print(f'{label}:')
+                print(text)
         sys.exit(1)
 
     print('')

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -95,7 +95,7 @@ def benchmark(config, config_path, args):
         baseline, test, load_script_name, args, shared_component_path
     )
 
-    run_dir = _get_run_dir(work_base, baseline, test)
+    run_dir = _get_run_dir(work_base, baseline, test, setup_command)
     baseline_dir = _get_baseline_dir(
         work_base,
         baseline,
@@ -701,18 +701,30 @@ def _get_setup_config(run_dir, polaris_config, wall_time, dry_run):
     return config_file
 
 
-def _get_run_dir(work_base, baseline, test):
+def _get_run_dir(work_base, baseline, test, setup_command):
     """
     Get the deterministic run directory for this pair of sides.
 
-    Every repository that differs appears in the name.  Benchmarking a
-    submodule change holds polaris fixed on both sides, so the polaris
-    hashes alone would be the same for every such benchmark run on a
-    given day.
+    The suite name comes first, since it is what tells one benchmark from
+    another: two benchmarks of the *same* pair of commits are set up under
+    different suite names and must not share a work directory.  Without
+    it, benchmarking one branch two ways on one day silently overwrote the
+    first run's test work directory, build directory, manifest and log.
+
+    The ``opts-<key>`` that names the baseline is deliberately left out.
+    A baseline is a cache, so reusing one that was built with a different
+    config file or load script would be wrong; a run directory is only
+    where this run's output lands, and the suite name already tells one
+    from another.
+
+    Every repository that differs appears next.  Benchmarking a submodule
+    change holds polaris fixed on both sides, so the polaris hashes alone
+    would be the same for every such benchmark run on a given day.
     """
     date = datetime.now().strftime('%Y%m%d')
     parts = [
         date,
+        polaris_run.get_suite_name(setup_command),
         f'polaris-{baseline.polaris_sha[:7]}-{test.polaris_sha[:7]}',
     ]
     baseline_shas = baseline.compare_shas

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -334,12 +334,13 @@ def _resolve_side(
     """Provision or adopt one side of the benchmark."""
     section = config[name]
     model = section['model']
-    if model not in gitrepo.MODEL_SUBMODULES:
+    if model not in gitrepo.MODELS:
         raise ValueError(
             f'Unsupported model "{model}" in the [{name}] section; expected '
-            f'one of {", ".join(gitrepo.MODEL_SUBMODULES)}.  Polaris only '
-            f'builds those models automatically, which a benchmark relies '
-            f'on.'
+            f'one of {", ".join(gitrepo.MODELS)}.  Polaris only builds the '
+            f'models it knows about automatically, which a benchmark relies '
+            f'on.  Use "{gitrepo.NO_MODEL}" for a task or suite that runs '
+            f'no model at all.'
         )
 
     source = section.get('source', fallback='worktree')
@@ -448,6 +449,15 @@ def _check_guardrails(baseline, test, load_script_name, args):
             f'attributed to a single change.  Rerun with '
             f'--allow-multiple-changes to proceed anyway.'
         )
+
+    if args.clean_build or args.rebuild:
+        for side in [baseline, test]:
+            if side.model == gitrepo.NO_MODEL:
+                raise ValueError(
+                    f'The [{side.name}] section uses model = '
+                    f'{gitrepo.NO_MODEL}, so there is no component to '
+                    f'build.  Drop --clean-build and --rebuild.'
+                )
 
     if not args.allow_env_mismatch:
         baseline_script = os.path.basename(baseline.load_script)
@@ -599,6 +609,7 @@ def _print_summary(manifest):
         print(f'  mode:    {side["mode"]}')
         print(f'  path:    {side["path"]}')
         print(f'  polaris: {side["polaris_ref"]} {side["polaris_sha"][:7]}')
+        print(f'  model:   {side["model"]}')
         for key, sha in sorted(side['submodule_shas'].items()):
             print(f'  {key}: {sha[:7]}')
     for name in ['baseline', 'test']:

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -497,9 +497,11 @@ def _get_run_dir(work_base, baseline, test):
     """
     date = datetime.now().strftime('%Y%m%d')
     parts = [date, baseline.polaris_sha[:7], test.polaris_sha[:7]]
+    baseline_shas = baseline.compare_shas
+    test_shas = test.compare_shas
     for key in gitrepo.SUBMODULE_PATHS:
-        baseline_sha = baseline.submodule_shas.get(key, '')
-        test_sha = test.submodule_shas.get(key, '')
+        baseline_sha = baseline_shas[key]
+        test_sha = test_shas[key]
         if baseline_sha != test_sha:
             parts.append(f'{key}-{baseline_sha[:7]}-{test_sha[:7]}')
     name = _slugify('-'.join(parts))

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -534,6 +534,17 @@ def _print_summary(manifest):
         print(f'  polaris: {side["polaris_ref"]} {side["polaris_sha"][:7]}')
         for key, sha in sorted(side['submodule_shas'].items()):
             print(f'  {key}: {sha[:7]}')
+    for name in ['baseline', 'test']:
+        side = manifest[name]
+        if not side['load_script_ready']:
+            print('')
+            print(
+                f'Note: the {name} worktree does not exist yet, so its load '
+                f'script\n  {side["load_script"]}\ncannot be checked.  It '
+                f'must exist before the benchmark can run; see the load '
+                f'script notes in utils/benchmark/README.md.'
+            )
+    print('')
     print(f'differing:    {", ".join(manifest["differing_repos"])}')
     print(f'reproducible: {manifest["reproducible"]}')
     print(f'baseline dir: {manifest["baseline_dir"]}')

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""
+Benchmark a Polaris, Omega or E3SM branch against a baseline.
+
+The driver resolves two "sides" of a benchmark -- a baseline and a test
+-- sets each of them up with the same Polaris task or suite, and gives
+the test side the baseline work directory with ``-b`` so that Polaris'
+own validation compares them.
+
+Each side is either *provisioned* (a detached ``git worktree`` created
+from a requested fork and ref) or *adopted* (an existing Polaris
+worktree, used read-only and never modified).
+
+Run with ``--dry-run`` first: it resolves every commit hash and prints
+the exact commands that would be run without building anything.
+"""
+
+import argparse
+import configparser
+import json
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import gitrepo  # noqa: E402
+import polaris_run  # noqa: E402
+from shared import get_logger, to_abs  # noqa: E402
+
+#: The name of the file that marks a completed benchmark work directory
+COMPLETE_MARKER = '.polaris_benchmark_complete'
+
+
+def benchmark(config, config_path, args):
+    """
+    Run a benchmark of a test configuration against a baseline
+
+    Parameters
+    ----------
+    config : configparser.ConfigParser
+        The benchmark config options
+    config_path : str
+        The directory the config file lives in, used to resolve relative
+        paths
+    args : argparse.Namespace
+        The parsed command-line arguments
+
+    Returns
+    -------
+    manifest : dict
+        A description of everything that was resolved and run
+    """
+    section = config['benchmark']
+    work_base = to_abs(section['work_base'], config_path)
+    primary_path = to_abs(
+        section.get('primary_path', fallback=config_path), config_path
+    )
+    load_script_name = section['load_script']
+    setup_command = section['setup_command']
+    run_command = section.get('run_command', fallback='polaris serial')
+    submit = section.getboolean('submit', fallback=False)
+
+    polaris_config = section.get('polaris_config_file', fallback='')
+    if polaris_config:
+        polaris_config = to_abs(polaris_config, config_path)
+    else:
+        polaris_config = None
+
+    polaris_run.check_setup_command(setup_command)
+
+    baseline = _resolve_side(
+        'baseline',
+        config,
+        config_path,
+        args,
+        primary_path,
+        work_base,
+        load_script_name,
+    )
+    test = _resolve_side(
+        'test',
+        config,
+        config_path,
+        args,
+        primary_path,
+        work_base,
+        load_script_name,
+    )
+
+    _check_guardrails(baseline, test, load_script_name, args)
+
+    run_dir = _get_run_dir(work_base, baseline, test)
+    baseline_dir = _get_baseline_dir(work_base, baseline, setup_command)
+    test_dir = os.path.join(run_dir, 'test')
+
+    logger = None
+    if not args.dry_run:
+        os.makedirs(run_dir, exist_ok=True)
+        logger = get_logger(
+            'benchmark', os.path.join(run_dir, 'benchmark.log')
+        )
+
+    manifest = {
+        'created': datetime.now().isoformat(timespec='seconds'),
+        'reproducible': not (baseline.dirty or test.dirty),
+        'run_dir': run_dir,
+        'baseline_dir': baseline_dir,
+        'test_dir': test_dir,
+        'setup_command': setup_command,
+        'run_command': run_command,
+        'submit': submit,
+        'differing_repos': gitrepo.check_single_variable(baseline, test),
+        'baseline': baseline.provenance(),
+        'test': test.provenance(),
+    }
+
+    baseline_job = _run_baseline(
+        baseline=baseline,
+        baseline_dir=baseline_dir,
+        run_dir=run_dir,
+        setup_command=setup_command,
+        run_command=run_command,
+        polaris_config=polaris_config,
+        submit=submit,
+        args=args,
+        logger=logger,
+        manifest=manifest,
+    )
+
+    manifest['test_job_id'] = polaris_run.setup_and_run(
+        state=test,
+        setup_command=setup_command,
+        run_command=run_command,
+        work_dir=test_dir,
+        component_path=os.path.join(run_dir, 'build_test'),
+        baseline_dir=baseline_dir,
+        config_file=polaris_config,
+        clean_build=args.clean_build,
+        rebuild=args.rebuild,
+        submit=submit,
+        dependency=baseline_job,
+        dry_run=args.dry_run,
+        logger=logger,
+    )
+    manifest['baseline_job_id'] = baseline_job
+
+    if not args.dry_run:
+        if not submit:
+            _mark_complete(test_dir)
+        _write_manifest(run_dir, manifest)
+
+    return manifest
+
+
+def main():
+    """Parse arguments and run a benchmark."""
+    args = parse_args()
+
+    config = configparser.ConfigParser(
+        interpolation=configparser.ExtendedInterpolation()
+    )
+    config_file = os.path.abspath(args.config_file)
+    if not os.path.exists(config_file):
+        raise FileNotFoundError(f'No such config file: {config_file}')
+    config.read(config_file)
+    config_path = os.path.dirname(config_file)
+
+    try:
+        manifest = benchmark(config, config_path, args)
+    except ValueError as exc:
+        print('')
+        print(f'Error: {exc}')
+        sys.exit(1)
+
+    print('')
+    print(72 * '-')
+    print('Benchmark summary')
+    print(72 * '-')
+    _print_summary(manifest)
+
+
+def parse_args():
+    """
+    Parse the command-line arguments
+
+    Returns
+    -------
+    args : argparse.Namespace
+        The parsed arguments
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmark a polaris, Omega or E3SM branch against a '
+        'baseline using a polaris task or suite'
+    )
+    parser.add_argument(
+        '-f',
+        '--config_file',
+        dest='config_file',
+        required=True,
+        help='Configuration file with benchmark options.',
+        metavar='FILE',
+    )
+    parser.add_argument(
+        '--dry-run',
+        dest='dry_run',
+        action='store_true',
+        help='Resolve commits and print the commands that would be run '
+        'without building or running anything.',
+    )
+    parser.add_argument(
+        '--allow-dirty',
+        dest='allow_dirty',
+        action='store_true',
+        help='Permit an adopted worktree with uncommitted or untracked '
+        'changes.  The run is recorded as not reproducible.',
+    )
+    parser.add_argument(
+        '--allow-multiple-changes',
+        dest='allow_multiple_changes',
+        action='store_true',
+        help='Permit the baseline and test to differ in more than one of '
+        'polaris, Omega and E3SM.',
+    )
+    parser.add_argument(
+        '--allow-env-mismatch',
+        dest='allow_env_mismatch',
+        action='store_true',
+        help='Permit the two sides to use different load scripts.',
+    )
+    parser.add_argument(
+        '--clean-build',
+        dest='clean_build',
+        action='store_true',
+        help='Start from a clean build directory on both sides.',
+    )
+    parser.add_argument(
+        '--rebuild',
+        dest='rebuild',
+        action='store_true',
+        help='Force a build even if the component is already built.',
+    )
+    for side in ['baseline', 'test']:
+        parser.add_argument(
+            f'--{side}-existing',
+            dest=f'{side}_existing',
+            help=f'Adopt an existing polaris worktree for the {side}.',
+            metavar='PATH',
+        )
+        parser.add_argument(
+            f'--{side}-polaris-fork',
+            dest=f'{side}_polaris_fork',
+            help=f'The polaris fork to use for the {side}.',
+            metavar='FORK',
+        )
+        parser.add_argument(
+            f'--{side}-polaris-ref',
+            dest=f'{side}_polaris_ref',
+            help=f'The polaris branch, tag or hash for the {side}.',
+            metavar='REF',
+        )
+        for key in gitrepo.SUBMODULE_PATHS:
+            parser.add_argument(
+                f'--{side}-{key}-fork',
+                dest=f'{side}_{key}_fork',
+                help=f'The {key} fork to use for the {side}.',
+                metavar='FORK',
+            )
+            parser.add_argument(
+                f'--{side}-{key}-ref',
+                dest=f'{side}_{key}_ref',
+                help=f'The {key} branch, tag or hash for the {side}.',
+                metavar='REF',
+            )
+
+    return parser.parse_args()
+
+
+def _resolve_side(
+    name,
+    config,
+    config_path,
+    args,
+    primary_path,
+    work_base,
+    load_script_name,
+):
+    """Provision or adopt one side of the benchmark."""
+    section = config[name]
+    model = section['model']
+    if model not in gitrepo.MODEL_SUBMODULES:
+        raise ValueError(
+            f'Unknown model "{model}" in the [{name}] section; expected one '
+            f'of {", ".join(gitrepo.MODEL_SUBMODULES)}'
+        )
+
+    source = section.get('source', fallback='worktree')
+    existing = getattr(args, f'{name}_existing')
+    if existing is not None:
+        # the command line overrides a config file that asks for a
+        # worktree, so the fork and ref options there are simply unused
+        return gitrepo.adopt(
+            name=name,
+            path=to_abs(existing, config_path),
+            model=model,
+            load_script_name=load_script_name,
+            allow_dirty=args.allow_dirty,
+        )
+
+    if source == 'existing':
+        _check_no_fork_keys(name, section)
+        return gitrepo.adopt(
+            name=name,
+            path=to_abs(section['path'], config_path),
+            model=model,
+            load_script_name=load_script_name,
+            allow_dirty=args.allow_dirty,
+        )
+
+    if source != 'worktree':
+        raise ValueError(
+            f'Unknown source "{source}" in the [{name}] section; expected '
+            f'"worktree" or "existing"'
+        )
+
+    fork = _option(args, section, name, 'polaris', 'fork', 'E3SM-Project')
+    ref = _option(args, section, name, 'polaris', 'ref', 'main')
+
+    submodule_specs = {}
+    for key in gitrepo.SUBMODULE_PATHS:
+        sub_fork = _option(args, section, name, key, 'fork', '')
+        sub_ref = _option(args, section, name, key, 'ref', '')
+        if sub_ref:
+            submodule_specs[key] = (sub_fork, sub_ref)
+        elif sub_fork:
+            raise ValueError(
+                f'{key}_fork is set without {key}_ref in the [{name}] section'
+            )
+
+    return gitrepo.provision(
+        name=name,
+        primary_path=primary_path,
+        work_base=work_base,
+        fork=fork,
+        ref=ref,
+        model=model,
+        load_script_name=load_script_name,
+        submodule_specs=submodule_specs,
+        dry_run=args.dry_run,
+    )
+
+
+def _option(args, section, name, repo, kind, default):
+    """Get an option from the command line, then the config, then default."""
+    value = getattr(args, f'{name}_{repo}_{kind}', None)
+    if value is not None:
+        return value
+    return section.get(f'{repo}_{kind}', fallback=default)
+
+
+def _check_no_fork_keys(name, section):
+    """Raise if fork/ref keys are set for an adopted worktree."""
+    found = [
+        key
+        for key in section
+        if key.endswith(('_fork', '_ref')) and section[key]
+    ]
+    if found:
+        raise ValueError(
+            f'The [{name}] section uses source = existing, so the fork and '
+            f'ref of the checkout are recorded rather than requested.  '
+            f'Remove: {", ".join(sorted(found))}'
+        )
+
+
+def _check_guardrails(baseline, test, load_script_name, args):
+    """Check the cross-cutting guardrails before anything is built."""
+    if baseline.path == test.path:
+        raise ValueError(
+            'The baseline and test resolve to the same worktree, so there '
+            'is nothing to compare.'
+        )
+
+    if baseline.model != test.model:
+        raise ValueError(
+            f'The baseline model "{baseline.model}" and test model '
+            f'"{test.model}" differ, so the results are not comparable.'
+        )
+
+    differing = gitrepo.check_single_variable(baseline, test)
+    if not differing:
+        raise ValueError(
+            'The baseline and test resolve to identical commits in polaris '
+            'and all submodules, so there is nothing to compare.'
+        )
+    if len(differing) > 1 and not args.allow_multiple_changes:
+        raise ValueError(
+            f'The baseline and test differ in more than one repository '
+            f'({", ".join(differing)}), so a difference could not be '
+            f'attributed to a single change.  Rerun with '
+            f'--allow-multiple-changes to proceed anyway.'
+        )
+
+    if not args.allow_env_mismatch:
+        baseline_script = os.path.basename(baseline.load_script)
+        test_script = os.path.basename(test.load_script)
+        if baseline_script and test_script and baseline_script != test_script:
+            raise ValueError(
+                f'The baseline uses {baseline_script} but the test uses '
+                f'{test_script}, so the machine, compiler or MPI library '
+                f'may differ.  Rerun with --allow-env-mismatch to proceed.'
+            )
+
+
+def _run_baseline(
+    baseline,
+    baseline_dir,
+    run_dir,
+    setup_command,
+    run_command,
+    polaris_config,
+    submit,
+    args,
+    logger,
+    manifest,
+):
+    """Run the baseline unless a complete one can be reused."""
+    if _is_complete(baseline_dir):
+        manifest['baseline_reused'] = True
+        message = f'Reusing the completed baseline at {baseline_dir}'
+        if logger is None:
+            print(message)
+        else:
+            logger.info(message)
+        return None
+
+    manifest['baseline_reused'] = False
+    job_id = polaris_run.setup_and_run(
+        state=baseline,
+        setup_command=setup_command,
+        run_command=run_command,
+        work_dir=baseline_dir,
+        component_path=os.path.join(run_dir, 'build_baseline'),
+        baseline_dir=None,
+        config_file=polaris_config,
+        clean_build=args.clean_build,
+        rebuild=args.rebuild,
+        submit=submit,
+        dry_run=args.dry_run,
+        logger=logger,
+    )
+    if not args.dry_run and not submit:
+        _mark_complete(baseline_dir)
+    return job_id
+
+
+def _get_run_dir(work_base, baseline, test):
+    """Get the deterministic run directory for this pair of sides."""
+    date = datetime.now().strftime('%Y%m%d')
+    name = f'{date}-{baseline.polaris_sha[:7]}-{test.polaris_sha[:7]}'
+    if baseline.dirty or test.dirty:
+        name = f'dirty-{name}'
+    return os.path.join(work_base, 'runs', name)
+
+
+def _get_baseline_dir(work_base, baseline, setup_command):
+    """
+    Get the cacheable baseline work directory.
+
+    A dirty baseline is never cached or reused, since it cannot be
+    reproduced from the recorded commit hashes.
+    """
+    suite = polaris_run.get_suite_name(setup_command)
+    shas = baseline.compare_shas
+    parts = [suite, baseline.model]
+    parts.extend(sha[:7] for sha in shas.values() if sha)
+    name = '_'.join(parts)
+    if baseline.dirty:
+        name = f'dirty_{name}_{datetime.now().strftime("%Y%m%d%H%M%S")}'
+    return os.path.join(work_base, 'baselines', name)
+
+
+def _is_complete(work_dir):
+    """Whether a work directory holds a completed run."""
+    return os.path.exists(os.path.join(work_dir, COMPLETE_MARKER))
+
+
+def _mark_complete(work_dir):
+    """Mark a work directory as holding a completed run."""
+    marker = os.path.join(work_dir, COMPLETE_MARKER)
+    with open(marker, 'w') as handle:
+        handle.write(datetime.now().isoformat(timespec='seconds') + '\n')
+
+
+def _write_manifest(run_dir, manifest):
+    """Write the manifest describing the benchmark to the run directory."""
+    filename = os.path.join(run_dir, 'manifest.json')
+    with open(filename, 'w') as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+        handle.write('\n')
+
+
+def _print_summary(manifest):
+    """Print a short summary of what was resolved and run."""
+    for name in ['baseline', 'test']:
+        side = manifest[name]
+        print(f'{name}:')
+        print(f'  mode:    {side["mode"]}')
+        print(f'  path:    {side["path"]}')
+        print(f'  polaris: {side["polaris_ref"]} {side["polaris_sha"][:7]}')
+        for key, sha in sorted(side['submodule_shas'].items()):
+            print(f'  {key}: {sha[:7]}')
+    print(f'differing:    {", ".join(manifest["differing_repos"])}')
+    print(f'reproducible: {manifest["reproducible"]}')
+    print(f'baseline dir: {manifest["baseline_dir"]}')
+    print(f'test dir:     {manifest["test_dir"]}')
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -320,8 +320,10 @@ def _resolve_side(
     model = section['model']
     if model not in gitrepo.MODEL_SUBMODULES:
         raise ValueError(
-            f'Unknown model "{model}" in the [{name}] section; expected one '
-            f'of {", ".join(gitrepo.MODEL_SUBMODULES)}'
+            f'Unsupported model "{model}" in the [{name}] section; expected '
+            f'one of {", ".join(gitrepo.MODEL_SUBMODULES)}.  Polaris only '
+            f'builds those models automatically, which a benchmark relies '
+            f'on.'
         )
 
     source = section.get('source', fallback='worktree')

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -73,6 +73,12 @@ def benchmark(config, config_path, args):
 
     wall_time = section.get('wall_time', fallback='').strip()
 
+    shared_component_path = section.get('component_path', fallback='').strip()
+    if shared_component_path:
+        shared_component_path = to_abs(shared_component_path, config_path)
+    else:
+        shared_component_path = None
+
     polaris_run.check_setup_command(setup_command)
 
     baseline = _resolve_side(
@@ -94,11 +100,17 @@ def benchmark(config, config_path, args):
         load_script_name,
     )
 
-    _check_guardrails(baseline, test, load_script_name, args)
+    _check_guardrails(
+        baseline, test, load_script_name, args, shared_component_path
+    )
 
     run_dir = _get_run_dir(work_base, baseline, test)
     baseline_dir = _get_baseline_dir(
-        work_base, baseline, setup_command, polaris_config
+        work_base,
+        baseline,
+        setup_command,
+        polaris_config,
+        shared_component_path,
     )
     test_dir = os.path.join(run_dir, 'test')
 
@@ -128,6 +140,7 @@ def benchmark(config, config_path, args):
         'wall_time': wall_time or None,
         'polaris_config_file': polaris_config,
         'setup_config_file': setup_config,
+        'component_path': shared_component_path,
         'differing_repos': gitrepo.check_single_variable(baseline, test),
         'baseline': baseline.provenance(),
         'test': test.provenance(),
@@ -137,6 +150,7 @@ def benchmark(config, config_path, args):
         baseline=baseline,
         baseline_dir=baseline_dir,
         run_dir=run_dir,
+        shared_component_path=shared_component_path,
         setup_command=setup_command,
         run_command=run_command,
         polaris_config=setup_config,
@@ -151,7 +165,9 @@ def benchmark(config, config_path, args):
         setup_command=setup_command,
         run_command=run_command,
         work_dir=test_dir,
-        component_path=os.path.join(run_dir, 'build_test'),
+        component_path=_get_component_path(
+            shared_component_path, run_dir, 'test'
+        ),
         baseline_dir=baseline_dir,
         config_file=setup_config,
         clean_build=args.clean_build,
@@ -434,7 +450,9 @@ def _check_no_fork_keys(name, section):
         )
 
 
-def _check_guardrails(baseline, test, load_script_name, args):
+def _check_guardrails(
+    baseline, test, load_script_name, args, shared_component_path
+):
     """Check the cross-cutting guardrails before anything is built."""
     if baseline.path == test.path:
         raise ValueError(
@@ -471,6 +489,33 @@ def _check_guardrails(baseline, test, load_script_name, args):
                     f'build.  Drop --clean-build and --rebuild.'
                 )
 
+    if shared_component_path is not None:
+        if baseline.model == gitrepo.NO_MODEL:
+            raise ValueError(
+                f'component_path is set, but model = {gitrepo.NO_MODEL}, so '
+                f'there is no component to build or to find.  Drop '
+                f'component_path.'
+            )
+        if args.clean_build:
+            raise ValueError(
+                f'--clean-build would delete the shared component_path '
+                f"{shared_component_path}, which is not this benchmark's "
+                f'to remove, and would then build it twice over.  Clean it '
+                f'yourself, or drop component_path to build each side in '
+                f'its own directory.'
+            )
+        key = gitrepo.MODEL_SUBMODULES[baseline.model]
+        baseline_sha = baseline.compare_shas[key]
+        test_sha = test.compare_shas[key]
+        if baseline_sha != test_sha:
+            raise ValueError(
+                f'component_path is set, so both sides would run one build '
+                f'of {baseline.model}, but they pin different {key} commits '
+                f'({baseline_sha[:7]} and {test_sha[:7]}).  One of the two '
+                f"sides would run the other's model.  Drop component_path "
+                f'so that each side builds its own.'
+            )
+
     if not args.allow_env_mismatch:
         baseline_script = os.path.basename(baseline.load_script)
         test_script = os.path.basename(test.load_script)
@@ -486,6 +531,7 @@ def _run_baseline(
     baseline,
     baseline_dir,
     run_dir,
+    shared_component_path,
     setup_command,
     run_command,
     polaris_config,
@@ -510,7 +556,9 @@ def _run_baseline(
         setup_command=setup_command,
         run_command=run_command,
         work_dir=baseline_dir,
-        component_path=os.path.join(run_dir, 'build_baseline'),
+        component_path=_get_component_path(
+            shared_component_path, run_dir, 'baseline'
+        ),
         baseline_dir=None,
         config_file=polaris_config,
         clean_build=args.clean_build,
@@ -522,6 +570,35 @@ def _run_baseline(
     if not args.dry_run and not submit:
         _mark_complete(baseline_dir)
     return job_id
+
+
+def _get_component_path(shared_component_path, run_dir, side):
+    """
+    Get the path passed to ``polaris setup`` with ``-p`` for one side
+
+    Each side builds in its own directory within the run directory unless
+    a shared ``component_path`` was configured.  Polaris builds the model
+    only when it does not find one at ``-p``, so a shared path means the
+    first side to be set up builds it and the second one finds it and
+    skips, which is the point of the option.
+
+    Parameters
+    ----------
+    shared_component_path : str or None
+        The configured ``component_path``, if there is one
+    run_dir : str
+        The run directory for this benchmark
+    side : str
+        Either ``baseline`` or ``test``
+
+    Returns
+    -------
+    component_path : str
+        The path to build the component in or find an existing build at
+    """
+    if shared_component_path is not None:
+        return shared_component_path
+    return os.path.join(run_dir, f'build_{side}')
 
 
 def _get_setup_config(run_dir, polaris_config, wall_time, dry_run):
@@ -601,7 +678,13 @@ def _get_run_dir(work_base, baseline, test):
     return os.path.join(work_base, 'runs', name)
 
 
-def _get_baseline_dir(work_base, baseline, setup_command, polaris_config):
+def _get_baseline_dir(
+    work_base,
+    baseline,
+    setup_command,
+    polaris_config,
+    shared_component_path=None,
+):
     """
     Get the cacheable baseline work directory.
 
@@ -620,10 +703,13 @@ def _get_baseline_dir(work_base, baseline, setup_command, polaris_config):
     reproduced from the recorded commit hashes.
     """
     shas = baseline.compare_shas
+    setup_key = _setup_key(
+        setup_command, polaris_config, baseline, shared_component_path
+    )
     parts = [
         polaris_run.get_suite_name(setup_command),
         baseline.model,
-        f'opts-{_setup_key(setup_command, polaris_config, baseline)}',
+        f'opts-{setup_key}',
         f'polaris-{shas["polaris"][:7]}',
     ]
     key = gitrepo.MODEL_SUBMODULES.get(baseline.model)
@@ -635,18 +721,28 @@ def _get_baseline_dir(work_base, baseline, setup_command, polaris_config):
     return os.path.join(work_base, 'baselines', name)
 
 
-def _setup_key(setup_command, polaris_config, baseline):
+def _setup_key(
+    setup_command, polaris_config, baseline, shared_component_path=None
+):
     """
     Get a short hash of what a baseline depends on besides the commits.
 
     ``polaris setup`` always reports the suite name ``custom``, so the
     tasks only appear here.  The polaris config file and the load script
     change the results too, so they are included as well.
+
+    A shared ``component_path`` is included because the driver cannot tell
+    what was built there: the directory names the submodule hash the
+    baseline pins, but the executable found at ``component_path`` was
+    built by whoever created it.  Pointing somewhere else therefore has to
+    invalidate the cached baseline rather than silently reuse it.
     """
     parts = [
         ' '.join(setup_command.split()),
         os.path.basename(baseline.load_script),
     ]
+    if shared_component_path is not None:
+        parts.append(shared_component_path)
     if polaris_config is not None:
         with open(polaris_config) as handle:
             parts.append(handle.read())
@@ -700,6 +796,14 @@ def _print_summary(manifest):
                 f'must exist before the benchmark can run; see the load '
                 f'script notes in utils/benchmark/README.md.'
             )
+    if manifest['component_path'] is not None:
+        print('')
+        print(
+            f'Both sides share one build at\n  '
+            f'{manifest["component_path"]}\nPolaris builds the model only '
+            f'when it does not find one there, so the first side set up '
+            f'builds it and the second reuses it.'
+        )
     print('')
     print(f'differing:    {", ".join(manifest["differing_repos"])}')
     print(f'reproducible: {manifest["reproducible"]}')

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -857,6 +857,17 @@ def _print_summary(manifest):
                 f'must exist before the benchmark can run; see the load '
                 f'script notes in utils/benchmark/README.md.'
             )
+    for name in ['baseline', 'test']:
+        side = manifest[name]
+        if side['untracked']:
+            listed = '\n'.join(f'    {entry}' for entry in side['untracked'])
+            print('')
+            print(
+                f'Note: the {name} worktree carries untracked files outside '
+                f'the polaris\n  package, which nothing a task runs reads, '
+                f'so they do not make it dirty:\n{listed}'
+            )
+
     if manifest['component_path'] is not None:
         print('')
         print(

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -81,29 +81,15 @@ def benchmark(config, config_path, args):
 
     polaris_run.check_setup_command(setup_command)
 
-    baseline = _resolve_side(
-        'baseline',
-        config,
-        config_path,
-        args,
-        primary_path,
-        work_base,
-        load_script_name,
+    baseline, test = _resolve_sides(
+        config=config,
+        config_path=config_path,
+        args=args,
+        primary_path=primary_path,
+        work_base=work_base,
+        load_script_name=load_script_name,
+        shared_component_path=shared_component_path,
     )
-    # with one shared build, only the baseline is ever the side polaris
-    # builds from, so the test side needs no model source of its own
-    test = _resolve_side(
-        'test',
-        config,
-        config_path,
-        args,
-        primary_path,
-        work_base,
-        load_script_name,
-        needs_model_source=shared_component_path is None,
-    )
-    if shared_component_path is not None:
-        test.component_source = baseline.component_branch_path or ''
 
     _check_guardrails(
         baseline, test, load_script_name, args, shared_component_path
@@ -353,6 +339,61 @@ def parse_args():
             )
 
     return parser.parse_args()
+
+
+def _resolve_sides(
+    config,
+    config_path,
+    args,
+    primary_path,
+    work_base,
+    load_script_name,
+    shared_component_path,
+):
+    """
+    Resolve both sides, reporting every problem with either of them
+
+    Neither side is built or run until both have resolved, so stopping on
+    the first problem only means the developer fixes it and meets the
+    next one on the next dry run.  Both sides are therefore resolved
+    before anything is raised.
+
+    Returns
+    -------
+    baseline, test : gitrepo.SourceState
+        The two resolved sides
+    """
+    states = {}
+    problems = []
+    # with one shared build, only the baseline is ever the side polaris
+    # builds from, so the test side needs no model source of its own
+    needs_model_source = {
+        'baseline': True,
+        'test': shared_component_path is None,
+    }
+    for name in ['baseline', 'test']:
+        try:
+            states[name] = _resolve_side(
+                name,
+                config,
+                config_path,
+                args,
+                primary_path,
+                work_base,
+                load_script_name,
+                needs_model_source=needs_model_source[name],
+            )
+        except ValueError as exc:
+            problems.append(str(exc))
+
+    if problems:
+        raise ValueError('\n\n'.join(problems))
+
+    baseline = states['baseline']
+    test = states['test']
+    if shared_component_path is not None:
+        test.component_source = baseline.component_branch_path or ''
+    return baseline, test
 
 
 def _resolve_side(

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -71,6 +71,8 @@ def benchmark(config, config_path, args):
     else:
         polaris_config = None
 
+    wall_time = section.get('wall_time', fallback='').strip()
+
     polaris_run.check_setup_command(setup_command)
 
     baseline = _resolve_side(
@@ -107,6 +109,13 @@ def benchmark(config, config_path, args):
             'benchmark', os.path.join(run_dir, 'benchmark.log')
         )
 
+    setup_config = _get_setup_config(
+        run_dir=run_dir,
+        polaris_config=polaris_config,
+        wall_time=wall_time,
+        dry_run=args.dry_run,
+    )
+
     manifest = {
         'created': datetime.now().isoformat(timespec='seconds'),
         'reproducible': not (baseline.dirty or test.dirty),
@@ -116,6 +125,9 @@ def benchmark(config, config_path, args):
         'setup_command': setup_command,
         'run_command': run_command,
         'submit': submit,
+        'wall_time': wall_time or None,
+        'polaris_config_file': polaris_config,
+        'setup_config_file': setup_config,
         'differing_repos': gitrepo.check_single_variable(baseline, test),
         'baseline': baseline.provenance(),
         'test': test.provenance(),
@@ -127,7 +139,7 @@ def benchmark(config, config_path, args):
         run_dir=run_dir,
         setup_command=setup_command,
         run_command=run_command,
-        polaris_config=polaris_config,
+        polaris_config=setup_config,
         submit=submit,
         args=args,
         logger=logger,
@@ -141,7 +153,7 @@ def benchmark(config, config_path, args):
         work_dir=test_dir,
         component_path=os.path.join(run_dir, 'build_test'),
         baseline_dir=baseline_dir,
-        config_file=polaris_config,
+        config_file=setup_config,
         clean_build=args.clean_build,
         rebuild=args.rebuild,
         submit=submit,
@@ -510,6 +522,56 @@ def _run_baseline(
     if not args.dry_run and not submit:
         _mark_complete(baseline_dir)
     return job_id
+
+
+def _get_setup_config(run_dir, polaris_config, wall_time, dry_run):
+    """
+    Get the polaris config file to pass on with ``-f``
+
+    ``polaris setup`` takes a single config file, so a ``wall_time`` from
+    the benchmark config is merged with ``polaris_config_file`` into one
+    generated file in the run directory.  Both sides are given the same
+    file, since a benchmark has to compare like with like.
+
+    ``wall_time`` wins over a ``[job] wall_time`` in
+    ``polaris_config_file``, and comments do not survive the merge, so the
+    user's own file is the one recorded in the manifest.
+
+    Parameters
+    ----------
+    run_dir : str
+        The run directory, which the generated file is written to
+    polaris_config : str or None
+        The user's ``polaris_config_file``, if there is one
+    wall_time : str
+        The requested wall-clock time, or an empty string for none
+    dry_run : bool
+        Whether to report the file that would be written without writing
+        it
+
+    Returns
+    -------
+    config_file : str or None
+        The config file to pass on with ``-f``
+    """
+    if not wall_time:
+        return polaris_config
+
+    config_file = os.path.join(run_dir, 'polaris_benchmark.cfg')
+    if dry_run:
+        return config_file
+
+    # configparser rather than appending text, since polaris reads the
+    # file strictly and a [job] section may already be in it
+    config = configparser.ConfigParser(interpolation=None)
+    if polaris_config is not None:
+        config.read(polaris_config)
+    if not config.has_section('job'):
+        config.add_section('job')
+    config.set('job', 'wall_time', wall_time)
+    with open(config_file, 'w') as handle:
+        config.write(handle)
+    return config_file
 
 
 def _get_run_dir(work_base, baseline, test):

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -33,6 +33,21 @@ from shared import get_logger, to_abs  # noqa: E402
 #: The name of the file that marks a completed benchmark work directory
 COMPLETE_MARKER = '.polaris_benchmark_complete'
 
+#: The file polaris itself writes at the end of a run, named for the suite
+#:
+#: ``_write_output_for_pull_request()`` is called from ``run_tasks()`` in
+#: ``polaris/run/serial.py`` immediately before ``_log_task_runtimes()``,
+#: which is what exits non-zero when a task fails.  So this file is there
+#: whether the run passed or failed, which is exactly the question a
+#: baseline cache has to answer: did the run *finish*.
+#:
+#: The driver relies on that, so renaming or removing this file in polaris
+#: would stop benchmark baselines from being reused.  It would fail safe --
+#: a baseline that cannot be recognized is simply run again -- but it would
+#: fail quietly, so the coupling is called out here, in the developer's
+#: guide, and in a comment beside the write in polaris itself.
+POLARIS_RUN_OUTPUT = '{suite}_output_for_pr.md'
+
 
 def benchmark(config, config_path, args):
     """
@@ -591,14 +606,22 @@ def _run_baseline(
     manifest,
 ):
     """Run the baseline unless a complete one can be reused."""
-    if _is_complete(baseline_dir):
+    suite_name = polaris_run.get_suite_name(setup_command)
+    if _is_complete(baseline_dir, suite_name):
         manifest['baseline_reused'] = True
-        message = f'Reusing the completed baseline at {baseline_dir}'
-        if logger is None:
-            print(message)
-        else:
-            logger.info(message)
+        _report(logger, f'Reusing the completed baseline at {baseline_dir}')
         return None
+
+    if os.path.exists(baseline_dir):
+        # the directory is there but nothing says the run in it finished,
+        # so it is run again.  Saying so makes the difference visible: a
+        # baseline that should have been reused and was not is otherwise
+        # just a benchmark that took longer than expected.
+        _report(
+            logger,
+            f'The baseline at {baseline_dir}\nexists but does not look '
+            f'complete, so it is being run again.',
+        )
 
     manifest['baseline_reused'] = False
     job_id = polaris_run.setup_and_run(
@@ -817,9 +840,41 @@ def _slugify(name):
     return re.sub(r'[^A-Za-z0-9_.-]', '-', name)
 
 
-def _is_complete(work_dir):
-    """Whether a work directory holds a completed run."""
-    return os.path.exists(os.path.join(work_dir, COMPLETE_MARKER))
+def _is_complete(work_dir, suite_name):
+    """
+    Whether a work directory holds a completed run
+
+    Two things can say so.  The driver writes ``COMPLETE_MARKER`` itself
+    when it runs polaris in place and sees it return.  When the run was
+    *submitted* instead, the driver is long gone by the time the job
+    finishes and never learns the outcome, so it falls back to the file
+    polaris writes at the end of its own run.
+
+    Parameters
+    ----------
+    work_dir : str
+        The work directory to test
+    suite_name : str
+        The suite the benchmark was set up under, which names polaris'
+        end-of-run file
+
+    Returns
+    -------
+    complete : bool
+        Whether the run in this directory finished
+    """
+    if os.path.exists(os.path.join(work_dir, COMPLETE_MARKER)):
+        return True
+    polaris_output = POLARIS_RUN_OUTPUT.format(suite=suite_name)
+    return os.path.exists(os.path.join(work_dir, polaris_output))
+
+
+def _report(logger, message):
+    """Log a message, or print it when there is no logger yet."""
+    if logger is None:
+        print(message)
+    else:
+        logger.info(message)
 
 
 def _mark_complete(work_dir):

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -17,6 +17,7 @@ the exact commands that would be run without building anything.
 
 import argparse
 import configparser
+import hashlib
 import json
 import os
 import sys
@@ -67,6 +68,8 @@ def benchmark(config, config_path, args):
     polaris_config = section.get('polaris_config_file', fallback='')
     if polaris_config:
         polaris_config = to_abs(polaris_config, config_path)
+        if not os.path.exists(polaris_config):
+            raise ValueError(f'No such polaris_config_file: {polaris_config}')
     else:
         polaris_config = None
 
@@ -94,7 +97,9 @@ def benchmark(config, config_path, args):
     _check_guardrails(baseline, test, load_script_name, args)
 
     run_dir = _get_run_dir(work_base, baseline, test)
-    baseline_dir = _get_baseline_dir(work_base, baseline, setup_command)
+    baseline_dir = _get_baseline_dir(
+        work_base, baseline, setup_command, polaris_config
+    )
     test_dir = os.path.join(run_dir, 'test')
 
     logger = None
@@ -487,9 +492,12 @@ def _get_run_dir(work_base, baseline, test):
     return os.path.join(work_base, 'runs', name)
 
 
-def _get_baseline_dir(work_base, baseline, setup_command):
+def _get_baseline_dir(work_base, baseline, setup_command, polaris_config):
     """
     Get the cacheable baseline work directory.
+
+    The name covers everything a baseline depends on, so that a baseline
+    is only ever reused by a benchmark it is actually comparable with.
 
     A dirty baseline is never cached or reused, since it cannot be
     reproduced from the recorded commit hashes.
@@ -497,11 +505,31 @@ def _get_baseline_dir(work_base, baseline, setup_command):
     suite = polaris_run.get_suite_name(setup_command)
     shas = baseline.compare_shas
     parts = [suite, baseline.model]
+    parts.append(_setup_key(setup_command, polaris_config, baseline))
     parts.extend(sha[:7] for sha in shas.values() if sha)
     name = '_'.join(parts)
     if baseline.dirty:
         name = f'dirty_{name}_{datetime.now().strftime("%Y%m%d%H%M%S")}'
     return os.path.join(work_base, 'baselines', name)
+
+
+def _setup_key(setup_command, polaris_config, baseline):
+    """
+    Get a short hash of what a baseline depends on besides the commits.
+
+    ``polaris setup`` always reports the suite name ``custom``, so the
+    tasks only appear here.  The polaris config file and the load script
+    change the results too, so they are included as well.
+    """
+    parts = [
+        ' '.join(setup_command.split()),
+        os.path.basename(baseline.load_script),
+    ]
+    if polaris_config is not None:
+        with open(polaris_config) as handle:
+            parts.append(handle.read())
+    text = '\n'.join(parts)
+    return hashlib.sha256(text.encode('utf-8')).hexdigest()[:7]
 
 
 def _is_complete(work_dir):

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -31,6 +31,9 @@ from shared import get_logger, to_abs  # noqa: E402
 #: The name of the file that marks a completed benchmark work directory
 COMPLETE_MARKER = '.polaris_benchmark_complete'
 
+#: Environment variables that config files may refer to as ``${NAME}``
+CONFIG_ENV_VARS = ['USER', 'HOME', 'SCRATCH']
+
 
 def benchmark(config, config_path, args):
     """
@@ -158,7 +161,8 @@ def main():
     args = parse_args()
 
     config = configparser.ConfigParser(
-        interpolation=configparser.ExtendedInterpolation()
+        defaults=environment_defaults(),
+        interpolation=configparser.ExtendedInterpolation(),
     )
     config_file = os.path.abspath(args.config_file)
     if not os.path.exists(config_file):
@@ -178,6 +182,26 @@ def main():
     print('Benchmark summary')
     print(72 * '-')
     _print_summary(manifest)
+
+
+def environment_defaults():
+    """
+    Get the environment variables config files may substitute
+
+    ``configparser`` has no notion of environment variables, so the ones
+    in ``CONFIG_ENV_VARS`` are added as defaults.  A config file can then
+    write ``${USER}`` in a path and get the expected substitution.
+
+    Returns
+    -------
+    defaults : dict
+        The environment variables that are set, keyed by name
+    """
+    return {
+        name: os.environ[name]
+        for name in CONFIG_ENV_VARS
+        if name in os.environ
+    }
 
 
 def parse_args():

--- a/utils/benchmark/benchmark.py
+++ b/utils/benchmark/benchmark.py
@@ -33,9 +33,6 @@ from shared import get_logger, to_abs  # noqa: E402
 #: The name of the file that marks a completed benchmark work directory
 COMPLETE_MARKER = '.polaris_benchmark_complete'
 
-#: Environment variables that config files may refer to as ``${NAME}``
-CONFIG_ENV_VARS = ['USER', 'HOME', 'SCRATCH']
-
 
 def benchmark(config, config_path, args):
     """
@@ -166,19 +163,15 @@ def main():
     """Parse arguments and run a benchmark."""
     args = parse_args()
 
-    config = configparser.ConfigParser(
-        defaults=environment_defaults(),
-        interpolation=configparser.ExtendedInterpolation(),
-    )
     config_file = os.path.abspath(args.config_file)
     if not os.path.exists(config_file):
         raise FileNotFoundError(f'No such config file: {config_file}')
-    config.read(config_file)
     config_path = os.path.dirname(config_file)
 
     try:
+        config = read_config(config_file)
         manifest = benchmark(config, config_path, args)
-    except ValueError as exc:
+    except (ValueError, configparser.Error) as exc:
         print('')
         print(f'Error: {exc}')
         sys.exit(1)
@@ -190,24 +183,47 @@ def main():
     _print_summary(manifest)
 
 
-def environment_defaults():
+def read_config(config_file):
     """
-    Get the environment variables config files may substitute
+    Read a benchmark config file, substituting environment variables
 
-    ``configparser`` has no notion of environment variables, so the ones
-    in ``CONFIG_ENV_VARS`` are added as defaults.  A config file can then
-    write ``${USER}`` in a path and get the expected substitution.
+    ``configparser`` has no notion of environment variables, so any
+    ``${NAME}`` that the config file does not define as an option is
+    replaced with the environment variable of that name before the file
+    is parsed.  An option therefore always wins over a variable, and a
+    name that is neither is left alone so that interpolation reports it.
+
+    Parameters
+    ----------
+    config_file : str
+        The path to the config file
 
     Returns
     -------
-    defaults : dict
-        The environment variables that are set, keyed by name
+    config : configparser.ConfigParser
+        The parsed config options
     """
-    return {
-        name: os.environ[name]
-        for name in CONFIG_ENV_VARS
-        if name in os.environ
-    }
+    with open(config_file) as handle:
+        text = handle.read()
+
+    raw = configparser.ConfigParser(interpolation=None)
+    raw.read_string(text, source=config_file)
+    options = set()
+    for section in raw.sections():
+        options.update(raw.options(section))
+
+    for name in sorted(set(re.findall(r'\$\{([^}]+)\}', text))):
+        if ':' in name or name.lower() in options:
+            # a reference to a config option, not to a variable
+            continue
+        if name in os.environ:
+            text = text.replace(f'${{{name}}}', os.environ[name])
+
+    config = configparser.ConfigParser(
+        interpolation=configparser.ExtendedInterpolation()
+    )
+    config.read_string(text, source=config_file)
+    return config
 
 
 def parse_args():

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -32,6 +32,12 @@ run_command = polaris serial
 # job is submitted with a dependency on the baseline job.
 submit = False
 
+# an optional wall-clock time for the job scripts on both sides.  Polaris
+# defaults to 1:00:00, which many tasks and most suites outgrow.  This is
+# merged with polaris_config_file below into a single config file in the
+# run directory, since polaris setup takes only one.
+wall_time =
+
 # an optional polaris config file passed on with -f
 polaris_config_file =
 

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -88,6 +88,35 @@ polaris_ref = add-surface-forcing-to-vmix
 model = ${baseline:model}
 
 
+# ===========================================================================
+# Which example below is yours?
+# ===========================================================================
+#
+# The [baseline] and [test] sections above benchmark one polaris branch
+# against another, both provisioned as fresh worktrees.  If that is not what
+# you are doing, replace them with one of these:
+#
+#   "an Omega branch"
+#       Omega differs, polaris is pinned on both sides, both worktrees are
+#       provisioned for you.
+#
+#   "the worktree you are already working in"
+#       polaris differs; the test side is a worktree you already have and
+#       the baseline is provisioned from main.
+#
+#   "a task that builds no model"
+#       polaris differs; both sides are worktrees you already have, and
+#       model = none, so nothing is built and no submodule is needed.
+#
+#   "an E3SM branch"
+#       E3SM differs, polaris is pinned on both sides, both worktrees are
+#       provisioned for you.
+#
+# Only one of polaris, Omega and E3SM may differ between the two sides, so
+# whichever repository is under test is the one to give a different fork or
+# ref; everything else stays identical.
+
+
 # ---------------------------------------------------------------------------
 # Example: benchmark an Omega branch with polaris pinned on both sides
 # ---------------------------------------------------------------------------

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -23,9 +23,13 @@ load_script = load_polaris_chrysalis_intel_openmpi.sh
 # the command to set up one or more tasks or a suite
 # note: --model, --branch, -p, -w, -b, -f and the build flags are appended
 #       automatically, so none of them may appear here
-# note: a "polaris setup" command must name its suite with --suite_name;
-#       polaris would otherwise call it "custom" and every benchmark set
-#       up that way would share one baseline directory
+# note: the suite name identifies the benchmark.  It names the baseline
+#       directory, the run directory and the job script, so two
+#       benchmarks of the same two commits are told apart by it and
+#       nothing else.  "polaris suite" takes it from -t; a "polaris
+#       setup" command must supply it with --suite_name, which the driver
+#       requires because polaris would otherwise call it "custom" and
+#       every benchmark set up that way would collide.
 setup_command = polaris suite -c ocean -t pr
 
 # the command used to run polaris in the work directory when submit = False

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -45,6 +45,10 @@ submit = False
 # both sides and only polaris differs; the driver refuses it when the two
 # sides pin different commits of the submodule the model is built from,
 # since one side would then run the other's model.
+#
+# The baseline is the side that builds, so --branch points at its
+# submodule for both.  The test side is never built from and does not
+# need the submodule initialized at all.
 component_path =
 
 # an optional wall-clock time for the job scripts on both sides.  Polaris

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -49,6 +49,11 @@ source = worktree
 polaris_fork = E3SM-Project
 polaris_ref = main
 # submodules not listed here stay at the hash pinned by polaris_ref
+#
+# model says which component polaris builds, not which component the task
+# belongs to.  Use none for a task or suite that runs no model (anything
+# under e3sm/init, mesh or seaice, and some ocean tasks); --model and
+# --branch are then not passed on and no submodule has to be initialized.
 model = mpas-ocean
 
 [test]
@@ -88,6 +93,23 @@ model = ${baseline:model}
 # source = existing
 # path = /lcrc/group/e3sm/${USER}/polaris-repo/add-surface-forcing-to-vmix
 # model = mpas-ocean
+
+# ---------------------------------------------------------------------------
+# Example: benchmark the branch you are working in against a main worktree,
+#          for a task that builds no model
+# ---------------------------------------------------------------------------
+# load_script = load_polaris_chrysalis_intel_openmpi.sh
+# setup_command = polaris setup -t e3sm/init/u.oi30.lr10/topo/cull
+#
+# [baseline]
+# source = existing
+# path = ../main
+# model = none
+#
+# [test]
+# source = existing
+# path = ../my-feature-branch
+# model = ${baseline:model}
 
 # ---------------------------------------------------------------------------
 # Example: benchmark an E3SM (MPAS-Ocean) branch with polaris pinned

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -35,6 +35,18 @@ run_command = polaris serial
 # job is submitted with a dependency on the baseline job.
 submit = False
 
+# an optional build directory shared by both sides, passed on with -p.
+# Each side otherwise builds in its own build_<side> directory within the
+# run directory.
+#
+# Polaris builds the model only when it does not already find one at -p,
+# so one shared path means the side set up first builds it and the other
+# finds it and skips.  That is what to use when the model is the same on
+# both sides and only polaris differs; the driver refuses it when the two
+# sides pin different commits of the submodule the model is built from,
+# since one side would then run the other's model.
+component_path =
+
 # an optional wall-clock time for the job scripts on both sides.  Polaris
 # defaults to 1:00:00, which many tasks and most suites outgrow.  This is
 # merged with polaris_config_file below into a single config file in the

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -23,6 +23,9 @@ load_script = load_polaris_chrysalis_intel_openmpi.sh
 # the command to set up one or more tasks or a suite
 # note: --model, --branch, -p, -w, -b, -f and the build flags are appended
 #       automatically, so none of them may appear here
+# note: a "polaris setup" command must name its suite with --suite_name;
+#       polaris would otherwise call it "custom" and every benchmark set
+#       up that way would share one baseline directory
 setup_command = polaris suite -c ocean -t pr
 
 # the command used to run polaris in the work directory when submit = False
@@ -105,7 +108,8 @@ model = ${baseline:model}
 #          for a task that builds no model
 # ---------------------------------------------------------------------------
 # load_script = load_polaris_chrysalis_intel_openmpi.sh
-# setup_command = polaris setup -t e3sm/init/u.oi30.lr10/topo/cull
+# setup_command = polaris setup --suite_name cull_topo \
+#     -t e3sm/init/u.oi30.lr10/topo/cull
 #
 # [baseline]
 # source = existing

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -4,6 +4,9 @@
 
 # the absolute or relative path for all benchmark output.  Worktrees,
 # baselines and per-run directories are created within it.
+#
+# ${USER}, ${HOME} and ${SCRATCH} are substituted from the environment
+# wherever they appear in this file, when they are set.
 work_base = /lcrc/group/e3sm/${USER}/polaris_benchmarks/vmix
 
 # the polaris clone that worktrees are created from and that forks are

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -1,0 +1,97 @@
+# config options for benchmarking a polaris, Omega or E3SM branch against a
+# baseline using a polaris task or suite
+[benchmark]
+
+# the absolute or relative path for all benchmark output.  Worktrees,
+# baselines and per-run directories are created within it.
+work_base = /lcrc/group/e3sm/${USER}/polaris_benchmarks/vmix
+
+# the polaris clone that worktrees are created from and that forks are
+# fetched into.  Defaults to the directory containing this config file.
+# This clone is only ever fetched from; its checkout is never modified.
+primary_path = .
+
+# the name of the load script to source within each worktree.  It must
+# already exist there: creating the polaris environment with ./deploy.py is
+# a developer action and is never done by this workflow.
+load_script = load_polaris_chrysalis_intel_openmpi.sh
+
+# the command to set up one or more tasks or a suite
+# note: --model, --branch, -p, -w, -b, -f and the build flags are appended
+#       automatically, so none of them may appear here
+setup_command = polaris suite -c ocean -t pr
+
+# the command used to run polaris in the work directory when submit = False
+run_command = polaris serial
+
+# whether to submit the job script instead of running in place.  The test
+# job is submitted with a dependency on the baseline job.
+submit = False
+
+# an optional polaris config file passed on with -f
+polaris_config_file =
+
+
+# The baseline and test sections take exactly the same options, so which
+# repository is being benchmarked is simply a matter of which refs differ.
+#
+# source = worktree (the default) provisions a detached git worktree at the
+#   requested fork and ref
+# source = existing adopts an existing polaris worktree read-only; it is
+#   never fetched, checked out, updated, reset or cleaned
+
+[baseline]
+source = worktree
+polaris_fork = E3SM-Project
+polaris_ref = main
+# submodules not listed here stay at the hash pinned by polaris_ref
+model = mpas-ocean
+
+[test]
+source = worktree
+polaris_fork = cbegeman
+polaris_ref = add-surface-forcing-to-vmix
+model = ${baseline:model}
+
+
+# ---------------------------------------------------------------------------
+# Example: benchmark an Omega branch with polaris pinned on both sides
+# ---------------------------------------------------------------------------
+# [baseline]
+# source = worktree
+# polaris_fork = E3SM-Project
+# polaris_ref = main
+# model = omega
+#
+# [test]
+# source = worktree
+# polaris_fork = E3SM-Project
+# polaris_ref = main
+# omega_fork = cbegeman
+# omega_ref = my-omega-feature
+# model = omega
+
+# ---------------------------------------------------------------------------
+# Example: benchmark the worktree you are already working in
+# ---------------------------------------------------------------------------
+# [baseline]
+# source = worktree
+# polaris_fork = E3SM-Project
+# polaris_ref = main
+# model = mpas-ocean
+#
+# [test]
+# source = existing
+# path = /lcrc/group/e3sm/${USER}/polaris-repo/add-surface-forcing-to-vmix
+# model = mpas-ocean
+
+# ---------------------------------------------------------------------------
+# Example: benchmark an E3SM (MPAS-Ocean) branch with polaris pinned
+# ---------------------------------------------------------------------------
+# [test]
+# source = worktree
+# polaris_fork = E3SM-Project
+# polaris_ref = main
+# e3sm_fork = cbegeman
+# e3sm_ref = my-mpaso-feature
+# model = mpas-ocean

--- a/utils/benchmark/example.cfg
+++ b/utils/benchmark/example.cfg
@@ -5,8 +5,9 @@
 # the absolute or relative path for all benchmark output.  Worktrees,
 # baselines and per-run directories are created within it.
 #
-# ${USER}, ${HOME} and ${SCRATCH} are substituted from the environment
-# wherever they appear in this file, when they are set.
+# Any environment variable can be substituted as ${NAME} anywhere in
+# this file, as ${USER} is below.  Point this wherever your other work
+# directories live.
 work_base = /lcrc/group/e3sm/${USER}/polaris_benchmarks/vmix
 
 # the polaris clone that worktrees are created from and that forks are

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -98,6 +98,9 @@ class SourceState:
         during a dry run of a worktree that has not been created
     model : str
         The Polaris ``--model`` value for this benchmark
+    component_source : str
+        The model source to build from instead of this side's own
+        submodule, set when both sides share one build
     """
 
     name: str
@@ -113,6 +116,7 @@ class SourceState:
     load_script: str = ''
     load_script_ready: bool = True
     model: str = ''
+    component_source: str = ''
 
     @property
     def component_branch_path(self):
@@ -122,6 +126,8 @@ class SourceState:
         """
         if self.model == NO_MODEL:
             return None
+        if self.component_source:
+            return self.component_source
         key = MODEL_SUBMODULES[self.model]
         return os.path.join(self.path, SUBMODULE_PATHS[key])
 
@@ -162,6 +168,7 @@ class SourceState:
             'load_script': self.load_script,
             'load_script_ready': self.load_script_ready,
             'model': self.model,
+            'component_branch_path': self.component_branch_path,
         }
 
 
@@ -176,6 +183,7 @@ def provision(
     submodule_specs=None,
     dry_run=False,
     logger=None,
+    needs_model_source=True,
 ):
     """
     Create (or reuse) a detached worktree at the requested fork and ref
@@ -204,6 +212,11 @@ def provision(
         Whether to only resolve commits and report planned commands
     logger : logging.Logger, optional
         A logger for command output
+    needs_model_source : bool, optional
+        Whether the model is built from this worktree's own submodule.
+        It is not when both sides share one build, and cloning the
+        submodule of the side that never builds is several GB of source
+        that nothing reads.
 
     Returns
     -------
@@ -258,7 +271,7 @@ def provision(
     # overridden, are needed; a bare `submodule update --init` would also
     # clone E3SM, MALI-Dev and jigsaw-python for an Omega benchmark
     needed = set(submodule_specs)
-    if model != NO_MODEL:
+    if model != NO_MODEL and needs_model_source:
         needed.add(MODEL_SUBMODULES[model])
     for key in sorted(needed):
         _git(
@@ -282,7 +295,14 @@ def provision(
     return state
 
 
-def adopt(name, path, model, load_script_name, allow_dirty=False):
+def adopt(
+    name,
+    path,
+    model,
+    load_script_name,
+    allow_dirty=False,
+    needs_model_source=True,
+):
     """
     Validate and record the state of an existing Polaris worktree
 
@@ -303,6 +323,11 @@ def adopt(name, path, model, load_script_name, allow_dirty=False):
     allow_dirty : bool, optional
         Whether to permit uncommitted or untracked changes.  The run is
         then marked as not reproducible.
+    needs_model_source : bool, optional
+        Whether the model is built from this worktree's own submodule.
+        It is not when both sides share one build, in which case this
+        worktree is never the one ``--branch`` points at and the
+        submodule does not have to be initialized in it.
 
     Returns
     -------
@@ -334,7 +359,7 @@ def adopt(name, path, model, load_script_name, allow_dirty=False):
         model=model,
     )
 
-    if model != NO_MODEL:
+    if model != NO_MODEL and needs_model_source:
         key = MODEL_SUBMODULES[model]
         sub_path = _submodule_path(path, key)
         if not os.path.exists(os.path.join(sub_path, '.git')):
@@ -347,7 +372,10 @@ def adopt(name, path, model, load_script_name, allow_dirty=False):
                 f'  git -C {path} submodule update --init '
                 f'{SUBMODULE_PATHS[key]}\n'
                 f'If the benchmark builds no component, use '
-                f'model = {NO_MODEL} instead.'
+                f'model = {NO_MODEL} instead.  If the other side has the '
+                f'submodule and the two pin the same commit of it, a '
+                f'shared component_path builds from that side instead, '
+                f'and this one then needs no submodule at all.'
             )
 
     state.pinned_shas = _pinned_submodule_shas(path, 'HEAD')
@@ -716,6 +744,11 @@ def _check_dirty(path, model):
 
     rel_path = SUBMODULE_PATHS[MODEL_SUBMODULES[model]]
     sub_path = os.path.join(path, rel_path)
+    if not os.path.exists(os.path.join(sub_path, '.git')):
+        # the model is built from the other side's submodule, so there is
+        # no source here to be dirty; ``git status`` in the empty
+        # directory would walk up and report on polaris again
+        return False, ''
     command = 'git status --porcelain --ignore-submodules=dirty'
     kind = 'uncommitted or untracked changes'
     if model in IN_SOURCE_BUILDS:

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -507,14 +507,27 @@ def _check_is_polaris_repo(path):
 
 
 def _ensure_remote(repo_path, fork):
-    """Add or update a remote for ``fork`` and return its name."""
+    """
+    Add a remote for ``fork`` and return its name.
+
+    An existing remote is used but never repointed, since ``repo_path``
+    is the developer's own clone.
+    """
     url = _fork_url(repo_path, fork)
     name = _remote_name(fork)
     remotes = check_output('git remote', cwd=repo_path).split()
-    if name in remotes:
-        _git(f'remote set-url {name} {url}', cwd=repo_path)
-    else:
+    if name not in remotes:
         _git(f'remote add {name} {url}', cwd=repo_path)
+        return name
+
+    existing = check_output(f'git remote get-url {name}', cwd=repo_path)
+    if existing != url:
+        raise ValueError(
+            f'The remote "{name}" in\n  {repo_path}\npoints at\n  '
+            f'{existing}\nrather than the expected\n  {url}\nThe '
+            f'benchmark will not repoint a remote in your clone.  Rename '
+            f'the remote, or give the fork as a full URL.'
+        )
     return name
 
 

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -359,23 +359,26 @@ def adopt(
         model=model,
     )
 
+    # every problem with the worktree is collected rather than raised on
+    # the spot, so that one dry run reports all of them instead of one
+    # per attempt; none of them stops the checks that follow
+    problems = []
+
     if model != NO_MODEL and needs_model_source:
         key = MODEL_SUBMODULES[model]
         sub_path = _submodule_path(path, key)
         if not os.path.exists(os.path.join(sub_path, '.git')):
-            raise ValueError(
-                f'The submodule {SUBMODULE_PATHS[key]} in the adopted '
-                f'worktree\n'
-                f'  {path}\n'
-                f'is not initialized.  This workflow will not modify an '
-                f'adopted worktree, so please run:\n'
+            problems.append(
+                f'The submodule {SUBMODULE_PATHS[key]} is not initialized, '
+                f'and this workflow will not modify an adopted worktree, so '
+                f'please run:\n'
                 f'  git -C {path} submodule update --init '
                 f'{SUBMODULE_PATHS[key]}\n'
                 f'If the benchmark builds no component, use '
                 f'model = {NO_MODEL} instead.  If the other side has the '
-                f'submodule and the two pin the same commit of it, a '
-                f'shared component_path builds from that side instead, '
-                f'and this one then needs no submodule at all.'
+                f'submodule and the two pin the same commit of it, a shared '
+                f'component_path builds from that side instead, and this one '
+                f'then needs no submodule at all.'
             )
 
     state.pinned_shas = _pinned_submodule_shas(path, 'HEAD')
@@ -383,15 +386,58 @@ def adopt(
     state.dirty, reason = _check_dirty(path, model)
 
     if state.dirty and not allow_dirty:
-        raise ValueError(
-            f'The adopted worktree\n  {path}\n{reason}, so the benchmark '
-            f'would not be reproducible from the recorded commit hashes.  '
-            f'Commit or stash the changes, or rerun with --allow-dirty to '
-            f'record the run as non-reproducible.'
+        problems.append(
+            f'It {reason}, so the benchmark would not be reproducible from '
+            f'the recorded commit hashes.  Commit or stash the changes, or '
+            f'rerun with --allow-dirty to record the run as '
+            f'non-reproducible.'
         )
 
-    state.load_script = _require_load_script(path, load_script_name)
+    load_script = load_script_path(path, load_script_name)
+    if os.path.exists(load_script):
+        state.load_script = load_script
+    else:
+        problems.append(
+            f'There is no load script\n'
+            f'  {load_script}\n'
+            f'Creating the polaris environment is a developer action, so '
+            f'it is never done for you.  Either run ./deploy.py in that '
+            f'worktree, or set load_script to the absolute path of an '
+            f'existing load script so that one deployment serves both sides.'
+        )
+
+    if problems:
+        raise ValueError(
+            describe_problems(f'{name} worktree {path}', problems)
+        )
+
     return state
+
+
+def describe_problems(subject, problems):
+    """
+    Get one error message listing everything wrong with one subject
+
+    Parameters
+    ----------
+    subject : str
+        What the problems are with, named so that several subjects can be
+        reported together
+    problems : list of str
+        One description per problem
+
+    Returns
+    -------
+    message : str
+        The problems as a numbered list under ``subject``
+    """
+    if len(problems) == 1:
+        return f'The {subject}:\n{_indent(problems[0], "  ")}'
+    listed = '\n'.join(
+        f'  {index}. {_indent(problem, "     ").lstrip()}'
+        for index, problem in enumerate(problems, start=1)
+    )
+    return f'The {subject} has {len(problems)} problems:\n{listed}'
 
 
 def resolve(repo_path, fork, ref, fetch=True):
@@ -773,6 +819,11 @@ def _require_load_script(worktree, load_script_name):
             f'sides, and try again.'
         )
     return load_script
+
+
+def _indent(text, prefix):
+    """Indent every line of ``text`` by ``prefix``."""
+    return '\n'.join(f'{prefix}{line}' for line in text.split('\n'))
 
 
 def _git(args, cwd, logger=None):

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -228,9 +228,20 @@ def provision(
         return state
 
     add_worktree(primary_path, sha, worktree, logger=logger)
-    _git('submodule update --init', cwd=worktree, logger=logger)
 
     state.pinned_shas = _pinned_submodule_shas(worktree, 'HEAD')
+
+    # only the submodule the model is built from, plus any that are
+    # overridden, are needed; a bare `submodule update --init` would also
+    # clone E3SM, MALI-Dev and jigsaw-python for an Omega benchmark
+    needed = {MODEL_SUBMODULES[model]}
+    needed.update(submodule_specs)
+    for key in sorted(needed):
+        _git(
+            f'submodule update --init {SUBMODULE_PATHS[key]}',
+            cwd=worktree,
+            logger=logger,
+        )
 
     for key, (sub_fork, sub_ref) in submodule_specs.items():
         sub_path = _submodule_path(worktree, key)

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -68,6 +68,9 @@ class SourceState:
     load_script : str
         The absolute path to the load script used to activate the
         environment
+    load_script_ready : bool
+        Whether the load script exists yet.  It can be ``False`` only
+        during a dry run of a worktree that has not been created
     model : str
         The Polaris ``--model`` value for this benchmark
     """
@@ -83,6 +86,7 @@ class SourceState:
     submodule_overrides: dict = field(default_factory=dict)
     dirty: bool = False
     load_script: str = ''
+    load_script_ready: bool = True
     model: str = ''
 
     @property
@@ -124,6 +128,7 @@ class SourceState:
             'submodule_overrides': dict(self.submodule_overrides),
             'dirty': self.dirty,
             'load_script': self.load_script,
+            'load_script_ready': self.load_script_ready,
             'model': self.model,
         }
 
@@ -193,6 +198,13 @@ def provision(
         model=model,
     )
 
+    load_script = load_script_path(worktree, load_script_name)
+    # a load script we can already resolve is checked before the worktree
+    # and its submodules are created, so that a missing one fails fast
+    predictable = os.path.isabs(load_script_name) or os.path.exists(worktree)
+    if predictable:
+        _require_load_script(worktree, load_script_name)
+
     if dry_run:
         state.pinned_shas = _pinned_submodule_shas(primary_path, sha)
         state.submodule_shas = dict(state.pinned_shas)
@@ -202,7 +214,8 @@ def provision(
                 'ref': sub_ref,
             }
             state.submodule_shas[key] = f'<{sub_fork}:{sub_ref}>'
-        state.load_script = os.path.join(worktree, load_script_name)
+        state.load_script = load_script
+        state.load_script_ready = predictable
         return state
 
     add_worktree(primary_path, sha, worktree, logger=logger)
@@ -453,6 +466,29 @@ def check_single_variable(baseline, test):
     return differing
 
 
+def load_script_path(worktree, load_script_name):
+    """
+    Get the path to the load script for a worktree
+
+    An absolute ``load_script_name`` is used as it is, which is how one
+    deployment can serve several worktrees.  A bare name is taken to be
+    relative to the worktree.
+
+    Parameters
+    ----------
+    worktree : str
+        The path to the Polaris worktree
+    load_script_name : str
+        The name of, or absolute path to, the load script
+
+    Returns
+    -------
+    load_script : str
+        The absolute path to the load script
+    """
+    return os.path.join(worktree, load_script_name)
+
+
 def _check_is_polaris_repo(path):
     """Raise a ValueError if ``path`` is not a Polaris work tree."""
     if not os.path.isdir(path):
@@ -575,13 +611,15 @@ def _is_dirty(repo_path):
 
 def _require_load_script(worktree, load_script_name):
     """Get the load script in a worktree, raising if it is missing."""
-    load_script = os.path.join(worktree, load_script_name)
+    load_script = load_script_path(worktree, load_script_name)
     if not os.path.exists(load_script):
         raise ValueError(
             f'Could not find the load script\n  {load_script}\n'
-            f'Creating the Polaris environment is a developer action.  '
-            f'Please run ./deploy.py in that worktree (or point '
-            f'load_script at an existing script) and try again.'
+            f'Creating the Polaris environment is a developer action, so '
+            f'it is never done for you.  Either run ./deploy.py in that '
+            f'worktree, or set load_script to the absolute path of an '
+            f'existing load script so that one deployment serves both '
+            f'sides, and try again.'
         )
     return load_script
 

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -41,6 +41,17 @@ MODEL_SUBMODULES = {
     'omega': 'omega',
 }
 
+#: The ``model`` value for a benchmark that builds no component
+#:
+#: This is not a Polaris ``--model`` value.  It says that the task or suite
+#: being benchmarked runs no model, as is the case for the ``e3sm/init``,
+#: ``mesh`` and ``seaice`` components, so neither ``--model`` nor
+#: ``--branch`` is passed on and no submodule is needed.
+NO_MODEL = 'none'
+
+#: The ``model`` values a side of a benchmark may use
+MODELS = list(MODEL_SUBMODULES) + [NO_MODEL]
+
 
 @dataclass
 class SourceState:
@@ -97,8 +108,11 @@ class SourceState:
     @property
     def component_branch_path(self):
         """
-        str : the path passed to ``polaris setup --branch`` for this model
+        str or None : the path passed to ``polaris setup --branch`` for this
+        model, or ``None`` when the benchmark builds no component
         """
+        if self.model == NO_MODEL:
+            return None
         key = MODEL_SUBMODULES[self.model]
         return os.path.join(self.path, SUBMODULE_PATHS[key])
 
@@ -234,8 +248,9 @@ def provision(
     # only the submodule the model is built from, plus any that are
     # overridden, are needed; a bare `submodule update --init` would also
     # clone E3SM, MALI-Dev and jigsaw-python for an Omega benchmark
-    needed = {MODEL_SUBMODULES[model]}
-    needed.update(submodule_specs)
+    needed = set(submodule_specs)
+    if model != NO_MODEL:
+        needed.add(MODEL_SUBMODULES[model])
     for key in sorted(needed):
         _git(
             f'submodule update --init {SUBMODULE_PATHS[key]}',
@@ -310,17 +325,21 @@ def adopt(name, path, model, load_script_name, allow_dirty=False):
         model=model,
     )
 
-    key = MODEL_SUBMODULES[model]
-    sub_path = _submodule_path(path, key)
-    if not os.path.exists(os.path.join(sub_path, '.git')):
-        raise ValueError(
-            f'The submodule {SUBMODULE_PATHS[key]} in the adopted worktree\n'
-            f'  {path}\n'
-            f'is not initialized.  This workflow will not modify an '
-            f'adopted worktree, so please run:\n'
-            f'  git -C {path} submodule update --init '
-            f'{SUBMODULE_PATHS[key]}'
-        )
+    if model != NO_MODEL:
+        key = MODEL_SUBMODULES[model]
+        sub_path = _submodule_path(path, key)
+        if not os.path.exists(os.path.join(sub_path, '.git')):
+            raise ValueError(
+                f'The submodule {SUBMODULE_PATHS[key]} in the adopted '
+                f'worktree\n'
+                f'  {path}\n'
+                f'is not initialized.  This workflow will not modify an '
+                f'adopted worktree, so please run:\n'
+                f'  git -C {path} submodule update --init '
+                f'{SUBMODULE_PATHS[key]}\n'
+                f'If the benchmark builds no component, use '
+                f'model = {NO_MODEL} instead.'
+            )
 
     state.pinned_shas = _pinned_submodule_shas(path, 'HEAD')
     state.submodule_shas = _submodule_shas(path)

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -1,0 +1,591 @@
+"""
+Resolve, provision and adopt Polaris source trees for benchmarking.
+
+Two modes are supported for each side of a benchmark:
+
+``provision``
+    Resolve a fork and ref to a commit, create a detached ``git worktree``
+    under the benchmark work base, initialize submodules, and optionally
+    check out a different fork/ref for one of the submodules.
+
+``adopt``
+    Use an existing Polaris worktree (typically the one the developer is
+    already working in) exactly as it is found.  The adopted tree is
+    treated as strictly read-only: no fetch, checkout, submodule update,
+    reset or clean is ever run against it.
+"""
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+
+from shared import check_call, check_output
+
+#: Mapping from a short submodule key to its path within Polaris
+SUBMODULE_PATHS = {
+    'e3sm': 'e3sm_submodules/E3SM-Project',
+    'omega': 'e3sm_submodules/Omega',
+    'mali': 'e3sm_submodules/MALI-Dev',
+}
+
+#: Mapping from a Polaris ``--model`` value to the submodule it is built from
+MODEL_SUBMODULES = {
+    'mpas-ocean': 'e3sm',
+    'omega': 'omega',
+    'mali': 'mali',
+}
+
+
+@dataclass
+class SourceState:
+    """
+    The fully resolved state of one side of a benchmark
+
+    Attributes
+    ----------
+    name : str
+        Either ``baseline`` or ``test``
+    mode : str
+        Either ``worktree`` (provisioned) or ``existing`` (adopted)
+    path : str
+        The absolute path to the Polaris worktree
+    polaris_sha : str
+        The full commit hash of Polaris at ``path``
+    polaris_ref : str
+        The branch name, tag or ref that was requested or is checked out
+    polaris_fork : str
+        The fork (owner or URL) the commit came from, when known
+    submodule_shas : dict
+        Commit hashes of the initialized submodules, keyed by short name
+    pinned_shas : dict
+        Commit hashes the Polaris commit pins for each submodule
+    submodule_overrides : dict
+        Submodules explicitly checked out to a different fork/ref
+    dirty : bool
+        Whether the worktree or any submodule has uncommitted or
+        untracked changes
+    load_script : str
+        The absolute path to the load script used to activate the
+        environment
+    model : str
+        The Polaris ``--model`` value for this benchmark
+    """
+
+    name: str
+    mode: str
+    path: str
+    polaris_sha: str = ''
+    polaris_ref: str = ''
+    polaris_fork: str = ''
+    submodule_shas: dict = field(default_factory=dict)
+    pinned_shas: dict = field(default_factory=dict)
+    submodule_overrides: dict = field(default_factory=dict)
+    dirty: bool = False
+    load_script: str = ''
+    model: str = ''
+
+    @property
+    def component_branch_path(self):
+        """
+        str : the path passed to ``polaris setup --branch`` for this model
+        """
+        key = MODEL_SUBMODULES[self.model]
+        return os.path.join(self.path, SUBMODULE_PATHS[key])
+
+    @property
+    def compare_shas(self):
+        """
+        dict : the commit hashes used by the one-variable guardrail
+        """
+        shas = {'polaris': self.polaris_sha}
+        for key in SUBMODULE_PATHS:
+            shas[key] = self.submodule_shas.get(key, '')
+        return shas
+
+    def provenance(self):
+        """
+        Get a dictionary describing this source state for the manifest
+
+        Returns
+        -------
+        provenance : dict
+            A JSON-serializable description of this source state
+        """
+        return {
+            'name': self.name,
+            'mode': self.mode,
+            'path': self.path,
+            'polaris_fork': self.polaris_fork,
+            'polaris_ref': self.polaris_ref,
+            'polaris_sha': self.polaris_sha,
+            'submodule_shas': dict(self.submodule_shas),
+            'pinned_shas': dict(self.pinned_shas),
+            'submodule_overrides': dict(self.submodule_overrides),
+            'dirty': self.dirty,
+            'load_script': self.load_script,
+            'model': self.model,
+        }
+
+
+def provision(
+    name,
+    primary_path,
+    work_base,
+    fork,
+    ref,
+    model,
+    load_script_name,
+    submodule_specs=None,
+    dry_run=False,
+    logger=None,
+):
+    """
+    Create (or reuse) a detached worktree at the requested fork and ref
+
+    Parameters
+    ----------
+    name : str
+        Either ``baseline`` or ``test``
+    primary_path : str
+        The Polaris clone to fetch from and create worktrees off of
+    work_base : str
+        The base directory for the benchmark; worktrees are created in a
+        ``worktrees`` subdirectory
+    fork : str
+        A GitHub owner (e.g. ``E3SM-Project``) or a full remote URL
+    ref : str
+        A branch, tag or commit hash in ``fork``
+    model : str
+        The Polaris ``--model`` value
+    load_script_name : str
+        The name of the load script to source within the worktree
+    submodule_specs : dict, optional
+        A mapping from submodule key to a ``(fork, ref)`` tuple for
+        submodules that should differ from the SHA pinned by Polaris
+    dry_run : bool, optional
+        Whether to only resolve commits and report planned commands
+    logger : logging.Logger, optional
+        A logger for command output
+
+    Returns
+    -------
+    state : SourceState
+        The resolved state of the provisioned worktree
+    """
+    if submodule_specs is None:
+        submodule_specs = {}
+
+    primary_path = os.path.abspath(primary_path)
+    _check_is_polaris_repo(primary_path)
+
+    sha = resolve(primary_path, fork, ref)
+    slug = _slugify(ref)
+    worktree = os.path.join(work_base, 'worktrees', f'{slug}-{sha[:7]}')
+
+    state = SourceState(
+        name=name,
+        mode='worktree',
+        path=worktree,
+        polaris_sha=sha,
+        polaris_ref=ref,
+        polaris_fork=fork,
+        model=model,
+    )
+
+    if dry_run:
+        state.pinned_shas = _pinned_submodule_shas(primary_path, sha)
+        state.submodule_shas = dict(state.pinned_shas)
+        for key, (sub_fork, sub_ref) in submodule_specs.items():
+            state.submodule_overrides[key] = {
+                'fork': sub_fork,
+                'ref': sub_ref,
+            }
+            state.submodule_shas[key] = f'<{sub_fork}:{sub_ref}>'
+        state.load_script = os.path.join(worktree, load_script_name)
+        return state
+
+    add_worktree(primary_path, sha, worktree, logger=logger)
+    _git('submodule update --init', cwd=worktree, logger=logger)
+
+    state.pinned_shas = _pinned_submodule_shas(worktree, 'HEAD')
+
+    for key, (sub_fork, sub_ref) in submodule_specs.items():
+        sub_path = _submodule_path(worktree, key)
+        sub_sha = resolve(sub_path, sub_fork, sub_ref)
+        checkout_submodule(sub_path, sub_sha, logger=logger)
+        state.submodule_overrides[key] = {
+            'fork': sub_fork,
+            'ref': sub_ref,
+            'sha': sub_sha,
+        }
+
+    state.submodule_shas = _submodule_shas(worktree)
+    state.load_script = _require_load_script(worktree, load_script_name)
+    return state
+
+
+def adopt(name, path, model, load_script_name, allow_dirty=False):
+    """
+    Validate and record the state of an existing Polaris worktree
+
+    The adopted worktree is never modified.  Only read-only ``git``
+    queries are run against it.
+
+    Parameters
+    ----------
+    name : str
+        Either ``baseline`` or ``test``
+    path : str
+        The path to the existing Polaris worktree
+    model : str
+        The Polaris ``--model`` value
+    load_script_name : str
+        The name of the load script to source within the worktree
+    allow_dirty : bool, optional
+        Whether to permit uncommitted or untracked changes.  The run is
+        then marked as not reproducible.
+
+    Returns
+    -------
+    state : SourceState
+        The recorded state of the adopted worktree
+
+    Raises
+    ------
+    ValueError
+        If the path is not a usable Polaris worktree, a required
+        submodule is not initialized, or the tree is dirty and
+        ``allow_dirty`` is not set
+    """
+    path = os.path.abspath(path)
+    _check_is_polaris_repo(path)
+
+    sha = check_output('git rev-parse HEAD', cwd=path)
+    ref = check_output('git rev-parse --abbrev-ref HEAD', cwd=path)
+    if ref == 'HEAD':
+        ref = 'DETACHED'
+
+    state = SourceState(
+        name=name,
+        mode='existing',
+        path=path,
+        polaris_sha=sha,
+        polaris_ref=ref,
+        polaris_fork=_fork_of_upstream(path),
+        model=model,
+    )
+
+    key = MODEL_SUBMODULES[model]
+    sub_path = _submodule_path(path, key)
+    if not os.path.exists(os.path.join(sub_path, '.git')):
+        raise ValueError(
+            f'The submodule {SUBMODULE_PATHS[key]} in the adopted worktree\n'
+            f'  {path}\n'
+            f'is not initialized.  This workflow will not modify an '
+            f'adopted worktree, so please run:\n'
+            f'  git -C {path} submodule update --init '
+            f'{SUBMODULE_PATHS[key]}'
+        )
+
+    state.pinned_shas = _pinned_submodule_shas(path, 'HEAD')
+    state.submodule_shas = _submodule_shas(path)
+    state.dirty = _is_dirty(path)
+
+    if state.dirty and not allow_dirty:
+        raise ValueError(
+            f'The adopted worktree\n  {path}\nhas uncommitted or untracked '
+            f'changes, so the benchmark would not be reproducible from the '
+            f'recorded commit hashes.  Commit or stash the changes, or '
+            f'rerun with --allow-dirty to record the run as '
+            f'non-reproducible.'
+        )
+
+    state.load_script = _require_load_script(path, load_script_name)
+    return state
+
+
+def resolve(repo_path, fork, ref, fetch=True):
+    """
+    Resolve a fork and ref to a full commit hash without changing HEAD
+
+    Parameters
+    ----------
+    repo_path : str
+        The path to the repository to resolve the ref in
+    fork : str
+        A GitHub owner or a full remote URL.  If empty, the ref is
+        resolved against the remotes already present.
+    ref : str
+        A branch, tag or commit hash
+    fetch : bool, optional
+        Whether to fetch from the fork before resolving
+
+    Returns
+    -------
+    sha : str
+        The full commit hash
+
+    Raises
+    ------
+    ValueError
+        If the ref cannot be resolved
+    """
+    remote = None
+    if fork:
+        remote = _ensure_remote(repo_path, fork)
+        if fetch:
+            _git(f'fetch --tags {remote}', cwd=repo_path)
+
+    candidates = []
+    if remote is not None:
+        candidates.append(f'refs/remotes/{remote}/{ref}')
+    candidates.extend([f'refs/tags/{ref}', ref])
+
+    for candidate in candidates:
+        try:
+            return check_output(
+                f'git rev-parse --verify --quiet {candidate}^{{commit}}',
+                cwd=repo_path,
+            )
+        except subprocess.CalledProcessError:
+            continue
+
+    raise ValueError(
+        f'Could not resolve ref "{ref}" in fork "{fork}" within {repo_path}'
+    )
+
+
+def add_worktree(repo_path, sha, dest, logger=None):
+    """
+    Create a detached worktree at a commit, reusing it if already correct
+
+    Parameters
+    ----------
+    repo_path : str
+        The Polaris clone to create the worktree from
+    sha : str
+        The commit hash to check out
+    dest : str
+        The path of the worktree to create
+    logger : logging.Logger, optional
+        A logger for command output
+
+    Returns
+    -------
+    dest : str
+        The path to the worktree
+
+    Raises
+    ------
+    ValueError
+        If ``dest`` exists but is not a worktree at ``sha``
+    """
+    if os.path.exists(dest):
+        try:
+            existing = check_output('git rev-parse HEAD', cwd=dest)
+        except subprocess.CalledProcessError as exc:
+            raise ValueError(
+                f'The worktree path {dest} exists but is not a git '
+                f'worktree.  Remove it or choose another work base.'
+            ) from exc
+        if existing != sha:
+            raise ValueError(
+                f'The worktree path {dest} exists but is at {existing[:7]} '
+                f'rather than the expected {sha[:7]}.'
+            )
+        return dest
+
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    _git(f'worktree add --detach {dest} {sha}', cwd=repo_path, logger=logger)
+    return dest
+
+
+def checkout_submodule(sub_path, sha, logger=None):
+    """
+    Check out a commit in a submodule of a provisioned worktree
+
+    Parameters
+    ----------
+    sub_path : str
+        The path to the submodule
+    sha : str
+        The commit hash to check out
+    logger : logging.Logger, optional
+        A logger for command output
+
+    Raises
+    ------
+    ValueError
+        If the submodule has local modifications
+    """
+    if _is_dirty(sub_path):
+        raise ValueError(
+            f'The submodule at {sub_path} has local modifications and will '
+            f'not be checked out.'
+        )
+    _git(f'checkout --detach {sha}', cwd=sub_path, logger=logger)
+    _git('submodule update --init --recursive', cwd=sub_path, logger=logger)
+
+
+def check_single_variable(baseline, test):
+    """
+    Get the repositories whose commits differ between the two sides
+
+    Parameters
+    ----------
+    baseline : SourceState
+        The baseline source state
+    test : SourceState
+        The test source state
+
+    Returns
+    -------
+    differing : list of str
+        The keys (``polaris``, ``e3sm``, ``omega``, ``mali``) that differ
+    """
+    baseline_shas = baseline.compare_shas
+    test_shas = test.compare_shas
+    differing = []
+    for key, sha in baseline_shas.items():
+        if sha != test_shas.get(key, ''):
+            differing.append(key)
+    return differing
+
+
+def _check_is_polaris_repo(path):
+    """Raise a ValueError if ``path`` is not a Polaris work tree."""
+    if not os.path.isdir(path):
+        raise ValueError(f'No such directory: {path}')
+    try:
+        check_output('git rev-parse --git-common-dir', cwd=path)
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f'{path} is not a git work tree') from exc
+    for expected in ['polaris/version.py', 'deploy.py']:
+        if not os.path.exists(os.path.join(path, expected)):
+            raise ValueError(
+                f'{path} does not look like a Polaris repository '
+                f'(missing {expected})'
+            )
+
+
+def _ensure_remote(repo_path, fork):
+    """Add or update a remote for ``fork`` and return its name."""
+    url = _fork_url(repo_path, fork)
+    name = _remote_name(fork)
+    remotes = check_output('git remote', cwd=repo_path).split()
+    if name in remotes:
+        _git(f'remote set-url {name} {url}', cwd=repo_path)
+    else:
+        _git(f'remote add {name} {url}', cwd=repo_path)
+    return name
+
+
+def _fork_url(repo_path, fork):
+    """Expand a GitHub owner into a URL matching the style of ``origin``."""
+    if '://' in fork or fork.startswith('git@'):
+        return fork
+    repo = _repo_name(repo_path)
+    origin = _origin_url(repo_path)
+    if origin.startswith('git@') or origin.startswith('ssh://'):
+        return f'git@github.com:{fork}/{repo}.git'
+    return f'https://github.com/{fork}/{repo}.git'
+
+
+def _origin_url(repo_path):
+    """Get the URL of ``origin``, or an empty string if there is none."""
+    try:
+        return check_output('git remote get-url origin', cwd=repo_path)
+    except subprocess.CalledProcessError:
+        return ''
+
+
+def _repo_name(repo_path):
+    """Get the repository name from the URL of ``origin``."""
+    origin = _origin_url(repo_path)
+    if not origin:
+        return os.path.basename(os.path.normpath(repo_path))
+    name = origin.rstrip('/').split('/')[-1]
+    if name.endswith('.git'):
+        name = name[: -len('.git')]
+    return name
+
+
+def _fork_of_upstream(repo_path):
+    """Get the owner of the ``origin`` remote, if it can be determined."""
+    origin = _origin_url(repo_path)
+    match = re.search(r'[:/]([^/:]+)/[^/]+?(\.git)?$', origin)
+    if match is None:
+        return ''
+    return match.group(1)
+
+
+def _remote_name(fork):
+    """Get a safe remote name for a fork."""
+    if '://' in fork or fork.startswith('git@'):
+        match = re.search(r'[:/]([^/:]+)/[^/]+?(\.git)?$', fork)
+        fork = match.group(1) if match is not None else 'benchmark'
+    return re.sub(r'[^A-Za-z0-9_.-]', '_', fork)
+
+
+def _slugify(ref):
+    """Get a filesystem-safe version of a ref name."""
+    return re.sub(r'[^A-Za-z0-9_.-]', '-', ref)
+
+
+def _submodule_path(worktree, key):
+    """Get the absolute path to a submodule within a worktree."""
+    if key not in SUBMODULE_PATHS:
+        raise ValueError(f'Unknown submodule "{key}"')
+    return os.path.join(worktree, SUBMODULE_PATHS[key])
+
+
+def _submodule_shas(worktree):
+    """Get the commit hashes of the initialized submodules."""
+    shas = {}
+    for key, rel_path in SUBMODULE_PATHS.items():
+        sub_path = os.path.join(worktree, rel_path)
+        if not os.path.exists(os.path.join(sub_path, '.git')):
+            continue
+        shas[key] = check_output('git rev-parse HEAD', cwd=sub_path)
+    return shas
+
+
+def _pinned_submodule_shas(repo_path, ref):
+    """Get the submodule commit hashes pinned by a Polaris commit."""
+    shas = {}
+    for key, rel_path in SUBMODULE_PATHS.items():
+        try:
+            output = check_output(
+                f'git ls-tree {ref} {rel_path}', cwd=repo_path
+            )
+        except subprocess.CalledProcessError:
+            continue
+        parts = output.split()
+        if len(parts) >= 3 and parts[1] == 'commit':
+            shas[key] = parts[2]
+    return shas
+
+
+def _is_dirty(repo_path):
+    """Whether a work tree has uncommitted or untracked changes."""
+    status = check_output('git status --porcelain', cwd=repo_path)
+    return status != ''
+
+
+def _require_load_script(worktree, load_script_name):
+    """Get the load script in a worktree, raising if it is missing."""
+    load_script = os.path.join(worktree, load_script_name)
+    if not os.path.exists(load_script):
+        raise ValueError(
+            f'Could not find the load script\n  {load_script}\n'
+            f'Creating the Polaris environment is a developer action.  '
+            f'Please run ./deploy.py in that worktree (or point '
+            f'load_script at an existing script) and try again.'
+        )
+    return load_script
+
+
+def _git(args, cwd, logger=None):
+    """Run a git command in a directory."""
+    check_call(f'git -C {cwd} {args}', logger=logger)

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -26,14 +26,15 @@ from shared import check_call, check_output
 SUBMODULE_PATHS = {
     'e3sm': 'e3sm_submodules/E3SM-Project',
     'omega': 'e3sm_submodules/Omega',
-    'mali': 'e3sm_submodules/MALI-Dev',
 }
 
 #: Mapping from a Polaris ``--model`` value to the submodule it is built from
+#:
+#: Only the models Polaris can build automatically belong here; see
+#: ``_build_model()`` in ``polaris/setup.py``.
 MODEL_SUBMODULES = {
     'mpas-ocean': 'e3sm',
     'omega': 'omega',
-    'mali': 'mali',
 }
 
 
@@ -455,7 +456,7 @@ def check_single_variable(baseline, test):
     Returns
     -------
     differing : list of str
-        The keys (``polaris``, ``e3sm``, ``omega``, ``mali``) that differ
+        The keys (``polaris``, ``e3sm``, ``omega``) that differ
     """
     baseline_shas = baseline.compare_shas
     test_shas = test.compare_shas

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -109,7 +109,11 @@ class SourceState:
         """
         shas = {'polaris': self.polaris_sha}
         for key in SUBMODULE_PATHS:
-            shas[key] = self.submodule_shas.get(key, '')
+            # a submodule that is not initialized is still pinned by the
+            # polaris commit, and the pin is what it would be checked out
+            # at, so report that rather than nothing
+            actual = self.submodule_shas.get(key, '')
+            shas[key] = actual or self.pinned_shas.get(key, '')
         return shas
 
     def provenance(self):

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -41,6 +41,15 @@ MODEL_SUBMODULES = {
     'omega': 'omega',
 }
 
+#: Models whose build writes into the submodule it is built from
+#:
+#: MPAS-Ocean is an in-source ``make``, so untracked files in its
+#: submodule are build products.  Omega is configured out of source
+#: (``cmake -S <omega>/components/omega -B <build_dir>``), so an untracked
+#: file there is source, and its CMakeLists globs ``*.cpp``, so a new one
+#: is compiled in without any tracked file changing.
+IN_SOURCE_BUILDS = {'mpas-ocean'}
+
 #: The ``model`` value for a benchmark that builds no component
 #:
 #: This is not a Polaris ``--model`` value.  It says that the task or suite
@@ -677,8 +686,10 @@ def _check_dirty(path, model):
 
     Edited *source* in the submodule the model is built from is another
     matter, since the build would then not match the recorded hash, so it
-    makes the whole side dirty.  Only untracked files are ignored there,
-    since those are the build products.
+    makes the whole side dirty.  Untracked files are ignored there only
+    for a model in ``IN_SOURCE_BUILDS``, where they are build products; an
+    out-of-source build leaves none behind, so an untracked file is source
+    that the build may well pick up.
 
     Parameters
     ----------
@@ -705,13 +716,14 @@ def _check_dirty(path, model):
 
     rel_path = SUBMODULE_PATHS[MODEL_SUBMODULES[model]]
     sub_path = os.path.join(path, rel_path)
-    status = check_output(
-        'git status --porcelain --ignore-submodules=dirty '
-        '--untracked-files=no',
-        cwd=sub_path,
-    )
+    command = 'git status --porcelain --ignore-submodules=dirty'
+    kind = 'uncommitted or untracked changes'
+    if model in IN_SOURCE_BUILDS:
+        command = f'{command} --untracked-files=no'
+        kind = 'uncommitted changes to source'
+    status = check_output(command, cwd=sub_path)
     if status:
-        return True, f'has uncommitted changes to source in {rel_path}'
+        return True, f'has {kind} in {rel_path}'
     return False, ''
 
 

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -88,8 +88,11 @@ class SourceState:
     submodule_overrides : dict
         Submodules explicitly checked out to a different fork/ref
     dirty : bool
-        Whether the worktree or any submodule has uncommitted or
-        untracked changes
+        Whether the worktree or any submodule has changes a benchmark
+        could not reproduce
+    untracked : list
+        Untracked paths outside the ``polaris`` package, which are
+        recorded but do not make the side dirty
     load_script : str
         The absolute path to the load script used to activate the
         environment
@@ -113,6 +116,7 @@ class SourceState:
     pinned_shas: dict = field(default_factory=dict)
     submodule_overrides: dict = field(default_factory=dict)
     dirty: bool = False
+    untracked: list = field(default_factory=list)
     load_script: str = ''
     load_script_ready: bool = True
     model: str = ''
@@ -165,6 +169,7 @@ class SourceState:
             'pinned_shas': dict(self.pinned_shas),
             'submodule_overrides': dict(self.submodule_overrides),
             'dirty': self.dirty,
+            'untracked': list(self.untracked),
             'load_script': self.load_script,
             'load_script_ready': self.load_script_ready,
             'model': self.model,
@@ -383,7 +388,7 @@ def adopt(
 
     state.pinned_shas = _pinned_submodule_shas(path, 'HEAD')
     state.submodule_shas = _submodule_shas(path)
-    state.dirty, reason = _check_dirty(path, model)
+    state.dirty, reason, state.untracked = _check_dirty(path, model)
 
     if state.dirty and not allow_dirty:
         problems.append(
@@ -758,6 +763,15 @@ def _check_dirty(path, model):
     one.  That matters for jigsaw-python and MALI-Dev, which affect
     results but are not among the hashes ``compare_shas`` records.
 
+    An untracked file outside the ``polaris`` package is not dirty
+    either.  A working polaris worktree normally carries notes, plan
+    documents and scratch output at its root, and none of that is
+    imported, registered or read by a task, so it cannot change a result.
+    Inside ``polaris`` it can: a new module is importable and a new task
+    directory is discovered, both without any tracked file changing.
+    Untracked files that are tolerated are reported and recorded rather
+    than ignored.
+
     Edited *source* in the submodule the model is built from is another
     matter, since the build would then not match the recorded hash, so it
     makes the whole side dirty.  Untracked files are ignored there only
@@ -778,15 +792,35 @@ def _check_dirty(path, model):
         Whether the worktree has changes that are not in a commit
     reason : str
         A phrase describing what was found, for the error message
+    untracked : list of str
+        Untracked paths that were tolerated, for the manifest
     """
-    status = check_output(
-        'git status --porcelain --ignore-submodules=dirty', cwd=path
+    # the two questions are asked separately rather than by parsing the
+    # prefixes of one `git status --porcelain`, whose leading space for an
+    # unstaged change does not survive being stripped
+    changed = check_output(
+        'git diff --name-only HEAD --ignore-submodules=dirty', cwd=path
     )
-    if status:
-        return True, 'has uncommitted or untracked changes'
+    tracked = [line for line in changed.split('\n') if line.strip()]
+    others = check_output('git ls-files --others --exclude-standard', cwd=path)
+    entries = [line for line in others.split('\n') if line.strip()]
+    in_package = [entry for entry in entries if _in_polaris_package(entry)]
+    untracked = [entry for entry in entries if not _in_polaris_package(entry)]
+
+    blocking = []
+    if tracked:
+        blocking.append(
+            f'uncommitted changes to tracked files ({_listed(tracked)})'
+        )
+    if in_package:
+        blocking.append(
+            f'untracked files in the polaris package ({_listed(in_package)})'
+        )
+    if blocking:
+        return True, f'has {" and ".join(blocking)}', []
 
     if model == NO_MODEL:
-        return False, ''
+        return False, '', untracked
 
     rel_path = SUBMODULE_PATHS[MODEL_SUBMODULES[model]]
     sub_path = os.path.join(path, rel_path)
@@ -794,7 +828,7 @@ def _check_dirty(path, model):
         # the model is built from the other side's submodule, so there is
         # no source here to be dirty; ``git status`` in the empty
         # directory would walk up and report on polaris again
-        return False, ''
+        return False, '', untracked
     command = 'git status --porcelain --ignore-submodules=dirty'
     kind = 'uncommitted or untracked changes'
     if model in IN_SOURCE_BUILDS:
@@ -802,8 +836,22 @@ def _check_dirty(path, model):
         kind = 'uncommitted changes to source'
     status = check_output(command, cwd=sub_path)
     if status:
-        return True, f'has {kind} in {rel_path}'
-    return False, ''
+        return True, f'has {kind} in {rel_path}', []
+    return False, '', untracked
+
+
+def _in_polaris_package(entry):
+    """Whether a path is inside the importable ``polaris`` package."""
+    entry = entry.strip('"')
+    return entry == 'polaris' or entry.startswith('polaris/')
+
+
+def _listed(entries, limit=5):
+    """List entries for an error message, cutting off a very long one."""
+    shown = ', '.join(entries[:limit])
+    if len(entries) > limit:
+        shown = f'{shown}, and {len(entries) - limit} more'
+    return shown
 
 
 def _require_load_script(worktree, load_script_name):

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -10,9 +10,13 @@ Two modes are supported for each side of a benchmark:
 
 ``adopt``
     Use an existing Polaris worktree (typically the one the developer is
-    already working in) exactly as it is found.  The adopted tree is
-    treated as strictly read-only: no fetch, checkout, submodule update,
-    reset or clean is ever run against it.
+    already working in) exactly as it is found.  This module never runs
+    fetch, checkout, submodule update, reset or clean against it.
+
+    Note that this is not the same as the tree being untouched.  Polaris
+    builds the component from ``--branch``, which for MPAS-Ocean is an
+    in-source ``make`` in the branch directory, and both build templates
+    run ``git submodule update --init --recursive`` there.
 """
 
 import os
@@ -243,8 +247,9 @@ def adopt(name, path, model, load_script_name, allow_dirty=False):
     """
     Validate and record the state of an existing Polaris worktree
 
-    The adopted worktree is never modified.  Only read-only ``git``
-    queries are run against it.
+    Only read-only ``git`` queries are run against the adopted worktree
+    here.  Polaris' own build still writes into it; see the note in the
+    module docstring.
 
     Parameters
     ----------

--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -343,15 +343,14 @@ def adopt(name, path, model, load_script_name, allow_dirty=False):
 
     state.pinned_shas = _pinned_submodule_shas(path, 'HEAD')
     state.submodule_shas = _submodule_shas(path)
-    state.dirty = _is_dirty(path)
+    state.dirty, reason = _check_dirty(path, model)
 
     if state.dirty and not allow_dirty:
         raise ValueError(
-            f'The adopted worktree\n  {path}\nhas uncommitted or untracked '
-            f'changes, so the benchmark would not be reproducible from the '
-            f'recorded commit hashes.  Commit or stash the changes, or '
-            f'rerun with --allow-dirty to record the run as '
-            f'non-reproducible.'
+            f'The adopted worktree\n  {path}\n{reason}, so the benchmark '
+            f'would not be reproducible from the recorded commit hashes.  '
+            f'Commit or stash the changes, or rerun with --allow-dirty to '
+            f'record the run as non-reproducible.'
         )
 
     state.load_script = _require_load_script(path, load_script_name)
@@ -660,6 +659,60 @@ def _is_dirty(repo_path):
     """Whether a work tree has uncommitted or untracked changes."""
     status = check_output('git status --porcelain', cwd=repo_path)
     return status != ''
+
+
+def _check_dirty(path, model):
+    """
+    Whether a worktree has changes a benchmark could not reproduce
+
+    A submodule that has been built in place is not dirty in any sense
+    that matters here.  Build products are regenerable from the recorded
+    commit hashes, and building in place is the normal state of a polaris
+    worktree, so a worktree that has ever built MPAS-Ocean would otherwise
+    be dirty forever.  Both checks therefore use
+    ``--ignore-submodules=dirty``, which ignores a submodule's work tree
+    but still reports one checked out at a commit other than the pinned
+    one.  That matters for jigsaw-python and MALI-Dev, which affect
+    results but are not among the hashes ``compare_shas`` records.
+
+    Edited *source* in the submodule the model is built from is another
+    matter, since the build would then not match the recorded hash, so it
+    makes the whole side dirty.  Only untracked files are ignored there,
+    since those are the build products.
+
+    Parameters
+    ----------
+    path : str
+        The path to the polaris worktree
+    model : str
+        The ``model`` value for this side of the benchmark
+
+    Returns
+    -------
+    dirty : bool
+        Whether the worktree has changes that are not in a commit
+    reason : str
+        A phrase describing what was found, for the error message
+    """
+    status = check_output(
+        'git status --porcelain --ignore-submodules=dirty', cwd=path
+    )
+    if status:
+        return True, 'has uncommitted or untracked changes'
+
+    if model == NO_MODEL:
+        return False, ''
+
+    rel_path = SUBMODULE_PATHS[MODEL_SUBMODULES[model]]
+    sub_path = os.path.join(path, rel_path)
+    status = check_output(
+        'git status --porcelain --ignore-submodules=dirty '
+        '--untracked-files=no',
+        cwd=sub_path,
+    )
+    if status:
+        return True, f'has uncommitted changes to source in {rel_path}'
+    return False, ''
 
 
 def _require_load_script(worktree, load_script_name):

--- a/utils/benchmark/polaris_run.py
+++ b/utils/benchmark/polaris_run.py
@@ -11,6 +11,14 @@ import re
 
 from shared import check_call, check_output, print_commands
 
+#: The job id reported for a submitted job during a dry run
+#:
+#: A dry run submits nothing, so there is no id to give the test side for
+#: its ``--dependency``.  Without a stand-in, the dry run prints an
+#: ``sbatch`` line that is not the one it would really run, which is how
+#: the dependency went unexamined long enough to ship as ``afterok``.
+DRY_RUN_JOB_ID = '<baseline job id>'
+
 
 def setup_and_run(
     state,
@@ -59,8 +67,8 @@ def setup_and_run(
     submit : bool, optional
         Whether to submit the job script rather than running in place
     dependency : str, optional
-        A Slurm job id that must complete successfully before this job
-        starts, used only when ``submit`` is set
+        A Slurm job id that must finish -- with or without failing tasks
+        -- before this job starts, used only when ``submit`` is set
     dry_run : bool, optional
         Whether to only report the commands that would be run
     logger : logging.Logger, optional
@@ -69,7 +77,10 @@ def setup_and_run(
     Returns
     -------
     job_id : str or None
-        The Slurm job id when ``submit`` is set, otherwise ``None``
+        The Slurm job id when ``submit`` is set, otherwise ``None``.  A
+        dry run submits nothing and reports ``DRY_RUN_JOB_ID``, so that
+        the ``sbatch`` line it prints for the test side is the one it
+        would really run.
     """
     full_setup = build_setup_command(
         setup_command=setup_command,
@@ -102,7 +113,20 @@ def setup_and_run(
         job_script = f'job_script.{get_suite_name(setup_command)}.sh'
         flags = ''
         if dependency is not None:
-            flags = f'--dependency=afterok:{dependency} '
+            # afterany, not afterok.  A suite exits non-zero when any
+            # task in it fails.  A baseline should not have failures, and
+            # one that does is worth fixing -- but a single failed task
+            # does not invalidate the rest, whose baseline output is on
+            # disk and comparable.  With afterok one failure cost the
+            # whole comparison, with nothing to do but run it all again.
+            #
+            # --kill-on-invalid-dep so that a dependency that can never be
+            # satisfied, as when the baseline job is cancelled, removes
+            # this job instead of leaving it queued forever.
+            flags = (
+                f'--dependency=afterany:{dependency} '
+                f'--kill-on-invalid-dep=yes '
+            )
         run_commands = (
             f'source {state.load_script} && '
             f'cd {work_dir} && '
@@ -119,7 +143,7 @@ def setup_and_run(
         logger=logger,
     )
     if dry_run:
-        return None
+        return DRY_RUN_JOB_ID if submit else None
 
     if not submit:
         check_call(run_commands, logger=logger)

--- a/utils/benchmark/polaris_run.py
+++ b/utils/benchmark/polaris_run.py
@@ -134,8 +134,17 @@ def setup_and_run(
         # over a worktree that was not part of the benchmark at all.
         run_commands = f'cd {work_dir} && sbatch {flags}{job_script}'
     else:
+        # source the load script from the worktree it belongs to, the way
+        # the setup command above does, and only then move to the work
+        # directory.  The script's version check imports polaris from the
+        # current directory, so sourcing it from wherever the driver
+        # happened to be launched compares this side against an unrelated
+        # worktree that shadows the import.
         run_commands = (
-            f'source {state.load_script} && cd {work_dir} && {run_command}'
+            f'cd {state.path} && '
+            f'source {state.load_script} && '
+            f'cd {work_dir} && '
+            f'{run_command}'
         )
 
     print_commands(

--- a/utils/benchmark/polaris_run.py
+++ b/utils/benchmark/polaris_run.py
@@ -1,0 +1,282 @@
+"""
+Build, set up and run Polaris for one side of a benchmark.
+
+This is the piece that is common to the baseline and test runs: the
+only difference between them is that the test run is given a baseline
+work directory with ``-b``.
+"""
+
+import os
+import re
+
+from shared import check_call, check_output, print_commands
+
+
+def setup_and_run(
+    state,
+    setup_command,
+    run_command,
+    work_dir,
+    component_path,
+    baseline_dir=None,
+    config_file=None,
+    clean_build=False,
+    rebuild=False,
+    submit=False,
+    dependency=None,
+    dry_run=False,
+    logger=None,
+):
+    """
+    Set up and run one side of a benchmark
+
+    The ``-p``, ``--branch``, ``-w``, ``-b``, ``-f`` and build flags are
+    appended automatically, so they must not appear in ``setup_command``.
+
+    Parameters
+    ----------
+    state : gitrepo.SourceState
+        The resolved state of this side of the benchmark
+    setup_command : str
+        A ``polaris setup`` or ``polaris suite`` command without paths
+    run_command : str
+        The command used to run Polaris in the work directory, typically
+        ``polaris serial``
+    work_dir : str
+        The work directory for this side of the benchmark
+    component_path : str
+        The path to build the component in or find an existing build at
+    baseline_dir : str, optional
+        A baseline work directory to validate against
+    config_file : str, optional
+        A config file to pass to Polaris with ``-f``
+    clean_build : bool, optional
+        Whether to start from a clean build directory
+    rebuild : bool, optional
+        Whether to force a build even if the component is already built
+    submit : bool, optional
+        Whether to submit the job script rather than running in place
+    dependency : str, optional
+        A Slurm job id that must complete successfully before this job
+        starts, used only when ``submit`` is set
+    dry_run : bool, optional
+        Whether to only report the commands that would be run
+    logger : logging.Logger, optional
+        A logger for command output
+
+    Returns
+    -------
+    job_id : str or None
+        The Slurm job id when ``submit`` is set, otherwise ``None``
+    """
+    full_setup = build_setup_command(
+        setup_command=setup_command,
+        state=state,
+        work_dir=work_dir,
+        component_path=component_path,
+        baseline_dir=baseline_dir,
+        config_file=config_file,
+        clean_build=clean_build,
+        rebuild=rebuild,
+    )
+
+    setup_commands = (
+        f'export NO_POLARIS_REINSTALL=true && '
+        f'cd {state.path} && '
+        f'source {state.load_script} && '
+        f'{full_setup}'
+    )
+
+    print_commands(
+        setup_commands,
+        header=f'Set up: {state.name}',
+        logger=logger,
+    )
+    if not dry_run:
+        os.makedirs(work_dir, exist_ok=True)
+        check_call(setup_commands, logger=logger)
+
+    if submit:
+        job_script = f'job_script.{get_suite_name(setup_command)}.sh'
+        flags = ''
+        if dependency is not None:
+            flags = f'--dependency=afterok:{dependency} '
+        run_commands = (
+            f'source {state.load_script} && '
+            f'cd {work_dir} && '
+            f'sbatch {flags}{job_script}'
+        )
+    else:
+        run_commands = (
+            f'source {state.load_script} && cd {work_dir} && {run_command}'
+        )
+
+    print_commands(
+        run_commands,
+        header=f'Run: {state.name}',
+        logger=logger,
+    )
+    if dry_run:
+        return None
+
+    if not submit:
+        check_call(run_commands, logger=logger)
+        return None
+
+    _check_job_script(work_dir, setup_command)
+    output = check_output(run_commands)
+    if logger is not None:
+        logger.info(output)
+    return _parse_job_id(output)
+
+
+def build_setup_command(
+    setup_command,
+    state,
+    work_dir,
+    component_path,
+    baseline_dir=None,
+    config_file=None,
+    clean_build=False,
+    rebuild=False,
+):
+    """
+    Append the paths and build flags to a Polaris setup command
+
+    Parameters
+    ----------
+    setup_command : str
+        A ``polaris setup`` or ``polaris suite`` command without paths
+    state : gitrepo.SourceState
+        The resolved state of this side of the benchmark
+    work_dir : str
+        The work directory for this side of the benchmark
+    component_path : str
+        The path to build the component in or find an existing build at
+    baseline_dir : str, optional
+        A baseline work directory to validate against
+    config_file : str, optional
+        A config file to pass to Polaris with ``-f``
+    clean_build : bool, optional
+        Whether to start from a clean build directory
+    rebuild : bool, optional
+        Whether to force a build even if the component is already built
+
+    Returns
+    -------
+    command : str
+        The full setup command
+
+    Raises
+    ------
+    ValueError
+        If the setup command already contains a flag that is added here
+    """
+    check_setup_command(setup_command)
+
+    command = (
+        f'{setup_command} '
+        f'--model {state.model} '
+        f'--branch {state.component_branch_path} '
+        f'-p {component_path} '
+        f'-w {work_dir}'
+    )
+    if baseline_dir is not None:
+        command = f'{command} -b {baseline_dir}'
+    if config_file is not None:
+        command = f'{command} -f {config_file}'
+    if clean_build:
+        command = f'{command} --clean_build'
+    elif rebuild:
+        command = f'{command} --build'
+    return command
+
+
+def check_setup_command(setup_command):
+    """
+    Check that a setup command does not contain automatically added flags
+
+    Parameters
+    ----------
+    setup_command : str
+        A ``polaris setup`` or ``polaris suite`` command
+
+    Raises
+    ------
+    ValueError
+        If a forbidden flag is present or the command is not a Polaris
+        setup or suite command
+    """
+    if not re.match(r'^polaris\s+(setup|suite)\b', setup_command.strip()):
+        raise ValueError(
+            f'setup_command must start with "polaris setup" or '
+            f'"polaris suite", got:\n  {setup_command}'
+        )
+
+    forbidden = [
+        '-p',
+        '--component_path',
+        '-w',
+        '--work_dir',
+        '-b',
+        '--baseline_dir',
+        '-f',
+        '--config_file',
+        '--branch',
+        '--model',
+        '--build',
+        '--clean_build',
+    ]
+    parts = setup_command.split()
+    found = [flag for flag in forbidden if flag in parts]
+    if found:
+        raise ValueError(
+            f'setup_command must not contain {", ".join(found)}; these are '
+            f'added automatically by the benchmark driver.'
+        )
+
+
+def get_suite_name(setup_command):
+    """
+    Get the suite name implied by a Polaris setup command
+
+    Parameters
+    ----------
+    setup_command : str
+        A ``polaris setup`` or ``polaris suite`` command
+
+    Returns
+    -------
+    suite : str
+        The suite name, which is ``custom`` for ``polaris setup``
+    """
+    parts = setup_command.split()
+    if parts[1] == 'suite':
+        for flag in ['-t', '--task_suite']:
+            if flag in parts:
+                index = parts.index(flag)
+                if len(parts) > index + 1:
+                    return parts[index + 1]
+        raise ValueError(
+            f'Could not determine the suite name from:\n  {setup_command}'
+        )
+    return 'custom'
+
+
+def _check_job_script(work_dir, setup_command):
+    """Raise an OSError if the expected job script is missing."""
+    job_script = f'job_script.{get_suite_name(setup_command)}.sh'
+    if not os.path.exists(os.path.join(work_dir, job_script)):
+        raise OSError(
+            f'Could not find the job script {job_script} in {work_dir}'
+        )
+
+
+def _parse_job_id(output):
+    """Get the Slurm job id from the output of ``sbatch``."""
+    match = re.search(r'Submitted batch job (\d+)', output)
+    if match is None:
+        raise ValueError(
+            f'Could not determine the job id from sbatch output:\n{output}'
+        )
+    return match.group(1)

--- a/utils/benchmark/polaris_run.py
+++ b/utils/benchmark/polaris_run.py
@@ -241,7 +241,12 @@ def check_setup_command(setup_command):
 
 def get_suite_name(setup_command):
     """
-    Get the suite name implied by a Polaris setup command
+    Get the name a Polaris setup command gives its suite
+
+    ``polaris suite`` takes the name from ``-t``.  ``polaris setup`` calls
+    its suite ``custom`` unless it is given ``--suite_name``, so the name
+    is required there: it is what tells one benchmark's baseline and job
+    script apart from another's.
 
     Parameters
     ----------
@@ -251,7 +256,12 @@ def get_suite_name(setup_command):
     Returns
     -------
     suite : str
-        The suite name, which is ``custom`` for ``polaris setup``
+        The suite name
+
+    Raises
+    ------
+    ValueError
+        If the command does not name its suite
     """
     parts = setup_command.split()
     if parts[1] == 'suite':
@@ -263,7 +273,18 @@ def get_suite_name(setup_command):
         raise ValueError(
             f'Could not determine the suite name from:\n  {setup_command}'
         )
-    return 'custom'
+
+    if '--suite_name' in parts:
+        index = parts.index('--suite_name')
+        if len(parts) > index + 1:
+            return parts[index + 1]
+
+    raise ValueError(
+        f'A "polaris setup" command must name its suite with --suite_name.  '
+        f'Polaris would otherwise call it "custom", so every benchmark set '
+        f'up this way would share one baseline directory and one job script '
+        f'name.  Got:\n  {setup_command}'
+    )
 
 
 def _check_job_script(work_dir, setup_command):

--- a/utils/benchmark/polaris_run.py
+++ b/utils/benchmark/polaris_run.py
@@ -30,8 +30,10 @@ def setup_and_run(
     """
     Set up and run one side of a benchmark
 
-    The ``-p``, ``--branch``, ``-w``, ``-b``, ``-f`` and build flags are
-    appended automatically, so they must not appear in ``setup_command``.
+    The ``-p``, ``--model``, ``--branch``, ``-w``, ``-b``, ``-f`` and build
+    flags are appended automatically, so they must not appear in
+    ``setup_command``.  ``--model`` and ``--branch`` are omitted when the
+    side's model is ``none``, since there is then no component to build.
 
     Parameters
     ----------
@@ -174,22 +176,23 @@ def build_setup_command(
     """
     check_setup_command(setup_command)
 
-    command = (
-        f'{setup_command} '
-        f'--model {state.model} '
-        f'--branch {state.component_branch_path} '
-        f'-p {component_path} '
-        f'-w {work_dir}'
-    )
+    parts = [setup_command]
+    # a side that builds no component has no model and no branch to pass on
+    branch = state.component_branch_path
+    if branch is not None:
+        parts.append(f'--model {state.model}')
+        parts.append(f'--branch {branch}')
+    parts.append(f'-p {component_path}')
+    parts.append(f'-w {work_dir}')
     if baseline_dir is not None:
-        command = f'{command} -b {baseline_dir}'
+        parts.append(f'-b {baseline_dir}')
     if config_file is not None:
-        command = f'{command} -f {config_file}'
+        parts.append(f'-f {config_file}')
     if clean_build:
-        command = f'{command} --clean_build'
+        parts.append('--clean_build')
     elif rebuild:
-        command = f'{command} --build'
-    return command
+        parts.append('--build')
+    return ' '.join(parts)
 
 
 def check_setup_command(setup_command):

--- a/utils/benchmark/polaris_run.py
+++ b/utils/benchmark/polaris_run.py
@@ -127,11 +127,12 @@ def setup_and_run(
                 f'--dependency=afterany:{dependency} '
                 f'--kill-on-invalid-dep=yes '
             )
-        run_commands = (
-            f'source {state.load_script} && '
-            f'cd {work_dir} && '
-            f'sbatch {flags}{job_script}'
-        )
+        # no load script: sbatch needs nothing from the polaris
+        # environment, and the job script sources it itself once the job
+        # starts.  Sourcing it here only added a way for submission to
+        # fail -- and did, when the load script's version check tripped
+        # over a worktree that was not part of the benchmark at all.
+        run_commands = f'cd {work_dir} && sbatch {flags}{job_script}'
     else:
         run_commands = (
             f'source {state.load_script} && cd {work_dir} && {run_command}'

--- a/utils/benchmark/shared.py
+++ b/utils/benchmark/shared.py
@@ -1,0 +1,158 @@
+"""
+Small helpers shared by the benchmark driver modules.
+
+These are intentionally self-contained so that ``utils/benchmark`` does
+not depend on the other utilities in ``utils/``.
+"""
+
+import logging
+import os
+import subprocess
+import sys
+
+
+def to_abs(path, base_path):
+    """
+    Convert a relative path to an absolute path
+
+    Parameters
+    ----------
+    path : str
+        A relative or absolute path
+    base_path : str
+        The base path to use to convert relative paths to absolute paths
+
+    Returns
+    -------
+    path : str
+        The original ``path`` as an absolute path
+    """
+    if not os.path.isabs(path):
+        path = os.path.normpath(os.path.join(base_path, path))
+    return path
+
+
+def get_logger(name, log_filename=None):
+    """
+    Get a logger that writes to stdout and, optionally, to a log file
+
+    Parameters
+    ----------
+    name : str
+        The name of the logger
+    log_filename : str, optional
+        The name of a file to write log output to in addition to stdout
+
+    Returns
+    -------
+    logger : logging.Logger
+        The logger
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    # start fresh in case this logger was already configured
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+
+    formatter = logging.Formatter('%(message)s')
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    if log_filename is not None:
+        directory = os.path.dirname(os.path.abspath(log_filename))
+        os.makedirs(directory, exist_ok=True)
+        file_handler = logging.FileHandler(log_filename, 'w')
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    return logger
+
+
+def check_call(args, logger=None, **kwargs):
+    """
+    Run a command, sending output to a logger if one is provided
+
+    Parameters
+    ----------
+    args : str
+        The command to run in a shell
+    logger : logging.Logger, optional
+        A logger to send output to
+    kwargs
+        Keyword arguments passed on to ``subprocess``
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the command returns a non-zero exit code
+    """
+    if logger is None:
+        subprocess.check_call(args, shell=True, **kwargs)
+        return
+
+    process = subprocess.Popen(
+        args,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        **kwargs,
+    )
+    assert process.stdout is not None
+    for line in process.stdout:
+        logger.info(line.decode('utf-8', errors='replace').rstrip('\n'))
+    process.wait()
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(process.returncode, args)
+
+
+def check_output(args, cwd=None):
+    """
+    Run a command and return its stripped standard output
+
+    Parameters
+    ----------
+    args : str
+        The command to run in a shell
+    cwd : str, optional
+        The directory to run the command in
+
+    Returns
+    -------
+    output : str
+        The standard output of the command with whitespace stripped
+    """
+    output = subprocess.check_output(
+        args, shell=True, cwd=cwd, stderr=subprocess.DEVNULL
+    )
+    return output.decode('utf-8').strip()
+
+
+def print_commands(commands, header=None, logger=None):
+    """
+    Print a chain of shell commands in a readable form
+
+    Parameters
+    ----------
+    commands : str
+        A command or chain of commands joined by ``&&``
+    header : str, optional
+        A header to print above the commands
+    logger : logging.Logger, optional
+        A logger to print to instead of stdout
+    """
+    lines = []
+    if header is not None:
+        lines.append(72 * '-')
+        lines.append(header)
+        lines.append(72 * '-')
+    pretty = commands.replace(' && ', '\n  ')
+    lines.append(f'  {pretty}')
+    text = '\n'.join(lines)
+    if logger is None:
+        print(text)
+    else:
+        logger.info(text)

--- a/utils/benchmark/shared.py
+++ b/utils/benchmark/shared.py
@@ -113,6 +113,14 @@ def check_output(args, cwd=None):
     """
     Run a command and return its stripped standard output
 
+    Standard error is captured rather than discarded, and is attached to
+    the exception raised on failure.  Capturing is not the same as
+    printing: several callers run a command they expect to fail, such as
+    probing a ref that may not exist, and would fill the terminal with
+    git errors if the stream were simply inherited.  Attaching it puts
+    the message where a caller that does *not* expect the failure can
+    report it, and leaves it unread where one does.
+
     Parameters
     ----------
     args : str
@@ -124,11 +132,29 @@ def check_output(args, cwd=None):
     -------
     output : str
         The standard output of the command with whitespace stripped
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the command returns a non-zero exit code, with its standard
+        output and standard error attached
     """
-    output = subprocess.check_output(
-        args, shell=True, cwd=cwd, stderr=subprocess.DEVNULL
+    process = subprocess.run(
+        args,
+        shell=True,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    return output.decode('utf-8').strip()
+    output = process.stdout.decode('utf-8', errors='replace')
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(
+            process.returncode,
+            args,
+            output=output,
+            stderr=process.stderr.decode('utf-8', errors='replace'),
+        )
+    return output.strip()
 
 
 def print_commands(commands, header=None, logger=None):


### PR DESCRIPTION
Add a guardrailed baseline-benchmarking driver for polaris, Omega and E3SM branches, reducing token usage by ~5x.

### What

Adds `utils/benchmark`, a driver that benchmarks a polaris, Omega, E3SM or MALI branch against a baseline using a polaris task or suite. It resolves two sides ([baseline] and [test]), provisions each as a detached git worktree or adopts an existing checkout, initializes submodules, sources the load script, sets up and builds both sides, and passes the baseline work directory to the test side with `-b` so that polaris' own validation performs the comparison.

`benchmark.py` — CLI, config handling, guardrails, orchestration
`gitrepo.py` — fork/ref resolution, worktree provisioning, read-only adoption
`polaris_run.py` — setup/build/run and job submission
`shared.py` — logging and manifest helpers
example.cfg, [README.md](vscode-file://vscode-app/private/var/folders/hz/25xh0y157dj_c_kl1lf6yd30000y50/T/AppTranslocation/772767C9-3A78-4521-8815-AC9883938053/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### Why

Setting up a baseline comparison by hand is a long sequence of git, environment, setup and build steps, and mistakes in it are only discovered after an expensive build. Consolidating it into one driver makes the comparison reproducible from recorded commit hashes and makes failures cheap.

It is also substantially cheaper to drive with an AI agent. Estimated cumulative context for a single baseline comparison drops from roughly 580k tokens (22 exploratory shell turns, two 31.6 kB build logs, retry loops) to roughly 100k (7 turns, a --dry-run plan and a manifest.json) — a ~5–6× reduction. Reused baselines cut the cost of each subsequent iteration by a further ~10×.

### Guardrails

The driver refuses to run, before anything is built, when the two sides are identical, differ in more than one repository, use different load scripts or models, or when an adopted worktree is dirty or missing a required submodule. Each has an explicit override (`--allow-multiple-changes`, `--allow-env-mismatch`, `--allow-dirty`); `--allow-dirty` marks the run `reproducible: false` and disables baseline caching. Adopted worktrees are strictly read-only — no fetch, checkout, submodule update, reset or clean — and `./deploy.py` is never run on the developer's behalf.

### Reproducibility

`manifest.json` records both sides in full: mode, path, fork, ref, commit hashes, pinned versus actual submodule hashes, overrides, dirty flag, load script, the commands run, the directories used and which repositories differ.

### Docs and agent instructions

New `docs/developers_guide/benchmarking.md`, added to the Developer's Guide toctree
Cross-reference added from `docs/developers_guide/framework/validation.md`
[benchmark.instructions.md](vscode-file://vscode-app/private/var/folders/hz/25xh0y157dj_c_kl1lf6yd30000y50/T/AppTranslocation/772767C9-3A78-4521-8815-AC9883938053/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), scoped to utils/benchmark/**: always --dry-run first, never mutate an adopted worktree, never weaken a guardrail, never run ./deploy.py, stop and report on build failure rather than retrying

### Testing

Verified with `--dry-run` on Chrysalis for worktree/worktree and existing/worktree pairings, and confirmed that each guardrail fires before any build.

### Not included

Result collection and report generation are deliberately out of scope; polaris writes its validation output to `case_outputs` in the test work directory.

Checklist
* [X] Developer's Guide has been updated
* [X] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes