### PR TITLE
Make analysis steps safe for task-parallelism

### DIFF
--- a/docs/design_docs/index.md
+++ b/docs/design_docs/index.md
@@ -10,6 +10,7 @@ land_locked_cells
 overflow_nonlinear_eos
 pstar_init
 shared_steps
+task_parallel_analysis_steps
 unified_base_mesh
 unified_mesh_prepare_coastline
 unified_mesh_prepare_river_network

--- a/docs/design_docs/task_parallel_analysis_steps.md
+++ b/docs/design_docs/task_parallel_analysis_steps.md
@@ -1,0 +1,410 @@
+# Task-Parallel-Safe Analysis Steps in Polaris
+
+Creation date: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+## Summary
+
+Polaris is adding task parallelism. The near-term driver is building
+analysis capability in Polaris equivalent to MPAS-Analysis, for Omega and
+possibly MPAS-Ocean. That work is heavily Python, and it is the workload
+that most needs to run concurrently: MPAS-Analysis implements task
+parallelism with `multiprocessing.Process`, which cannot span nodes, and
+that single-node ceiling is a known choke point at high resolution --
+exactly Omega's target.
+
+Whether Polaris can run analysis steps concurrently is only partly a
+property of the scheduler. It is equally a property of the steps. A step
+that changes the working directory, mutates module-level configuration or
+writes to a shared path cannot safely run beside another step in the same
+process, and cannot be dispatched to a worker on another node at all.
+
+This document sets out the properties an analysis step must have in order to
+be scheduled concurrently, and proposes adopting them as groundrules now,
+while the analysis capability is still being designed. The cost of adopting
+them up front is close to zero; the cost of retrofitting them later is
+rewriting every analysis step already written.
+
+These rules are deliberately written so that a conforming step does not need
+to know which executor runs it. The same step should be runnable in the
+scheduler process, in a subprocess, or in a distributed worker on another
+node, without modification.
+
+Existing Polaris code does not follow these rules today, and this document
+does not require it to. The framework itself does `os.chdir(step.work_dir)`
+around each step, sets `mpas_tools.io.default_format` and
+`default_engine` as process globals, and `polaris.viz` assigns
+`plt.rcParams['savefig.dpi']`. Those are safe under today's one-step-at-a-time
+execution and are called out here because they are the concrete patterns new
+analysis steps must avoid, and because the framework will have to offer
+alternatives before it can require them.
+
+Success means a newly written analysis step, following these rules, can be
+run concurrently with other steps -- including on a different node -- with no
+change to the step, no interference between steps, and identical results to
+running it alone.
+
+## Requirements
+
+### Requirement: No Process-Global State Mutation
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+An analysis step shall not mutate state that is shared by the whole process.
+
+This includes the current working directory, environment variables,
+module-level configuration in third-party libraries, and global
+plotting state. Any of
+these makes two steps running in one process interfere with each other, and
+the interference is timing-dependent, so it surfaces as intermittent wrong
+answers rather than as a clean failure.
+
+Where a step needs behavior that is conventionally set globally, the
+framework shall provide a scoped alternative.
+
+### Requirement: Explicit Configuration
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+An analysis step shall obtain all of its configuration through objects
+passed to it, and shall not depend on configuration having been applied to
+the process by some earlier step or by the framework's startup.
+
+A step dispatched to a worker on another node begins in a process that never
+ran that startup, so any dependence on it is a latent failure that appears
+only once the step is scheduled remotely.
+
+### Requirement: Working-Directory Independence
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+An analysis step shall address every file by an explicit path and shall not
+depend on the process's working directory being its own work directory.
+
+The step shall continue to be given a work directory, and relative paths
+within the step's own definition of its inputs and outputs remain the normal
+way to describe them; the requirement is that resolution to an absolute path
+happen through the step rather than through `os.getcwd()`.
+
+### Requirement: Isolated Outputs and Temporary Files
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+An analysis step shall write only within its own work directory, and shall
+place temporary files there rather than in a shared location.
+
+Two concurrent steps must not be able to choose the same temporary path.
+Steps shall not write into another step's work directory, and shall not
+depend on being able to read a file that a concurrently running step is
+still writing.
+
+### Requirement: Logging Through the Step's Logger
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+An analysis step shall emit output through the logger it is given, and shall
+not write to `stdout`, `stderr` or the root logger directly.
+
+When several steps run at once, output written to shared streams interleaves,
+and the resulting log cannot be attributed to a step. This requirement is
+what makes per-step logs remain readable under concurrency.
+
+### Requirement: Declared Resources
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+An analysis step shall declare the resources it needs, including CPU cores
+and memory, so that the scheduler can decide how many steps may run at once.
+
+Memory is the requirement that distinguishes analysis steps from most
+existing Polaris steps. At high resolution an analysis step may need a large
+fraction of a node, and a scheduler that packs by cores alone will
+oversubscribe memory and fail. A step that cannot fit in a node's memory
+shall be reported as infeasible rather than attempted.
+
+### Requirement: Dispatchable to a Remote Worker
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+An analysis step shall be able to be sent to a worker process, potentially
+on another node, and run there.
+
+Whatever the framework must transfer in order to do this shall be
+transferable. In practice this means a step shall not hold open file
+handles, live network connections, database handles or other unserializable
+state across the boundary between being defined and being run.
+
+### Requirement: Restartable and Idempotent
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Rerunning an analysis step that has already completed shall be safe, and
+shall produce the same result.
+
+Under concurrency a run is more likely to be interrupted partway, because
+more work is in flight when a failure or a wall-clock limit arrives. Steps
+shall not accumulate state by appending to existing outputs, and shall
+tolerate the presence of outputs from a previous partial run.
+
+### Requirement: Bounded Process Launching
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+An analysis step shall not launch more parallel work than it declared.
+
+A step that internally starts its own pool of processes or threads sized to
+the whole machine will oversubscribe the node as soon as a second step runs
+beside it. Any internal parallelism shall be sized from the resources the
+step was given, not from the machine.
+
+## Algorithm Design
+
+### Algorithm Design: Scoped Alternatives to Global State
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The framework should offer a scoped replacement for each global that steps
+currently rely on, so that following the rules is easier than breaking them.
+
+For NetCDF output format and engine, the framework should provide the values
+through the step rather than through `mpas_tools.io` module globals, and
+should pass them explicitly at each write. Setting the module globals inside
+a worker, as the Phase 1 task-parallel work had to do, is a workaround that
+only holds while one step runs per worker.
+
+For plotting, the framework should offer a context manager that applies
+Matplotlib settings for the duration of a plot and restores them afterwards,
+rather than steps assigning to `plt.rcParams`. Matplotlib's own
+`plt.rc_context` is sufficient. Steps should also use the object-oriented
+Figure API rather than the implicit `pyplot` current-figure state, which is
+process-global.
+
+For temporary files, the framework should provide a helper that creates them
+under the step's work directory, so that the natural thing to write is also
+the isolated thing.
+
+### Algorithm Design: Resource Declaration for Analysis Steps
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Analysis steps should express CPU needs the way non-MPI work actually uses
+them -- as a core count for the step -- rather than through MPI task counts.
+Memory should be expressed as a target and a minimum, in the same style as
+the existing target-and-minimum resource fields, so that the scheduler can
+run a step in less memory when the allocation is tight and can report a
+step as infeasible when even the minimum does not fit.
+
+The measurement needed to set these numbers sensibly is being gathered
+separately, by instrumenting a high-resolution MPAS-Analysis run for
+per-task duration, peak resident memory and dependency-graph width. Default
+values should not be guessed before that data exists.
+
+### Algorithm Design: Making Conformance Checkable
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Rules that are only written down are not adopted. Most of these rules can be
+checked mechanically, and should be.
+
+Working-directory independence, global-state mutation and unbounded process
+launching can be checked at runtime by running a step with the process
+working directory set somewhere unrelated, snapshotting the globals a step is
+forbidden to touch, and comparing them afterwards. Dispatchability can be
+checked by round-tripping the step through serialization before running it.
+Isolation can be checked by comparing the set of files a step wrote against
+its declared outputs and its work directory.
+
+These checks are cheap enough to run as part of ordinary testing, and are
+most valuable while the analysis capability is small.
+
+## Implementation
+
+### Implementation: Framework Support
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The framework changes implied by this document are small and independent of
+the scheduler work:
+
+- a scoped IO-configuration path that does not depend on
+  `mpas_tools.io` module globals;
+- a Matplotlib context manager in `polaris.viz`, replacing the
+  assignment to `plt.rcParams['savefig.dpi']` in
+  `polaris/viz/spherical.py`;
+- a step method that returns a temporary directory inside the step's work
+  directory;
+- memory fields alongside the existing resource fields on `Step`.
+
+None of these require the task-parallel scheduler to exist, and all of them
+are useful on their own.
+
+### Implementation: Conformance Checks
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A conformance helper should run a step under adverse conditions and assert
+the rules. In outline:
+
+```python
+def check_task_parallel_safe(step):
+    """Run a step the way a remote worker would, and check it behaves."""
+    before = snapshot_process_state()   # cwd, env, mpas_tools.io, rcParams
+    step = round_trip(step)             # must survive serialization
+    run_from_unrelated_directory(step)
+    after = snapshot_process_state()
+    assert before == after
+    assert files_written(step) <= allowed_paths(step)
+```
+
+Steps that are known not to conform yet should be marked, so the check can
+be required of new analysis steps without first fixing every existing step.
+This is the same shape as the `task_parallelism_allowed` metadata already
+proposed for the scheduler, and the two should use one mechanism rather
+than two.
+
+### Implementation: Adoption
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+These rules should apply to new analysis steps from the start. Existing
+Polaris steps should not be required to conform until there is a reason:
+they run one at a time today and are correct under that assumption.
+
+The order that matters is that the rules exist before the analysis
+capability is written. If the analysis steps are written first and the rules
+come later, the outcome is a port of Polaris analysis to meet the needs of
+task parallelism -- which is the specific outcome this document exists to
+avoid.
+
+## Testing
+
+### Testing and Validation: Conformance
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Unit tests shall cover the conformance helper itself, using deliberately
+non-conforming steps: one that changes the working directory, one that
+mutates a forbidden global, one that writes outside its work directory, one
+that cannot be serialized and one that launches unbounded parallelism. Each
+shall be detected.
+
+Every new analysis step shall have a test that runs it through the
+conformance helper.
+
+### Testing and Validation: Concurrent Execution
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Once the scheduler can run steps concurrently, a test shall run a set of
+conforming analysis steps both serially and concurrently and compare the
+outputs, which shall be identical.
+
+A test shall also run steps concurrently with deliberately interleaved
+timing, so that two steps are inside their plotting and IO code at the same
+time, since that is where shared global state would otherwise surface.
+
+### Testing and Validation: Resource Declaration
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Tests shall verify that a step declaring more memory than a node has is
+reported as infeasible rather than attempted, and that the scheduler does
+not pack steps whose combined declared memory exceeds what is available.
+
+Validation on a real workload shall compare declared memory against measured
+peak resident memory, since a declaration that is badly wrong is worse than
+no declaration: it will either waste the allocation or oversubscribe it.

--- a/docs/design_docs/task_parallel_analysis_steps.md
+++ b/docs/design_docs/task_parallel_analysis_steps.md
@@ -21,7 +21,7 @@ Whether Polaris can run analysis steps concurrently is only partly a
 property of the scheduler. It is equally a property of the steps. A step
 that changes the working directory, mutates module-level configuration or
 writes to a shared path cannot safely run beside another step in the same
-process, and cannot be dispatched to a worker on another node at all.
+process.
 
 This document sets out the properties an analysis step must have in order to
 be scheduled concurrently, and proposes adopting them as groundrules now,
@@ -29,19 +29,42 @@ while the analysis capability is still being designed. The cost of adopting
 them up front is close to zero; the cost of retrofitting them later is
 rewriting every analysis step already written.
 
-These rules are deliberately written so that a conforming step does not need
-to know which executor runs it. The same step should be runnable in the
-scheduler process, in a subprocess, or in a distributed worker on another
-node, without modification.
+### What Polaris already guarantees
 
-Existing Polaris code does not follow these rules today, and this document
-does not require it to. The framework itself does `os.chdir(step.work_dir)`
-around each step, sets `mpas_tools.io.default_format` and
-`default_engine` as process globals, and `polaris.viz` assigns
-`plt.rcParams['savefig.dpi']`. Those are safe under today's one-step-at-a-time
-execution and are called out here because they are the concrete patterns new
-analysis steps must avoid, and because the framework will have to offer
-alternatives before it can require them.
+Much of what a distributed executor would otherwise have to demand of a step
+is already true, because of how Polaris sets steps up and runs them. These
+are stated here so the requirements below do not repeat them:
+
+- **Steps are already serializable.** `polaris setup` builds the step objects
+  in one process and pickles each one to `step.pickle` in its work
+  directory; `polaris serial` unpickles it in a different process to run it.
+  A step that held an open file handle, a live connection or any other
+  unserializable state would already fail at setup today --
+  `ModelStep` clears its streams tree before pickling for exactly this
+  reason. Sending a step to a worker on another node adds no new
+  requirement.
+- **Configuration already comes from a file, not from process state.** Each
+  step's config file is written into the work directory at setup and re-read
+  with `setup_config()` immediately before the step runs. A step run in a
+  fresh process gets the same config as one run in the scheduler process.
+- **Declared inputs and outputs are already absolute paths.**
+  `Step.process_inputs_and_outputs()` resolves them against the step's work
+  directory at setup, so `self.inputs` and `self.outputs` do not depend on
+  the process working directory.
+- **Every step already has its own work directory and its own logger,** both
+  assigned by the framework.
+- **`Step.max_memory` already exists,** added as a placeholder for task
+  parallelism.
+
+What is *not* already handled is process-global state. The framework sets
+`mpas_tools.io.default_format` and `default_engine` as process globals
+before running, and `polaris.viz` assigns
+`plt.rcParams['savefig.dpi']`. Steps open bare relative filenames in
+`run()` and rely on the framework's `os.chdir(step.work_dir)` to make
+that work. Those are safe under today's one-step-at-a-time execution, and
+are called out here because they are the concrete patterns new analysis
+steps must avoid, and because the framework will have to offer alternatives
+before it can require them.
 
 Success means a newly written analysis step, following these rules, can be
 run concurrently with other steps -- including on a different node -- with no
@@ -62,31 +85,15 @@ Contributors:
 An analysis step shall not mutate state that is shared by the whole process.
 
 This includes the current working directory, environment variables,
-module-level configuration in third-party libraries, and global
-plotting state. Any of
-these makes two steps running in one process interfere with each other, and
-the interference is timing-dependent, so it surfaces as intermittent wrong
-answers rather than as a clean failure.
+module-level configuration in third-party libraries such as
+`mpas_tools.io`, and global plotting state such as `plt.rcParams` and the
+`pyplot` current figure. Any of these makes two steps running in one
+process interfere with each other, and the interference is
+timing-dependent, so it surfaces as intermittent wrong answers rather than
+as a clean failure.
 
 Where a step needs behavior that is conventionally set globally, the
 framework shall provide a scoped alternative.
-
-### Requirement: Explicit Configuration
-
-Date last modified: 2026/08/23
-
-Contributors:
-
-- Xylar Asay-Davis
-- Claude
-
-An analysis step shall obtain all of its configuration through objects
-passed to it, and shall not depend on configuration having been applied to
-the process by some earlier step or by the framework's startup.
-
-A step dispatched to a worker on another node begins in a process that never
-ran that startup, so any dependence on it is a latent failure that appears
-only once the step is scheduled remotely.
 
 ### Requirement: Working-Directory Independence
 
@@ -100,12 +107,13 @@ Contributors:
 An analysis step shall address every file by an explicit path and shall not
 depend on the process's working directory being its own work directory.
 
-The step shall continue to be given a work directory, and relative paths
-within the step's own definition of its inputs and outputs remain the normal
-way to describe them; the requirement is that resolution to an absolute path
-happen through the step rather than through `os.getcwd()`.
+Relative paths in the step's declaration of its inputs and outputs remain
+the normal way to describe them, and setup already resolves those to
+absolute paths. The requirement is about the body of `run()`: a filename
+opened there shall be resolved through the step rather than left to
+`os.getcwd()`.
 
-### Requirement: Isolated Outputs and Temporary Files
+### Requirement: Temporary Files in the Step's Work Directory
 
 Date last modified: 2026/08/23
 
@@ -114,13 +122,15 @@ Contributors:
 - Xylar Asay-Davis
 - Claude
 
-An analysis step shall write only within its own work directory, and shall
-place temporary files there rather than in a shared location.
+An analysis step shall place temporary files in its own work directory
+rather than in a shared location such as `/tmp` or the base work
+directory.
 
-Two concurrent steps must not be able to choose the same temporary path.
-Steps shall not write into another step's work directory, and shall not
-depend on being able to read a file that a concurrently running step is
-still writing.
+Each step already has a work directory of its own, so writing there is
+enough to guarantee that two concurrent steps cannot choose the same
+temporary path. A step shall likewise not write into another step's work
+directory, and shall not depend on reading a file that a concurrently
+running step is still writing.
 
 ### Requirement: Logging Through the Step's Logger
 
@@ -131,8 +141,9 @@ Contributors:
 - Xylar Asay-Davis
 - Claude
 
-An analysis step shall emit output through the logger it is given, and shall
-not write to `stdout`, `stderr` or the root logger directly.
+An analysis step shall emit output through the logger it is given in
+`self.logger`, and shall not write to `stdout`, `stderr` or the root
+logger directly.
 
 When several steps run at once, output written to shared streams interleaves,
 and the resulting log cannot be attributed to a step. This requirement is
@@ -155,40 +166,6 @@ existing Polaris steps. At high resolution an analysis step may need a large
 fraction of a node, and a scheduler that packs by cores alone will
 oversubscribe memory and fail. A step that cannot fit in a node's memory
 shall be reported as infeasible rather than attempted.
-
-### Requirement: Dispatchable to a Remote Worker
-
-Date last modified: 2026/08/23
-
-Contributors:
-
-- Xylar Asay-Davis
-- Claude
-
-An analysis step shall be able to be sent to a worker process, potentially
-on another node, and run there.
-
-Whatever the framework must transfer in order to do this shall be
-transferable. In practice this means a step shall not hold open file
-handles, live network connections, database handles or other unserializable
-state across the boundary between being defined and being run.
-
-### Requirement: Restartable and Idempotent
-
-Date last modified: 2026/08/23
-
-Contributors:
-
-- Xylar Asay-Davis
-- Claude
-
-Rerunning an analysis step that has already completed shall be safe, and
-shall produce the same result.
-
-Under concurrency a run is more likely to be interrupted partway, because
-more work is in flight when a failure or a wall-clock limit arrives. Steps
-shall not accumulate state by appending to existing outputs, and shall
-tolerate the presence of outputs from a previous partial run.
 
 ### Requirement: Bounded Process Launching
 
@@ -251,7 +228,8 @@ them -- as a core count for the step -- rather than through MPI task counts.
 Memory should be expressed as a target and a minimum, in the same style as
 the existing target-and-minimum resource fields, so that the scheduler can
 run a step in less memory when the allocation is tight and can report a
-step as infeasible when even the minimum does not fit.
+step as infeasible when even the minimum does not fit. `Step.max_memory`
+is the placeholder this should build on.
 
 The measurement needed to set these numbers sensibly is being gathered
 separately, by instrumenting a high-resolution MPAS-Analysis run for
@@ -273,10 +251,10 @@ checked mechanically, and should be.
 Working-directory independence, global-state mutation and unbounded process
 launching can be checked at runtime by running a step with the process
 working directory set somewhere unrelated, snapshotting the globals a step is
-forbidden to touch, and comparing them afterwards. Dispatchability can be
-checked by round-tripping the step through serialization before running it.
-Isolation can be checked by comparing the set of files a step wrote against
-its declared outputs and its work directory.
+forbidden to touch, and comparing them afterwards. Isolation can be checked
+by comparing the set of files a step wrote against its declared outputs and
+its work directory. Serializability needs no check of its own, since setup
+already pickles every step.
 
 These checks are cheap enough to run as part of ordinary testing, and are
 most valuable while the analysis capability is small.
@@ -302,7 +280,8 @@ the scheduler work:
   `polaris/viz/spherical.py`;
 - a step method that returns a temporary directory inside the step's work
   directory;
-- memory fields alongside the existing resource fields on `Step`.
+- target and minimum memory fields on `Step`, alongside the existing
+  `max_memory` placeholder and the other resource fields.
 
 None of these require the task-parallel scheduler to exist, and all of them
 are useful on their own.
@@ -323,7 +302,6 @@ the rules. In outline:
 def check_task_parallel_safe(step):
     """Run a step the way a remote worker would, and check it behaves."""
     before = snapshot_process_state()   # cwd, env, mpas_tools.io, rcParams
-    step = round_trip(step)             # must survive serialization
     run_from_unrelated_directory(step)
     after = snapshot_process_state()
     assert before == after
@@ -368,9 +346,8 @@ Contributors:
 
 Unit tests shall cover the conformance helper itself, using deliberately
 non-conforming steps: one that changes the working directory, one that
-mutates a forbidden global, one that writes outside its work directory, one
-that cannot be serialized and one that launches unbounded parallelism. Each
-shall be detected.
+mutates a forbidden global, one that writes outside its work directory and
+one that launches unbounded parallelism. Each shall be detected.
 
 Every new analysis step shall have a test that runs it through the
 conformance helper.

--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -160,6 +160,7 @@ seaice/api
    Step.setup
    Step.runtime_setup
    Step.run
+   Step.work_path
    Step.add_input_file
    Step.add_output_file
    Step.add_dependency

--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -446,10 +446,10 @@ seaice/api
    determine_time_variable
    get_projection
    get_viz_defaults
+   mplstyle_context
    plot_horiz_field
    plot_global_lat_lon_field
    plot_global_mpas_field
-   use_mplstyle
 ```
 
 ### yaml

--- a/docs/developers_guide/framework/index.md
+++ b/docs/developers_guide/framework/index.md
@@ -30,6 +30,7 @@ build
 parallel
 provenance
 remapping
+task_parallelism
 validation
 visualization
 ```

--- a/docs/developers_guide/framework/task_parallelism.md
+++ b/docs/developers_guide/framework/task_parallelism.md
@@ -145,8 +145,14 @@ in `polaris.viz` -- and the shared building blocks have been converted:
 `polaris.viz`, `polaris.mesh.spherical`, and
 `polaris.ocean.convergence.analysis`.
 
-Most task-level analysis and visualization steps have **not** been converted;
-they still open files by bare relative name and use the `pyplot` current
-figure.  That is correct under today's one-step-at-a-time execution and will be
-addressed as the analysis capability is built out.  Do not copy those steps as
-a template for new work.
+One task-level step,
+{py:class}`polaris.tasks.seaice.single_column.standard_physics.viz.Viz`, has
+been converted as a worked example of what a conforming step looks like: it is
+small, it plots, and it reads and writes files, so it exercises most of the
+rules above in one place.
+
+Most other task-level analysis and visualization steps have **not** been
+converted; they still open files by bare relative name and use the `pyplot`
+current figure.  That is correct under today's one-step-at-a-time execution and
+will be addressed as the analysis capability is built out.  Do not copy those
+steps as a template for new work.

--- a/docs/developers_guide/framework/task_parallelism.md
+++ b/docs/developers_guide/framework/task_parallelism.md
@@ -1,0 +1,152 @@
+(dev-task-parallelism)=
+
+# Writing task-parallel-safe steps
+
+Polaris runs one step at a time today, and a step that changes the process
+working directory or mutates a module-level global is correct under that
+assumption.  It stops being correct as soon as two steps run concurrently in
+one process, and the failure is timing-dependent: it shows up as intermittent
+wrong answers rather than as a clean error.
+
+Polaris is adding task parallelism so that analysis steps, which are heavily
+Python and are the workload that most needs to run concurrently, can be
+scheduled together and across nodes.  The rules below are what a step must
+satisfy to be scheduled that way.  They are cheap to follow when a step is
+first written and expensive to retrofit, so **new analysis steps should follow
+them from the start**.  Existing steps are being converted only where they are
+shared building blocks; see {ref}`dev-task-parallelism-status`.
+
+The reasoning behind the rules, and the scheduler work they support, is in the
+{ref}`design documents <design-docs>`, under
+"Task-Parallel-Safe Analysis Steps in Polaris".
+
+## What Polaris already guarantees
+
+Several properties a distributed executor would otherwise have to demand are
+already true, so a step does not have to do anything special about them:
+
+- **Steps are already serializable.**  `polaris setup` pickles each step to
+  `step.pickle` in its work directory and `polaris serial` unpickles it in a
+  different process.  A step holding an open file handle or a live connection
+  would already fail today.
+- **Config options already come from a file.**  Each step's config file is
+  written into its work directory at setup and re-read immediately before the
+  step runs, so a step run in a fresh process sees the same config.
+- **Declared inputs and outputs are already absolute.**
+  `Step.process_inputs_and_outputs()` resolves the `filename` arguments to
+  `add_input_file()` and `add_output_file()` against the step's work directory
+  at setup, so `self.inputs` and `self.outputs` do not depend on the process
+  working directory.
+- **Every step already has its own work directory and its own logger.**
+
+## The rules
+
+### Address files through the step, not the working directory
+
+Polaris changes the process working directory to the step's work directory
+before calling `run()`, so a bare relative filename works today.  The working
+directory is process-global, so it cannot stay pointed at your step once
+another step is running beside you.
+
+Build paths with {py:meth}`polaris.Step.work_path()` instead:
+
+```python
+class Viz(Step):
+    def run(self):
+        with xr.open_dataset(self.work_path('output.nc')) as ds:
+            ...
+        fig.savefig(self.work_path('comparison.png'))
+```
+
+This applies to paths handed to subprocesses and to third-party libraries as
+well, since those inherit or resolve against the same working directory.  The
+`filename` arguments to `add_input_file()` and `add_output_file()` are
+unaffected -- they are relative by design and already resolved at setup.
+
+### Do not mutate process-global state
+
+A step must not change anything shared by the whole process: the working
+directory, environment variables, module-level configuration in libraries such
+as `mpas_tools.io`, or global plotting state.  In particular:
+
+- Do not assign to `plt.rcParams` or call `plt.style.use()`.  Use the
+  {py:func}`polaris.viz.mplstyle_context()` context manager, which applies the
+  Polaris style (and an optional `dpi`) for the duration of a `with` block and
+  restores the previous settings afterwards.
+- Do not call `plt.switch_backend()`.  Matplotlib already selects a
+  non-interactive backend where Polaris steps run, and the object-oriented
+  figure API does not consult the backend at all.
+
+### Use the object-oriented figure API
+
+`pyplot`'s "current figure" is process-global.  `plt.figure()`,
+`plt.subplot()`, `plt.title()`, `plt.colorbar()` and `plt.savefig()` all act on
+whichever figure `pyplot` made most recently, so two steps plotting at the same
+time draw into each other's figures.  Build the figure explicitly instead:
+
+```python
+from matplotlib.figure import Figure
+
+from polaris.viz import mplstyle_context
+
+with mplstyle_context():
+    fig = Figure(figsize=(8, 4.5))
+    ax = fig.add_subplot(111)
+    ax.plot(x, y)
+    ax.set_title('...')
+    fig.colorbar(handle, ax=ax)
+    fig.savefig(self.work_path('my_plot.png'))
+```
+
+A figure built this way is never registered with `pyplot`, so there is also
+nothing to `plt.close()`.
+
+### Keep temporary files in the step's work directory
+
+Write scratch files under the step's own work directory rather than in `/tmp`
+or the base work directory, so that two concurrent steps cannot choose the same
+path.  A step must also not write into another step's work directory, and must
+not read a file that a concurrently running step is still writing.
+
+### Log through the step's logger
+
+Emit output with `self.logger`, never with `print()` or by writing to `stdout`,
+`stderr` or the root logger.  Output written to shared streams interleaves once
+several steps run at once, and the resulting log cannot be attributed to a
+step.  Pass `self.logger` to any helper function or subprocess that produces
+output; see {ref}`dev-logging`.
+
+### Declare the resources you need
+
+A step must declare the resources it needs so that the scheduler can decide how
+many steps may run at once.  Memory is the field that distinguishes analysis
+steps from most existing Polaris steps: at high resolution an analysis step may
+need a large fraction of a node, and a scheduler that packs by cores alone will
+oversubscribe memory.
+
+### Size internal parallelism from what you were given
+
+A step that starts its own pool of processes or threads must size it from the
+resources the step was given, not from the machine.  A pool sized to
+`os.cpu_count()` oversubscribes the node as soon as a second step runs beside
+it.  Use `self.cpus_per_task`:
+
+```python
+n_workers = min(self.cpus_per_task, len(work_items))
+```
+
+(dev-task-parallelism-status)=
+
+## Current status
+
+The framework support exists -- {py:meth}`polaris.Step.work_path()`,
+{py:func}`polaris.viz.mplstyle_context()`, and the object-oriented figure API
+in `polaris.viz` -- and the shared building blocks have been converted:
+`polaris.viz`, `polaris.mesh.spherical`, and
+`polaris.ocean.convergence.analysis`.
+
+Most task-level analysis and visualization steps have **not** been converted;
+they still open files by bare relative name and use the `pyplot` current
+figure.  That is correct under today's one-step-at-a-time execution and will be
+addressed as the analysis capability is built out.  Do not copy those steps as
+a template for new work.

--- a/docs/developers_guide/framework/visualization.md
+++ b/docs/developers_guide/framework/visualization.md
@@ -36,7 +36,9 @@ It is a context manager rather than a plain function because matplotlib's
 into every plot made afterwards, including plots made by other steps once
 steps can run concurrently in a single process.  Pass `dpi` to override the
 resolution of saved figures for the duration of the context, rather than
-setting `rcParams['savefig.dpi']` directly.
+setting `rcParams['savefig.dpi']` directly.  See {ref}`dev-task-parallelism`
+for the other properties a step needs in order to plot safely alongside other
+steps.
 
 (dev-visualization-planar)=
 

--- a/docs/developers_guide/framework/visualization.md
+++ b/docs/developers_guide/framework/visualization.md
@@ -15,12 +15,28 @@ shared visualization routines are provided in `polaris.viz`:
 
 ## common matplotlib style
 
-The function {py:func}`polaris.viz.use_mplstyle()` loads a common 
+The context manager {py:func}`polaris.viz.mplstyle_context()` applies a common
 [matplotlib style sheet](https://matplotlib.org/stable/users/explain/customizing.html#customizing-with-style-sheets)
-that can be used to make font sizes and other plotting options more consistent
-across Polaris.  The plotting functions described below make use of this common
-style.  Custom plotting should call {py:func}`polaris.viz.use_mplstyle()`
-before creating a `matplotlib` figure.
+that makes font sizes and other plotting options more consistent across
+Polaris.  The plotting functions described below make use of this common
+style.  Custom plotting should create and save its figures inside the context
+manager:
+
+```python
+from polaris.viz import mplstyle_context
+
+with mplstyle_context():
+    fig, ax = plt.subplots()
+    ...
+    fig.savefig(self.work_path('my_plot.png'))
+```
+
+It is a context manager rather than a plain function because matplotlib's
+`rcParams` are global to the process.  Assigning to them leaks the settings
+into every plot made afterwards, including plots made by other steps once
+steps can run concurrently in a single process.  Pass `dpi` to override the
+resolution of saved figures for the duration of the context, rather than
+setting `rcParams['savefig.dpi']` directly.
 
 (dev-visualization-planar)=
 

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -728,6 +728,9 @@ The `filename` arguments to `add_input_file()` and `add_output_file()` are
 unaffected: those are relative to the work directory by design, and setup
 already resolves them to absolute paths in `self.inputs` and `self.outputs`.
 
+See {ref}`dev-task-parallelism` for this and the other properties a step needs
+in order to run concurrently with other steps.
+
 (dev-step-inputs-outputs)=
 
 ## inputs and outputs

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -703,6 +703,31 @@ MPI, threading and memory resources.
 To get a feel for different types of `run()` methods, it may be best to
 explore different steps that are already implemented in Polaris.
 
+(dev-step-work-path)=
+
+### paths within run()
+
+Polaris changes the process working directory to the step's work directory
+before calling `run()`, so a bare relative filename like `'output.nc'` works
+today.  That will not remain true once steps can run concurrently in one
+process, because the working directory is shared by the whole process.
+
+New steps -- and analysis steps in particular -- should instead build paths
+with {py:meth}`polaris.Step.work_path()`, which joins one or more path
+components onto the step's own work directory and returns an absolute path:
+
+```python
+class Viz(Step):
+    def run(self):
+        with xr.open_dataset(self.work_path('output.nc')) as ds:
+            ...
+        fig.savefig(self.work_path('comparison.png'))
+```
+
+The `filename` arguments to `add_input_file()` and `add_output_file()` are
+unaffected: those are relative to the work directory by design, and setup
+already resolves them to absolute paths in `self.inputs` and `self.outputs`.
+
 (dev-step-inputs-outputs)=
 
 ## inputs and outputs

--- a/polaris/mesh/base/so/__init__.py
+++ b/polaris/mesh/base/so/__init__.py
@@ -54,7 +54,7 @@ class SOBaseMesh(QuasiUniformSphericalMeshStep):
             lon=lon,
             high_res_km=min_res,
             low_res_km=max_res,
-            region_filename='high_res_region.geojson',
+            region_filename=self.work_path('high_res_region.geojson'),
         )
 
         return cell_width, lon, lat

--- a/polaris/mesh/spherical/__init__.py
+++ b/polaris/mesh/spherical/__init__.py
@@ -1,10 +1,10 @@
 import cartopy
 import cartopy.crs as ccrs
 import jigsawpy
-import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from jigsawpy.savejig import savejig
+from matplotlib.figure import Figure
 from mpas_tools.io import open_dataset, write_netcdf
 from mpas_tools.logging import check_call
 from mpas_tools.mesh.creation.jigsaw_to_netcdf import jigsaw_to_netcdf
@@ -87,11 +87,28 @@ class SphericalBaseStep(Step):
             coords={'lat': lat, 'lon': lon},
             name='cellWidth',
         )
-        cell_width_filename = section.get('cell_width_filename')
+        cell_width_filename = self.work_path(
+            section.get('cell_width_filename')
+        )
         da.to_netcdf(cell_width_filename)
 
         if section.getboolean('plot_cell_width'):
             self._plot_cell_width(cell_width)
+
+    def runtime_setup(self):
+        """
+        Make the JIGSAW file names absolute
+
+        JIGSAW's config file records these paths verbatim and the ``jigsaw``
+        executable then opens them, so they must not depend on the working
+        directory of whichever process happens to launch it.
+        """
+        super().runtime_setup()
+        opts = self.opts
+        for attr in ['mesh_file', 'geom_file', 'jcfg_file', 'hfun_file']:
+            filename = getattr(opts, attr)
+            if filename is not None:
+                setattr(opts, attr, self.work_path(filename))
 
     def setup(self):
         """
@@ -126,21 +143,24 @@ class SphericalBaseStep(Step):
 
         section = config['spherical_mesh']
         earth_radius = get_constant('mean_radius')
-        jigsaw_mesh_filename = section.get('jigsaw_mesh_filename')
-        mpas_mesh_filename = section.get('mpas_mesh_filename')
+        jigsaw_mesh_filename = self.work_path(
+            section.get('jigsaw_mesh_filename')
+        )
+        mpas_mesh_filename = self.work_path(section.get('mpas_mesh_filename'))
+        triangles_filename = self.work_path('mesh_triangles.nc')
 
         logger.info('Convert triangles from jigsaw format to netcdf')
         jigsaw_to_netcdf(
             msh_filename=jigsaw_mesh_filename,
-            output_name='mesh_triangles.nc',
+            output_name=triangles_filename,
             on_sphere=True,
             sphere_radius=earth_radius,
         )
 
         logger.info('Convert from triangles to MPAS mesh')
 
-        tmp_mesh_filename = 'mpas_mesh_netcdf4.nc'
-        args = ['MpasMeshConverter.x', 'mesh_triangles.nc', tmp_mesh_filename]
+        tmp_mesh_filename = self.work_path('mpas_mesh_netcdf4.nc')
+        args = ['MpasMeshConverter.x', triangles_filename, tmp_mesh_filename]
         check_call(args=args, logger=logger)
 
         # open the mesh and rewrite it in the desired NetCDF format
@@ -157,8 +177,8 @@ class SphericalBaseStep(Step):
             logger.info(
                 'Compute vector-reconstruction weights at cell centers'
             )
-            reconstruction_weights_filename = section.get(
-                'reconstruction_weights_filename'
+            reconstruction_weights_filename = self.work_path(
+                section.get('reconstruction_weights_filename')
             )
             ds_weights = compute_reconstruction_weights(
                 ds_mesh, location='cell'
@@ -167,7 +187,9 @@ class SphericalBaseStep(Step):
 
         if section.getboolean('add_mesh_density'):
             logger.info('Add meshDensity into the mesh file')
-            cell_width_filename = section.get('cell_width_filename')
+            cell_width_filename = self.work_path(
+                section.get('cell_width_filename')
+            )
             ds = xr.open_dataset(cell_width_filename)
             inject_spherical_meshDensity(
                 ds.cellWidth.values,
@@ -177,7 +199,7 @@ class SphericalBaseStep(Step):
             )
 
         if section.getboolean('convert_to_vtk'):
-            vtk_dir = section.get('vtk_dir')
+            vtk_dir = self.work_path(section.get('vtk_dir'))
             # only use progress bars if we're not writing to a log file
             use_progress_bar = self.log_filename is None
             lat_lon = section.getboolean('vtk_lat_lon')
@@ -194,7 +216,8 @@ class SphericalBaseStep(Step):
             )
 
         make_graph_file(
-            mesh_filename=mpas_mesh_filename, graph_filename='graph.info'
+            mesh_filename=mpas_mesh_filename,
+            graph_filename=self.work_path('graph.info'),
         )
 
     def _check_cell_polygon_quality(self, ds_mesh):
@@ -238,12 +261,12 @@ class SphericalBaseStep(Step):
         """
         config = self.config
         cmap = config.get('spherical_mesh', 'cell_width_colormap')
-        image_filename = config.get(
-            'spherical_mesh', 'cell_width_image_filename'
+        image_filename = self.work_path(
+            config.get('spherical_mesh', 'cell_width_image_filename')
         )
         register_sci_viz_colormaps()
-        fig = plt.figure(figsize=[16.0, 8.0])
-        ax = plt.axes(projection=ccrs.PlateCarree())
+        fig = Figure(figsize=[16.0, 8.0])
+        ax = fig.add_subplot(111, projection=ccrs.PlateCarree())
         ax.set_global()
         im = ax.imshow(
             cell_width,
@@ -267,13 +290,15 @@ class SphericalBaseStep(Step):
         gl.right_labels = False
         min_width = np.amin(cell_width)
         max_width = np.amax(cell_width)
-        plt.title(
+        ax.set_title(
             f'Grid cell size, km, min: {min_width:.1f} max: {max_width:.1f}'
         )
-        plt.colorbar(im, shrink=0.60)
-        fig.canvas.draw()
-        plt.savefig(image_filename, bbox_inches='tight')
-        plt.close()
+        fig.colorbar(im, ax=ax, shrink=0.60)
+        # Save with the default margins.  bbox_inches='tight' on a
+        # fixed-aspect GeoAxes with an attached colorbar collapses the map
+        # axes, leaving an image that is nothing but the colorbar -- the same
+        # failure that was fixed in plot_global_mpas_field().
+        fig.savefig(image_filename)
 
 
 class QuasiUniformSphericalMeshStep(SphericalBaseStep):

--- a/polaris/mesh/spherical/unified/base_mesh.py
+++ b/polaris/mesh/spherical/unified/base_mesh.py
@@ -116,7 +116,8 @@ class UnifiedBaseMeshStep(QuasiUniformSphericalMeshStep):
         """
         Read the cell width, lon, and lat directly from sizing_field.nc.
         """
-        with xr.open_dataset(self.sizing_field_filename) as ds_sizing:
+        sizing_field_filename = self.work_path(self.sizing_field_filename)
+        with xr.open_dataset(sizing_field_filename) as ds_sizing:
             if 'cellWidth' not in ds_sizing:
                 raise ValueError(
                     'Expected variable "cellWidth" in sizing_field.nc.'
@@ -155,7 +156,7 @@ class UnifiedBaseMeshStep(QuasiUniformSphericalMeshStep):
         )
         geom = _build_unified_jigsaw_geometry(
             earth_radius=earth_radius,
-            river_network_filename=self.river_network_filename,
+            river_network_filename=self.work_path(self.river_network_filename),
             snap_tolerance_km=snap_tolerance_km,
         )
         jigsawpy.savemsh(opts.geom_file, geom)

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -1,8 +1,8 @@
 import os
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlib.figure import Figure
 
 from polaris.mpas import area_for_field, time_since_start
 from polaris.ocean.convergence import (
@@ -172,7 +172,6 @@ class ConvergenceAnalysis(OceanIOStep):
         """
         Run this step of the test case
         """
-        plt.switch_backend('Agg')
         convergence_vars = self.convergence_vars
         variables_failed = []
         for var in convergence_vars:
@@ -247,7 +246,7 @@ class ConvergenceAnalysis(OceanIOStep):
         filename = f'convergence_{variable_name}.csv'
         data = np.stack((refinement_array, error_array), axis=1)
         df = pd.DataFrame(data, columns=[header, error_type])
-        df.to_csv(f'convergence_{variable_name}.csv', index=False)
+        df.to_csv(self.work_path(filename), index=False)
 
         convergence_failed = False
         poly = np.polyfit(np.log10(refinement_array), np.log10(error_array), 1)
@@ -266,7 +265,7 @@ class ConvergenceAnalysis(OceanIOStep):
         )
 
         with mplstyle_context():
-            fig = plt.figure()
+            fig = Figure()
 
             error_dict = {'l2': 'L2 norm', 'inf': 'L-infinity norm'}
             error_title = error_dict[error_type]
@@ -326,11 +325,10 @@ class ConvergenceAnalysis(OceanIOStep):
             ax.legend(loc='lower left')
             ax.invert_xaxis()
             fig.savefig(
-                f'convergence_{variable_name}.png',
+                self.work_path(f'convergence_{variable_name}.png'),
                 bbox_inches='tight',
                 pad_inches=0.1,
             )
-            plt.close()
 
             logger.info(f'Order of convergence for {title}: {conv_round:1.3f}')
 
@@ -373,7 +371,7 @@ class ConvergenceAnalysis(OceanIOStep):
         norm_type = {'l2': None, 'inf': np.inf}
         config = self.config
         ds_mesh = self.open_model_dataset(
-            f'mesh_r{refinement_factor:02g}.nc', config
+            self.work_path(f'mesh_r{refinement_factor:02g}.nc'), config
         )
         section = config['convergence']
         eval_time = section.getfloat('convergence_eval_time')
@@ -443,7 +441,7 @@ class ConvergenceAnalysis(OceanIOStep):
         """
 
         ds_init = self.open_model_dataset(
-            f'init_r{refinement_factor:02g}.nc', self.config
+            self.work_path(f'init_r{refinement_factor:02g}.nc'), self.config
         )
         ds_init = ds_init.isel(Time=0)
         if zidx is not None:
@@ -476,7 +474,9 @@ class ConvergenceAnalysis(OceanIOStep):
         """
         config = self.config
         ds_out = self.open_model_dataset(
-            f'output_r{refinement_factor:02g}.nc', config, decode_times=False
+            self.work_path(f'output_r{refinement_factor:02g}.nc'),
+            config,
+            decode_times=False,
         )
 
         model = config.get('ocean', 'model')

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -10,7 +10,7 @@ from polaris.ocean.convergence import (
     get_timestep_for_task,
 )
 from polaris.ocean.model import OceanIOStep
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class ConvergenceAnalysis(OceanIOStep):
@@ -265,82 +265,84 @@ class ConvergenceAnalysis(OceanIOStep):
             * (refinement_array / refinement_array[-1]) ** 2
         )
 
-        use_mplstyle()
-        fig = plt.figure()
+        with mplstyle_context():
+            fig = plt.figure()
 
-        error_dict = {'l2': 'L2 norm', 'inf': 'L-infinity norm'}
-        error_title = error_dict[error_type]
+            error_dict = {'l2': 'L2 norm', 'inf': 'L-infinity norm'}
+            error_title = error_dict[error_type]
 
-        ax = fig.add_subplot(111)
-        ax.loglog(
-            refinement_array, order1, '--k', label='first order', alpha=0.3
-        )
-        ax.loglog(
-            refinement_array, order2, 'k', label='second order', alpha=0.3
-        )
-        ax.loglog(
-            refinement_array,
-            fit,
-            'k',
-            label=f'linear fit (order={convergence:1.3f})',
-        )
-        ax.loglog(refinement_array, error_array, 'o', label='numerical')
-
-        if self.baseline_dir is not None:
-            baseline_filename = os.path.join(self.baseline_dir, filename)
-            if os.path.exists(baseline_filename):
-                data = pd.read_csv(baseline_filename)
-                if error_type not in data.keys():
-                    raise ValueError(
-                        f'{error_type} not available for baseline'
-                    )
-                else:
-                    refinement_array = data.resolution.to_numpy()
-                    error_array = data[error_type].to_numpy()
-                    poly = np.polyfit(
-                        np.log10(refinement_array), np.log10(error_array), 1
-                    )
-                    base_convergence = poly[0]
-                    conv_round = base_convergence
-
-                    fit = refinement_array ** poly[0] * 10 ** poly[1]
-                    ax.loglog(
-                        refinement_array,
-                        error_array,
-                        'o',
-                        color='#ff7f0e',
-                        label='baseline',
-                    )
-                    ax.loglog(
-                        refinement_array,
-                        fit,
-                        color='#ff7f0e',
-                        label=f'linear fit, baseline '
-                        f'(order={base_convergence:1.3f})',
-                    )
-        ax.set_xlabel(x_label)
-        ax.set_ylabel(f'{error_title}')
-        ax.set_title(f'Error Convergence of {title}')
-        ax.legend(loc='lower left')
-        ax.invert_xaxis()
-        fig.savefig(
-            f'convergence_{variable_name}.png',
-            bbox_inches='tight',
-            pad_inches=0.1,
-        )
-        plt.close()
-
-        logger.info(f'Order of convergence for {title}: {conv_round:1.3f}')
-
-        if conv_round < conv_thresh:
-            logger.error(
-                f'Error: order of convergence for {title}\n'
-                f'  {conv_round:1.3f} < min tolerance '
-                f'{conv_thresh}'
+            ax = fig.add_subplot(111)
+            ax.loglog(
+                refinement_array, order1, '--k', label='first order', alpha=0.3
             )
-            convergence_failed = True
+            ax.loglog(
+                refinement_array, order2, 'k', label='second order', alpha=0.3
+            )
+            ax.loglog(
+                refinement_array,
+                fit,
+                'k',
+                label=f'linear fit (order={convergence:1.3f})',
+            )
+            ax.loglog(refinement_array, error_array, 'o', label='numerical')
 
-        return convergence_failed
+            if self.baseline_dir is not None:
+                baseline_filename = os.path.join(self.baseline_dir, filename)
+                if os.path.exists(baseline_filename):
+                    data = pd.read_csv(baseline_filename)
+                    if error_type not in data.keys():
+                        raise ValueError(
+                            f'{error_type} not available for baseline'
+                        )
+                    else:
+                        refinement_array = data.resolution.to_numpy()
+                        error_array = data[error_type].to_numpy()
+                        poly = np.polyfit(
+                            np.log10(refinement_array),
+                            np.log10(error_array),
+                            1,
+                        )
+                        base_convergence = poly[0]
+                        conv_round = base_convergence
+
+                        fit = refinement_array ** poly[0] * 10 ** poly[1]
+                        ax.loglog(
+                            refinement_array,
+                            error_array,
+                            'o',
+                            color='#ff7f0e',
+                            label='baseline',
+                        )
+                        ax.loglog(
+                            refinement_array,
+                            fit,
+                            color='#ff7f0e',
+                            label=f'linear fit, baseline '
+                            f'(order={base_convergence:1.3f})',
+                        )
+            ax.set_xlabel(x_label)
+            ax.set_ylabel(f'{error_title}')
+            ax.set_title(f'Error Convergence of {title}')
+            ax.legend(loc='lower left')
+            ax.invert_xaxis()
+            fig.savefig(
+                f'convergence_{variable_name}.png',
+                bbox_inches='tight',
+                pad_inches=0.1,
+            )
+            plt.close()
+
+            logger.info(f'Order of convergence for {title}: {conv_round:1.3f}')
+
+            if conv_round < conv_thresh:
+                logger.error(
+                    f'Error: order of convergence for {title}\n'
+                    f'  {conv_round:1.3f} < min tolerance '
+                    f'{conv_thresh}'
+                )
+                convergence_failed = True
+
+            return convergence_failed
 
     def compute_error(
         self, refinement_factor, variable_name, zidx=None, error_type='l2'

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -472,7 +472,8 @@ class Step:
 
         Steps should use this method (rather than a bare relative filename)
         for any file they open in ``run()``, so that the step does not depend
-        on the process working directory being its own work directory.
+        on the process working directory being its own work directory.  See
+        :ref:`dev-task-parallelism`.
 
         Parameters
         ----------

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -465,6 +465,33 @@ class Step:
         """
         pass
 
+    def work_path(self, *filenames):
+        """
+        Get the absolute path to a file or directory in the step's work
+        directory
+
+        Steps should use this method (rather than a bare relative filename)
+        for any file they open in ``run()``, so that the step does not depend
+        on the process working directory being its own work directory.
+
+        Parameters
+        ----------
+        *filenames : str
+            One or more path components, relative to the step's work
+            directory
+
+        Returns
+        -------
+        path : str
+            The absolute path to the file or directory
+        """
+        if not self.work_dir:
+            raise ValueError(
+                f'The work directory of step {self.name} has not been set '
+                f'yet, so work_path() cannot be used.'
+            )
+        return os.path.abspath(os.path.join(self.work_dir, *filenames))
+
     def add_input_file(
         self,
         filename=None,

--- a/polaris/tasks/mesh/spherical/unified/coastline/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/coastline/viz.py
@@ -23,7 +23,7 @@ from polaris.tasks.mesh.spherical.unified.coastline.compute import (
 from polaris.tasks.mesh.spherical.unified.coastline.remap import (
     RemapCoastlineStep,
 )
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 CoastlineStep: TypeAlias = Union[ComputeCoastlineStep, RemapCoastlineStep]
 
@@ -74,60 +74,63 @@ class VizCoastlineStep(Step):
         """
         Run this step.
         """
-        use_mplstyle()
+        with mplstyle_context():
+            viz_section = self.config['viz_coastline']
+            prepare_section = self.config['coastline']
+            dpi = viz_section.getint('dpi')
+            antarctic_max_latitude = viz_section.getfloat(
+                'antarctic_max_latitude'
+            )
+            finest_plot_stride = viz_section.getint('finest_plot_stride')
+            signed_distance_limit = viz_section.getfloat(
+                'signed_distance_limit'
+            )
+            plot_info = _get_plot_info_from_file(
+                self.coastline_step.output_filenames[CONVENTIONS[0]],
+                finest_plot_stride=finest_plot_stride,
+            )
+            line_overlays = None
+            if prepare_section.getboolean('include_critical_transects'):
+                try:
+                    line_overlays = _get_critical_transect_overlays()
+                except Exception:  # pragma: no cover - diagnostic fallback
+                    self.logger.warning(
+                        'Could not load critical transects for coastline '
+                        'overlays.',
+                        exc_info=True,
+                    )
 
-        viz_section = self.config['viz_coastline']
-        prepare_section = self.config['coastline']
-        dpi = viz_section.getint('dpi')
-        antarctic_max_latitude = viz_section.getfloat('antarctic_max_latitude')
-        finest_plot_stride = viz_section.getint('finest_plot_stride')
-        signed_distance_limit = viz_section.getfloat('signed_distance_limit')
-        plot_info = _get_plot_info_from_file(
-            self.coastline_step.output_filenames[CONVENTIONS[0]],
-            finest_plot_stride=finest_plot_stride,
-        )
-        line_overlays = None
-        if prepare_section.getboolean('include_critical_transects'):
-            try:
-                line_overlays = _get_critical_transect_overlays()
-            except Exception:  # pragma: no cover - diagnostic fallback
-                self.logger.warning(
-                    'Could not load critical transects for coastline '
-                    'overlays.',
-                    exc_info=True,
-                )
+            with open('debug_summary.txt', 'w') as summary:
+                for convention in CONVENTIONS:
+                    filename = self.coastline_step.output_filenames[convention]
+                    with xr.open_dataset(filename) as ds_coastline:
+                        ocean_mask = ds_coastline.ocean_mask.values > 0
+                        signed_distance = ds_coastline.signed_distance.values
 
-        with open('debug_summary.txt', 'w') as summary:
-            for convention in CONVENTIONS:
-                filename = self.coastline_step.output_filenames[convention]
-                with xr.open_dataset(filename) as ds_coastline:
-                    ocean_mask = ds_coastline.ocean_mask.values > 0
-                    signed_distance = ds_coastline.signed_distance.values
-
-                self._plot_binary_field(
-                    plot_info=plot_info,
-                    field=ocean_mask,
-                    title=f'{convention} ocean mask',
-                    out_prefix=f'{convention}_ocean_mask',
-                    dpi=dpi,
-                    antarctic_max_latitude=antarctic_max_latitude,
-                    line_overlays=line_overlays,
-                )
-                self._plot_signed_distance(
-                    plot_info=plot_info,
-                    signed_distance=signed_distance,
-                    title=f'{convention} signed distance',
-                    out_prefix=f'{convention}_signed_distance',
-                    distance_limit=signed_distance_limit,
-                    dpi=dpi,
-                    antarctic_max_latitude=antarctic_max_latitude,
-                )
-                self._write_convention_summary(
-                    summary=summary,
-                    convention=convention,
-                    ocean_mask=ocean_mask,
-                    signed_distance=signed_distance,
-                )
+                    self._plot_binary_field(
+                        plot_info=plot_info,
+                        field=ocean_mask,
+                        title=f'{convention} ocean mask',
+                        out_prefix=f'{convention}_ocean_mask',
+                        dpi=dpi,
+                        antarctic_max_latitude=antarctic_max_latitude,
+                        line_overlays=line_overlays,
+                    )
+                    self._plot_signed_distance(
+                        plot_info=plot_info,
+                        signed_distance=signed_distance,
+                        title=f'{convention} signed distance',
+                        out_prefix=f'{convention}_signed_distance',
+                        distance_limit=signed_distance_limit,
+                        dpi=dpi,
+                        antarctic_max_latitude=antarctic_max_latitude,
+                    )
+                    self._write_convention_summary(
+                        summary=summary,
+                        convention=convention,
+                        ocean_mask=ocean_mask,
+                        signed_distance=signed_distance,
+                    )
 
     def _plot_binary_field(
         self,

--- a/polaris/tasks/mesh/spherical/unified/river/simplify.py
+++ b/polaris/tasks/mesh/spherical/unified/river/simplify.py
@@ -1,3 +1,4 @@
+import logging
 import multiprocessing
 import os
 from collections import defaultdict
@@ -146,7 +147,8 @@ class SimplifyRiverNetworkStep(Step):
         """
         import time
 
-        print(f'cpus_per_task = {self.cpus_per_task}', flush=True)
+        logger = self.logger
+        logger.info(f'cpus_per_task = {self.cpus_per_task}')
 
         section = self.config['river_network']
         archive_filename = section.get('hydrorivers_archive_filename')
@@ -180,10 +182,7 @@ class SimplifyRiverNetworkStep(Step):
             shp_filename=os.path.join(shp_directory, shp_filename),
             drainage_area_threshold=drainage_area_threshold,
         )
-        print(
-            f'read shapefile (filtered): {time.time() - t0:.1f} s',
-            flush=True,
-        )
+        logger.info(f'read shapefile (filtered): {time.time() - t0:.1f} s')
 
         t0 = time.time()
         simplified_fc = simplify_river_network_feature_collection(
@@ -192,8 +191,9 @@ class SimplifyRiverNetworkStep(Step):
             branch_distance_tolerance=branch_distance_tolerance,
             tributary_area_ratio=section.getfloat('tributary_area_ratio'),
             n_cpus=self.cpus_per_task,
+            logger=logger,
         )
-        print(f'simplify: {time.time() - t0:.1f} s', flush=True)
+        logger.info(f'simplify: {time.time() - t0:.1f} s')
         simplified_fc['metadata'] = dict(
             mesh_name=self.config.get('unified_mesh', 'mesh_name'),
             resolution_latlon=self.config.getfloat(
@@ -209,7 +209,7 @@ class SimplifyRiverNetworkStep(Step):
         )
         t0 = time.time()
         write_geojson(simplified_fc, self.simplified_filename)
-        print(f'write outputs: {time.time() - t0:.1f} s', flush=True)
+        logger.info(f'write outputs: {time.time() - t0:.1f} s')
 
 
 def _unpack_hydrorivers_archive(archive_filename, data_directory):
@@ -280,6 +280,7 @@ def simplify_river_network_feature_collection(
     branch_distance_tolerance,
     tributary_area_ratio=0.05,
     n_cpus=1,
+    logger=None,
 ):
     """
     Simplify a HydroRIVERS-style feature collection.
@@ -303,6 +304,11 @@ def simplify_river_network_feature_collection(
         Number of parallel worker processes for basin traversal.
         Defaults to 1 (single-process).
 
+    logger : logging.Logger, optional
+        A logger to write progress to.  A step should pass its own
+        ``self.logger`` so that its output is not interleaved with that of
+        other steps running at the same time.
+
     Returns
     -------
     simplified_fc : dict
@@ -310,6 +316,9 @@ def simplify_river_network_feature_collection(
 
     """
     import time
+
+    if logger is None:
+        logger = logging.getLogger(__name__)
 
     t0 = time.time()
     segments = read_river_segments_from_feature_collection(feature_collection)
@@ -319,10 +328,9 @@ def simplify_river_network_feature_collection(
         for segment in segments
         if segment.drainage_area >= drainage_area_threshold
     ]
-    print(
+    logger.info(
         f'  read segments: {n_raw} raw, {len(segments)} after area filter, '
-        f'{time.time() - t0:.1f} s',
-        flush=True,
+        f'{time.time() - t0:.1f} s'
     )
     if len(segments) == 0:
         raise ValueError(
@@ -341,22 +349,18 @@ def simplify_river_network_feature_collection(
     terminal_segments = [
         segment for segment in segments if segment.next_down == 0
     ]
-    print(
-        f'  terminal basin roots: {len(terminal_segments)}',
-        flush=True,
-    )
+    logger.info(f'  terminal basin roots: {len(terminal_segments)}')
 
     t0 = time.time()
     seg_list = list(segments)
     seg_tree = STRtree([seg.geometry for seg in seg_list])
-    print(
-        f'  build STRtree ({len(seg_list)} geoms): {time.time() - t0:.1f} s',
-        flush=True,
+    logger.info(
+        f'  build STRtree ({len(seg_list)} geoms): {time.time() - t0:.1f} s'
     )
 
     retained_segments: dict[int, RiverSegment] = {}
     n_workers = min(n_cpus, len(terminal_segments))
-    print(f'  basin traversal: n_workers={n_workers}', flush=True)
+    logger.info(f'  basin traversal: n_workers={n_workers}')
     t0 = time.time()
     if n_workers > 1:
         global _WORKER_UPSTREAM_MAP, _WORKER_SEGMENT_BY_ID
@@ -395,7 +399,7 @@ def simplify_river_network_feature_collection(
                 seg_list=seg_list,
             )
 
-    print(f'  basin traversal: {time.time() - t0:.1f} s', flush=True)
+    logger.info(f'  basin traversal: {time.time() - t0:.1f} s')
 
     annotated_segments = _annotate_river_networks(
         segments=retained_segments.values(),

--- a/polaris/tasks/mesh/spherical/unified/river/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/river/viz.py
@@ -13,7 +13,7 @@ from polaris.mesh.spherical.unified.river.distance import (
 )
 from polaris.mesh.spherical.unified.river.geojson import read_geojson
 from polaris.step import Step
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 CONUS_EXTENT = (-128.0, -65.0, 22.0, 52.0)
 
@@ -110,50 +110,50 @@ class VizRiverStep(Step):
         """
         Run this step.
         """
-        use_mplstyle()
-        config = self.config
+        with mplstyle_context():
+            config = self.config
 
-        dpi = config['viz_river_network'].getint('dpi')
-        mesh_name = config['unified_mesh'].get('mesh_name')
+            dpi = config['viz_river_network'].getint('dpi')
+            mesh_name = config['unified_mesh'].get('mesh_name')
 
-        simplified_fc = read_geojson('simplified_river_network.geojson')
-        clipped_fc = read_geojson('clipped_river_network.geojson')
+            simplified_fc = read_geojson('simplified_river_network.geojson')
+            clipped_fc = read_geojson('clipped_river_network.geojson')
 
-        with xr.open_dataset('river_network.nc') as ds_river:
-            lon = ds_river.lon.values
-            lat = ds_river.lat.values
-            river_channel_mask = ds_river.river_channel_mask.values > 0
+            with xr.open_dataset('river_network.nc') as ds_river:
+                lon = ds_river.lon.values
+                lat = ds_river.lat.values
+                river_channel_mask = ds_river.river_channel_mask.values > 0
 
-        with xr.open_dataset('coastline.nc') as ds_coastline:
-            ocean_mask = ds_coastline.ocean_mask.values > 0
-            land_mask = _get_land_mask(ds_coastline)
+            with xr.open_dataset('coastline.nc') as ds_coastline:
+                ocean_mask = ds_coastline.ocean_mask.values > 0
+                land_mask = _get_land_mask(ds_coastline)
 
-        self._plot_network_overlay(
-            lon=lon,
-            lat=lat,
-            land_mask=land_mask,
-            ocean_mask=ocean_mask,
-            simplified_fc=simplified_fc,
-            clipped_fc=clipped_fc,
-            mesh_name=mesh_name,
-            dpi=dpi,
-            out_filename='river_network_overlay.png',
-        )
-        self._plot_rasterized_network(
-            lon=lon,
-            lat=lat,
-            river_channel_mask=river_channel_mask,
-            mesh_name=mesh_name,
-            dpi=dpi,
-            out_filename='rasterized_river_network.png',
-        )
+            self._plot_network_overlay(
+                lon=lon,
+                lat=lat,
+                land_mask=land_mask,
+                ocean_mask=ocean_mask,
+                simplified_fc=simplified_fc,
+                clipped_fc=clipped_fc,
+                mesh_name=mesh_name,
+                dpi=dpi,
+                out_filename='river_network_overlay.png',
+            )
+            self._plot_rasterized_network(
+                lon=lon,
+                lat=lat,
+                river_channel_mask=river_channel_mask,
+                mesh_name=mesh_name,
+                dpi=dpi,
+                out_filename='rasterized_river_network.png',
+            )
 
-        _write_summary(
-            filename='debug_summary.txt',
-            simplified_fc=simplified_fc,
-            clipped_fc=clipped_fc,
-            river_channel_mask=river_channel_mask,
-        )
+            _write_summary(
+                filename='debug_summary.txt',
+                simplified_fc=simplified_fc,
+                clipped_fc=clipped_fc,
+                river_channel_mask=river_channel_mask,
+            )
 
     def _plot_network_overlay(
         self,

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/viz.py
@@ -8,7 +8,7 @@ import numpy as np
 import xarray as xr
 
 from polaris.step import Step
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class VizSizingFieldStep(Step):
@@ -75,114 +75,125 @@ class VizSizingFieldStep(Step):
         """
         Create simple global diagnostic plots and a text summary.
         """
-        use_mplstyle()
-        dpi = self.config['sizing_field_viz'].getint('dpi')
-        cmap = self.config['sizing_field_viz'].get('cell_width_cmap')
+        with mplstyle_context():
+            dpi = self.config['sizing_field_viz'].getint('dpi')
+            cmap = self.config['sizing_field_viz'].get('cell_width_cmap')
 
-        with xr.open_dataset('sizing_field.nc') as ds:
-            lon = ds.lon.values
-            lat = ds.lat.values
-            cell_width_fields = [
-                ('cellWidth', 'Final cell width (km)'),
-                ('ocean_background_cell_width', 'Ocean background (km)'),
-                ('land_river_cell_width', 'Land/river composite (km)'),
-            ]
-            delta_field = ds.coastal_transition_delta.values
+            with xr.open_dataset('sizing_field.nc') as ds:
+                lon = ds.lon.values
+                lat = ds.lat.values
+                cell_width_fields = [
+                    ('cellWidth', 'Final cell width (km)'),
+                    ('ocean_background_cell_width', 'Ocean background (km)'),
+                    ('land_river_cell_width', 'Land/river composite (km)'),
+                ]
+                delta_field = ds.coastal_transition_delta.values
 
-            fig = plt.figure(
-                figsize=(15.0, 9.2), dpi=dpi, constrained_layout=True
-            )
-            grid = fig.add_gridspec(4, 2, height_ratios=[1.0, 1.0, 0.12, 0.14])
-            axes = np.array(
-                [
-                    fig.add_subplot(grid[0, 0], projection=ccrs.PlateCarree()),
-                    fig.add_subplot(grid[0, 1], projection=ccrs.PlateCarree()),
-                    fig.add_subplot(grid[1, 0], projection=ccrs.PlateCarree()),
-                    fig.add_subplot(grid[1, 1], projection=ccrs.PlateCarree()),
-                ]
-            )
-            delta_cax = fig.add_subplot(grid[2, 1])
-            shared_cax = fig.add_subplot(grid[3, :])
-            norm, ticks = _get_cell_width_norm_and_ticks(
-                fields=[
-                    ds[var_name].values for var_name, _ in cell_width_fields
-                ]
-            )
-            image = None
-            for ax, (var_name, title) in zip(
-                axes[:3], cell_width_fields, strict=True
-            ):
+                fig = plt.figure(
+                    figsize=(15.0, 9.2), dpi=dpi, constrained_layout=True
+                )
+                grid = fig.add_gridspec(
+                    4, 2, height_ratios=[1.0, 1.0, 0.12, 0.14]
+                )
+                axes = np.array(
+                    [
+                        fig.add_subplot(
+                            grid[0, 0], projection=ccrs.PlateCarree()
+                        ),
+                        fig.add_subplot(
+                            grid[0, 1], projection=ccrs.PlateCarree()
+                        ),
+                        fig.add_subplot(
+                            grid[1, 0], projection=ccrs.PlateCarree()
+                        ),
+                        fig.add_subplot(
+                            grid[1, 1], projection=ccrs.PlateCarree()
+                        ),
+                    ]
+                )
+                delta_cax = fig.add_subplot(grid[2, 1])
+                shared_cax = fig.add_subplot(grid[3, :])
+                norm, ticks = _get_cell_width_norm_and_ticks(
+                    fields=[
+                        ds[var_name].values
+                        for var_name, _ in cell_width_fields
+                    ]
+                )
+                image = None
+                for ax, (var_name, title) in zip(
+                    axes[:3], cell_width_fields, strict=True
+                ):
+                    image = self._plot_scalar_field(
+                        ax=ax,
+                        lon=lon,
+                        lat=lat,
+                        field=ds[var_name].values,
+                        title=title,
+                        cmap=cmap,
+                        norm=norm,
+                        add_colorbar=False,
+                    )
+                delta_norm, delta_ticks = _get_difference_norm_and_ticks(
+                    field=delta_field
+                )
+                delta_image = self._plot_scalar_field(
+                    ax=axes[3],
+                    lon=lon,
+                    lat=lat,
+                    field=delta_field,
+                    title='Coastal transition delta (km)',
+                    cmap='cmo.balance',
+                    norm=delta_norm,
+                    add_colorbar=False,
+                )
+                assert image is not None
+                colorbar = fig.colorbar(
+                    image,
+                    cax=shared_cax,
+                    orientation='horizontal',
+                    label='Cell width (km)',
+                )
+                if ticks is not None:
+                    colorbar.set_ticks(np.asarray(ticks).tolist())
+                delta_colorbar = fig.colorbar(
+                    delta_image,
+                    cax=delta_cax,
+                    orientation='horizontal',
+                    label='Final minus pre-coastline cell width (km)',
+                )
+                if delta_ticks is not None:
+                    delta_colorbar.set_ticks(delta_ticks)
+                fig.savefig('sizing_field_overview.png', bbox_inches='tight')
+                plt.close(fig)
+
+                fig = plt.figure(figsize=(11.0, 5.0), dpi=dpi)
+                ax = plt.axes(projection=ccrs.PlateCarree())
+                control_cmap = mcolors.ListedColormap(
+                    ['#3b528b', '#5ec962', '#fdae61']
+                )
+                control_norm = mcolors.BoundaryNorm(
+                    np.arange(-0.5, 3.5, 1.0), control_cmap.N
+                )
                 image = self._plot_scalar_field(
                     ax=ax,
                     lon=lon,
                     lat=lat,
-                    field=ds[var_name].values,
-                    title=title,
-                    cmap=cmap,
-                    norm=norm,
+                    field=ds.active_control.values,
+                    title='Active sizing control',
+                    cmap=control_cmap,
+                    norm=control_norm,
                     add_colorbar=False,
                 )
-            delta_norm, delta_ticks = _get_difference_norm_and_ticks(
-                field=delta_field
-            )
-            delta_image = self._plot_scalar_field(
-                ax=axes[3],
-                lon=lon,
-                lat=lat,
-                field=delta_field,
-                title='Coastal transition delta (km)',
-                cmap='cmo.balance',
-                norm=delta_norm,
-                add_colorbar=False,
-            )
-            assert image is not None
-            colorbar = fig.colorbar(
-                image,
-                cax=shared_cax,
-                orientation='horizontal',
-                label='Cell width (km)',
-            )
-            if ticks is not None:
-                colorbar.set_ticks(np.asarray(ticks).tolist())
-            delta_colorbar = fig.colorbar(
-                delta_image,
-                cax=delta_cax,
-                orientation='horizontal',
-                label='Final minus pre-coastline cell width (km)',
-            )
-            if delta_ticks is not None:
-                delta_colorbar.set_ticks(delta_ticks)
-            fig.savefig('sizing_field_overview.png', bbox_inches='tight')
-            plt.close(fig)
+                colorbar = fig.colorbar(
+                    image, ax=ax, ticks=np.arange(3), shrink=0.75
+                )
+                colorbar.ax.set_yticklabels(
+                    ['background', 'coastline', 'river channel']
+                )
+                fig.savefig('active_control.png', bbox_inches='tight')
+                plt.close(fig)
 
-            fig = plt.figure(figsize=(11.0, 5.0), dpi=dpi)
-            ax = plt.axes(projection=ccrs.PlateCarree())
-            control_cmap = mcolors.ListedColormap(
-                ['#3b528b', '#5ec962', '#fdae61']
-            )
-            control_norm = mcolors.BoundaryNorm(
-                np.arange(-0.5, 3.5, 1.0), control_cmap.N
-            )
-            image = self._plot_scalar_field(
-                ax=ax,
-                lon=lon,
-                lat=lat,
-                field=ds.active_control.values,
-                title='Active sizing control',
-                cmap=control_cmap,
-                norm=control_norm,
-                add_colorbar=False,
-            )
-            colorbar = fig.colorbar(
-                image, ax=ax, ticks=np.arange(3), shrink=0.75
-            )
-            colorbar.ax.set_yticklabels(
-                ['background', 'coastline', 'river channel']
-            )
-            fig.savefig('active_control.png', bbox_inches='tight')
-            plt.close(fig)
-
-            self._write_summary(ds)
+                self._write_summary(ds)
 
     def _plot_scalar_field(
         self,

--- a/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
+++ b/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
@@ -81,7 +81,6 @@ class Analysis(OceanIOStep):
             ds_vert_coord=ds_vert_coord,
         )
 
-        plt.switch_backend('Agg')
         sim_count = len(nus)
         time = section.getfloat('plot_time')
         min_temp = section.getfloat('min_temp')

--- a/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
+++ b/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from polaris.ocean.model import OceanIOStep, get_days_since_start
 from polaris.ocean.rpe import compute_rpe
-from polaris.viz import plot_horiz_field, use_mplstyle
+from polaris.viz import mplstyle_context, plot_horiz_field
 
 
 class Analysis(OceanIOStep):
@@ -92,42 +92,45 @@ class Analysis(OceanIOStep):
         )
         times = get_days_since_start(ds)
 
-        use_mplstyle()
-        fig = plt.figure()
-        for i in range(sim_count):
-            rpe_norm = np.divide((rpe[i, :] - rpe[i, 0]), rpe[i, 0])
-            plt.plot(times, rpe_norm, label=f'$\\nu_h=${nus[i]}')
-        plt.xlabel('Time, days')
-        plt.ylabel('RPE-RPE(0)/RPE(0)')
-        plt.legend()
-        plt.savefig('rpe_t.png')
-        plt.close(fig)
+        with mplstyle_context():
+            fig = plt.figure()
+            for i in range(sim_count):
+                rpe_norm = np.divide((rpe[i, :] - rpe[i, 0]), rpe[i, 0])
+                plt.plot(times, rpe_norm, label=f'$\\nu_h=${nus[i]}')
+            plt.xlabel('Time, days')
+            plt.ylabel('RPE-RPE(0)/RPE(0)')
+            plt.legend()
+            plt.savefig('rpe_t.png')
+            plt.close(fig)
 
-        fig, axes = plt.subplots(
-            1, sim_count, figsize=(3 * sim_count, 5.0), constrained_layout=True
-        )
-
-        for row_index, nu in enumerate(nus):
-            ax = axes[row_index]
-            ds = self.open_model_dataset(
-                f'output_nu_{nu:g}.nc', self.config, decode_times=True
+            fig, axes = plt.subplots(
+                1,
+                sim_count,
+                figsize=(3 * sim_count, 5.0),
+                constrained_layout=True,
             )
-            ds = ds.isel(nVertLevels=0)
-            times = get_days_since_start(ds)
-            time_index = np.argmin(np.abs(times - time))
 
-            cell_mask = ds_vert_coord.maxLevelCell >= 1
-            plot_horiz_field(
-                ds_mesh,
-                ds['temperature'],
-                ax=ax,
-                cmap='cmo.thermal',
-                t_index=time_index,
-                vmin=min_temp,
-                vmax=max_temp,
-                cmap_title='SST (C)',
-                field_mask=cell_mask,
-            )
-            ax.set_title(f'day {times[time_index]:g}, $\\nu_h=${nu:g}')
+            for row_index, nu in enumerate(nus):
+                ax = axes[row_index]
+                ds = self.open_model_dataset(
+                    f'output_nu_{nu:g}.nc', self.config, decode_times=True
+                )
+                ds = ds.isel(nVertLevels=0)
+                times = get_days_since_start(ds)
+                time_index = np.argmin(np.abs(times - time))
 
-        plt.savefig(output_filename)
+                cell_mask = ds_vert_coord.maxLevelCell >= 1
+                plot_horiz_field(
+                    ds_mesh,
+                    ds['temperature'],
+                    ax=ax,
+                    cmap='cmo.thermal',
+                    t_index=time_index,
+                    vmin=min_temp,
+                    vmax=max_temp,
+                    cmap_title='SST (C)',
+                    field_mask=cell_mask,
+                )
+                ax.set_title(f'day {times[time_index]:g}, $\\nu_h=${nu:g}')
+
+            plt.savefig(output_filename)

--- a/polaris/tasks/ocean/barotropic_gyre/analysis.py
+++ b/polaris/tasks/ocean/barotropic_gyre/analysis.py
@@ -9,7 +9,7 @@ from mpas_tools.ocean import compute_barotropic_streamfunction
 
 from polaris.mpas import area_for_field
 from polaris.ocean.model import OceanIOStep
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class Analysis(OceanIOStep):
@@ -97,77 +97,77 @@ class Analysis(OceanIOStep):
 
         descriptor = mosaic.Descriptor(ds_mesh)
 
-        use_mplstyle()
-        pad = 20
-        x0 = ds_mesh.xEdge.min().values
-        y0 = ds_mesh.yEdge.min().values
+        with mplstyle_context():
+            pad = 20
+            x0 = ds_mesh.xEdge.min().values
+            y0 = ds_mesh.yEdge.min().values
 
-        # offset coordinates
-        descriptor.vertex_patches[..., 0] -= x0
-        descriptor.vertex_patches[..., 1] -= y0
-        # convert to km
-        descriptor.vertex_patches *= 1.0e-3
+            # offset coordinates
+            descriptor.vertex_patches[..., 0] -= x0
+            descriptor.vertex_patches[..., 1] -= y0
+            # convert to km
+            descriptor.vertex_patches *= 1.0e-3
 
-        fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(12, 2))
+            fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(12, 2))
 
-        eta0 = max(
-            np.max(np.abs(field_exact.values)),
-            np.max(np.abs(field_mpas.values)),
-        )
+            eta0 = max(
+                np.max(np.abs(field_exact.values)),
+                np.max(np.abs(field_mpas.values)),
+            )
 
-        bounds = np.linspace(-eta0, eta0, 21)
-        norm = mcolors.BoundaryNorm(bounds, cmocean.cm.amp.N)
-        s = mosaic.polypcolor(
-            axes[0],
-            descriptor,
-            field_mpas,
-            cmap='cmo.balance',
-            norm=norm,
-            antialiased=False,
-        )
-        cbar = fig.colorbar(s, ax=axes[0])
-        cbar.ax.set_title(r'$\psi$')
-        s = mosaic.polypcolor(
-            axes[1],
-            descriptor,
-            field_exact,
-            cmap='cmo.balance',
-            norm=norm,
-            antialiased=False,
-        )
-        cbar = fig.colorbar(s, ax=axes[1])
-        cbar.ax.set_title(r'$\psi$')
+            bounds = np.linspace(-eta0, eta0, 21)
+            norm = mcolors.BoundaryNorm(bounds, cmocean.cm.amp.N)
+            s = mosaic.polypcolor(
+                axes[0],
+                descriptor,
+                field_mpas,
+                cmap='cmo.balance',
+                norm=norm,
+                antialiased=False,
+            )
+            cbar = fig.colorbar(s, ax=axes[0])
+            cbar.ax.set_title(r'$\psi$')
+            s = mosaic.polypcolor(
+                axes[1],
+                descriptor,
+                field_exact,
+                cmap='cmo.balance',
+                norm=norm,
+                antialiased=False,
+            )
+            cbar = fig.colorbar(s, ax=axes[1])
+            cbar.ax.set_title(r'$\psi$')
 
-        eta0 = np.max(np.abs(field_mpas.values - field_exact.values))
-        bounds = np.linspace(-eta0, eta0, 11)
-        norm = mcolors.BoundaryNorm(bounds, cmocean.cm.balance.N)
-        s = mosaic.polypcolor(
-            axes[2],
-            descriptor,
-            field_mpas - field_exact,
-            cmap='cmo.balance',
-            norm=norm,
-            antialiased=False,
-        )
-        cbar = fig.colorbar(s, ax=axes[2])
-        cbar.ax.set_title(r'$d\psi$')
-        axes[0].set_title('Numerical solution', pad=pad)
-        axes[0].set_ylabel('y (km)')
-        axes[0].set_xlabel('x (km)')
-        axes[1].set_title('Analytical solution', pad=pad)
-        axes[1].set_xlabel('x (km)')
-        axes[2].set_title('Error (Numerical - Analytical)', pad=pad)
-        axes[2].set_xlabel('x (km)')
+            eta0 = np.max(np.abs(field_mpas.values - field_exact.values))
+            bounds = np.linspace(-eta0, eta0, 11)
+            norm = mcolors.BoundaryNorm(bounds, cmocean.cm.balance.N)
+            s = mosaic.polypcolor(
+                axes[2],
+                descriptor,
+                field_mpas - field_exact,
+                cmap='cmo.balance',
+                norm=norm,
+                antialiased=False,
+            )
+            cbar = fig.colorbar(s, ax=axes[2])
+            cbar.ax.set_title(r'$d\psi$')
+            axes[0].set_title('Numerical solution', pad=pad)
+            axes[0].set_ylabel('y (km)')
+            axes[0].set_xlabel('x (km)')
+            axes[1].set_title('Analytical solution', pad=pad)
+            axes[1].set_xlabel('x (km)')
+            axes[2].set_title('Error (Numerical - Analytical)', pad=pad)
+            axes[2].set_xlabel('x (km)')
 
-        xmin = descriptor.vertex_patches[..., 0].min()
-        xmax = descriptor.vertex_patches[..., 0].max()
-        ymin = descriptor.vertex_patches[..., 1].min()
-        ymax = descriptor.vertex_patches[..., 1].max()
-        for ax in axes:
-            ax.set_xlim(xmin, xmax)
-            ax.set_ylim(ymin, ymax)
-            ax.set_aspect('equal')
-        fig.savefig('comparison.png', bbox_inches='tight', pad_inches=0.1)
+            xmin = descriptor.vertex_patches[..., 0].min()
+            xmax = descriptor.vertex_patches[..., 0].max()
+            ymin = descriptor.vertex_patches[..., 1].min()
+            ymax = descriptor.vertex_patches[..., 1].max()
+            for ax in axes:
+                ax.set_xlim(xmin, xmax)
+                ax.set_ylim(ymin, ymax)
+                ax.set_aspect('equal')
+            fig.savefig('comparison.png', bbox_inches='tight', pad_inches=0.1)
 
     def compute_error(
         self,

--- a/polaris/tasks/ocean/cosine_bell/analysis.py
+++ b/polaris/tasks/ocean/cosine_bell/analysis.py
@@ -69,7 +69,7 @@ class Analysis(ConvergenceAnalysis):
         """
 
         if field_name != 'tracer1':
-            print(
+            self.logger.info(
                 f'Variable {field_name} not available as an analytic '
                 'solution for the cosine_bell test case'
             )

--- a/polaris/tasks/ocean/customizable_viz/viz_horiz_field.py
+++ b/polaris/tasks/ocean/customizable_viz/viz_horiz_field.py
@@ -104,8 +104,11 @@ class VizHorizField(OceanIOStep):
                 lon_cell <= max_longitude
             )
         cell_indices = np.where(lat_mask & lon_mask)
-        print(f'min lon {min_longitude}, max lon {max_longitude} \n')
-        print(f'min lon {min_longitude_copy}, max lon {max_longitude_copy} \n')
+        logger = self.logger
+        logger.info(f'min lon {min_longitude}, max lon {max_longitude}')
+        logger.info(
+            f'min lon {min_longitude_copy}, max lon {max_longitude_copy}'
+        )
         if len(cell_indices[0]) == 0:
             raise ValueError(
                 f'No cells of {ds_mesh.sizes["nCells"]} cells found within the'
@@ -116,7 +119,7 @@ class VizHorizField(OceanIOStep):
                 f'longitude {lon_cell.min().values},{lon_cell.max().values}'
                 f'min lon {min_longitude}, max lon {max_longitude} \n'
             )
-        print(
+        logger.info(
             f'Using {len(cell_indices[0])} cells of '
             f'{ds_mesh.sizes["nCells"]} cells in the mesh'
         )
@@ -131,9 +134,9 @@ class VizHorizField(OceanIOStep):
                 if dz[z_index] > 0 and z_index > 0:
                     z_index -= 1
                 z_mean = z_bottom.mean(dim='nCells')[z_index].values
-                print(
+                logger.info(
                     f'Using z_index {z_index} for z_target {z_target} '
-                    f'with mean depth {z_mean} '
+                    f'with mean depth {z_mean}'
                 )
             else:
                 z_index = 0
@@ -196,12 +199,12 @@ class VizHorizField(OceanIOStep):
                 elif var_name == 'columnThickness':
                     ds[full_var_name] = ds.bottomDepth + ds.ssh
                 else:
-                    print(
+                    logger.info(
                         f'Skipping {full_var_name}, '
                         f'not found in {self.input_file}'
                     )
                     continue
-            print(f'Plotting {full_var_name}')
+            logger.info(f'Plotting {full_var_name}')
             filename_suffix = ''
             mpas_field = ds[full_var_name]
             if 'nVertLevels' in mpas_field.sizes:

--- a/polaris/tasks/ocean/customizable_viz/viz_transect.py
+++ b/polaris/tasks/ocean/customizable_viz/viz_transect.py
@@ -112,12 +112,12 @@ class VizTransect(OceanIOStep):
                 elif var_name == 'columnThickness':
                     ds[full_var_name] = ds.bottomDepth + ds.ssh
                 else:
-                    print(
+                    self.logger.info(
                         f'Skipping {full_var_name}, '
                         f'not found in {self.input_file}'
                     )
                     continue
-            print(f'Plotting {full_var_name}')
+            self.logger.info(f'Plotting {full_var_name}')
             mpas_field = ds[f'{full_var_name}']
             data = ds_data[f'{full_var_name}']
             if var_name in viz_dict.keys():

--- a/polaris/tasks/ocean/external_gravity_wave/analysis.py
+++ b/polaris/tasks/ocean/external_gravity_wave/analysis.py
@@ -94,7 +94,7 @@ class Analysis(ConvergenceAnalysis):
         """
 
         if field_name != 'layerThickness' and field_name != 'normalVelocity':
-            print(
+            self.logger.info(
                 f'Variable {field_name} not available as a reference '
                 'solution for the external gravity wave test case'
             )

--- a/polaris/tasks/ocean/geostrophic/analysis.py
+++ b/polaris/tasks/ocean/geostrophic/analysis.py
@@ -68,7 +68,7 @@ class Analysis(ConvergenceAnalysis):
         """
 
         if field_name not in ['h', 'normalVelocity']:
-            print(
+            self.logger.info(
                 f'Variable {field_name} not available as an analytic '
                 'solution for the geostrophic test case'
             )
@@ -116,9 +116,9 @@ class Analysis(ConvergenceAnalysis):
         """
 
         if field_name not in ['h', 'normalVelocity']:
-            print(
-                f'Variable {field_name} not available for analysis in the '
-                f'geostrophic test case'
+            self.logger.info(
+                f'Variable {field_name} not available for analysis in '
+                f'the geostrophic test case'
             )
 
         if field_name == 'normalVelocity':

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -86,7 +86,6 @@ class Analysis(OceanIOStep):
         """
         Run this step of the test case
         """
-        plt.switch_backend('Agg')
         logger = self.logger
         config = self.config
 

--- a/polaris/tasks/ocean/horiz_press_grad/analysis.py
+++ b/polaris/tasks/ocean/horiz_press_grad/analysis.py
@@ -5,7 +5,7 @@ import xarray as xr
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.vertical.ztilde import Gravity, RhoSw
 from polaris.tasks.ocean.horiz_press_grad.reference import ReferenceColumn
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class Analysis(OceanIOStep):
@@ -539,25 +539,27 @@ def _plot_errors(
     """
     Plot RMS error vs. horizontal resolution with a power-law fit.
     """
-    use_mplstyle()
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+    with mplstyle_context():
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
 
-    if fit is not None:
-        if slope is None:
-            raise ValueError('slope must be provided when fit is provided.')
-        ax.loglog(
-            resolution_km,
-            fit,
-            'k',
-            label=f'power-law fit (slope={slope:1.3f})',
-        )
-    ax.loglog(resolution_km, rms_error, 'o', label='RMS error')
+        if fit is not None:
+            if slope is None:
+                raise ValueError(
+                    'slope must be provided when fit is provided.'
+                )
+            ax.loglog(
+                resolution_km,
+                fit,
+                'k',
+                label=f'power-law fit (slope={slope:1.3f})',
+            )
+        ax.loglog(resolution_km, rms_error, 'o', label='RMS error')
 
-    ax.set_xlabel('Horizontal resolution (km)')
-    ax.set_ylabel(y_label)
-    ax.set_title(title)
-    ax.legend(loc='lower right')
-    ax.invert_xaxis()
-    fig.savefig(output, bbox_inches='tight', pad_inches=0.1)
-    plt.close()
+        ax.set_xlabel('Horizontal resolution (km)')
+        ax.set_ylabel(y_label)
+        ax.set_title(title)
+        ax.legend(loc='lower right')
+        ax.invert_xaxis()
+        fig.savefig(output, bbox_inches='tight', pad_inches=0.1)
+        plt.close()

--- a/polaris/tasks/ocean/inertial_gravity_wave/viz.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/viz.py
@@ -126,7 +126,6 @@ class Viz(OceanIOStep):
         """
         Run this step of the test case
         """
-        plt.switch_backend('Agg')
         config = self.config
 
         if self.refinement == 'time':

--- a/polaris/tasks/ocean/inertial_gravity_wave/viz.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/viz.py
@@ -11,7 +11,7 @@ from polaris.ocean.model import OceanIOStep
 from polaris.tasks.ocean.inertial_gravity_wave.exact_solution import (
     ExactSolution,
 )
-from polaris.viz import plot_horiz_field, use_mplstyle
+from polaris.viz import mplstyle_context, plot_horiz_field
 
 
 class Viz(OceanIOStep):
@@ -141,103 +141,106 @@ class Viz(OceanIOStep):
 
         model = config.get('ocean', 'model')
 
-        use_mplstyle()
-        fig, axes = plt.subplots(nrows=nres, ncols=3, figsize=(12, 2 * nres))
-        rmse = []
-        error_range = None
-        for i, refinement_factor in enumerate(refinement_factors):
-            resolution = get_resolution_for_task(
-                config, refinement_factor, refinement=self.refinement
+        with mplstyle_context():
+            fig, axes = plt.subplots(
+                nrows=nres, ncols=3, figsize=(12, 2 * nres)
             )
-            ds_mesh = self.open_model_dataset(
-                f'mesh_r{refinement_factor:02g}.nc', config
-            )
-            ds_init = self.open_model_dataset(
-                f'init_r{refinement_factor:02g}.nc', config
-            )
-            ds_vert_coord = self.open_vert_coord_dataset(
-                ds_init,
-                vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
-            )
-            ds = self.open_model_dataset(
-                f'output_r{refinement_factor:02g}.nc', config
-            )
-            exact = ExactSolution(ds_mesh, config)
+            rmse = []
+            error_range = None
+            for i, refinement_factor in enumerate(refinement_factors):
+                resolution = get_resolution_for_task(
+                    config, refinement_factor, refinement=self.refinement
+                )
+                ds_mesh = self.open_model_dataset(
+                    f'mesh_r{refinement_factor:02g}.nc', config
+                )
+                ds_init = self.open_model_dataset(
+                    f'init_r{refinement_factor:02g}.nc', config
+                )
+                ds_vert_coord = self.open_vert_coord_dataset(
+                    ds_init,
+                    vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
+                )
+                ds = self.open_model_dataset(
+                    f'output_r{refinement_factor:02g}.nc', config
+                )
+                exact = ExactSolution(ds_mesh, config)
 
-            if model == 'mpas-o':
-                dt = time_since_start(ds.xtime.values)
-                t = float(dt[-1])
-            else:
-                # time is seconds since the start of the simulation in Omega
-                t = float(ds.Time.values[-1])
-            ssh_model = ds.ssh.values[-1, :]
-            rmse.append(
-                np.sqrt(np.mean((ssh_model - exact.ssh(t).values) ** 2))
-            )
+                if model == 'mpas-o':
+                    dt = time_since_start(ds.xtime.values)
+                    t = float(dt[-1])
+                else:
+                    # time is seconds since the start of the
+                    # simulation in Omega
+                    t = float(ds.Time.values[-1])
+                ssh_model = ds.ssh.values[-1, :]
+                rmse.append(
+                    np.sqrt(np.mean((ssh_model - exact.ssh(t).values) ** 2))
+                )
 
-            # Comparison plots
-            ds['ssh_exact'] = exact.ssh(t)
-            ds['ssh_error'] = ssh_model - exact.ssh(t)
-            if error_range is None:
-                error_range = np.max(np.abs(ds.ssh_error.values))
+                # Comparison plots
+                ds['ssh_exact'] = exact.ssh(t)
+                ds['ssh_error'] = ssh_model - exact.ssh(t)
+                if error_range is None:
+                    error_range = np.max(np.abs(ds.ssh_error.values))
 
-            cell_mask = ds_vert_coord.maxLevelCell >= 1
-            descriptor = plot_horiz_field(
-                ds_mesh,
-                ds['ssh'],
-                ax=axes[i, 0],
-                cmap='cmo.balance',
-                t_index=ds.sizes['Time'] - 1,
-                vmin=-eta0,
-                vmax=eta0,
-                cmap_title='SSH (m)',
-                field_mask=cell_mask,
-            )
-            plot_horiz_field(
-                ds_mesh,
-                ds['ssh_exact'],
-                ax=axes[i, 1],
-                cmap='cmo.balance',
-                vmin=-eta0,
-                vmax=eta0,
-                cmap_title='SSH (m)',
-                descriptor=descriptor,
-            )
-            plot_horiz_field(
-                ds_mesh,
-                ds['ssh_error'],
-                ax=axes[i, 2],
-                cmap='cmo.balance',
-                cmap_title=r'$\Delta$ SSH (m)',
-                vmin=-error_range,
-                vmax=error_range,
-                descriptor=descriptor,
-            )
+                cell_mask = ds_vert_coord.maxLevelCell >= 1
+                descriptor = plot_horiz_field(
+                    ds_mesh,
+                    ds['ssh'],
+                    ax=axes[i, 0],
+                    cmap='cmo.balance',
+                    t_index=ds.sizes['Time'] - 1,
+                    vmin=-eta0,
+                    vmax=eta0,
+                    cmap_title='SSH (m)',
+                    field_mask=cell_mask,
+                )
+                plot_horiz_field(
+                    ds_mesh,
+                    ds['ssh_exact'],
+                    ax=axes[i, 1],
+                    cmap='cmo.balance',
+                    vmin=-eta0,
+                    vmax=eta0,
+                    cmap_title='SSH (m)',
+                    descriptor=descriptor,
+                )
+                plot_horiz_field(
+                    ds_mesh,
+                    ds['ssh_error'],
+                    ax=axes[i, 2],
+                    cmap='cmo.balance',
+                    cmap_title=r'$\Delta$ SSH (m)',
+                    vmin=-error_range,
+                    vmax=error_range,
+                    descriptor=descriptor,
+                )
 
-        axes[0, 0].set_title('Numerical solution')
-        axes[0, 1].set_title('Analytical solution')
-        axes[0, 2].set_title('Error (Numerical - Analytical)')
+            axes[0, 0].set_title('Numerical solution')
+            axes[0, 1].set_title('Analytical solution')
+            axes[0, 2].set_title('Error (Numerical - Analytical)')
 
-        pad = 5
-        for ax, refinement_factor in zip(
-            axes[:, 0], refinement_factors, strict=False
-        ):
-            timestep, _ = get_timestep_for_task(
-                config, refinement_factor, refinement=self.refinement
-            )
-            resolution = get_resolution_for_task(
-                config, refinement_factor, refinement=self.refinement
-            )
+            pad = 5
+            for ax, refinement_factor in zip(
+                axes[:, 0], refinement_factors, strict=False
+            ):
+                timestep, _ = get_timestep_for_task(
+                    config, refinement_factor, refinement=self.refinement
+                )
+                resolution = get_resolution_for_task(
+                    config, refinement_factor, refinement=self.refinement
+                )
 
-            ax.annotate(
-                f'{resolution}km\n{timestep}s',
-                xy=(0, 0.5),
-                xytext=(-ax.yaxis.labelpad - pad, 0),
-                xycoords=ax.yaxis.label,
-                textcoords='offset points',
-                size='large',
-                ha='right',
-                va='center',
-            )
+                ax.annotate(
+                    f'{resolution}km\n{timestep}s',
+                    xy=(0, 0.5),
+                    xytext=(-ax.yaxis.labelpad - pad, 0),
+                    xycoords=ax.yaxis.label,
+                    textcoords='offset points',
+                    size='large',
+                    ha='right',
+                    va='center',
+                )
 
-        fig.savefig('comparison.png', bbox_inches='tight', pad_inches=0.1)
+            fig.savefig('comparison.png', bbox_inches='tight', pad_inches=0.1)

--- a/polaris/tasks/ocean/internal_wave/rpe/analysis.py
+++ b/polaris/tasks/ocean/internal_wave/rpe/analysis.py
@@ -78,7 +78,6 @@ class Analysis(OceanIOStep):
             ds_vert_coord=ds_vert_coord,
         )
 
-        plt.switch_backend('Agg')
         sim_count = len(nus)
         time = section.getfloat('plot_time')
         min_temp = section.getfloat('min_temp')

--- a/polaris/tasks/ocean/internal_wave/rpe/analysis.py
+++ b/polaris/tasks/ocean/internal_wave/rpe/analysis.py
@@ -6,7 +6,7 @@ from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 
 from polaris.ocean.model import OceanIOStep, get_days_since_start
 from polaris.ocean.rpe import compute_rpe
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class Analysis(OceanIOStep):
@@ -89,64 +89,64 @@ class Analysis(OceanIOStep):
         )
         times = get_days_since_start(ds)
 
-        use_mplstyle()
-        fig = plt.figure()
-        for i in range(sim_count):
-            rpe_norm = np.divide((rpe[i, :] - rpe[i, 0]), rpe[i, 0])
-            plt.plot(times, rpe_norm, label=f'$\\nu_h=${nus[i]}')
-        plt.xlabel('Time, days')
-        plt.ylabel('RPE-RPE(0)/RPE(0)')
-        plt.legend()
-        plt.savefig('rpe_t.png')
-        plt.close(fig)
+        with mplstyle_context():
+            fig = plt.figure()
+            for i in range(sim_count):
+                rpe_norm = np.divide((rpe[i, :] - rpe[i, 0]), rpe[i, 0])
+                plt.plot(times, rpe_norm, label=f'$\\nu_h=${nus[i]}')
+            plt.xlabel('Time, days')
+            plt.ylabel('RPE-RPE(0)/RPE(0)')
+            plt.legend()
+            plt.savefig('rpe_t.png')
+            plt.close(fig)
 
-        fig, axes = plt.subplots(
-            1,
-            sim_count,
-            sharey=True,
-            figsize=(3 * sim_count, 5.0),
-            constrained_layout=True,
-        )
-        fig.suptitle(f'day {time}')
-        x_mid = ds_mesh.xCell.median()
-        y_min = ds_mesh.yCell.min()
-        y_max = ds_mesh.yCell.max()
-        x = xr.DataArray(data=[x_mid, x_mid], dims=('nPoints',))
-        y = xr.DataArray(data=[y_min, y_max], dims=('nPoints',))
-        for row_index, nu in enumerate(nus):
-            ax = axes[row_index]
-            ds = self.open_model_dataset(
-                f'output_nu_{nu:g}.nc', self.config, decode_times=True
+            fig, axes = plt.subplots(
+                1,
+                sim_count,
+                sharey=True,
+                figsize=(3 * sim_count, 5.0),
+                constrained_layout=True,
             )
-            times = get_days_since_start(ds)
-            time_index = np.argmin(np.abs(times - time))
-            ds_transect = compute_transect(
-                x=x,
-                y=y,
-                ds_horiz_mesh=ds_mesh,
-                layer_thickness=ds.layerThickness.isel(Time=time_index),
-                bottom_depth=ds_vert_coord.bottomDepth,
-                min_level_cell=ds_vert_coord.minLevelCell - 1,
-                max_level_cell=ds_vert_coord.maxLevelCell - 1,
-                spherical=False,
-            )
+            fig.suptitle(f'day {time}')
+            x_mid = ds_mesh.xCell.median()
+            y_min = ds_mesh.yCell.min()
+            y_max = ds_mesh.yCell.max()
+            x = xr.DataArray(data=[x_mid, x_mid], dims=('nPoints',))
+            y = xr.DataArray(data=[y_min, y_max], dims=('nPoints',))
+            for row_index, nu in enumerate(nus):
+                ax = axes[row_index]
+                ds = self.open_model_dataset(
+                    f'output_nu_{nu:g}.nc', self.config, decode_times=True
+                )
+                times = get_days_since_start(ds)
+                time_index = np.argmin(np.abs(times - time))
+                ds_transect = compute_transect(
+                    x=x,
+                    y=y,
+                    ds_horiz_mesh=ds_mesh,
+                    layer_thickness=ds.layerThickness.isel(Time=time_index),
+                    bottom_depth=ds_vert_coord.bottomDepth,
+                    min_level_cell=ds_vert_coord.minLevelCell - 1,
+                    max_level_cell=ds_vert_coord.maxLevelCell - 1,
+                    spherical=False,
+                )
 
-            if row_index == len(nus) - 1:
-                colorbar_label = r'$^{\circ}$C'
-            else:
-                colorbar_label = None
-            plot_transect(
-                ds_transect,
-                mpas_field=ds.temperature.isel(Time=time_index),
-                ax=ax,
-                title='temperature',
-                interface_color='grey',
-                vmin=min_temp,
-                vmax=max_temp,
-                colorbar_label=colorbar_label,
-                cmap='cmo.thermal',
-            )
-            ax.set_title(f'$\\nu_h=${nu:g}')
-            if row_index != 0:
-                ax.set_ylabel(None)
-        plt.savefig(output_filename)
+                if row_index == len(nus) - 1:
+                    colorbar_label = r'$^{\circ}$C'
+                else:
+                    colorbar_label = None
+                plot_transect(
+                    ds_transect,
+                    mpas_field=ds.temperature.isel(Time=time_index),
+                    ax=ax,
+                    title='temperature',
+                    interface_color='grey',
+                    vmin=min_temp,
+                    vmax=max_temp,
+                    colorbar_label=colorbar_label,
+                    cmap='cmo.thermal',
+                )
+                ax.set_title(f'$\\nu_h=${nu:g}')
+                if row_index != 0:
+                    ax.set_ylabel(None)
+            plt.savefig(output_filename)

--- a/polaris/tasks/ocean/manufactured_solution/viz.py
+++ b/polaris/tasks/ocean/manufactured_solution/viz.py
@@ -11,7 +11,7 @@ from polaris.ocean.model import OceanIOStep
 from polaris.tasks.ocean.manufactured_solution.exact_solution import (
     ExactSolution,
 )
-from polaris.viz import plot_horiz_field, use_mplstyle
+from polaris.viz import mplstyle_context, plot_horiz_field
 
 
 class Viz(OceanIOStep):
@@ -142,109 +142,113 @@ class Viz(OceanIOStep):
 
         model = config.get('ocean', 'model')
 
-        use_mplstyle()
-        fig, axes = plt.subplots(nrows=nres, ncols=3, figsize=(12, 2 * nres))
-        error_range = None
-
-        section = config['convergence']
-        eval_time = section.getfloat('convergence_eval_time')
-        s_per_hour = 3600.0
-        time = eval_time * s_per_hour
-
-        for i, refinement_factor in enumerate(refinement_factors):
-            ds_mesh = self.open_model_dataset(
-                f'mesh_r{refinement_factor:02g}.nc', config
+        with mplstyle_context():
+            fig, axes = plt.subplots(
+                nrows=nres, ncols=3, figsize=(12, 2 * nres)
             )
-            ds_init = self.open_model_dataset(
-                f'init_r{refinement_factor:02g}.nc', config
-            )
-            ds_vert_coord = self.open_vert_coord_dataset(
-                ds_init,
-                vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
-            )
-            ds = self.open_model_dataset(
-                f'output_r{refinement_factor:02g}.nc',
-                config,
-                decode_times=False,
-            )
+            error_range = None
 
-            exact = ExactSolution(config, ds_mesh)
+            section = config['convergence']
+            eval_time = section.getfloat('convergence_eval_time')
+            s_per_hour = 3600.0
+            time = eval_time * s_per_hour
 
-            if model == 'mpas-o':
-                dt = time_since_start(ds.xtime.values)
-            else:
-                # time is seconds since the start of the simulation in Omega
-                dt = ds.Time.values
-            tidx = np.argmin(np.abs(dt - time))
+            for i, refinement_factor in enumerate(refinement_factors):
+                ds_mesh = self.open_model_dataset(
+                    f'mesh_r{refinement_factor:02g}.nc', config
+                )
+                ds_init = self.open_model_dataset(
+                    f'init_r{refinement_factor:02g}.nc', config
+                )
+                ds_vert_coord = self.open_vert_coord_dataset(
+                    ds_init,
+                    vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
+                )
+                ds = self.open_model_dataset(
+                    f'output_r{refinement_factor:02g}.nc',
+                    config,
+                    decode_times=False,
+                )
 
-            ssh_model = ds.ssh.isel(Time=tidx)
-            if 'nVertLevels' in ssh_model.dims:
-                # Omega v0 uses stacked shallow water where ssh has nVertLevels
-                ssh_model = ssh_model.isel(nVertLevels=0)
+                exact = ExactSolution(config, ds_mesh)
 
-            # Comparison plots
-            ssh_exact = exact.ssh(time)
-            ds['ssh_exact'] = ssh_exact
-            ds['ssh_error'] = ssh_model - ssh_exact
-            if error_range is None:
-                error_range = np.max(np.abs(ds.ssh_error.values))
+                if model == 'mpas-o':
+                    dt = time_since_start(ds.xtime.values)
+                else:
+                    # time is seconds since the start of the
+                    # simulation in Omega
+                    dt = ds.Time.values
+                tidx = np.argmin(np.abs(dt - time))
 
-            cell_mask = ds_vert_coord.maxLevelCell >= 1
-            descriptor = plot_horiz_field(
-                ds_mesh,
-                ssh_model,
-                ax=axes[i, 0],
-                cmap='cmo.balance',
-                vmin=-eta0,
-                vmax=eta0,
-                cmap_title='SSH',
-                field_mask=cell_mask,
-            )
-            plot_horiz_field(
-                ds_mesh,
-                ds['ssh_exact'],
-                ax=axes[i, 1],
-                cmap='cmo.balance',
-                vmin=-eta0,
-                vmax=eta0,
-                cmap_title='SSH',
-                descriptor=descriptor,
-            )
-            plot_horiz_field(
-                ds_mesh,
-                ds['ssh_error'],
-                ax=axes[i, 2],
-                cmap='cmo.balance',
-                cmap_title='dSSH',
-                vmin=-error_range,
-                vmax=error_range,
-                descriptor=descriptor,
-            )
+                ssh_model = ds.ssh.isel(Time=tidx)
+                if 'nVertLevels' in ssh_model.dims:
+                    # Omega v0 uses stacked shallow water where ssh
+                    # has nVertLevels
+                    ssh_model = ssh_model.isel(nVertLevels=0)
 
-        axes[0, 0].set_title('Numerical solution')
-        axes[0, 1].set_title('Analytical solution')
-        axes[0, 2].set_title('Error (Numerical - Analytical)')
+                # Comparison plots
+                ssh_exact = exact.ssh(time)
+                ds['ssh_exact'] = ssh_exact
+                ds['ssh_error'] = ssh_model - ssh_exact
+                if error_range is None:
+                    error_range = np.max(np.abs(ds.ssh_error.values))
 
-        pad = 5
-        for ax, refinement_factor in zip(
-            axes[:, 0], refinement_factors, strict=False
-        ):
-            timestep, _ = get_timestep_for_task(
-                config, refinement_factor, refinement=self.refinement
-            )
-            resolution = get_resolution_for_task(
-                config, refinement_factor, refinement=self.refinement
-            )
+                cell_mask = ds_vert_coord.maxLevelCell >= 1
+                descriptor = plot_horiz_field(
+                    ds_mesh,
+                    ssh_model,
+                    ax=axes[i, 0],
+                    cmap='cmo.balance',
+                    vmin=-eta0,
+                    vmax=eta0,
+                    cmap_title='SSH',
+                    field_mask=cell_mask,
+                )
+                plot_horiz_field(
+                    ds_mesh,
+                    ds['ssh_exact'],
+                    ax=axes[i, 1],
+                    cmap='cmo.balance',
+                    vmin=-eta0,
+                    vmax=eta0,
+                    cmap_title='SSH',
+                    descriptor=descriptor,
+                )
+                plot_horiz_field(
+                    ds_mesh,
+                    ds['ssh_error'],
+                    ax=axes[i, 2],
+                    cmap='cmo.balance',
+                    cmap_title='dSSH',
+                    vmin=-error_range,
+                    vmax=error_range,
+                    descriptor=descriptor,
+                )
 
-            ax.annotate(
-                f'{resolution}km\n{timestep}s',
-                xy=(0, 0.5),
-                xytext=(-ax.yaxis.labelpad - pad, 0),
-                xycoords=ax.yaxis.label,
-                textcoords='offset points',
-                size='large',
-                ha='right',
-                va='center',
-            )
+            axes[0, 0].set_title('Numerical solution')
+            axes[0, 1].set_title('Analytical solution')
+            axes[0, 2].set_title('Error (Numerical - Analytical)')
 
-        fig.savefig('comparison.png', bbox_inches='tight', pad_inches=0.1)
+            pad = 5
+            for ax, refinement_factor in zip(
+                axes[:, 0], refinement_factors, strict=False
+            ):
+                timestep, _ = get_timestep_for_task(
+                    config, refinement_factor, refinement=self.refinement
+                )
+                resolution = get_resolution_for_task(
+                    config, refinement_factor, refinement=self.refinement
+                )
+
+                ax.annotate(
+                    f'{resolution}km\n{timestep}s',
+                    xy=(0, 0.5),
+                    xytext=(-ax.yaxis.labelpad - pad, 0),
+                    xycoords=ax.yaxis.label,
+                    textcoords='offset points',
+                    size='large',
+                    ha='right',
+                    va='center',
+                )
+
+            fig.savefig('comparison.png', bbox_inches='tight', pad_inches=0.1)

--- a/polaris/tasks/ocean/manufactured_solution/viz.py
+++ b/polaris/tasks/ocean/manufactured_solution/viz.py
@@ -127,7 +127,6 @@ class Viz(OceanIOStep):
         """
         Run this step of the test case
         """
-        plt.switch_backend('Agg')
         config = self.config
         if self.refinement == 'time':
             option = 'refinement_factors_time'

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -6,7 +6,7 @@ from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 
 from polaris.mpas import time_since_start
 from polaris.ocean.model import OceanIOStep
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class Viz(OceanIOStep):
@@ -88,120 +88,124 @@ class Viz(OceanIOStep):
         model = config.get('ocean', 'model')
         section = config['merry_go_round']
 
-        use_mplstyle()
-        fig, axes = plt.subplots(
-            nrows=2,
-            ncols=2,
-            figsize=(8, 5),
-            constrained_layout=True,
-            sharex=True,
-            sharey=True,
-        )
+        with mplstyle_context():
+            fig, axes = plt.subplots(
+                nrows=2,
+                ncols=2,
+                figsize=(8, 5),
+                constrained_layout=True,
+                sharex=True,
+                sharey=True,
+            )
 
-        section = config['convergence']
-        eval_time = section.getfloat('convergence_eval_time')
-        s_per_hour = 3600.0
-        time = eval_time * s_per_hour
+            section = config['convergence']
+            eval_time = section.getfloat('convergence_eval_time')
+            s_per_hour = 3600.0
+            time = eval_time * s_per_hour
 
-        ds_mesh = self.open_model_dataset('mesh.nc', config)
-        ds_init = self.open_model_dataset('init.nc', config)
-        ds_vert_coord = self.open_vert_coord_dataset(ds_init)
-        ds = self.open_model_dataset(
-            'output.nc',
-            config,
-            mesh_filename='mesh.nc',
-            vert_filename='vert_coord.nc',
-            coeffs_filename='coeffs.nc',
-            decode_times=False,
-            reconstruct_variables=['normalVelocity'],
-            reconstruct_method='RBF',
-        )
-        x_min = ds_mesh.xVertex.min().values
-        x_max = ds_mesh.xVertex.max().values
-        y_mid = ds_mesh.yCell.median().values
+            ds_mesh = self.open_model_dataset('mesh.nc', config)
+            ds_init = self.open_model_dataset('init.nc', config)
+            ds_vert_coord = self.open_vert_coord_dataset(ds_init)
+            ds = self.open_model_dataset(
+                'output.nc',
+                config,
+                mesh_filename='mesh.nc',
+                vert_filename='vert_coord.nc',
+                coeffs_filename='coeffs.nc',
+                decode_times=False,
+                reconstruct_variables=['normalVelocity'],
+                reconstruct_method='RBF',
+            )
+            x_min = ds_mesh.xVertex.min().values
+            x_max = ds_mesh.xVertex.max().values
+            y_mid = ds_mesh.yCell.median().values
 
-        x = xr.DataArray(data=np.linspace(x_min, x_max, 2), dims=('nPoints',))
-        y = y_mid * xr.ones_like(x)
+            x = xr.DataArray(
+                data=np.linspace(x_min, x_max, 2), dims=('nPoints',)
+            )
+            y = y_mid * xr.ones_like(x)
 
-        if model == 'mpas-o':
-            dt = time_since_start(ds.xtime.values)
-        else:
-            # time is seconds since the start of the simulation in Omega
-            dt = ds.Time.values
-        tidx = np.argmin(np.abs(dt - time))
+            if model == 'mpas-o':
+                dt = time_since_start(ds.xtime.values)
+            else:
+                # time is seconds since the start of the simulation in Omega
+                dt = ds.Time.values
+            tidx = np.argmin(np.abs(dt - time))
 
-        ds_transect = compute_transect(
-            x=x,
-            y=y,
-            ds_horiz_mesh=ds_mesh,
-            layer_thickness=ds_init.layerThickness.isel(Time=0),
-            bottom_depth=ds_vert_coord.bottomDepth,
-            min_level_cell=ds_vert_coord.minLevelCell - 1,
-            max_level_cell=ds_vert_coord.maxLevelCell - 1,
-            spherical=False,
-        )
+            ds_transect = compute_transect(
+                x=x,
+                y=y,
+                ds_horiz_mesh=ds_mesh,
+                layer_thickness=ds_init.layerThickness.isel(Time=0),
+                bottom_depth=ds_vert_coord.bottomDepth,
+                min_level_cell=ds_vert_coord.minLevelCell - 1,
+                max_level_cell=ds_vert_coord.maxLevelCell - 1,
+                spherical=False,
+            )
 
-        vert_velocity = ds.vertVelocityTop.isel(Time=tidx)
-        tracer_exact = ds_init.tracer1.isel(Time=0)
-        tracer_model = ds.tracer1.isel(Time=tidx)
-        tracer_error = tracer_model - tracer_exact
+            vert_velocity = ds.vertVelocityTop.isel(Time=tidx)
+            tracer_exact = ds_init.tracer1.isel(Time=0)
+            tracer_model = ds.tracer1.isel(Time=tidx)
+            tracer_error = tracer_model - tracer_exact
 
-        data_min = np.min(np.abs(tracer_exact.values))
-        data_max = np.max(np.abs(tracer_exact.values))
-        error_range = np.max(np.abs(tracer_error.values))
+            data_min = np.min(np.abs(tracer_exact.values))
+            data_max = np.max(np.abs(tracer_exact.values))
+            error_range = np.max(np.abs(tracer_error.values))
 
-        if 'velocityX' in ds.keys():
-            horz_velocity = ds.velocityX.isel(Time=tidx)
+            if 'velocityX' in ds.keys():
+                horz_velocity = ds.velocityX.isel(Time=tidx)
+                plot_transect(
+                    ds_transect=ds_transect,
+                    mpas_field=horz_velocity,
+                    ax=axes[0, 0],
+                    vmin=-0.008,
+                    vmax=0.008,
+                    cmap='cmo.balance',
+                    colorbar_label='horizontal velocity',
+                    color_start_and_end=False,
+                )
+
             plot_transect(
                 ds_transect=ds_transect,
-                mpas_field=horz_velocity,
-                ax=axes[0, 0],
-                vmin=-0.008,
-                vmax=0.008,
+                mpas_field=vert_velocity,
+                ax=axes[0, 1],
+                vmin=-0.02,
+                vmax=0.02,
                 cmap='cmo.balance',
-                colorbar_label='horizontal velocity',
+                colorbar_label='vertical velocity',
                 color_start_and_end=False,
             )
 
-        plot_transect(
-            ds_transect=ds_transect,
-            mpas_field=vert_velocity,
-            ax=axes[0, 1],
-            vmin=-0.02,
-            vmax=0.02,
-            cmap='cmo.balance',
-            colorbar_label='vertical velocity',
-            color_start_and_end=False,
-        )
+            plot_transect(
+                ds_transect=ds_transect,
+                mpas_field=tracer_exact,
+                ax=axes[1, 0],
+                vmin=data_min,
+                vmax=data_max,
+                cmap='cmo.thermal',
+                colorbar_label='tracer1 at t=0',
+                color_start_and_end=False,
+            )
 
-        plot_transect(
-            ds_transect=ds_transect,
-            mpas_field=tracer_exact,
-            ax=axes[1, 0],
-            vmin=data_min,
-            vmax=data_max,
-            cmap='cmo.thermal',
-            colorbar_label='tracer1 at t=0',
-            color_start_and_end=False,
-        )
+            plot_transect(
+                ds_transect=ds_transect,
+                mpas_field=tracer_error,
+                ax=axes[1, 1],
+                vmin=-error_range,
+                vmax=error_range,
+                cmap='cmo.curl',
+                colorbar_label=f'delta(tracer1) at t={eval_time:g}h',
+                color_start_and_end=False,
+            )
 
-        plot_transect(
-            ds_transect=ds_transect,
-            mpas_field=tracer_error,
-            ax=axes[1, 1],
-            vmin=-error_range,
-            vmax=error_range,
-            cmap='cmo.curl',
-            colorbar_label=f'delta(tracer1) at t={eval_time:g}h',
-            color_start_and_end=False,
-        )
+            axes[0, 0].set_xlabel(None)
+            axes[0, 1].set_xlabel(None)
 
-        axes[0, 0].set_xlabel(None)
-        axes[0, 1].set_xlabel(None)
+            axes[0, 1].set_ylabel(None)
+            axes[1, 1].set_ylabel(None)
 
-        axes[0, 1].set_ylabel(None)
-        axes[1, 1].set_ylabel(None)
-
-        fig.savefig(
-            'merry_go_round_section.png', bbox_inches='tight', pad_inches=0.1
-        )
+            fig.savefig(
+                'merry_go_round_section.png',
+                bbox_inches='tight',
+                pad_inches=0.1,
+            )

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -82,7 +82,6 @@ class Viz(OceanIOStep):
         """
         Run this step of the test case
         """
-        plt.switch_backend('Agg')
         config = self.config
 
         model = config.get('ocean', 'model')

--- a/polaris/tasks/ocean/merry_go_round/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/viz.py
@@ -11,7 +11,7 @@ from polaris.ocean.convergence import (
     get_timestep_for_task,
 )
 from polaris.ocean.model import OceanIOStep
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class Viz(OceanIOStep):
@@ -141,159 +141,162 @@ class Viz(OceanIOStep):
         model = config.get('ocean', 'model')
         section = config['merry_go_round']
 
-        use_mplstyle()
-        fig, axes = plt.subplots(
-            nrows=nres,
-            ncols=3,
-            figsize=(12, 2 * nres),
-            constrained_layout=True,
-            sharex=True,
-            sharey=True,
-        )
-
-        section = config['convergence']
-        eval_time = section.getfloat('convergence_eval_time')
-        s_per_hour = 3600.0
-        time = eval_time * s_per_hour
-
-        for i, refinement_factor in enumerate(refinement_factors):
-            timestep, _ = get_timestep_for_task(
-                config, refinement_factor, refinement=self.refinement
-            )
-            resolution = get_resolution_for_task(
-                config, refinement_factor, refinement=self.refinement
+        with mplstyle_context():
+            fig, axes = plt.subplots(
+                nrows=nres,
+                ncols=3,
+                figsize=(12, 2 * nres),
+                constrained_layout=True,
+                sharex=True,
+                sharey=True,
             )
 
-            ds_mesh = self.open_model_dataset(
-                f'mesh_r{refinement_factor:02g}.nc', config
-            )
-            ds_init = self.open_model_dataset(
-                f'init_r{refinement_factor:02g}.nc', config
-            )
-            ds_vert_coord = self.open_vert_coord_dataset(
-                ds_init,
-                vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
-            )
-            ds = self.open_model_dataset(
-                f'output_r{refinement_factor:02g}.nc',
-                config,
-                decode_times=False,
-            )
+            section = config['convergence']
+            eval_time = section.getfloat('convergence_eval_time')
+            s_per_hour = 3600.0
+            time = eval_time * s_per_hour
 
-            dz = ds_init.layerThickness.mean().values
-
-            x_min = ds_mesh.xVertex.min().values
-            x_max = ds_mesh.xVertex.max().values
-            y_mid = ds_mesh.yCell.median().values
-
-            x = xr.DataArray(
-                data=np.linspace(x_min, x_max, 2), dims=('nPoints',)
-            )
-            y = y_mid * xr.ones_like(x)
-
-            if model == 'mpas-o':
-                dt = time_since_start(ds.xtime.values)
-            else:
-                # time is seconds since the start of the simulation in Omega
-                dt = ds.Time.values
-            tidx = np.argmin(np.abs(dt - time))
-
-            ds_transect = compute_transect(
-                x=x,
-                y=y,
-                ds_horiz_mesh=ds_mesh,
-                layer_thickness=ds_init.layerThickness.isel(Time=0),
-                bottom_depth=ds_vert_coord.bottomDepth,
-                min_level_cell=ds_vert_coord.minLevelCell - 1,
-                max_level_cell=ds_vert_coord.maxLevelCell - 1,
-                spherical=False,
-            )
-
-            tracer_exact = ds_init.tracer1.isel(Time=0)
-            tracer_model = ds.tracer1.isel(Time=tidx)
-            tracer_error = tracer_model - tracer_exact
-
-            # compute norm bounds using the coarsest simulation
-            if i == 0:
-                data_min = np.min(np.abs(tracer_exact.values))
-                data_max = np.max(np.abs(tracer_exact.values))
-                error_range = np.max(np.abs(tracer_error.values))
-
-                tracer_norm = mcolors.Normalize(vmin=data_min, vmax=data_max)
-                error_norm = mcolors.Normalize(
-                    vmin=-error_range, vmax=error_range
+            for i, refinement_factor in enumerate(refinement_factors):
+                timestep, _ = get_timestep_for_task(
+                    config, refinement_factor, refinement=self.refinement
+                )
+                resolution = get_resolution_for_task(
+                    config, refinement_factor, refinement=self.refinement
                 )
 
-            plot_transect(
-                ds_transect=ds_transect,
-                mpas_field=tracer_model,
-                ax=axes[i, 0],
-                vmin=tracer_norm.vmin,
-                vmax=tracer_norm.vmax,
-                cmap='cmo.thermal',
-                color_start_and_end=False,
+                ds_mesh = self.open_model_dataset(
+                    f'mesh_r{refinement_factor:02g}.nc', config
+                )
+                ds_init = self.open_model_dataset(
+                    f'init_r{refinement_factor:02g}.nc', config
+                )
+                ds_vert_coord = self.open_vert_coord_dataset(
+                    ds_init,
+                    vert_coord_filename=f'vert_coord_r{refinement_factor:02g}.nc',
+                )
+                ds = self.open_model_dataset(
+                    f'output_r{refinement_factor:02g}.nc',
+                    config,
+                    decode_times=False,
+                )
+
+                dz = ds_init.layerThickness.mean().values
+
+                x_min = ds_mesh.xVertex.min().values
+                x_max = ds_mesh.xVertex.max().values
+                y_mid = ds_mesh.yCell.median().values
+
+                x = xr.DataArray(
+                    data=np.linspace(x_min, x_max, 2), dims=('nPoints',)
+                )
+                y = y_mid * xr.ones_like(x)
+
+                if model == 'mpas-o':
+                    dt = time_since_start(ds.xtime.values)
+                else:
+                    # time is seconds since the start of the
+                    # simulation in Omega
+                    dt = ds.Time.values
+                tidx = np.argmin(np.abs(dt - time))
+
+                ds_transect = compute_transect(
+                    x=x,
+                    y=y,
+                    ds_horiz_mesh=ds_mesh,
+                    layer_thickness=ds_init.layerThickness.isel(Time=0),
+                    bottom_depth=ds_vert_coord.bottomDepth,
+                    min_level_cell=ds_vert_coord.minLevelCell - 1,
+                    max_level_cell=ds_vert_coord.maxLevelCell - 1,
+                    spherical=False,
+                )
+
+                tracer_exact = ds_init.tracer1.isel(Time=0)
+                tracer_model = ds.tracer1.isel(Time=tidx)
+                tracer_error = tracer_model - tracer_exact
+
+                # compute norm bounds using the coarsest simulation
+                if i == 0:
+                    data_min = np.min(np.abs(tracer_exact.values))
+                    data_max = np.max(np.abs(tracer_exact.values))
+                    error_range = np.max(np.abs(tracer_error.values))
+
+                    tracer_norm = mcolors.Normalize(
+                        vmin=data_min, vmax=data_max
+                    )
+                    error_norm = mcolors.Normalize(
+                        vmin=-error_range, vmax=error_range
+                    )
+
+                plot_transect(
+                    ds_transect=ds_transect,
+                    mpas_field=tracer_model,
+                    ax=axes[i, 0],
+                    vmin=tracer_norm.vmin,
+                    vmax=tracer_norm.vmax,
+                    cmap='cmo.thermal',
+                    color_start_and_end=False,
+                )
+
+                plot_transect(
+                    ds_transect=ds_transect,
+                    mpas_field=tracer_exact,
+                    ax=axes[i, 1],
+                    vmin=data_min,
+                    vmax=data_max,
+                    cmap='cmo.thermal',
+                    color_start_and_end=False,
+                )
+
+                plot_transect(
+                    ds_transect=ds_transect,
+                    mpas_field=tracer_error,
+                    ax=axes[i, 2],
+                    vmin=error_norm.vmin,
+                    vmax=error_norm.vmax,
+                    cmap='cmo.curl',
+                    color_start_and_end=False,
+                )
+
+                axes[i, 0].annotate(
+                    (
+                        f'$\\Delta z$={dz:g}m\n'
+                        f'$\\Delta x$={resolution * 1e3:g}m \n'
+                        f'$\\Delta t$={timestep}s'
+                    ),
+                    xy=(0, 0.5),
+                    xytext=(-axes[i, 0].yaxis.labelpad - 5, 0),
+                    xycoords=axes[i, 0].yaxis.label,
+                    textcoords='offset points',
+                    size='large',
+                    ha='right',
+                    va='center',
+                )
+
+                axes[i, 1].set_ylabel(None)
+                axes[i, 2].set_ylabel(None)
+
+                if i != 2:
+                    axes[i, 0].set_xlabel(None)
+                    axes[i, 1].set_xlabel(None)
+                    axes[i, 2].set_xlabel(None)
+
+            fig.colorbar(
+                plt.cm.ScalarMappable(norm=tracer_norm, cmap='cmo.thermal'),
+                label='Numerical solution',
+                ax=axes[:, 0],
+                location='top',
+            )
+            fig.colorbar(
+                plt.cm.ScalarMappable(norm=tracer_norm, cmap='cmo.thermal'),
+                label='Analytical solution',
+                ax=axes[:, 1],
+                location='top',
+            )
+            fig.colorbar(
+                plt.cm.ScalarMappable(norm=error_norm, cmap='cmo.curl'),
+                label='Error (Numerical - Analytical)',
+                ax=axes[:, 2],
+                location='top',
             )
 
-            plot_transect(
-                ds_transect=ds_transect,
-                mpas_field=tracer_exact,
-                ax=axes[i, 1],
-                vmin=data_min,
-                vmax=data_max,
-                cmap='cmo.thermal',
-                color_start_and_end=False,
-            )
-
-            plot_transect(
-                ds_transect=ds_transect,
-                mpas_field=tracer_error,
-                ax=axes[i, 2],
-                vmin=error_norm.vmin,
-                vmax=error_norm.vmax,
-                cmap='cmo.curl',
-                color_start_and_end=False,
-            )
-
-            axes[i, 0].annotate(
-                (
-                    f'$\\Delta z$={dz:g}m\n'
-                    f'$\\Delta x$={resolution * 1e3:g}m \n'
-                    f'$\\Delta t$={timestep}s'
-                ),
-                xy=(0, 0.5),
-                xytext=(-axes[i, 0].yaxis.labelpad - 5, 0),
-                xycoords=axes[i, 0].yaxis.label,
-                textcoords='offset points',
-                size='large',
-                ha='right',
-                va='center',
-            )
-
-            axes[i, 1].set_ylabel(None)
-            axes[i, 2].set_ylabel(None)
-
-            if i != 2:
-                axes[i, 0].set_xlabel(None)
-                axes[i, 1].set_xlabel(None)
-                axes[i, 2].set_xlabel(None)
-
-        fig.colorbar(
-            plt.cm.ScalarMappable(norm=tracer_norm, cmap='cmo.thermal'),
-            label='Numerical solution',
-            ax=axes[:, 0],
-            location='top',
-        )
-        fig.colorbar(
-            plt.cm.ScalarMappable(norm=tracer_norm, cmap='cmo.thermal'),
-            label='Analytical solution',
-            ax=axes[:, 1],
-            location='top',
-        )
-        fig.colorbar(
-            plt.cm.ScalarMappable(norm=error_norm, cmap='cmo.curl'),
-            label='Error (Numerical - Analytical)',
-            ax=axes[:, 2],
-            location='top',
-        )
-
-        fig.savefig('comparison.png', bbox_inches='tight', pad_inches=0.1)
+            fig.savefig('comparison.png', bbox_inches='tight', pad_inches=0.1)

--- a/polaris/tasks/ocean/merry_go_round/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/viz.py
@@ -126,7 +126,6 @@ class Viz(OceanIOStep):
         """
         Run this step of the test case
         """
-        plt.switch_backend('Agg')
         config = self.config
         if self.refinement == 'time':
             option = 'refinement_factors_time'

--- a/polaris/tasks/ocean/overflow/rpe/analysis.py
+++ b/polaris/tasks/ocean/overflow/rpe/analysis.py
@@ -6,7 +6,7 @@ from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 
 from polaris.ocean.model import OceanIOStep, get_days_since_start
 from polaris.ocean.rpe import compute_rpe
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class Analysis(OceanIOStep):
@@ -100,67 +100,71 @@ class Analysis(OceanIOStep):
         )
         times = get_days_since_start(ds)
 
-        use_mplstyle()
-        fig = plt.figure()
-        for i in range(sim_count):
-            rpe_norm = np.divide((rpe[i, :] - rpe[i, 0]), rpe[i, 0])
-            plt.plot(times, rpe_norm, label=f'$\\nu_h=${nus[i]}')
-        plt.xlabel('Time, days')
-        plt.ylabel('RPE-RPE(0)/RPE(0)')
-        plt.legend()
-        plt.savefig('rpe_t.png')
-        plt.close(fig)
+        with mplstyle_context():
+            fig = plt.figure()
+            for i in range(sim_count):
+                rpe_norm = np.divide((rpe[i, :] - rpe[i, 0]), rpe[i, 0])
+                plt.plot(times, rpe_norm, label=f'$\\nu_h=${nus[i]}')
+            plt.xlabel('Time, days')
+            plt.ylabel('RPE-RPE(0)/RPE(0)')
+            plt.legend()
+            plt.savefig('rpe_t.png')
+            plt.close(fig)
 
-        time = section.getfloat('plot_time')
+            time = section.getfloat('plot_time')
 
-        fig, axes = plt.subplots(
-            1,
-            sim_count,
-            sharey=True,
-            figsize=(3 * sim_count, 5.0),
-            constrained_layout=True,
-        )
-        x_min = ds_mesh.xVertex.min().values
-        x_max = ds_mesh.xVertex.max().values
-        y_mid = ds_mesh.yCell.median().values
-
-        x = xr.DataArray(data=np.linspace(x_min, x_max, 2), dims=('nPoints',))
-        y = y_mid * xr.ones_like(x)
-        for row_index, nu in enumerate(nus):
-            ax = axes[row_index]
-            ds = self.open_model_dataset(
-                f'output_nu_{nu:g}.nc', config=self.config, decode_times=True
+            fig, axes = plt.subplots(
+                1,
+                sim_count,
+                sharey=True,
+                figsize=(3 * sim_count, 5.0),
+                constrained_layout=True,
             )
-            times = get_days_since_start(ds)
-            time_index = np.argmin(np.abs(times - time))
-            time = times[time_index]
-            ds_transect = compute_transect(
-                x=x,
-                y=y,
-                ds_horiz_mesh=ds_mesh,
-                layer_thickness=ds.layerThickness.isel(Time=time_index),
-                bottom_depth=ds_vert_coord.bottomDepth,
-                min_level_cell=ds_vert_coord.minLevelCell - 1,
-                max_level_cell=ds_vert_coord.maxLevelCell - 1,
-                spherical=False,
-            )
+            x_min = ds_mesh.xVertex.min().values
+            x_max = ds_mesh.xVertex.max().values
+            y_mid = ds_mesh.yCell.median().values
 
-            if row_index == len(nus) - 1:
-                colorbar_label = r'$^{\circ}$C'
-            else:
-                colorbar_label = None
-            plot_transect(
-                ds_transect,
-                mpas_field=ds.temperature.isel(Time=time_index),
-                ax=ax,
-                title='temperature at {time:.2f} days',
-                interface_color='grey',
-                vmin=min_temp,
-                vmax=max_temp,
-                colorbar_label=colorbar_label,
-                cmap='cmo.thermal',
+            x = xr.DataArray(
+                data=np.linspace(x_min, x_max, 2), dims=('nPoints',)
             )
-            ax.set_title(f'$\\nu_h=${nu:g}')
-            if row_index != 0:
-                ax.set_ylabel(None)
-        plt.savefig(output_filename)
+            y = y_mid * xr.ones_like(x)
+            for row_index, nu in enumerate(nus):
+                ax = axes[row_index]
+                ds = self.open_model_dataset(
+                    f'output_nu_{nu:g}.nc',
+                    config=self.config,
+                    decode_times=True,
+                )
+                times = get_days_since_start(ds)
+                time_index = np.argmin(np.abs(times - time))
+                time = times[time_index]
+                ds_transect = compute_transect(
+                    x=x,
+                    y=y,
+                    ds_horiz_mesh=ds_mesh,
+                    layer_thickness=ds.layerThickness.isel(Time=time_index),
+                    bottom_depth=ds_vert_coord.bottomDepth,
+                    min_level_cell=ds_vert_coord.minLevelCell - 1,
+                    max_level_cell=ds_vert_coord.maxLevelCell - 1,
+                    spherical=False,
+                )
+
+                if row_index == len(nus) - 1:
+                    colorbar_label = r'$^{\circ}$C'
+                else:
+                    colorbar_label = None
+                plot_transect(
+                    ds_transect,
+                    mpas_field=ds.temperature.isel(Time=time_index),
+                    ax=ax,
+                    title='temperature at {time:.2f} days',
+                    interface_color='grey',
+                    vmin=min_temp,
+                    vmax=max_temp,
+                    colorbar_label=colorbar_label,
+                    cmap='cmo.thermal',
+                )
+                ax.set_title(f'$\\nu_h=${nu:g}')
+                if row_index != 0:
+                    ax.set_ylabel(None)
+            plt.savefig(output_filename)

--- a/polaris/tasks/ocean/overflow/rpe/analysis.py
+++ b/polaris/tasks/ocean/overflow/rpe/analysis.py
@@ -90,7 +90,6 @@ class Analysis(OceanIOStep):
             ds_vert_coord=ds_vert_coord,
         )
 
-        plt.switch_backend('Agg')
         sim_count = len(nus)
         min_temp = section.getfloat('min_temp')
         max_temp = section.getfloat('max_temp')

--- a/polaris/tasks/ocean/realistic_global/analysis_members/stats_analysis.py
+++ b/polaris/tasks/ocean/realistic_global/analysis_members/stats_analysis.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.model.time import get_days_since_start
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class StatsAnalysis(OceanIOStep):
@@ -43,48 +43,50 @@ class StatsAnalysis(OceanIOStep):
             self.add_output_file(f'{variable_name}_stats.png')
 
     def run(self):
-        use_mplstyle()
-        model = self.config.get('ocean', 'model')
-        ds = self.open_model_dataset('output.nc', self.config)
-        if 'Scalar' in ds.dims:
-            ds = ds.isel(Scalar=0)
-        time = get_days_since_start(ds)
-        for variable_name in self.variables:
-            fig, axes = plt.subplots(
-                nrows=2, ncols=1, sharex=True, sharey=False, figsize=(5, 8)
-            )
-            suffix = 'Min'
-            var = ds[f'{variable_name}{suffix}']
-            axes[0].plot(time, var, ':k', label=suffix)
-            axes[1].plot(time, var - var[0], ':k', label=suffix)
-            suffix = 'Max'
-            var = ds[f'{variable_name}{suffix}']
-            axes[0].plot(time, var, '--k', label=suffix)
-            axes[1].plot(time, var - var[0], '--k', label=suffix)
-            suffix = 'Avg'
-            var_mean = ds[f'{variable_name}{suffix}']
-            axes[0].plot(time, var_mean, '-k', label=suffix)
-            axes[1].plot(time, var_mean - var_mean[0], '-k', label=suffix)
-            suffix = 'Rms'
-            if model == 'omega':
-                var_std = ds[f'{variable_name}{suffix}'].values
-            else:
-                var_rms = ds[f'{variable_name}{suffix}']
-                var_std = np.sqrt(var_rms.values**2.0 - var_mean.values**2.0)
-            axes[0].fill_between(
-                time,
-                var_mean.values + var_std,
-                var_mean.values - var_std,
-                color='k',
-                alpha=0.5,
-                label='SD',
-            )
-            axes[0].legend()
-            axes[1].legend()
-            axes[0].set_xlabel('Days')
-            axes[1].set_xlabel('Days')
-            axes[0].set_ylabel(variable_name)
-            axes[1].set_ylabel(f'{variable_name} - {variable_name} at t=0')
-            axes[0].set_xlim([min(time), max(time)])
-            fig.savefig(f'{variable_name}_stats.png', bbox_inches='tight')
-            plt.close(fig)
+        with mplstyle_context():
+            model = self.config.get('ocean', 'model')
+            ds = self.open_model_dataset('output.nc', self.config)
+            if 'Scalar' in ds.dims:
+                ds = ds.isel(Scalar=0)
+            time = get_days_since_start(ds)
+            for variable_name in self.variables:
+                fig, axes = plt.subplots(
+                    nrows=2, ncols=1, sharex=True, sharey=False, figsize=(5, 8)
+                )
+                suffix = 'Min'
+                var = ds[f'{variable_name}{suffix}']
+                axes[0].plot(time, var, ':k', label=suffix)
+                axes[1].plot(time, var - var[0], ':k', label=suffix)
+                suffix = 'Max'
+                var = ds[f'{variable_name}{suffix}']
+                axes[0].plot(time, var, '--k', label=suffix)
+                axes[1].plot(time, var - var[0], '--k', label=suffix)
+                suffix = 'Avg'
+                var_mean = ds[f'{variable_name}{suffix}']
+                axes[0].plot(time, var_mean, '-k', label=suffix)
+                axes[1].plot(time, var_mean - var_mean[0], '-k', label=suffix)
+                suffix = 'Rms'
+                if model == 'omega':
+                    var_std = ds[f'{variable_name}{suffix}'].values
+                else:
+                    var_rms = ds[f'{variable_name}{suffix}']
+                    var_std = np.sqrt(
+                        var_rms.values**2.0 - var_mean.values**2.0
+                    )
+                axes[0].fill_between(
+                    time,
+                    var_mean.values + var_std,
+                    var_mean.values - var_std,
+                    color='k',
+                    alpha=0.5,
+                    label='SD',
+                )
+                axes[0].legend()
+                axes[1].legend()
+                axes[0].set_xlabel('Days')
+                axes[1].set_xlabel('Days')
+                axes[0].set_ylabel(variable_name)
+                axes[1].set_ylabel(f'{variable_name} - {variable_name} at t=0')
+                axes[0].set_xlim([min(time), max(time)])
+                fig.savefig(f'{variable_name}_stats.png', bbox_inches='tight')
+                plt.close(fig)

--- a/polaris/tasks/ocean/realistic_global/hydrography/woa23/viz.py
+++ b/polaris/tasks/ocean/realistic_global/hydrography/woa23/viz.py
@@ -5,7 +5,7 @@ import pyproj
 import xarray as xr
 
 from polaris import Step
-from polaris.viz import plot_global_lat_lon_field, use_mplstyle
+from polaris.viz import mplstyle_context, plot_global_lat_lon_field
 from polaris.viz.spherical import setup_colormap
 
 
@@ -86,15 +86,14 @@ class Woa23VizStep(Step):
         """
         Plot horizontal fields at selected depths and two Antarctic transects.
         """
-        use_mplstyle()
+        with mplstyle_context():
+            with xr.open_dataset('woa.nc', decode_times=False) as ds_woa:
+                ds_woa = ds_woa.load()
+            with xr.open_dataset('topography.nc') as ds_topo:
+                ds_topo = ds_topo.load()
 
-        with xr.open_dataset('woa.nc', decode_times=False) as ds_woa:
-            ds_woa = ds_woa.load()
-        with xr.open_dataset('topography.nc') as ds_topo:
-            ds_topo = ds_topo.load()
-
-        self._plot_horizontal_maps(ds_woa=ds_woa, ds_topo=ds_topo)
-        self._plot_configured_transects(ds_woa=ds_woa, ds_topo=ds_topo)
+            self._plot_horizontal_maps(ds_woa=ds_woa, ds_topo=ds_topo)
+            self._plot_configured_transects(ds_woa=ds_woa, ds_topo=ds_topo)
 
     def _plot_horizontal_maps(self, ds_woa, ds_topo):
         logger = self.logger

--- a/polaris/tasks/ocean/realistic_global/viz.py
+++ b/polaris/tasks/ocean/realistic_global/viz.py
@@ -103,7 +103,7 @@ class Viz(OceanIOStep):
             )
 
         for var in variables_to_plot:
-            print(f'Plotting {var}')
+            self.logger.info(f'Plotting {var}')
             colormap_section = f'realistic_global_viz_{var}'
             if var not in ds_init.keys():
                 self.logger.info(f'{var} not found in init.nc')

--- a/polaris/tasks/ocean/single_column/ekman/analysis.py
+++ b/polaris/tasks/ocean/single_column/ekman/analysis.py
@@ -6,7 +6,7 @@ import numpy as np
 from polaris.constants import get_constant
 from polaris.mpas import area_for_field
 from polaris.ocean.model import OceanIOStep, get_days_since_start
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class Analysis(OceanIOStep):
@@ -57,78 +57,87 @@ class Analysis(OceanIOStep):
         Run this step of the test case
         """
         logger = self.logger
-        use_mplstyle()
-
-        config = self.config
-        f = config.getfloat('coriolis', 'constant_f')
-        bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
-        tau_x = config.getfloat('single_column_forcing', 'wind_stress_zonal')
-        nu = config.getfloat('single_column_ekman', 'vertical_viscosity')
-        tol = config.getfloat('single_column_ekman', 'L2_error_norm_max')
-
-        ds_mesh = self.open_model_dataset('mesh.nc', config)
-        ds = self.open_model_dataset(
-            'output.nc',
-            config,
-            decode_times=True,
-            mesh_filename='mesh.nc',
-            reconstruct_variables=['normalVelocity'],
-            reconstruct_method='RBF',
-            coeffs_filename='coeffs.nc',
-        )
-
-        t_index = -1
-        ds = ds.isel(Time=t_index)
-        t_days = get_days_since_start(ds)
-        z_mid = ds.zMid.mean(dim='nCells').values
-        if 'density' in ds.keys():
-            rho_0 = ds['density'].mean(dim='nCells').isel(nVertLevels=0).values
-        elif 'SpecVol' in ds.keys():
-            rho_0 = np.divide(
-                1, ds['SpecVol'].mean(dim='nCells').isel(nVertLevels=0).values
+        with mplstyle_context():
+            config = self.config
+            f = config.getfloat('coriolis', 'constant_f')
+            bottom_depth = config.getfloat('vertical_grid', 'bottom_depth')
+            tau_x = config.getfloat(
+                'single_column_forcing', 'wind_stress_zonal'
             )
-        else:
-            rho_0 = get_constant('seawater_density_reference')
-        u = ds['velocityZonal'].mean(dim='nCells')
-        v = ds['velocityMeridional'].mean(dim='nCells')
-        z_max = bottom_depth / 3.0
-        zidx = np.argmin(np.abs(z_mid + z_max))
+            nu = config.getfloat('single_column_ekman', 'vertical_viscosity')
+            tol = config.getfloat('single_column_ekman', 'L2_error_norm_max')
 
-        u_exact, v_exact = _exact_solution(
-            z_mid[:zidx], nu, f, tau_x=tau_x / rho_0
-        )
-        normal_velocity_exact = u * np.cos(ds_mesh.angleEdge) + v * np.sin(
-            ds_mesh.angleEdge
-        )
-        diff = ds.normalVelocity - normal_velocity_exact
-        z_slice = slice(0, zidx)
-        diff = diff.isel(nVertLevels=z_slice)
-        normal_velocity_exact = normal_velocity_exact.isel(nVertLevels=z_slice)
-        error = _compute_error(ds_mesh, diff, normal_velocity_exact)
-
-        plt.figure(figsize=(3, 5))
-        ax = plt.subplot(111)
-        ax.plot(u_exact, z_mid[:zidx], '-k', label='u')
-        ax.plot(v_exact, z_mid[:zidx], '-b', label='v')
-        ax.plot(u[:zidx], z_mid[:zidx], '.k')
-        ax.plot(v[:zidx], z_mid[:zidx], '.b')
-        ax.set_xlabel('Velocity (m/s)')
-        ax.set_ylabel('z (m)')
-        ax.legend()
-        plt.tight_layout(pad=0.5)
-        plt.savefig(f'velocity_comparison_day{t_days:02g}.png')
-        plt.close()
-
-        # Write out some information about the error
-        logger.info(f'L2 norm of normal velocity: {error:1.1e}')
-
-        # Test case fails if the L2 norm exceeds some value
-        if error > tol:
-            logger.error(
-                'error: L2 norm of normal velocity '
-                f'{error:1.1e} exceeds tolerance {tol:1.1e}'
+            ds_mesh = self.open_model_dataset('mesh.nc', config)
+            ds = self.open_model_dataset(
+                'output.nc',
+                config,
+                decode_times=True,
+                mesh_filename='mesh.nc',
+                reconstruct_variables=['normalVelocity'],
+                reconstruct_method='RBF',
+                coeffs_filename='coeffs.nc',
             )
-            raise ValueError('L2 norm exceeds tolerance')
+
+            t_index = -1
+            ds = ds.isel(Time=t_index)
+            t_days = get_days_since_start(ds)
+            z_mid = ds.zMid.mean(dim='nCells').values
+            if 'density' in ds.keys():
+                rho_0 = (
+                    ds['density'].mean(dim='nCells').isel(nVertLevels=0).values
+                )
+            elif 'SpecVol' in ds.keys():
+                rho_0 = np.divide(
+                    1,
+                    ds['SpecVol']
+                    .mean(dim='nCells')
+                    .isel(nVertLevels=0)
+                    .values,
+                )
+            else:
+                rho_0 = get_constant('seawater_density_reference')
+            u = ds['velocityZonal'].mean(dim='nCells')
+            v = ds['velocityMeridional'].mean(dim='nCells')
+            z_max = bottom_depth / 3.0
+            zidx = np.argmin(np.abs(z_mid + z_max))
+
+            u_exact, v_exact = _exact_solution(
+                z_mid[:zidx], nu, f, tau_x=tau_x / rho_0
+            )
+            normal_velocity_exact = u * np.cos(ds_mesh.angleEdge) + v * np.sin(
+                ds_mesh.angleEdge
+            )
+            diff = ds.normalVelocity - normal_velocity_exact
+            z_slice = slice(0, zidx)
+            diff = diff.isel(nVertLevels=z_slice)
+            normal_velocity_exact = normal_velocity_exact.isel(
+                nVertLevels=z_slice
+            )
+            error = _compute_error(ds_mesh, diff, normal_velocity_exact)
+
+            plt.figure(figsize=(3, 5))
+            ax = plt.subplot(111)
+            ax.plot(u_exact, z_mid[:zidx], '-k', label='u')
+            ax.plot(v_exact, z_mid[:zidx], '-b', label='v')
+            ax.plot(u[:zidx], z_mid[:zidx], '.k')
+            ax.plot(v[:zidx], z_mid[:zidx], '.b')
+            ax.set_xlabel('Velocity (m/s)')
+            ax.set_ylabel('z (m)')
+            ax.legend()
+            plt.tight_layout(pad=0.5)
+            plt.savefig(f'velocity_comparison_day{t_days:02g}.png')
+            plt.close()
+
+            # Write out some information about the error
+            logger.info(f'L2 norm of normal velocity: {error:1.1e}')
+
+            # Test case fails if the L2 norm exceeds some value
+            if error > tol:
+                logger.error(
+                    'error: L2 norm of normal velocity '
+                    f'{error:1.1e} exceeds tolerance {tol:1.1e}'
+                )
+                raise ValueError('L2 norm exceeds tolerance')
 
 
 def _exact_solution(depth, nu, f, u_g=0.0, v_g=0.0, tau_x=0.0, tau_y=0.0):

--- a/polaris/tasks/ocean/single_column/inertial/analysis.py
+++ b/polaris/tasks/ocean/single_column/inertial/analysis.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from polaris.ocean.model import OceanIOStep, get_days_since_start
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class Analysis(OceanIOStep):
@@ -49,85 +49,84 @@ class Analysis(OceanIOStep):
         Run this step of the test case
         """
         logger = self.logger
-        use_mplstyle()
-
-        config = self.config
-        f = config.getfloat('coriolis', 'constant_f')
-        tol = config.getfloat(
-            'single_column_inertial', 'period_tolerance_fraction'
-        )
-
-        ds = self.open_model_dataset(
-            'output.nc',
-            config=config,
-            decode_times=True,
-            mesh_filename='../init/culled_mesh.nc',
-            reconstruct_variables=['normalVelocity'],
-            reconstruct_method='RBF',
-            coeffs_filename='../forward/coeffs.nc',
-        )
-        t = get_days_since_start(ds)
-        s_per_day = 24.0 * 3600.0
-        dt = (t[1] - t[0]) * s_per_day
-        u = ds['velocityZonal'].mean(dim='nCells')
-        v = ds['velocityMeridional'].mean(dim='nCells')
-        u = ds['velocityZonal'].mean(dim='nCells')
-        u_max = u.max(dim='nVertLevels')
-        v_max = v.max(dim='nVertLevels')
-
-        # Compute the FFT of the u-component and extract the frequency with
-        # the most power
-        freq = np.fft.fftfreq(len(u_max), dt)
-        power = abs(np.fft.fft(u_max))
-        dominant_frequency = abs(freq[np.argmax(power[1:]) + 1])
-        dominant_period = (1 / dominant_frequency) / 3600.0  # in hours
-        expected_period = (2 * np.pi / f) / 3600.0  # in hours
-
-        # Plot a time series of the maximum u and v components
-        plt.figure(figsize=(8, 5))
-        ax = plt.subplot(111)
-        ax.plot(t, u_max, '-b')
-        ax.plot(t, v_max, '--b')
-        ymin, ymax = ax.get_ylim()
-        ax.plot(
-            [expected_period / 24.0, expected_period / 24.0],
-            [ymin, ymax],
-            '--g',
-            label='expected period',
-        )
-        ax.plot(
-            [dominant_period / 24.0, dominant_period / 24.0],
-            [ymin, ymax],
-            '--k',
-            label='dominant period',
-        )
-        ax.set_xlabel('Time (days)')
-        ax.set_ylabel('Maximum velocity (m/s)')
-        ax.set_ylim([ymin, ymax])
-        plt.legend()
-        plt.tight_layout(pad=0.5)
-        plt.savefig('velocity_tseries.png')
-        plt.close()
-
-        # Write out some information about the inertial oscillations
-        logger.info(f'Dominant period: {dominant_period:1.3f} (h)')
-        logger.info(
-            'Expected period for inertial oscillations: '
-            f'{expected_period:1.3f} (h)'
-        )
-
-        period_frac_diff = (
-            dominant_period - expected_period
-        ) / expected_period
-
-        # Test case fails if the oscillations have a frequency that is too
-        # different from the theoretical frequency
-        if abs(period_frac_diff) > tol:
-            logger.error(
-                'error: Discrepancy in inertial oscillation frequency '
-                f'{period_frac_diff * 1.0e2} %\n'
-                f'  max fractional tolerance {tol}'
+        with mplstyle_context():
+            config = self.config
+            f = config.getfloat('coriolis', 'constant_f')
+            tol = config.getfloat(
+                'single_column_inertial', 'period_tolerance_fraction'
             )
-            raise ValueError(
-                'Inertial oscillation falls outside expected frequency'
+
+            ds = self.open_model_dataset(
+                'output.nc',
+                config=config,
+                decode_times=True,
+                mesh_filename='../init/culled_mesh.nc',
+                reconstruct_variables=['normalVelocity'],
+                reconstruct_method='RBF',
+                coeffs_filename='../forward/coeffs.nc',
             )
+            t = get_days_since_start(ds)
+            s_per_day = 24.0 * 3600.0
+            dt = (t[1] - t[0]) * s_per_day
+            u = ds['velocityZonal'].mean(dim='nCells')
+            v = ds['velocityMeridional'].mean(dim='nCells')
+            u = ds['velocityZonal'].mean(dim='nCells')
+            u_max = u.max(dim='nVertLevels')
+            v_max = v.max(dim='nVertLevels')
+
+            # Compute the FFT of the u-component and extract the frequency with
+            # the most power
+            freq = np.fft.fftfreq(len(u_max), dt)
+            power = abs(np.fft.fft(u_max))
+            dominant_frequency = abs(freq[np.argmax(power[1:]) + 1])
+            dominant_period = (1 / dominant_frequency) / 3600.0  # in hours
+            expected_period = (2 * np.pi / f) / 3600.0  # in hours
+
+            # Plot a time series of the maximum u and v components
+            plt.figure(figsize=(8, 5))
+            ax = plt.subplot(111)
+            ax.plot(t, u_max, '-b')
+            ax.plot(t, v_max, '--b')
+            ymin, ymax = ax.get_ylim()
+            ax.plot(
+                [expected_period / 24.0, expected_period / 24.0],
+                [ymin, ymax],
+                '--g',
+                label='expected period',
+            )
+            ax.plot(
+                [dominant_period / 24.0, dominant_period / 24.0],
+                [ymin, ymax],
+                '--k',
+                label='dominant period',
+            )
+            ax.set_xlabel('Time (days)')
+            ax.set_ylabel('Maximum velocity (m/s)')
+            ax.set_ylim([ymin, ymax])
+            plt.legend()
+            plt.tight_layout(pad=0.5)
+            plt.savefig('velocity_tseries.png')
+            plt.close()
+
+            # Write out some information about the inertial oscillations
+            logger.info(f'Dominant period: {dominant_period:1.3f} (h)')
+            logger.info(
+                'Expected period for inertial oscillations: '
+                f'{expected_period:1.3f} (h)'
+            )
+
+            period_frac_diff = (
+                dominant_period - expected_period
+            ) / expected_period
+
+            # Test case fails if the oscillations have a frequency that is too
+            # different from the theoretical frequency
+            if abs(period_frac_diff) > tol:
+                logger.error(
+                    'error: Discrepancy in inertial oscillation frequency '
+                    f'{period_frac_diff * 1.0e2} %\n'
+                    f'  max fractional tolerance {tol}'
+                )
+                raise ValueError(
+                    'Inertial oscillation falls outside expected frequency'
+                )

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from polaris.ocean.model import OceanIOStep, get_days_since_start
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 # TODO import rho_0 from constants
 
@@ -82,157 +82,168 @@ class Viz(OceanIOStep):
         """
         Run this step of the test case
         """
-        use_mplstyle()
-        section = self.config['single_column']
-        if section.has_option('run_duration'):
-            t_target = section.getfloat('run_duration')
-        else:
-            self.logger.info(
-                'run_duration not found in config; using default plotting '
-                'time of 10 days'
-            )
-            t_target = 10.0
-
-        ds_list = []
-        time_ds = []
-        # Remove missing comparison so it won't be used later
-        comparisons = dict()
-        for comparison_name in self.comparisons.keys():
-            if os.path.exists(f'{comparison_name}.nc'):
-                comparisons[comparison_name] = self.comparisons[
-                    comparison_name
-                ]
+        with mplstyle_context():
+            section = self.config['single_column']
+            if section.has_option('run_duration'):
+                t_target = section.getfloat('run_duration')
             else:
-                continue
-            if os.path.exists('coeffs.nc'):
-                ds_comp = self.open_model_dataset(
-                    f'{comparison_name}.nc',
-                    decode_times=True,
-                    mesh_filename='mesh.nc',
-                    reconstruct_variables=['normalVelocity'],
-                    reconstruct_method='RBF',
-                    coeffs_filename='coeffs.nc',
-                    config=self.config,
+                self.logger.info(
+                    'run_duration not found in config; using default plotting '
+                    'time of 10 days'
                 )
-            else:
-                ds_comp = self.open_model_dataset(
-                    f'{comparison_name}.nc',
-                    decode_times=True,
-                    config=self.config,
-                )
-            t_arr = get_days_since_start(ds_comp)
-            t_index = np.argmin(np.abs(t_arr - t_target))
-            time_ds.append(float(t_arr[t_index]))
-            ds_list.append(ds_comp.isel(Time=t_index))
-        ds_init = self.open_model_dataset('init.nc', config=self.config)
-        ds_init = ds_init.isel(Time=0)
-        z_mid_init = ds_init['zMid'].mean(dim='nCells')
+                t_target = 10.0
 
-        z_mid_final = z_mid_init
-        self.logger.warn(
-            'Using initial zMid values; may not represent plotted state'
-        )
-
-        # Plot depth profiles of variables
-        for field_name, field_units in self.variables.items():
-            curves_plotted = 0
-            fig = plt.figure(figsize=(3, 5))
-            colors = ['k', 'b', 'r', 'darkgreen']
-            for comparison_name, ds_comp, t_days, color in zip(
-                self.comparisons.keys(), ds_list, time_ds, colors, strict=False
-            ):
-                # TODO use this line when Omega zMid is correct
-                # z_mid_final = ds_comp['zMid'].mean(dim='nCells')
-                # TODO compare with z_mid computed from layerThickness
-                # z_mid_final = depth_from_thickness(ds_comp).mean(
-                #    dim='nCells'
-                # )
-                if field_name == 'velocity':
-                    if (
-                        'velocityZonal' not in ds_comp.keys()
-                        and 'velocityMeridional' not in ds_comp.keys()
-                    ):
-                        self.logger.info(
-                            '\tvelocityZonal,Meridional not found; skipping '
-                            f'plot for {comparison_name}'
-                        )
-                        continue
-                    self.logger.info(
-                        f'Plot {field_name} for {comparison_name} at {t_days} '
-                        'days'
-                    )
-                    u_final = ds_comp['velocityZonal'].mean(dim='nCells')
-                    v_final = ds_comp['velocityMeridional'].mean(dim='nCells')
-                    plt.plot(
-                        u_final,
-                        z_mid_final,
-                        '-',
-                        color=color,
-                        label=f'u {comparison_name}, {t_days:2g} days',
-                    )
-                    plt.plot(
-                        v_final,
-                        z_mid_final,
-                        '--',
-                        color=color,
-                        label=f'v {comparison_name}, {t_days:2g} days',
-                    )
-                    curves_plotted += 1
-                else:
-                    if field_name not in ds_comp.keys():
-                        self.logger.info(
-                            f'\t{field_name} not found; skipping plot for '
-                            f'{comparison_name}'
-                        )
-                        continue
-                    var_comp = ds_comp[field_name].mean(dim='nCells')
-                    if 'nVertLevelsP1' in var_comp.dims:
-                        var_comp = var_comp.isel(nVertLevelsP1=slice(0, -1))
-                    # TODO delete this line when MPAS-O bug is fixed
-                    if field_name == 'RiTopOfCell':
-                        var_comp[0] = np.nan
-                    plt.plot(
-                        var_comp,
-                        z_mid_final,
-                        '-',
-                        color=color,
-                        label=f'{comparison_name}, {t_days:2g} days',
-                    )
-                    curves_plotted += 1
-                    # Plot initial state if available and hasn't already been
-                    # plotted
-                    existing_labels = [
-                        lbl
-                        for lbl in plt.gca().get_legend_handles_labels()[1]
-                        if isinstance(lbl, str)
+            ds_list = []
+            time_ds = []
+            # Remove missing comparison so it won't be used later
+            comparisons = dict()
+            for comparison_name in self.comparisons.keys():
+                if os.path.exists(f'{comparison_name}.nc'):
+                    comparisons[comparison_name] = self.comparisons[
+                        comparison_name
                     ]
-                    if (
-                        field_name in ds_init.keys()
-                        and 'initial' not in existing_labels
-                    ):
-                        var_init = ds_init[field_name].mean(dim='nCells')
-                        plt.plot(var_init, z_mid_init, '--k', label='initial')
-                        curves_plotted += 1
-            if curves_plotted == 0:
-                self.logger.warn(
-                    f'No data plotted for {field_name}, skipping save'
-                )
-                plt.close()
-                continue
-            plt.ylim([-100, 0])
-            if field_name == 'temperature':
-                plt.xlim([15, 25])
-            else:
-                plt.xlim(auto=True)
-            plt.xlabel(f'{field_name} ({field_units})')
-            plt.ylabel('z (m)')
-            # Place a single legend centered below the x-axis
-            fig.legend(
-                loc='upper center',
-                bbox_to_anchor=(0.5, -0.08),
-                ncol=1,
-                frameon=False,
+                else:
+                    continue
+                if os.path.exists('coeffs.nc'):
+                    ds_comp = self.open_model_dataset(
+                        f'{comparison_name}.nc',
+                        decode_times=True,
+                        mesh_filename='mesh.nc',
+                        reconstruct_variables=['normalVelocity'],
+                        reconstruct_method='RBF',
+                        coeffs_filename='coeffs.nc',
+                        config=self.config,
+                    )
+                else:
+                    ds_comp = self.open_model_dataset(
+                        f'{comparison_name}.nc',
+                        decode_times=True,
+                        config=self.config,
+                    )
+                t_arr = get_days_since_start(ds_comp)
+                t_index = np.argmin(np.abs(t_arr - t_target))
+                time_ds.append(float(t_arr[t_index]))
+                ds_list.append(ds_comp.isel(Time=t_index))
+            ds_init = self.open_model_dataset('init.nc', config=self.config)
+            ds_init = ds_init.isel(Time=0)
+            z_mid_init = ds_init['zMid'].mean(dim='nCells')
+
+            z_mid_final = z_mid_init
+            self.logger.warn(
+                'Using initial zMid values; may not represent plotted state'
             )
-            plt.savefig(f'{field_name}.png', bbox_inches='tight')
-            print(f'Plotted {field_name}')
-            plt.close()
+
+            # Plot depth profiles of variables
+            for field_name, field_units in self.variables.items():
+                curves_plotted = 0
+                fig = plt.figure(figsize=(3, 5))
+                colors = ['k', 'b', 'r', 'darkgreen']
+                for comparison_name, ds_comp, t_days, color in zip(
+                    self.comparisons.keys(),
+                    ds_list,
+                    time_ds,
+                    colors,
+                    strict=False,
+                ):
+                    # TODO use this line when Omega zMid is correct
+                    # z_mid_final = ds_comp['zMid'].mean(dim='nCells')
+                    # TODO compare with z_mid computed from layerThickness
+                    # z_mid_final = depth_from_thickness(ds_comp).mean(
+                    #    dim='nCells'
+                    # )
+                    if field_name == 'velocity':
+                        if (
+                            'velocityZonal' not in ds_comp.keys()
+                            and 'velocityMeridional' not in ds_comp.keys()
+                        ):
+                            self.logger.info(
+                                '\tvelocityZonal,Meridional not '
+                                f'found; skipping plot for '
+                                f'{comparison_name}'
+                            )
+                            continue
+                        self.logger.info(
+                            f'Plot {field_name} for '
+                            f'{comparison_name} at {t_days} days'
+                        )
+                        u_final = ds_comp['velocityZonal'].mean(dim='nCells')
+                        v_final = ds_comp['velocityMeridional'].mean(
+                            dim='nCells'
+                        )
+                        plt.plot(
+                            u_final,
+                            z_mid_final,
+                            '-',
+                            color=color,
+                            label=f'u {comparison_name}, {t_days:2g} days',
+                        )
+                        plt.plot(
+                            v_final,
+                            z_mid_final,
+                            '--',
+                            color=color,
+                            label=f'v {comparison_name}, {t_days:2g} days',
+                        )
+                        curves_plotted += 1
+                    else:
+                        if field_name not in ds_comp.keys():
+                            self.logger.info(
+                                f'\t{field_name} not found; skipping plot for '
+                                f'{comparison_name}'
+                            )
+                            continue
+                        var_comp = ds_comp[field_name].mean(dim='nCells')
+                        if 'nVertLevelsP1' in var_comp.dims:
+                            var_comp = var_comp.isel(
+                                nVertLevelsP1=slice(0, -1)
+                            )
+                        # TODO delete this line when MPAS-O bug is fixed
+                        if field_name == 'RiTopOfCell':
+                            var_comp[0] = np.nan
+                        plt.plot(
+                            var_comp,
+                            z_mid_final,
+                            '-',
+                            color=color,
+                            label=f'{comparison_name}, {t_days:2g} days',
+                        )
+                        curves_plotted += 1
+                        # Plot initial state if available and
+                        # hasn't already been plotted
+                        existing_labels = [
+                            lbl
+                            for lbl in plt.gca().get_legend_handles_labels()[1]
+                            if isinstance(lbl, str)
+                        ]
+                        if (
+                            field_name in ds_init.keys()
+                            and 'initial' not in existing_labels
+                        ):
+                            var_init = ds_init[field_name].mean(dim='nCells')
+                            plt.plot(
+                                var_init, z_mid_init, '--k', label='initial'
+                            )
+                            curves_plotted += 1
+                if curves_plotted == 0:
+                    self.logger.warn(
+                        f'No data plotted for {field_name}, skipping save'
+                    )
+                    plt.close()
+                    continue
+                plt.ylim([-100, 0])
+                if field_name == 'temperature':
+                    plt.xlim([15, 25])
+                else:
+                    plt.xlim(auto=True)
+                plt.xlabel(f'{field_name} ({field_units})')
+                plt.ylabel('z (m)')
+                # Place a single legend centered below the x-axis
+                fig.legend(
+                    loc='upper center',
+                    bbox_to_anchor=(0.5, -0.08),
+                    ncol=1,
+                    frameon=False,
+                )
+                plt.savefig(f'{field_name}.png', bbox_inches='tight')
+                print(f'Plotted {field_name}')
+                plt.close()

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -245,5 +245,5 @@ class Viz(OceanIOStep):
                     frameon=False,
                 )
                 plt.savefig(f'{field_name}.png', bbox_inches='tight')
-                print(f'Plotted {field_name}')
+                self.logger.info(f'Plotted {field_name}')
                 plt.close()

--- a/polaris/tasks/ocean/sphere_transport/filament_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/filament_analysis.py
@@ -5,7 +5,7 @@ import pandas as pd
 from polaris.ocean.convergence import get_resolution_for_task
 from polaris.ocean.model import OceanIOStep, get_days_since_start
 from polaris.resolution import resolution_to_string
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class FilamentAnalysis(OceanIOStep):
@@ -104,45 +104,47 @@ class FilamentAnalysis(OceanIOStep):
         num_tau = 21
         filament_tau = np.linspace(0, 1, num_tau)
         filament_norm = np.zeros((len(resolutions), num_tau))
-        use_mplstyle()
-        fig, ax = plt.subplots()
-        for i, refinement_factor in enumerate(self.refinement_factors):
-            mesh_name = resolution_to_string(resolutions[i])
-            ds_mesh = self.open_model_dataset(
-                f'mesh_r{refinement_factor:02g}.nc', self.config
-            )
-            ds = self.open_model_dataset(
-                f'output_r{refinement_factor:02g}.nc', self.config
-            )
-            t_days = get_days_since_start(ds)
-            time_index = np.argmin(
-                np.abs(np.subtract(t_days, eval_time * s_per_day))
-            )
-            tracer = ds[variable_name]
-            area_cell = ds_mesh['areaCell']
-            for j, tau in enumerate(filament_tau):
-                cells_above_tau = tracer[time_index, :, zidx] >= tau
-                cells_above_tau0 = tracer[0, :, zidx] >= tau
-                if np.sum(cells_above_tau0 * area_cell) == 0.0:
-                    filament_norm[i, j] = np.nan
-                else:
-                    filament_norm[i, j] = np.divide(
-                        np.sum(area_cell * cells_above_tau),
-                        np.sum(cells_above_tau0 * area_cell),
-                    )
-            plt.plot(filament_tau, filament_norm[i, :], '.-', label=mesh_name)
-        plt.plot([filament_tau[0], filament_tau[-1]], [1.0, 1.0], 'k--')
-        ax.set_xlim([filament_tau[0], filament_tau[-1]])
-        ax.set_xlabel(r'$\tau$')
-        ax.set_ylabel(r'$l_f$')
-        plt.title(f'Filament preservation diagnostic for {variable_name}')
-        plt.legend()
-        fig.savefig('filament.png', bbox_inches='tight')
+        with mplstyle_context():
+            fig, ax = plt.subplots()
+            for i, refinement_factor in enumerate(self.refinement_factors):
+                mesh_name = resolution_to_string(resolutions[i])
+                ds_mesh = self.open_model_dataset(
+                    f'mesh_r{refinement_factor:02g}.nc', self.config
+                )
+                ds = self.open_model_dataset(
+                    f'output_r{refinement_factor:02g}.nc', self.config
+                )
+                t_days = get_days_since_start(ds)
+                time_index = np.argmin(
+                    np.abs(np.subtract(t_days, eval_time * s_per_day))
+                )
+                tracer = ds[variable_name]
+                area_cell = ds_mesh['areaCell']
+                for j, tau in enumerate(filament_tau):
+                    cells_above_tau = tracer[time_index, :, zidx] >= tau
+                    cells_above_tau0 = tracer[0, :, zidx] >= tau
+                    if np.sum(cells_above_tau0 * area_cell) == 0.0:
+                        filament_norm[i, j] = np.nan
+                    else:
+                        filament_norm[i, j] = np.divide(
+                            np.sum(area_cell * cells_above_tau),
+                            np.sum(cells_above_tau0 * area_cell),
+                        )
+                plt.plot(
+                    filament_tau, filament_norm[i, :], '.-', label=mesh_name
+                )
+            plt.plot([filament_tau[0], filament_tau[-1]], [1.0, 1.0], 'k--')
+            ax.set_xlim([filament_tau[0], filament_tau[-1]])
+            ax.set_xlabel(r'$\tau$')
+            ax.set_ylabel(r'$l_f$')
+            plt.title(f'Filament preservation diagnostic for {variable_name}')
+            plt.legend()
+            fig.savefig('filament.png', bbox_inches='tight')
 
-        res_array = np.array(resolutions, dtype=float)
-        data = np.column_stack((res_array, filament_norm))
-        col_headers = ['resolution']
-        for tau in filament_tau:
-            col_headers.append(f'{tau:g}')
-        df = pd.DataFrame(data, columns=col_headers)
-        df.to_csv('filament.csv', index=False)
+            res_array = np.array(resolutions, dtype=float)
+            data = np.column_stack((res_array, filament_norm))
+            col_headers = ['resolution']
+            for tau in filament_tau:
+                col_headers.append(f'{tau:g}')
+            df = pd.DataFrame(data, columns=col_headers)
+            df.to_csv('filament.csv', index=False)

--- a/polaris/tasks/ocean/sphere_transport/filament_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/filament_analysis.py
@@ -88,7 +88,6 @@ class FilamentAnalysis(OceanIOStep):
         """
         Run this step of the test case
         """
-        plt.switch_backend('Agg')
         resolutions = list()
         for refinement_factor in self.refinement_factors:
             resolution = get_resolution_for_task(

--- a/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
@@ -12,7 +12,7 @@ from polaris.ocean.convergence import (
 )
 from polaris.ocean.model import OceanIOStep, get_days_since_start
 from polaris.resolution import resolution_to_string
-from polaris.viz import use_mplstyle
+from polaris.viz import mplstyle_context
 
 
 class MixingAnalysis(OceanIOStep):
@@ -110,38 +110,42 @@ class MixingAnalysis(OceanIOStep):
         s_per_day = 86400.0
         zidx = 0
         nrows = int(ceil(len(resolutions) / 2))
-        use_mplstyle()
-        fig, axes = plt.subplots(
-            nrows=nrows, ncols=2, sharex=True, sharey=True, figsize=(5.5, 7)
-        )
-        for i, refinement_factor in enumerate(self.refinement_factors):
-            ax = axes[int(i / 2), i % 2]
-            _init_triplot_axes(ax)
-            mesh_name = resolution_to_string(resolutions[i])
-            ax.set(title=mesh_name)
-            ds = self.open_model_dataset(
-                f'output_r{refinement_factor:02g}.nc', self.config
+        with mplstyle_context():
+            fig, axes = plt.subplots(
+                nrows=nrows,
+                ncols=2,
+                sharex=True,
+                sharey=True,
+                figsize=(5.5, 7),
             )
-            if i % 2 == 0:
-                ax.set_ylabel('tracer3')
-            if int(i / 2) == nrows - 1:
-                ax.set_xlabel('tracer2')
-            t_days = get_days_since_start(ds)
-            time_index = np.argmin(
-                np.abs(np.subtract(t_days, eval_time * s_per_day))
-            )
-            ds = ds.isel(Time=time_index)
-            ds = ds.isel(nVertLevels=zidx)
-            tracer2 = ds['tracer2'].values
-            tracer3 = ds['tracer3'].values
-            ax.plot(tracer2, tracer3, '.', markersize=1)
-            ax.set_aspect('equal')
-        if i % 2 < 1:
-            ax = axes[int(i / 2), 1]
-            ax.set_axis_off()
-        plt.subplots_adjust(wspace=0.1, hspace=0.1)
-        fig.suptitle('Correlated tracers 2-d')
-        fig.savefig('triplots.png', bbox_inches='tight')
+            for i, refinement_factor in enumerate(self.refinement_factors):
+                ax = axes[int(i / 2), i % 2]
+                _init_triplot_axes(ax)
+                mesh_name = resolution_to_string(resolutions[i])
+                ax.set(title=mesh_name)
+                ds = self.open_model_dataset(
+                    f'output_r{refinement_factor:02g}.nc', self.config
+                )
+                if i % 2 == 0:
+                    ax.set_ylabel('tracer3')
+                if int(i / 2) == nrows - 1:
+                    ax.set_xlabel('tracer2')
+                t_days = get_days_since_start(ds)
+                time_index = np.argmin(
+                    np.abs(np.subtract(t_days, eval_time * s_per_day))
+                )
+                ds = ds.isel(Time=time_index)
+                ds = ds.isel(nVertLevels=zidx)
+                tracer2 = ds['tracer2'].values
+                tracer3 = ds['tracer3'].values
+                ax.plot(tracer2, tracer3, '.', markersize=1)
+                ax.set_aspect('equal')
+            if i % 2 < 1:
+                ax = axes[int(i / 2), 1]
+                ax.set_axis_off()
+            plt.subplots_adjust(wspace=0.1, hspace=0.1)
+            fig.suptitle('Correlated tracers 2-d')
+            fig.savefig('triplots.png', bbox_inches='tight')
 
 
 def _init_triplot_axes(ax):

--- a/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
@@ -97,7 +97,6 @@ class MixingAnalysis(OceanIOStep):
         """
         Run this step of the test case
         """
-        plt.switch_backend('Agg')
         resolutions = list()
         for refinement_factor in self.refinement_factors:
             resolution = get_resolution_for_task(

--- a/polaris/tasks/seaice/single_column/standard_physics/viz.py
+++ b/polaris/tasks/seaice/single_column/standard_physics/viz.py
@@ -1,9 +1,8 @@
-import importlib.resources as imp_res
-
-import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
 from mpas_tools.io import open_dataset
 
 from polaris import Step
+from polaris.viz import mplstyle_context
 
 
 class Viz(Step):
@@ -34,46 +33,48 @@ class Viz(Step):
         """
         Run this step of the test case
         """
-        style_filename = str(imp_res.files('polaris.viz') / 'polaris.mplstyle')
-        plt.style.use(style_filename)
-        ds = open_dataset('output.2000.nc', decode_times=False)
+        ds = open_dataset(self.work_path('output.2000.nc'), decode_times=False)
         daysSinceStartOfSim = ds.daysSinceStartOfSim.values
         snowVolumeCell = ds.snowVolumeCell.values
         iceVolumeCell = ds.iceVolumeCell.values
         surfaceTemperatureCell = ds.surfaceTemperatureCell.values
 
-        fig, axis = plt.subplots(figsize=(8, 8))
+        with mplstyle_context():
+            fig = Figure(figsize=(8, 8))
+            axis = fig.add_subplot(111)
 
-        axis.plot(
-            daysSinceStartOfSim,
-            surfaceTemperatureCell,
-            color='green',
-            label='surfaceTemperature',
-        )
-        axis.set_ylabel('Temperature (C)')
-        axis.set_xlabel('Days')
-        axis.set_xlim(0, daysSinceStartOfSim[-1])
-        axis.set_ylim(None, 0)
-        axis.set_title('MPAS_Seaice single cell')
+            axis.plot(
+                daysSinceStartOfSim,
+                surfaceTemperatureCell,
+                color='green',
+                label='surfaceTemperature',
+            )
+            axis.set_ylabel('Temperature (C)')
+            axis.set_xlabel('Days')
+            axis.set_xlim(0, daysSinceStartOfSim[-1])
+            axis.set_ylim(None, 0)
+            axis.set_title('MPAS_Seaice single cell')
 
-        plt.legend()
+            axis.legend()
 
-        axis2 = axis.twinx()
+            axis2 = axis.twinx()
 
-        axis2.plot(
-            daysSinceStartOfSim, iceVolumeCell, color='red', label='iceVolume'
-        )
-        axis2.plot(
-            daysSinceStartOfSim,
-            snowVolumeCell,
-            color='blue',
-            label='snowVolume',
-        )
-        axis2.set_ylabel('Thickness (m)')
-        axis2.set_ylim(0, None)
+            axis2.plot(
+                daysSinceStartOfSim,
+                iceVolumeCell,
+                color='red',
+                label='iceVolume',
+            )
+            axis2.plot(
+                daysSinceStartOfSim,
+                snowVolumeCell,
+                color='blue',
+                label='snowVolume',
+            )
+            axis2.set_ylabel('Thickness (m)')
+            axis2.set_ylim(0, None)
 
-        plt.legend()
-        plt.tight_layout()
-        plt.savefig('single_cell.pdf')
-        plt.savefig('single_cell.png', dpi=300)
-        plt.close()
+            axis2.legend()
+            fig.tight_layout()
+            fig.savefig(self.work_path('single_cell.pdf'))
+            fig.savefig(self.work_path('single_cell.png'), dpi=300)

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -15,4 +15,4 @@ from polaris.viz.spherical import (
     plot_global_mpas_field as plot_global_mpas_field,
 )
 from polaris.viz.spherical import setup_colormap as setup_colormap
-from polaris.viz.style import use_mplstyle as use_mplstyle
+from polaris.viz.style import mplstyle_context as mplstyle_context

--- a/polaris/viz/planar.py
+++ b/polaris/viz/planar.py
@@ -7,7 +7,7 @@ import mosaic
 import numpy as np
 from matplotlib.colors import LogNorm
 
-from polaris.viz.style import use_mplstyle
+from polaris.viz.style import mplstyle_context
 
 
 def plot_horiz_field(  # noqa: C901
@@ -138,130 +138,129 @@ def plot_horiz_field(  # noqa: C901
             'You must supply both transect_x and transect_y or neither'
         )
 
-    use_mplstyle()
+    with mplstyle_context():
+        create_fig = True
+        if ax is not None:
+            create_fig = False
 
-    create_fig = True
-    if ax is not None:
-        create_fig = False
+        if create_fig:
+            if out_file_name is None:
+                out_file_name = f'{field.name}.png'
+            try:
+                os.makedirs(os.path.dirname(out_file_name))
+            except OSError:
+                pass
 
-    if create_fig:
-        if out_file_name is None:
-            out_file_name = f'{field.name}.png'
-        try:
-            os.makedirs(os.path.dirname(out_file_name))
-        except OSError:
-            pass
+        if title is None:
+            title = field.name
 
-    if title is None:
-        title = field.name
+        if 'Time' in field.dims and t_index is None:
+            t_index = 0
+        if t_index is not None:
+            field = field.isel(Time=t_index)
+        if vert_dim in field.dims and z_index is None:
+            z_index = 0
+        if z_index is not None:
+            field = field.isel({vert_dim: z_index})
 
-    if 'Time' in field.dims and t_index is None:
-        t_index = 0
-    if t_index is not None:
-        field = field.isel(Time=t_index)
-    if vert_dim in field.dims and z_index is None:
-        z_index = 0
-    if z_index is not None:
-        field = field.isel({vert_dim: z_index})
+        if descriptor is None:
+            descriptor = mosaic.Descriptor(ds_mesh)
 
-    if descriptor is None:
-        descriptor = mosaic.Descriptor(ds_mesh)
-
-    pcolor_kwargs = dict(
-        cmap=None, edgecolor='face', norm=None, vmin=vmin, vmax=vmax
-    )
-
-    if cmap is not None:
-        if isinstance(cmap, str):
-            cmap = matplotlib.colormaps[cmap]
-        if cmap_set_under is not None:
-            cmap.set_under(cmap_set_under)
-        if cmap_set_over is not None:
-            cmap.set_over(cmap_set_over)
-
-        pcolor_kwargs['cmap'] = cmap
-
-    if show_patch_edges:
-        pcolor_kwargs['edgecolor'] = 'black'
-        pcolor_kwargs['linewidth'] = 0.25
-
-    if cmap_scale == 'log':
-        pcolor_kwargs['norm'] = LogNorm(vmin=vmin, vmax=vmax, clip=False)
-        pcolor_kwargs.pop('vmin', None)
-        pcolor_kwargs.pop('vmax', None)
-
-    if figsize is None:
-        width = ds_mesh.xCell.max() - ds_mesh.xCell.min()
-        length = ds_mesh.yCell.max() - ds_mesh.yCell.min()
-        aspect_ratio = width.values / length.values
-        fig_width = 4
-        legend_width = fig_width / 5
-        figsize = (fig_width + legend_width, fig_width / aspect_ratio)
-
-    if create_fig:
-        plt.figure(figsize=figsize)
-        ax = plt.subplot(111)
-
-    if field_mask is not None:
-        if field_mask.shape != field.shape:
-            raise ValueError(
-                f'The shape of `field_mask`: {field_mask.shape} '
-                f'does match shape of `field array`: '
-                f'{field.shape} make sure both arrays are defined'
-                f' at the same location'
-            )
-
-        if np.any(~field_mask):
-            field = field.where(field_mask)
-
-    collection = mosaic.polypcolor(ax, descriptor, field, **pcolor_kwargs)
-
-    ax.set_xlabel('x (km)')
-    ax.set_ylabel('y (km)')
-    ax.set_aspect('equal')
-
-    if descriptor.is_periodic:
-        if descriptor.x_period and not descriptor.y_period:
-            ax.autoscale(axis='y', tight=True)
-        elif not descriptor.x_period and descriptor.y_period:
-            ax.autoscale(axis='x', tight=True)
-    else:
-        ax.autoscale(axis='both', tight=True)
-
-    # scale ticks to be in kilometers
-    ax.xaxis.set_major_formatter(lambda x, pos: f'{x / 1e3:g}')
-    ax.yaxis.set_major_formatter(lambda x, pos: f'{x / 1e3:g}')
-
-    cbar = plt.colorbar(collection, extend='both', shrink=0.7, ax=ax)
-    if cmap_title is not None:
-        cbar.set_label(cmap_title)
-
-    if transect_x is not None:
-        ax.plot(
-            transect_x,
-            transect_y,
-            color=transect_color,
-            linewidth=transect_linewidth,
+        pcolor_kwargs = dict(
+            cmap=None, edgecolor='face', norm=None, vmin=vmin, vmax=vmax
         )
-        if transect_start is not None:
-            ax.plot(
-                transect_x[0],
-                transect_y[0],
-                '.',
-                color=transect_start,
-                markersize=transect_markersize,
-            )
-        if transect_end is not None:
-            ax.plot(
-                transect_x[-1],
-                transect_y[-1],
-                '.',
-                color=transect_end,
-                markersize=transect_markersize,
-            )
-    if create_fig:
-        plt.title(title)
-        plt.savefig(out_file_name, bbox_inches='tight', pad_inches=0.2)
-        plt.close()
 
-    return descriptor
+        if cmap is not None:
+            if isinstance(cmap, str):
+                cmap = matplotlib.colormaps[cmap]
+            if cmap_set_under is not None:
+                cmap.set_under(cmap_set_under)
+            if cmap_set_over is not None:
+                cmap.set_over(cmap_set_over)
+
+            pcolor_kwargs['cmap'] = cmap
+
+        if show_patch_edges:
+            pcolor_kwargs['edgecolor'] = 'black'
+            pcolor_kwargs['linewidth'] = 0.25
+
+        if cmap_scale == 'log':
+            pcolor_kwargs['norm'] = LogNorm(vmin=vmin, vmax=vmax, clip=False)
+            pcolor_kwargs.pop('vmin', None)
+            pcolor_kwargs.pop('vmax', None)
+
+        if figsize is None:
+            width = ds_mesh.xCell.max() - ds_mesh.xCell.min()
+            length = ds_mesh.yCell.max() - ds_mesh.yCell.min()
+            aspect_ratio = width.values / length.values
+            fig_width = 4
+            legend_width = fig_width / 5
+            figsize = (fig_width + legend_width, fig_width / aspect_ratio)
+
+        if create_fig:
+            plt.figure(figsize=figsize)
+            ax = plt.subplot(111)
+
+        if field_mask is not None:
+            if field_mask.shape != field.shape:
+                raise ValueError(
+                    f'The shape of `field_mask`: {field_mask.shape} '
+                    f'does match shape of `field array`: '
+                    f'{field.shape} make sure both arrays are defined'
+                    f' at the same location'
+                )
+
+            if np.any(~field_mask):
+                field = field.where(field_mask)
+
+        collection = mosaic.polypcolor(ax, descriptor, field, **pcolor_kwargs)
+
+        ax.set_xlabel('x (km)')
+        ax.set_ylabel('y (km)')
+        ax.set_aspect('equal')
+
+        if descriptor.is_periodic:
+            if descriptor.x_period and not descriptor.y_period:
+                ax.autoscale(axis='y', tight=True)
+            elif not descriptor.x_period and descriptor.y_period:
+                ax.autoscale(axis='x', tight=True)
+        else:
+            ax.autoscale(axis='both', tight=True)
+
+        # scale ticks to be in kilometers
+        ax.xaxis.set_major_formatter(lambda x, pos: f'{x / 1e3:g}')
+        ax.yaxis.set_major_formatter(lambda x, pos: f'{x / 1e3:g}')
+
+        cbar = plt.colorbar(collection, extend='both', shrink=0.7, ax=ax)
+        if cmap_title is not None:
+            cbar.set_label(cmap_title)
+
+        if transect_x is not None:
+            ax.plot(
+                transect_x,
+                transect_y,
+                color=transect_color,
+                linewidth=transect_linewidth,
+            )
+            if transect_start is not None:
+                ax.plot(
+                    transect_x[0],
+                    transect_y[0],
+                    '.',
+                    color=transect_start,
+                    markersize=transect_markersize,
+                )
+            if transect_end is not None:
+                ax.plot(
+                    transect_x[-1],
+                    transect_y[-1],
+                    '.',
+                    color=transect_end,
+                    markersize=transect_markersize,
+                )
+        if create_fig:
+            plt.title(title)
+            plt.savefig(out_file_name, bbox_inches='tight', pad_inches=0.2)
+            plt.close()
+
+        return descriptor

--- a/polaris/viz/planar.py
+++ b/polaris/viz/planar.py
@@ -2,10 +2,10 @@ import os
 
 import cmocean  # noqa: F401
 import matplotlib
-import matplotlib.pyplot as plt
 import mosaic
 import numpy as np
 from matplotlib.colors import LogNorm
+from matplotlib.figure import Figure
 
 from polaris.viz.style import mplstyle_context
 
@@ -198,8 +198,10 @@ def plot_horiz_field(  # noqa: C901
             figsize = (fig_width + legend_width, fig_width / aspect_ratio)
 
         if create_fig:
-            plt.figure(figsize=figsize)
-            ax = plt.subplot(111)
+            fig = Figure(figsize=figsize)
+            ax = fig.add_subplot(111)
+        else:
+            fig = ax.get_figure()
 
         if field_mask is not None:
             if field_mask.shape != field.shape:
@@ -231,7 +233,7 @@ def plot_horiz_field(  # noqa: C901
         ax.xaxis.set_major_formatter(lambda x, pos: f'{x / 1e3:g}')
         ax.yaxis.set_major_formatter(lambda x, pos: f'{x / 1e3:g}')
 
-        cbar = plt.colorbar(collection, extend='both', shrink=0.7, ax=ax)
+        cbar = fig.colorbar(collection, extend='both', shrink=0.7, ax=ax)
         if cmap_title is not None:
             cbar.set_label(cmap_title)
 
@@ -259,8 +261,7 @@ def plot_horiz_field(  # noqa: C901
                     markersize=transect_markersize,
                 )
         if create_fig:
-            plt.title(title)
-            plt.savefig(out_file_name, bbox_inches='tight', pad_inches=0.2)
-            plt.close()
+            ax.set_title(title)
+            fig.savefig(out_file_name, bbox_inches='tight', pad_inches=0.2)
 
         return descriptor

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -14,7 +14,7 @@ from pyremap.descriptor.utility import interp_extrap_corner
 from ruamel.yaml import YAML
 
 from polaris.viz.helper import get_projection
-from polaris.viz.style import use_mplstyle
+from polaris.viz.style import mplstyle_context
 
 
 def plot_global_mpas_field(
@@ -107,116 +107,120 @@ def plot_global_mpas_field(
         needs to be created once per mesh file.
     """
 
-    use_mplstyle()
-    if dpi:
-        plt.rcParams['savefig.dpi'] = dpi
+    with mplstyle_context(dpi=dpi):
+        transform = cartopy.crs.Geodetic()
+        projection = get_projection(
+            projection_name, central_longitude=central_longitude
+        )
 
-    transform = cartopy.crs.Geodetic()
-    projection = get_projection(
-        projection_name, central_longitude=central_longitude
-    )
-
-    if descriptor is None:
-        if mesh_filename is None:
-            raise ValueError(
-                'Either mesh_filename or descriptor must be given'
-                ' as parameters to Descriptor'
-            )
-        mesh_ds = open_dataset(mesh_filename)
-        model = config.get('ocean', 'model')
-        if model == 'omega':
-            package = 'polaris.ocean.model'
-            filename = 'mpaso_to_omega.yaml'
-            text = imp_res.files(package).joinpath(filename).read_text()
-            yaml_data = YAML(typ='rt')
-            nested_dict = yaml_data.load(text)
-            mpaso_to_omega_dim_map = nested_dict['dimensions']
-            mpaso_to_omega_var_map = nested_dict['variables']
-            # map Omega dimension and variable names back to their
-            # MPAS-Ocean equivalents
-            rename = {
-                omega_dim: mpaso_dim
-                for mpaso_dim, omega_dim in mpaso_to_omega_dim_map.items()
-                if omega_dim in mesh_ds.dims
-            }
-            rename.update(
-                {
-                    omega_var: mpaso_var
-                    for mpaso_var, omega_var in mpaso_to_omega_var_map.items()
-                    if omega_var in mesh_ds
+        if descriptor is None:
+            if mesh_filename is None:
+                raise ValueError(
+                    'Either mesh_filename or descriptor must be given'
+                    ' as parameters to Descriptor'
+                )
+            mesh_ds = open_dataset(mesh_filename)
+            model = config.get('ocean', 'model')
+            if model == 'omega':
+                package = 'polaris.ocean.model'
+                filename = 'mpaso_to_omega.yaml'
+                text = imp_res.files(package).joinpath(filename).read_text()
+                yaml_data = YAML(typ='rt')
+                nested_dict = yaml_data.load(text)
+                mpaso_to_omega_dim_map = nested_dict['dimensions']
+                mpaso_to_omega_var_map = nested_dict['variables']
+                # map Omega dimension and variable names back to their
+                # MPAS-Ocean equivalents
+                rename = {
+                    omega_dim: mpaso_dim
+                    for mpaso_dim, omega_dim in mpaso_to_omega_dim_map.items()
+                    if omega_dim in mesh_ds.dims
                 }
+                rename.update(
+                    {
+                        omega_var: mpaso_var
+                        for mpaso_var, omega_var in (
+                            mpaso_to_omega_var_map.items()
+                        )
+                        if omega_var in mesh_ds
+                    }
+                )
+                if rename:
+                    mesh_ds = mesh_ds.rename(rename)
+            mesh_ds.attrs['is_periodic'] = 'NO'
+
+            if cell_indices is not None:
+                mesh_ds = mesh_ds.isel(nCells=cell_indices)
+            descriptor = mosaic.Descriptor(
+                mesh_ds,
+                projection=projection,
+                transform=transform,
+                use_latlon=True,
             )
-            if rename:
-                mesh_ds = mesh_ds.rename(rename)
-        mesh_ds.attrs['is_periodic'] = 'NO'
 
-        if cell_indices is not None:
-            mesh_ds = mesh_ds.isel(nCells=cell_indices)
-        descriptor = mosaic.Descriptor(
-            mesh_ds,
-            projection=projection,
-            transform=transform,
-            use_latlon=True,
+        fig, ax = plt.subplots(
+            figsize=figsize,
+            constrained_layout=True,
+            subplot_kw=dict(projection=projection),
         )
 
-    fig, ax = plt.subplots(
-        figsize=figsize,
-        constrained_layout=True,
-        subplot_kw=dict(projection=projection),
-    )
+        if title is not None:
+            fig.suptitle(title, y=0.935)
 
-    if title is not None:
-        fig.suptitle(title, y=0.935)
+        colormap, norm, ticks = setup_colormap(config, colormap_section)
 
-    colormap, norm, ticks = setup_colormap(config, colormap_section)
-
-    pcolor_kwargs = dict(cmap=colormap, norm=norm, zorder=1, edgecolors='face')
-
-    if patch_edge_color is not None:
-        pcolor_kwargs['edgecolors'] = patch_edge_color
-
-    gl = ax.gridlines(color='gray', linestyle=':', zorder=5, draw_labels=True)
-    gl.right_labels = False
-    gl.top_labels = False
-
-    if plot_land:
-        _add_land_lakes_coastline(ax)
-
-    pc = mosaic.polypcolor(ax, descriptor, da, **pcolor_kwargs)
-
-    cbar = fig.colorbar(
-        pc, ax=ax, label=colorbar_label, extend='both', shrink=0.6
-    )
-    if ds_transect is not None:
-        ax.plot(
-            ds_transect.lonNode.values,
-            ds_transect.latNode.values,
-            '.r',
-            transform=transform,
+        pcolor_kwargs = dict(
+            cmap=colormap, norm=norm, zorder=1, edgecolors='face'
         )
 
-    if enforce_aspect_ratio:
-        min_latitude = np.rad2deg(mesh_ds.latCell.min().values)
-        max_latitude = np.rad2deg(mesh_ds.latCell.max().values)
-        min_longitude = np.rad2deg(mesh_ds.lonCell.min().values)
-        max_longitude = np.rad2deg(mesh_ds.lonCell.max().values)
-        geod = Geodesic()
-        x_distance = geod.inverse(
-            [min_longitude, min_latitude], [max_longitude, min_latitude]
-        )[0, 0]
-        y_distance = geod.inverse(
-            [min_longitude, min_latitude], [min_longitude, max_latitude]
-        )[0, 0]
-        ax.set_aspect(y_distance / x_distance)
+        if patch_edge_color is not None:
+            pcolor_kwargs['edgecolors'] = patch_edge_color
 
-    if ticks is not None:
-        cbar.set_ticks(ticks)
-        cbar.set_ticklabels([f'{tick}' for tick in ticks])
+        gl = ax.gridlines(
+            color='gray', linestyle=':', zorder=5, draw_labels=True
+        )
+        gl.right_labels = False
+        gl.top_labels = False
 
-    # Let constrained_layout manage the margins; combining it with
-    # bbox_inches='tight' on a fixed-aspect GeoAxes with an attached colorbar
-    # can collapse the map axes so only part of the globe is drawn.
-    fig.savefig(out_filename)
+        if plot_land:
+            _add_land_lakes_coastline(ax)
+
+        pc = mosaic.polypcolor(ax, descriptor, da, **pcolor_kwargs)
+
+        cbar = fig.colorbar(
+            pc, ax=ax, label=colorbar_label, extend='both', shrink=0.6
+        )
+        if ds_transect is not None:
+            ax.plot(
+                ds_transect.lonNode.values,
+                ds_transect.latNode.values,
+                '.r',
+                transform=transform,
+            )
+
+        if enforce_aspect_ratio:
+            min_latitude = np.rad2deg(mesh_ds.latCell.min().values)
+            max_latitude = np.rad2deg(mesh_ds.latCell.max().values)
+            min_longitude = np.rad2deg(mesh_ds.lonCell.min().values)
+            max_longitude = np.rad2deg(mesh_ds.lonCell.max().values)
+            geod = Geodesic()
+            x_distance = geod.inverse(
+                [min_longitude, min_latitude], [max_longitude, min_latitude]
+            )[0, 0]
+            y_distance = geod.inverse(
+                [min_longitude, min_latitude], [min_longitude, max_latitude]
+            )[0, 0]
+            ax.set_aspect(y_distance / x_distance)
+
+        if ticks is not None:
+            cbar.set_ticks(ticks)
+            cbar.set_ticklabels([f'{tick}' for tick in ticks])
+
+        # Let constrained_layout manage the margins; combining it with
+        # bbox_inches='tight' on a fixed-aspect GeoAxes with an
+        # attached colorbar can collapse the map axes so only part of
+        # the globe is drawn.
+        fig.savefig(out_filename)
 
 
 def plot_global_lat_lon_field(
@@ -277,89 +281,90 @@ def plot_global_lat_lon_field(
         Label on the colorbar
     """
 
-    use_mplstyle()
+    with mplstyle_context():
+        nlat, nlon = data_array.shape
+        if lon.shape[0] == nlon:
+            lon_corner = interp_extrap_corner(lon)
+        elif lon.shape[0] == nlon + 1:
+            lon_corner = lon
+        else:
+            raise ValueError(
+                f'Unexpected length of lon {lon.shape[0]}. Should '
+                f'be either {nlon} or {nlon + 1}'
+            )
 
-    nlat, nlon = data_array.shape
-    if lon.shape[0] == nlon:
-        lon_corner = interp_extrap_corner(lon)
-    elif lon.shape[0] == nlon + 1:
-        lon_corner = lon
-    else:
-        raise ValueError(
-            f'Unexpected length of lon {lon.shape[0]}. Should '
-            f'be either {nlon} or {nlon + 1}'
+        if lat.shape[0] == nlat:
+            lat_corner = interp_extrap_corner(lat)
+        elif lat.shape[0] == nlat + 1:
+            lat_corner = lat
+        else:
+            raise ValueError(
+                f'Unexpected length of lat {lat.shape[0]}. Should '
+                f'be either {nlat} or {nlat + 1}'
+            )
+
+        figsize = (8, 4.5)
+        fig = plt.figure(figsize=figsize)
+        if title is not None:
+            fig.suptitle(title, y=0.935)
+
+        subplots = [111]
+        ref_projection = cartopy.crs.PlateCarree()
+        central_longitude = 0.5 * (lon_corner[0] + lon_corner[-1])
+        projection = cartopy.crs.PlateCarree(
+            central_longitude=central_longitude
         )
 
-    if lat.shape[0] == nlat:
-        lat_corner = interp_extrap_corner(lat)
-    elif lat.shape[0] == nlat + 1:
-        lat_corner = lat
-    else:
-        raise ValueError(
-            f'Unexpected length of lat {lat.shape[0]}. Should '
-            f'be either {nlat} or {nlat + 1}'
+        extent = [lon_corner[0], lon_corner[-1], lat_corner[0], lat_corner[-1]]
+
+        colormap, norm, ticks = setup_colormap(config, colormap_section)
+
+        ax = plt.subplot(subplots[0], projection=projection)
+
+        ax.set_extent(extent, crs=ref_projection)
+
+        gl = ax.gridlines(
+            crs=ref_projection,
+            color='gray',
+            linestyle=':',
+            zorder=5,
+            draw_labels=True,
+        )
+        gl.right_labels = False
+        gl.top_labels = False
+
+        plotHandle = ax.pcolormesh(
+            lon_corner,
+            lat_corner,
+            data_array,
+            cmap=colormap,
+            norm=norm,
+            transform=ref_projection,
+            zorder=1,
         )
 
-    figsize = (8, 4.5)
-    fig = plt.figure(figsize=figsize)
-    if title is not None:
-        fig.suptitle(title, y=0.935)
+        if plot_land:
+            _add_land_lakes_coastline(ax)
 
-    subplots = [111]
-    ref_projection = cartopy.crs.PlateCarree()
-    central_longitude = 0.5 * (lon_corner[0] + lon_corner[-1])
-    projection = cartopy.crs.PlateCarree(central_longitude=central_longitude)
+        cax = inset_axes(
+            ax,
+            width='3%',
+            height='60%',
+            loc='center right',
+            bbox_to_anchor=(0.08, 0.0, 1, 1),
+            bbox_transform=ax.transAxes,
+            borderpad=0,
+        )
 
-    extent = [lon_corner[0], lon_corner[-1], lat_corner[0], lat_corner[-1]]
+        cbar = plt.colorbar(plotHandle, cax=cax, extend='both')
+        cbar.set_label(colorbar_label)
+        if ticks is not None:
+            cbar.set_ticks(ticks)
+            cbar.set_ticklabels([f'{tick}' for tick in ticks])
 
-    colormap, norm, ticks = setup_colormap(config, colormap_section)
+        plt.savefig(out_filename, bbox_inches='tight', pad_inches=0.2)
 
-    ax = plt.subplot(subplots[0], projection=projection)
-
-    ax.set_extent(extent, crs=ref_projection)
-
-    gl = ax.gridlines(
-        crs=ref_projection,
-        color='gray',
-        linestyle=':',
-        zorder=5,
-        draw_labels=True,
-    )
-    gl.right_labels = False
-    gl.top_labels = False
-
-    plotHandle = ax.pcolormesh(
-        lon_corner,
-        lat_corner,
-        data_array,
-        cmap=colormap,
-        norm=norm,
-        transform=ref_projection,
-        zorder=1,
-    )
-
-    if plot_land:
-        _add_land_lakes_coastline(ax)
-
-    cax = inset_axes(
-        ax,
-        width='3%',
-        height='60%',
-        loc='center right',
-        bbox_to_anchor=(0.08, 0.0, 1, 1),
-        bbox_transform=ax.transAxes,
-        borderpad=0,
-    )
-
-    cbar = plt.colorbar(plotHandle, cax=cax, extend='both')
-    cbar.set_label(colorbar_label)
-    if ticks is not None:
-        cbar.set_ticks(ticks)
-        cbar.set_ticklabels([f'{tick}' for tick in ticks])
-
-    plt.savefig(out_filename, bbox_inches='tight', pad_inches=0.2)
-
-    plt.close()
+        plt.close()
 
 
 def setup_colormap(config, colormap_section):

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -4,10 +4,11 @@ import importlib.resources as imp_res
 import cartopy
 import cmocean  # noqa: F401
 import matplotlib.colors as cols
-import matplotlib.pyplot as plt
 import mosaic
 import numpy as np
 from cartopy.geodesic import Geodesic
+from matplotlib import colormaps
+from matplotlib.figure import Figure
 from mpas_tools.io import open_dataset
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from pyremap.descriptor.utility import interp_extrap_corner
@@ -158,11 +159,8 @@ def plot_global_mpas_field(
                 use_latlon=True,
             )
 
-        fig, ax = plt.subplots(
-            figsize=figsize,
-            constrained_layout=True,
-            subplot_kw=dict(projection=projection),
-        )
+        fig = Figure(figsize=figsize, constrained_layout=True)
+        ax = fig.add_subplot(111, projection=projection)
 
         if title is not None:
             fig.suptitle(title, y=0.935)
@@ -304,7 +302,7 @@ def plot_global_lat_lon_field(
             )
 
         figsize = (8, 4.5)
-        fig = plt.figure(figsize=figsize)
+        fig = Figure(figsize=figsize)
         if title is not None:
             fig.suptitle(title, y=0.935)
 
@@ -319,7 +317,7 @@ def plot_global_lat_lon_field(
 
         colormap, norm, ticks = setup_colormap(config, colormap_section)
 
-        ax = plt.subplot(subplots[0], projection=projection)
+        ax = fig.add_subplot(subplots[0], projection=projection)
 
         ax.set_extent(extent, crs=ref_projection)
 
@@ -356,15 +354,13 @@ def plot_global_lat_lon_field(
             borderpad=0,
         )
 
-        cbar = plt.colorbar(plotHandle, cax=cax, extend='both')
+        cbar = fig.colorbar(plotHandle, cax=cax, extend='both')
         cbar.set_label(colorbar_label)
         if ticks is not None:
             cbar.set_ticks(ticks)
             cbar.set_ticklabels([f'{tick}' for tick in ticks])
 
-        plt.savefig(out_filename, bbox_inches='tight', pad_inches=0.2)
-
-        plt.close()
+        fig.savefig(out_filename, bbox_inches='tight', pad_inches=0.2)
 
 
 def setup_colormap(config, colormap_section):
@@ -406,7 +402,7 @@ def setup_colormap(config, colormap_section):
         is an array of values where ticks should be placed
     """
 
-    colormap = plt.get_cmap(config.get(colormap_section, 'colormap_name'))
+    colormap = colormaps[config.get(colormap_section, 'colormap_name')]
 
     section = config[colormap_section]
 

--- a/polaris/viz/style.py
+++ b/polaris/viz/style.py
@@ -1,20 +1,48 @@
 import importlib.resources as imp_res
+import threading
+from contextlib import contextmanager
 
 import matplotlib.pyplot as plt
+import matplotlib.style
 from mpas_tools.viz.colormaps import register_sci_viz_colormaps
 
+_COLORMAP_LOCK = threading.Lock()
 _SCI_VIZ_COLORMAPS_REGISTERED = False
 
 
-def use_mplstyle():
+@contextmanager
+def mplstyle_context(dpi=None):
     """
-    Use the Polaris matplotlib style file
+    A context manager that applies the Polaris matplotlib style for the
+    duration of a plot and restores the previous settings afterwards
+
+    Matplotlib's ``rcParams`` are global to the process, so a step that
+    assigns to them changes the appearance of plots made by any other step
+    running at the same time.  Plotting inside this context manager keeps the
+    settings scoped to the plot that needs them.
+
+    Parameters
+    ----------
+    dpi : int, optional
+        Dots per inch for saved figures, overriding the value from the
+        Polaris style file
+    """
+    _register_colormaps()
+
+    style_filename = str(imp_res.files('polaris.viz') / 'polaris.mplstyle')
+    overrides = {} if dpi is None else {'savefig.dpi': dpi}
+    with matplotlib.style.context(style_filename), plt.rc_context(overrides):
+        yield
+
+
+def _register_colormaps():
+    """
+    Add the scientific visualization colormaps to Matplotlib's registry, once
+    per process
     """
     global _SCI_VIZ_COLORMAPS_REGISTERED
 
-    if not _SCI_VIZ_COLORMAPS_REGISTERED:
-        register_sci_viz_colormaps()
-        _SCI_VIZ_COLORMAPS_REGISTERED = True
-
-    style_filename = str(imp_res.files('polaris.viz') / 'polaris.mplstyle')
-    plt.style.use(style_filename)
+    with _COLORMAP_LOCK:
+        if not _SCI_VIZ_COLORMAPS_REGISTERED:
+            register_sci_viz_colormaps()
+            _SCI_VIZ_COLORMAPS_REGISTERED = True

--- a/tests/mesh/spherical/unified/test_base_mesh.py
+++ b/tests/mesh/spherical/unified/test_base_mesh.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import numpy as np
 
@@ -29,6 +28,9 @@ def test_unified_base_mesh_step_writes_river_geometry(tmp_path, monkeypatch):
         component=Component(name='mesh'),
         subdir='spherical/unified/test/base_mesh',
     )
+    # the step finds its files through its work directory, not through the
+    # process working directory
+    step.work_dir = str(tmp_path)
     step.opts.hfun_file = 'hfun.msh'
     step.opts.geom_file = 'geom.msh'
     step.opts.jcfg_file = 'jigsaw.jig'
@@ -82,12 +84,7 @@ def test_unified_base_mesh_step_writes_river_geometry(tmp_path, monkeypatch):
     cell_width = np.full((lat.size, lon.size), 30.0)
 
     step.config.set('river_network', 'base_mesh_simplify_tolerance_km', '2.0')
-    cwd = os.getcwd()
-    try:
-        os.chdir(tmp_path)
-        step.make_jigsaw_mesh(lon=lon, lat=lat, cell_width=cell_width)
-    finally:
-        os.chdir(cwd)
+    step.make_jigsaw_mesh(lon=lon, lat=lat, cell_width=cell_width)
 
     geom = saved_meshes['geom.msh']
     assert geom.edge2.size == 3
@@ -110,6 +107,9 @@ def test_unified_base_mesh_step_uses_prepared_clipped_river_geometry(
         component=Component(name='mesh'),
         subdir='spherical/unified/test/base_mesh',
     )
+    # the step finds its files through its work directory, not through the
+    # process working directory
+    step.work_dir = str(tmp_path)
     step.opts.hfun_file = 'hfun.msh'
     step.opts.geom_file = 'geom.msh'
     step.opts.jcfg_file = 'jigsaw.jig'
@@ -152,12 +152,7 @@ def test_unified_base_mesh_step_uses_prepared_clipped_river_geometry(
     cell_width = np.full((lat.size, lon.size), 30.0)
 
     step.config.set('river_network', 'base_mesh_simplify_tolerance_km', '2.0')
-    cwd = os.getcwd()
-    try:
-        os.chdir(tmp_path)
-        step.make_jigsaw_mesh(lon=lon, lat=lat, cell_width=cell_width)
-    finally:
-        os.chdir(cwd)
+    step.make_jigsaw_mesh(lon=lon, lat=lat, cell_width=cell_width)
 
     geom = saved_meshes['geom.msh']
     assert geom.edge2.size == 1

--- a/tests/test_work_path.py
+++ b/tests/test_work_path.py
@@ -1,0 +1,52 @@
+import os
+
+import pytest
+
+from polaris import Component, Step
+
+
+def _step(work_dir):
+    component = Component(name='ocean')
+    step = Step(component=component, name='test_step')
+    step.work_dir = work_dir
+    return step
+
+
+def test_work_path_is_absolute_and_under_work_dir(tmp_path):
+    step = _step(str(tmp_path))
+    assert step.work_path('output.nc') == os.path.join(
+        str(tmp_path), 'output.nc'
+    )
+
+
+def test_work_path_joins_multiple_components(tmp_path):
+    step = _step(str(tmp_path))
+    assert step.work_path('plots', 'final.png') == os.path.join(
+        str(tmp_path), 'plots', 'final.png'
+    )
+
+
+def test_work_path_does_not_depend_on_cwd(tmp_path, monkeypatch):
+    """The whole point of the helper: the answer must be the same no matter
+    where the process happens to be running from."""
+    step = _step(str(tmp_path))
+    from_here = step.work_path('output.nc')
+    other_dir = tmp_path / 'elsewhere'
+    other_dir.mkdir()
+    monkeypatch.chdir(other_dir)
+    assert step.work_path('output.nc') == from_here
+
+
+def test_work_path_normalizes_relative_components(tmp_path):
+    step = _step(str(tmp_path))
+    expected = os.path.join(os.path.dirname(str(tmp_path)), 'sibling.nc')
+    assert step.work_path('..', 'sibling.nc') == expected
+
+
+def test_work_path_raises_before_setup():
+    """A step that has not been set up has no work directory, and silently
+    returning a path relative to the process working directory would be
+    exactly the bug the helper exists to prevent."""
+    step = _step('')
+    with pytest.raises(ValueError, match='work directory'):
+        step.work_path('output.nc')


### PR DESCRIPTION
This PR adds a design document setting out the properties an analysis step must have in order to be scheduled concurrently, and then adopts those groundrules in the Polaris framework and in the shared steps that new analysis steps will build on.

Polaris is adding task parallelism, and the near-term driver is building analysis capability equivalent to MPAS-Analysis for Omega. Whether Polaris can run analysis steps concurrently is only partly a property of the scheduler; it is equally a property of the steps. A step that changes the working directory, mutates module-level configuration, or writes to a shared path cannot safely run beside another step in the same process, and the interference is timing-dependent, so it surfaces as intermittent wrong answers rather than as a clean failure. The cost of adopting the rules now, while the analysis capability is still being designed, is close to zero; the cost of retrofitting them later is rewriting every analysis step already written.

## The rules

The design document (`docs/design_docs/task_parallel_analysis_steps.md`) states what Polaris already guarantees — steps are already picklable, config already comes from a file, declared inputs and outputs are already absolute, every step already has its own work directory and logger — and then the six requirements that are not yet guaranteed: no process-global state mutation, working-directory independence, temporary files in the step's own work directory, logging through the step's logger, declared resources, and bounded process launching.

`docs/developers_guide/framework/task_parallelism.md` restates those rules where a developer writing a new analysis step will actually find them, next to the framework support that makes following them easier than breaking them.

## Framework additions

`Step.work_path(*filenames)` returns an absolute path inside the step's own work directory, so a step can address its files without reference to `os.getcwd()`. It raises rather than guessing when the work directory has not been set, since silently falling back to the process working directory is the bug it exists to prevent.

`polaris.viz.mplstyle_context(dpi=None)` replaces `polaris.viz.use_mplstyle()`. `plt.style.use()` rewrote matplotlib's `rcParams` for the whole process and never restored them, and `plot_global_mpas_field()` went further by assigning `rcParams['savefig.dpi']` directly. The context manager applies the Polaris style sheet, and an optional dpi override, for the duration of a `with` block and restores the previous settings on exit. Registering the SciVisColor colormaps stays a one-time process-global action, since it is additive and identical for every step, but it is now guarded by a lock so two steps registering at once cannot race.

## What was converted

`polaris.viz.planar` and `polaris.viz.spherical` now build figures with `matplotlib.figure.Figure` rather than through pyplot's process-global current figure. `setup_colormap()` moves from `plt.get_cmap()` to `matplotlib.colormaps`. A figure built this way is never registered with pyplot, so `plt.close()` is no longer needed anywhere.

`polaris.mesh.spherical` resolves every file it touches through `work_path()`: the cell-width and mesh files, the intermediate triangle mesh, the `MpasMeshConverter.x` arguments, the VTK directory, the graph file, the Southern Ocean region file, and the unified mesh's sizing field and river network. The JIGSAW file names need the same treatment but are consumed indirectly — `savejig()` writes them verbatim into the `.jig` config file and the `jigsaw` executable then opens them — so they are resolved in `runtime_setup()`, before either `make_jigsaw_mesh()` implementation runs. `_plot_cell_width()` also moves to the object-oriented figure API.

`polaris.ocean.convergence.analysis` is the base class every convergence task's analysis step inherits, so it is held to the rules even though the tasks using it are not yet. It no longer calls `plt.switch_backend('Agg')`, builds its figure with `Figure`, and reaches its CSV, PNG and three per-refinement input datasets through `work_path()`.

Across the task steps, two narrow sweeps were applied without otherwise converting those files: `plt.switch_backend('Agg')` is removed at all ten remaining call sites, and `print()` is replaced by `self.logger` in the eight analysis and visualization steps that used it. In the river-network simplification the messages come from a module-level helper, which now takes a `logger` argument that the step fills in with its own.

One task-level step is fully converted as a worked example: the sea-ice single-column `Viz` step. It is small, it plots, and it reads and writes files, so it exercises most of the rules in one place, and the Developer's Guide points at it. It had also escaped the `use_mplstyle()` sweep because it inlined those two lines rather than calling the function, so it was still rewriting the process's `rcParams` directly. Its two bare `plt.legend()` calls turned out not to be duplicates — `twinx()` makes the new axes current, so the first legended the temperature axis and the second the thickness axis — which is a small illustration of why the pyplot current figure is worth getting rid of.

## Bug fixed along the way

`_plot_cell_width()` saved with `bbox_inches='tight'`, and with the currently deployed matplotlib and cartopy that collapses the fixed-aspect `GeoAxes` so `cellWidthGlobal.png` contained nothing but the colorbar. This is a library regression rather than a new problem — a 2024 run of the same code produced a correct map — and it is the same failure that was fixed in `plot_global_mpas_field()` in #635. Dropping the tight bounding box restores the map. Every spherical base mesh built recently has a broken `cellWidthGlobal.png`; they will be correct on the next build.

## Testing

`pytest tests/` passes, 410 tests. `Step.work_path()` has new unit tests covering path joining, independence from the process working directory, and the unset-work-directory error. The unified base-mesh tests previously `chdir`'d into a temporary directory so the step would find its river network there; they now set the step's work directory instead, which is what the step actually reads.

`plot_horiz_field()`, `plot_global_mpas_field()`, `plot_global_lat_lon_field()` and `_plot_cell_width()` were each rendered before and after the conversion to the object-oriented figure API and the output PNGs are pixel-identical, including the dpi-override path. Each leaves zero figures in the pyplot registry and restores `rcParams` exactly.

The sea-ice single-column `Viz` step renders pixel-identical output, both legends included, and was then run from an unrelated working directory: it wrote both images into its own work directory, wrote nothing outside it, and left the working directory, `rcParams` and the pyplot figure registry unchanged.

`mesh/spherical/icos/base_mesh/480km` and `mesh/spherical/qu/base_mesh/480km` were set up and run to completion on chrysalis. Both were then re-run adversarially, unpickled and executed from an unrelated working directory: both succeeded, wrote nothing outside their own work directory, and left the working directory, `rcParams`, the pyplot figure registry and the `mpas_tools.io` module globals unchanged. The generated `opts.jig` carries absolute paths, and `cellWidthGlobal.png` now renders a full map.

## What this PR deliberately does not do

Most task-level analysis and visualization steps are not converted. They still open files by bare relative name and use the pyplot current figure. That is correct under today's one-step-at-a-time execution, and the design document argues explicitly that existing steps should not be required to conform until there is a reason. The new Developer's Guide page says so, and says not to copy those steps as a template for new work.

One known item is left for later: `numba.set_num_threads()` in `polaris/tasks/e3sm/init/topo/combine/viz.py` is a process-global mutation, though it is correctly sized from `cpus_per_task` and numba offers no scoped alternative.

The resource-declaration and bounded-parallelism rules are stated but not yet enforced. Target and minimum memory fields on `Step`, and the conformance helper that would check these rules mechanically, depend on measurements that are being gathered separately from an instrumented high-resolution MPAS-Analysis run, and on the scheduler work itself.

Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite
