### PR TITLE
Add task parallelism design

### DIFF
--- a/docs/design_docs/index.md
+++ b/docs/design_docs/index.md
@@ -13,6 +13,11 @@ overflow_nonlinear_eos
 pstar_init
 shared_steps
 task_parallel_analysis_steps
+task_parallelism
+task_parallelism_phase_a
+task_parallelism_phase_b
+task_parallelism_phase_c
+task_parallelism_phase_d
 unified_base_mesh
 unified_mesh_prepare_coastline
 unified_mesh_prepare_river_network

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -45,15 +45,43 @@ what each one unblocks rather than for which matters more.
 
 Before designing anything, we measured whether the machines Polaris targets
 can actually run several placed pieces of work at once inside a single
-allocation. They can, all five of them. The details are recorded in
-`utils/launcher_spike/README.md`; the conclusions that shape this design
-are:
+allocation. They can, all five of them. The measurements were made in
+August 2026 with throwaway scripts; the results are recorded here because
+this document is where they need to survive.
 
-- **Launching work is cheap.** Between 60 and 670 launches per minute
-  depending on machine. A long-standing suspicion that Perlmutter throttles
-  launches to about one a minute turned out to describe a different problem.
-  (The measurements were taken off-peak, so this is not the last word on a
-  busy weekday.)
+In each test, four pieces of work were launched at once inside one
+allocation, each asking to be confined to its own cores and, where
+relevant, its own GPUs. Each reported back which cores and GPUs it could
+actually see and when it ran, so that genuine overlap could be told from
+work that merely queued.
+
+| machine | batch system | what confines a launch | cores | GPUs |
+| --- | --- | --- | --- | --- |
+| Chrysalis | Slurm 20.02 | explicit CPU binding | disjoint | n/a |
+| Perlmutter CPU | Slurm 25.11 | resource request | disjoint | n/a |
+| Perlmutter GPU | Slurm 25.11 | request + GPU total | disjoint | disjoint |
+| Frontier | Slurm 25.11 | request + GPU total | disjoint | disjoint |
+| Aurora | PBS with PALS | host list + core list | disjoint | disjoint |
+
+All five ran all four launches concurrently.
+
+The GPU machines were also tested at MPI width -- four concurrent two-rank
+MPI launches -- and partitioned cleanly there too. On Frontier the four
+launches received GPUs 4,5 / 6,7 / 0,1 / 2,3.
+
+The conclusions that shape this design are:
+
+- **Launching work is cheap.** Measured sequentially: roughly 60 per minute
+  on Perlmutter GPU and Aurora, 150 on Perlmutter CPU, 500-600 on Frontier
+  and Chrysalis. A long-standing suspicion that Perlmutter throttles
+  launches to about one a minute turned out to describe a different problem
+  -- concurrent launches queueing, not launches being rate limited.
+
+  Two caveats worth carrying. The tail is heavy: Frontier showed two of ten
+  launches near two seconds against a median of 0.11 s on an otherwise idle
+  system. And all of this was measured off-peak, so a busy weekday has not
+  been ruled out. If a future run finds launching unexpectedly slow, this is
+  the first thing to re-measure rather than the last.
 - **The scheduler will keep concurrent work apart, if asked properly.** Each
   piece of work gets its own cores, and its own GPUs, enforced by the batch
   system rather than by Polaris. This is a stronger guarantee than we
@@ -71,6 +99,19 @@ are:
   constraint on how Polaris describes step resources, and it differs from
   how CPU resources are described today.
 
+One more result is worth recording because it cost a round of testing: on
+CUDA machines the visible-device variable is renumbered for each launch, so
+four launches on four different GPUs all report device `0`. Anything
+verifying GPU placement must use the scheduler's global identifiers
+instead.
+
+Two approaches were tried and rejected. Allowing launches to overlap without
+constraining them gives concurrency but every launch then shares every core
+and GPU, which is oversubscription rather than scheduling. Constraining a
+launch and *also* pinning it with an explicit CPU mask fails outright on
+newer Slurm, because the two contradict each other; explicit masks remain
+the only mechanism on Slurm older than 20.11, where they work.
+
 The practical consequence is that no new dependency is needed. We considered
 adopting Flux, a nested scheduler that would sidestep the batch system
 entirely, and it is not necessary.
@@ -82,7 +123,7 @@ useful.
 
 ### Phase A -- Placement
 
-`docs/design_docs/task_parallelism_phase_a.md`
+[Task Parallelism Phase A: Placement](task_parallelism_phase_a.md)
 
 Give Polaris the ability to run a step on a **named part** of its allocation
 rather than on all of it, and give steps a way to say what they need,
@@ -93,7 +134,7 @@ This is a prerequisite for everything else, and most of the work is in
 
 ### Phase B -- Concurrency
 
-`docs/design_docs/task_parallelism_phase_b.md`
+[Task Parallelism Phase B: Concurrency](task_parallelism_phase_b.md)
 
 Build the dependency graph, the resource pool and an executor that runs each
 step in its own process. Run independent steps at the same time -- MPI and
@@ -104,7 +145,7 @@ This is where the regression-suite speedup lands.
 
 ### Phase C -- Python worker pool
 
-`docs/design_docs/task_parallelism_phase_c.md`
+[Task Parallelism Phase C: Python Worker Pool](task_parallelism_phase_c.md)
 
 Add a second executor: a pool of workers spread across the allocation's
 nodes, for Python work that is too fine-grained to give a process of its
@@ -113,7 +154,7 @@ MPAS-Analysis today, and it is the phase the analysis capability depends on.
 
 ### Phase D -- Coexistence and elasticity
 
-`docs/design_docs/task_parallelism_phase_d.md`
+[Task Parallelism Phase D: Coexistence and Elasticity](task_parallelism_phase_d.md)
 
 Let the worker pool and ordinary steps share an allocation, and let the pool
 grow and shrink as the amount of ready Python work changes, so that it does
@@ -131,8 +172,10 @@ not hold nodes idle once that work drains.
 - These documents do not cover writing the analysis capability itself. The
   properties an analysis step needs in order to be safely run concurrently
   are a separate document,
-  `docs/design_docs/task_parallel_analysis_steps.md`, which is worth
-  adopting before analysis steps are written rather than after.
+  *Task-Parallel-Safe Analysis Steps in Polaris*, which is worth adopting
+  before analysis steps are written rather than after. That document is
+  being prepared on its own branch and should land alongside these; once it
+  does, this should become a link to it.
 
 ## What success looks like
 

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -58,14 +58,18 @@ are:
   piece of work gets its own cores, and its own GPUs, enforced by the batch
   system rather than by Polaris. This is a stronger guarantee than we
   expected to get.
-- **A piece of work claims every GPU on its node unless it says otherwise.**
-  This, and not memory or CPU contention, is what prevented concurrency on
-  the GPU machines. The fix is for each step to state how many GPUs it
-  needs.
-- **GPUs must be requested as a total per step, not as a count per MPI
-  rank.** The per-rank form does not work. This is a real constraint on how
-  Polaris describes step resources, and it differs from how CPU resources
-  are described today.
+- **Silence about GPUs is not neutral at the launcher.** Polaris steps use
+  no GPUs unless they say so, and that stays true. But if Polaris passes
+  that silence on, the batch system reads it as "give this work the node's
+  GPUs" and reserves all of them, which is what stopped concurrency on the
+  GPU machines -- not memory or CPU contention. Polaris must therefore state
+  a step's GPU need explicitly in every case, **including when it is zero**.
+  Since most Polaris steps use no GPUs at all, saying "none" is the common
+  path, not the exception.
+- **When a step does want GPUs, it must ask for a total, not a count per MPI
+  rank.** The per-rank form does not confine a step at all. This is a real
+  constraint on how Polaris describes step resources, and it differs from
+  how CPU resources are described today.
 
 The practical consequence is that no new dependency is needed. We considered
 adopting Flux, a nested scheduler that would sidestep the batch system

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -69,6 +69,57 @@ The GPU machines were also tested at MPI width -- four concurrent two-rank
 MPI launches -- and partitioned cleanly there too. On Frontier the four
 launches received GPUs 4,5 / 6,7 / 0,1 / 2,3.
 
+### What the rendered commands did
+
+The table above was produced with commands written by hand. That establishes
+what the machines can do, not that the commands Polaris and `mache` build
+between them do it, which is a different claim and the one that gates the
+`mache` change. It was checked separately, in August 2026, by constructing
+disjoint placements, rendering each through `mache` and launching them
+together:
+
+| machine | placement | GPUs | note |
+| --- | --- | --- | --- |
+| Chrysalis | exact cores | n/a | clean first time |
+| Frontier | honored | disjoint, 0,1 / 2,3 / 4,5 / 6,7 | clean first time |
+| Perlmutter GPU | honored | disjoint, 0 / 1 / 2 / 3 | clean after a fix |
+| Aurora | exact cores | disjoint masks | clean after a fix |
+| Perlmutter CPU | not run | n/a | the remaining gap |
+
+Two defects were found this way and both were fixed in `mache` rather than
+worked around. On Aurora, `--env-remove` is not an option the PALS
+`mpiexec` accepts, and it rejected the whole command, so every placed launch
+failed to start. On Perlmutter GPU, a `gpu_bind` of `none` carried from the
+machine config alongside an explicit GPU request, and under concurrency
+three of four launches silently received no GPU at all and exited zero --
+the same class of failure as silently losing placement, and the reason this
+verification was worth doing separately from the hand-written one.
+
+One limit of the Aurora result should be carried with it. On Slurm the GPUs
+a launch can see are read from the scheduler's own variables, so the verdict
+is independent evidence. On PALS nothing assigns GPUs, so `mache` renders
+the indices the caller chose and the check reads that same value back: it
+confirms the plumbing, not that the runtime honors it. Whether Level Zero
+reads an empty mask as "no devices" or as "no mask at all" is still open,
+and a clean Aurora run does not close it.
+
+### Where measurements live, and what does not
+
+Both sets of results above were produced by harnesses written to answer a
+question. Neither harness is part of what Polaris ships, and the findings
+are recorded in this document rather than in the directories that produced
+them. This is deliberate and has already been learned once: an earlier
+version of these documents pointed at a README on a branch that was never
+going to merge, so the reference would have dangled and the evidence would
+have been lost with it.
+
+The rule worth stating, so that it does not have to be learned a third time:
+**a harness built to answer a question is not part of the deliverable, its
+findings belong in the design document, and it does not merge.** Anything
+from such a harness that deserves to keep running -- a regression test, a
+standing check -- has to be moved somewhere permanent before the harness
+goes, not after.
+
 The conclusions that shape this design are:
 
 - **Launching work is cheap.** Measured sequentially: roughly 60 per minute

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -98,20 +98,30 @@ The conclusions that shape this design are:
   rank.** The per-rank form does not confine a step at all. This is a real
   constraint on how Polaris describes step resources, and it differs from
   how CPU resources are described today.
-- **The batch system will not manage memory for us.** Asking a launch for a
-  share of the node's memory changed nothing that was measured: it neither
-  fixed the serialization -- silence about GPUs did that -- nor, as far as
-  we can tell, reserved anything. Memory is therefore not a resource Polaris
-  can hand to the launcher and forget about. It is a budget Polaris has to
-  keep itself, by declining to start a step that will not fit, which means
-  it belongs to the scheduler in Phase B rather than to placement in Phase
-  A.
+- **The batch system will not schedule memory for us, but on newer Slurm it
+  will enforce it.** These are different things and the difference decides
+  how memory is handled. Asking a launch for a share of the node's memory
+  did not fix the serialization -- silence about GPUs did that -- and it
+  reserved nothing that any measurement could see. But a later measurement
+  on the same machines showed a memory request is not inert: a launch
+  allowed 1024 MB and told to take 4 GB is killed at 960 MB on Perlmutter
+  GPU and on Frontier, and runs to completion on Chrysalis, whose Slurm
+  predates the 20.11 change.
 
-  The limit of that evidence should be stated: it shows memory was not
-  causing the serialization, not that no machine anywhere applies a limit
-  when asked. Whether a launch given a small memory allowance is actually
-  killed for exceeding it has not been tested, and is worth one cheap
-  measurement while the placement testing is being done anyway.
+  So the launcher will not tell Polaris what fits, and deciding that remains
+  a budget Polaris keeps itself, in the scheduler in Phase B. What the
+  launcher will do, on some machines, is hold a launch to a number it was
+  given. That makes a memory figure passed to a launcher a **cap** rather
+  than a reservation, which is a thing worth doing deliberately for a step
+  that stated its own number and not worth doing to a step the framework
+  guessed at.
+
+  One worry this raised does not materialize. Silence about memory does not
+  repeat the trap that silence about GPUs sets: four concurrent launches
+  that said nothing about memory all started within 40 ms of each other and
+  ran their full duration on both machines that enforce. An unstated memory
+  requirement is not read as a claim on the node's memory. Aurora and
+  Perlmutter CPU are unmeasured on this point.
 
 One more result is worth recording because it cost a round of testing: on
 CUDA machines the visible-device variable is renumbered for each launch, so

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -208,8 +208,8 @@ launcher is asked to enforce; deciding what fits is Phase B's job.
 
 This is a prerequisite for everything else, and most of the work is in
 `mache`, which owns how Polaris launches parallel work. That `mache` change
-exists as pull request #470 and is not yet merged or released, so Phase A
-is developed against a branch rather than a released version for now.
+is merged and released as `mache` 3.12.0, which Polaris requires; while it
+was unreleased Phase A was developed against the branch.
 
 ### Phase B -- Concurrency
 

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -74,9 +74,9 @@ launches received GPUs 4,5 / 6,7 / 0,1 / 2,3.
 The table above was produced with commands written by hand. That establishes
 what the machines can do, not that the commands Polaris and `mache` build
 between them do it, which is a different claim and the one that gates the
-`mache` change. It was checked separately, in August 2026, by constructing
-disjoint placements, rendering each through `mache` and launching them
-together:
+`mache` change. It was checked separately, in August 2026, on all five
+machines, by constructing disjoint placements, rendering each through
+`mache` and launching them together:
 
 | machine | placement | GPUs | note |
 | --- | --- | --- | --- |
@@ -84,7 +84,7 @@ together:
 | Frontier | honored | disjoint, 0,1 / 2,3 / 4,5 / 6,7 | clean first time |
 | Perlmutter GPU | honored | disjoint, 0 / 1 / 2 / 3 | clean after a fix |
 | Aurora | exact cores | disjoint masks | clean after a fix |
-| Perlmutter CPU | not run | n/a | the remaining gap |
+| Perlmutter CPU | honored | n/a | clean first time |
 
 Two defects were found this way and both were fixed in `mache` rather than
 worked around. On Aurora, `--env-remove` is not an option the PALS

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -170,6 +170,14 @@ nodes, for Python work that is too fine-grained to give a process of its
 own. This is what lifts the single-node ceiling that constrains
 MPAS-Analysis today, and it is the phase the analysis capability depends on.
 
+Measurement has since confirmed the premise: a high-resolution analysis run
+is fine-grained, with a median task of about five seconds and half of them
+shorter. Phase C records what else that run showed, including two of its
+headline numbers that do not mean what they appear to. It is worth stating
+here that analysis is the pool's first demanding customer and not its
+specification -- most Polaris workflows share no single large input, and a
+pool built around one would serve the general case badly.
+
 ### Phase D -- Coexistence and elasticity
 
 [Task Parallelism Phase D: Coexistence and Elasticity](task_parallelism_phase_d.md)

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -1,0 +1,138 @@
+# Task Parallelism in Polaris
+
+Creation date: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+## Summary
+
+Polaris runs one step at a time. This document describes adding the ability
+to run independent steps at the same time, and maps out four phases of work
+to get there.
+
+"Task parallelism" is the historical name for this effort. The unit Polaris
+actually schedules is a `Step`, not a `Task`, and steps that run together may
+come from one task or from several tasks in a suite.
+
+### Two workloads, not one
+
+Two quite different kinds of work motivate this, and keeping them distinct
+is what makes the phasing sensible.
+
+**Regression suites** such as `omega_pr` are dominated by many small MPI
+model runs. On a recent `omega_pr` run on Chrysalis, 79% of the time in
+steps was MPI forward runs and 21% was everything else. The whole suite took
+12:26 while its longest single task took 106 s, so the work is there: it is
+simply run one step after another. Running independent steps together should
+give roughly a 2.5-3x improvement on the same three-node allocation, limited
+by the total core-seconds of MPI work rather than by dependencies.
+
+**Analysis** is the larger long-term need. Polaris is to gain analysis
+capability equivalent to MPAS-Analysis, for Omega and possibly MPAS-Ocean.
+That workload is heavily Python. MPAS-Analysis already has task parallelism,
+but it is built on `multiprocessing`, which cannot span nodes, and that
+single-node ceiling is a known choke point at high resolution -- exactly
+Omega's target. What this workload needs is not just concurrency but
+concurrency **across nodes**.
+
+Neither is optional, and the phases below deliver them in an order chosen for
+what each one unblocks rather than for which matters more.
+
+### What we already established
+
+Before designing anything, we measured whether the machines Polaris targets
+can actually run several placed pieces of work at once inside a single
+allocation. They can, all five of them. The details are recorded in
+`utils/launcher_spike/README.md`; the conclusions that shape this design
+are:
+
+- **Launching work is cheap.** Between 60 and 670 launches per minute
+  depending on machine. A long-standing suspicion that Perlmutter throttles
+  launches to about one a minute turned out to describe a different problem.
+  (The measurements were taken off-peak, so this is not the last word on a
+  busy weekday.)
+- **The scheduler will keep concurrent work apart, if asked properly.** Each
+  piece of work gets its own cores, and its own GPUs, enforced by the batch
+  system rather than by Polaris. This is a stronger guarantee than we
+  expected to get.
+- **A piece of work claims every GPU on its node unless it says otherwise.**
+  This, and not memory or CPU contention, is what prevented concurrency on
+  the GPU machines. The fix is for each step to state how many GPUs it
+  needs.
+- **GPUs must be requested as a total per step, not as a count per MPI
+  rank.** The per-rank form does not work. This is a real constraint on how
+  Polaris describes step resources, and it differs from how CPU resources
+  are described today.
+
+The practical consequence is that no new dependency is needed. We considered
+adopting Flux, a nested scheduler that would sidestep the batch system
+entirely, and it is not necessary.
+
+## The phases
+
+Each phase is a separate design document and is intended to be independently
+useful.
+
+### Phase A -- Placement
+
+`docs/design_docs/task_parallelism_phase_a.md`
+
+Give Polaris the ability to run a step on a **named part** of its allocation
+rather than on all of it, and give steps a way to say what they need,
+including GPUs as a per-step total and memory. Still one step at a time.
+
+This is a prerequisite for everything else, and most of the work is in
+`mache`, which owns how Polaris launches parallel work.
+
+### Phase B -- Concurrency
+
+`docs/design_docs/task_parallelism_phase_b.md`
+
+Build the dependency graph, the resource pool and an executor that runs each
+step in its own process. Run independent steps at the same time -- MPI and
+non-MPI alike, since with Phase A in place there is no reason to stage one
+behind the other.
+
+This is where the regression-suite speedup lands.
+
+### Phase C -- Python worker pool
+
+`docs/design_docs/task_parallelism_phase_c.md`
+
+Add a second executor: a pool of workers spread across the allocation's
+nodes, for Python work that is too fine-grained to give a process of its
+own. This is what lifts the single-node ceiling that constrains
+MPAS-Analysis today, and it is the phase the analysis capability depends on.
+
+### Phase D -- Coexistence and elasticity
+
+`docs/design_docs/task_parallelism_phase_d.md`
+
+Let the worker pool and ordinary steps share an allocation, and let the pool
+grow and shrink as the amount of ready Python work changes, so that it does
+not hold nodes idle once that work drains.
+
+## Scope and non-goals
+
+- `polaris serial` **stays**, unchanged, as the compatibility baseline. The
+  new capability arrives on a separate path. There is no plan in these
+  documents to remove `polaris serial`; that can be revisited once the new
+  path has been used in anger.
+- Polaris will not request larger allocations by default just because it can
+  now use them. Allocation sizing stays as it is; users asking for more
+  nodes is a deliberate act.
+- These documents do not cover writing the analysis capability itself. The
+  properties an analysis step needs in order to be safely run concurrently
+  are a separate document,
+  `docs/design_docs/task_parallel_analysis_steps.md`, which is worth
+  adopting before analysis steps are written rather than after.
+
+## What success looks like
+
+Polaris can run a suite's independent steps at the same time, on any
+supported machine, with the batch system keeping them from treading on each
+other, producing the same results as running them one at a time; and Python
+analysis work can spread across more than one node.

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -98,6 +98,20 @@ The conclusions that shape this design are:
   rank.** The per-rank form does not confine a step at all. This is a real
   constraint on how Polaris describes step resources, and it differs from
   how CPU resources are described today.
+- **The batch system will not manage memory for us.** Asking a launch for a
+  share of the node's memory changed nothing that was measured: it neither
+  fixed the serialization -- silence about GPUs did that -- nor, as far as
+  we can tell, reserved anything. Memory is therefore not a resource Polaris
+  can hand to the launcher and forget about. It is a budget Polaris has to
+  keep itself, by declining to start a step that will not fit, which means
+  it belongs to the scheduler in Phase B rather than to placement in Phase
+  A.
+
+  The limit of that evidence should be stated: it shows memory was not
+  causing the serialization, not that no machine anywhere applies a limit
+  when asked. Whether a launch given a small memory allowance is actually
+  killed for exceeding it has not been tested, and is worth one cheap
+  measurement while the placement testing is being done anyway.
 
 One more result is worth recording because it cost a round of testing: on
 CUDA machines the visible-device variable is renumbered for each launch, so
@@ -128,6 +142,8 @@ useful.
 Give Polaris the ability to run a step on a **named part** of its allocation
 rather than on all of it, and give steps a way to say what they need,
 including GPUs as a per-step total and memory. Still one step at a time.
+Memory is declared here and shown to the step, but it is not something the
+launcher is asked to enforce; deciding what fits is Phase B's job.
 
 This is a prerequisite for everything else, and most of the work is in
 `mache`, which owns how Polaris launches parallel work. That `mache` change

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -130,7 +130,9 @@ rather than on all of it, and give steps a way to say what they need,
 including GPUs as a per-step total and memory. Still one step at a time.
 
 This is a prerequisite for everything else, and most of the work is in
-`mache`, which owns how Polaris launches parallel work.
+`mache`, which owns how Polaris launches parallel work. That `mache` change
+exists as pull request #470 and is not yet merged or released, so Phase A
+is developed against a branch rather than a released version for now.
 
 ### Phase B -- Concurrency
 

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -259,10 +259,10 @@ not hold nodes idle once that work drains.
 - These documents do not cover writing the analysis capability itself. The
   properties an analysis step needs in order to be safely run concurrently
   are a separate document,
-  *Task-Parallel-Safe Analysis Steps in Polaris*, which is worth adopting
-  before analysis steps are written rather than after. That document is
-  being prepared on its own branch and should land alongside these; once it
-  does, this should become a link to it.
+  [Task-Parallel-Safe Analysis Steps in Polaris](task_parallel_analysis_steps.md),
+  which is worth adopting before analysis steps are written rather than
+  after. Its rules are also written up for step authors in the developer
+  guide, under {ref}`dev-task-parallelism`.
 
 ## What success looks like
 

--- a/docs/design_docs/task_parallelism.md
+++ b/docs/design_docs/task_parallelism.md
@@ -95,13 +95,32 @@ three of four launches silently received no GPU at all and exited zero --
 the same class of failure as silently losing placement, and the reason this
 verification was worth doing separately from the hand-written one.
 
-One limit of the Aurora result should be carried with it. On Slurm the GPUs
-a launch can see are read from the scheduler's own variables, so the verdict
-is independent evidence. On PALS nothing assigns GPUs, so `mache` renders
-the indices the caller chose and the check reads that same value back: it
-confirms the plumbing, not that the runtime honors it. Whether Level Zero
-reads an empty mask as "no devices" or as "no mask at all" is still open,
-and a clean Aurora run does not close it.
+One limit of the Aurora result had to be carried with it, and asking about it
+turned up a real defect. On Slurm the GPUs a launch can see are read from the
+scheduler's own variables, so the verdict is independent evidence. On PALS
+nothing assigns GPUs, so `mache` renders the indices the caller chose and the
+check reads that same value back: it confirms the plumbing, not that the
+runtime honors it. A clean Aurora run therefore did not establish that a
+launch asking for no GPUs got none.
+
+It has since been asked properly, by enumerating what the runtime can see
+rather than reading back what it was told, and the answer is that **an empty
+`ZE_AFFINITY_MASK` hides nothing**. Level Zero reads an empty value as "no
+mask", which means every device: six cards visible with the variable unset,
+and the same six with it set and empty. So the explicit "no GPUs" `mache`
+renders on PALS is a no-op.
+
+Two controls make that a finding rather than a guess, and both were
+necessary. The variable arrived at the process *set and empty* rather than
+dropped, which separates Level Zero's semantics from a plumbing bug; and a
+mask naming a subset, in the same launch style, did confine the launch, which
+rules out the mask simply being inert there. Two enumerators agreed, one of
+them reaching Level Zero with no SYCL layer in between.
+
+The consequence is small now and not small later. Nothing on PALS reserves
+GPUs, so a step seeing hardware it declined costs only tidiness, and neither
+Phase A nor Phase B is affected. It becomes an isolation question in Phase C,
+where it is recorded.
 
 ### Where measurements live, and what does not
 

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -775,33 +775,39 @@ node, at which point the failure appears far from its cause and looks like a
 step's bug. Recording which machines have been measured, in the `mache`
 configs themselves, is what makes the omission visible.
 
-**A machine may not have one answer.** The first measurements found
-Perlmutter CPU returning nodes of two different sizes -- roughly 257 GB and
-515 GB, at the same core count -- within what the configuration treats as
-one machine. This design previously argued that describing a machine with a
-single figure was an existing convention whose limitation memory did not
-worsen. That was wrong, and the difference is worth being precise about:
-cores are the same on both of those nodes, so one figure describes them
-correctly, while memory differs by a factor of two and one figure cannot.
+**A measurement is only as good as the label on it.** An early reading
+appeared to show Perlmutter CPU returning nodes of two different sizes
+within one machine, and this document briefly recorded that as a finding. It
+was not one. The small node was a Perlmutter *GPU* node: the run had been
+labelled from the deployment's machine name rather than from the node it
+landed on, and three hardware signals agree it was misfiled -- the job held
+four GPUs, its hyperthread siblings were 64 apart rather than 128, and its
+memory matched a GPU node. There is at present no evidence that any machine
+Polaris targets is heterogeneous in memory.
 
-Where nodes differ, the **smallest** binds, because the figure exists to say
-what a caller must not exceed. A configured value larger than the smallest
-node will over-admit whenever a step lands on a small one, which is the
-direction that kills a job rather than the one that wastes it. The measured
-values bear this out: the shipped estimate for Perlmutter CPU is close to
-twice what the smaller nodes actually have.
+The episode is worth keeping for what it says about the measurements
+generally, which is that they are labelled by configuration and confirmed by
+nothing. A harness that records what a deployment claims, while the node it
+ran on says otherwise, will mislabel silently and produce a finding that
+looks like a property of the machine. Any measurement taken this way should
+cross-check the label against the hardware -- GPUs present where the
+configuration says there are none, or a physical core count that disagrees
+with `cores_per_node` -- and refuse to record a result it cannot vouch for.
 
-That also means a single sample cannot establish the number, and most of
-the measurements taken so far are single samples. The reliable method costs
-no allocation: query every node in the partition and take the minimum,
-rather than asking one node what it has. It should be done for each machine
-before `mache` releases these values.
+Two precautions stand regardless, since neither depended on that finding.
+**Where nodes differ, the smallest binds**, because the figure exists to say
+what a caller must not exceed and a value above the smallest node
+over-admits whenever work lands on one -- the direction that kills a job
+rather than wasting it. And **a single sample cannot establish the number**:
+most measurements taken so far are single samples, and the reliable method
+costs no allocation, being to query every node in a partition and take the
+minimum rather than asking whichever node one happens to be on.
 
-A node that turns up with unexpectedly little memory should be treated as a
-finding rather than a curiosity, and reported. It means either that a
-machine's configured figure is wrong, or that the machine has become
-heterogeneous since it was measured, and both are things a caller needs to
-learn about from a message rather than from an exhausted node.
+A node that turns up with unexpectedly little memory shall be treated as a
+finding rather than a curiosity, and reported. It means a configured figure
+is wrong, or a machine has changed, or -- as here -- that something is not
+the machine it was thought to be. All three are things to learn from a
+message rather than from an exhausted node.
 
 **The configured figure plans; the allocation's own nodes account.** These
 are two uses with different requirements and only one of them has to be
@@ -819,9 +825,14 @@ or the machine has changed, and neither should be discovered silently.
 
 This does not make the configured figure unnecessary; it makes it a
 planning estimate rather than a promise, which is what it can honestly be.
-It also retires heterogeneity as a thing to chase: a machine whose nodes
-differ is simply a run whose nodes differ, observed rather than predicted,
-and a configured value that has gone stale can no longer over-admit.
+
+It also answers the class of problem the mislabelled run belongs to, rather
+than the specific one. A run that reads what its nodes actually report, and
+says so when that disagrees with what was configured, catches a stale
+figure, a machine that has changed, and a job that is not on the machine it
+was thought to be -- without anyone having to anticipate which. The
+mislabelling above went unnoticed because nothing compared the two; the
+comparison is cheap and belongs in the run rather than in a later query.
 
 ### Testing and Validation: No Regression
 

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -775,6 +775,34 @@ node, at which point the failure appears far from its cause and looks like a
 step's bug. Recording which machines have been measured, in the `mache`
 configs themselves, is what makes the omission visible.
 
+**A machine may not have one answer.** The first measurements found
+Perlmutter CPU returning nodes of two different sizes -- roughly 257 GB and
+515 GB, at the same core count -- within what the configuration treats as
+one machine. This design previously argued that describing a machine with a
+single figure was an existing convention whose limitation memory did not
+worsen. That was wrong, and the difference is worth being precise about:
+cores are the same on both of those nodes, so one figure describes them
+correctly, while memory differs by a factor of two and one figure cannot.
+
+Where nodes differ, the **smallest** binds, because the figure exists to say
+what a caller must not exceed. A configured value larger than the smallest
+node will over-admit whenever a step lands on a small one, which is the
+direction that kills a job rather than the one that wastes it. The measured
+values bear this out: the shipped estimate for Perlmutter CPU is close to
+twice what the smaller nodes actually have.
+
+That also means a single sample cannot establish the number, and most of
+the measurements taken so far are single samples. The reliable method costs
+no allocation: query every node in the partition and take the minimum,
+rather than asking one node what it has. It should be done for each machine
+before `mache` releases these values.
+
+A node that turns up with unexpectedly little memory should be treated as a
+finding rather than a curiosity, and reported. It means either that a
+machine's configured figure is wrong, or that the machine has become
+heterogeneous since it was measured, and both are things a caller needs to
+learn about from a message rather than from an exhausted node.
+
 ### Testing and Validation: No Regression
 
 Date last modified: 2026/08/23

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -258,15 +258,43 @@ Contributors:
 
 `mache.parallel.ParallelSystem.get_parallel_command()` gains an optional
 placement argument, and each subclass renders it appropriately. This is the
-contract change, and it must land in `mache` and be released before Polaris
-can depend on it. Its design is
-*Design Document: parallel placement*, at `docs/design/parallel_placement.md`
-in the `mache` repository. It is a separate repository, so this cannot be a
-cross-reference.
+contract change, and it must land in `mache` before Polaris can depend on
+it. Its design is *Design Document: parallel placement*, at
+`docs/design/parallel_placement.md` in the `mache` repository. It is a
+separate repository, so this cannot be a cross-reference.
 
-Polaris should depend on the `mache` version that provides it and should
-fail clearly, at setup, if an older `mache` is present -- a run that silently
-loses placement would appear to work while oversubscribing the machine.
+That work exists: **`mache` pull request #470**, which adds a
+`ResourcePlacement` type and the optional argument, renders it for Slurm
+both before and after 20.11, for PBS with PALS and for a single node, and
+adds a test that renders a placement against every shipped machine config.
+It is not merged. Xylar's condition for merging it is that Polaris testing
+first confirms the rendered commands behave as intended on real machines,
+so Phase A and that pull request unblock each other and should be worked on
+together.
+
+Until a released `mache` provides this, Polaris must deploy against the
+pull request branch rather than a released version. `deploy.py` already
+supports this, so no change to Polaris's deployment machinery is needed:
+
+```
+./deploy.py --mache-fork xylar/mache --mache-branch parallel-placement ...
+```
+
+`deploy.py` and `deploy/cli_spec.json` are contract files shared with
+`mache` and must not be edited in Polaris to accommodate this.
+
+This is a temporary state and should be treated as one. Phase A should not
+be merged into Polaris while it depends on an unreleased branch. The order
+is: Polaris testing confirms the rendering works, `mache` merges and
+releases, Polaris pins the released version, and only then does Phase A
+land. Anything built on Phase A in the meantime is developed against a
+moving dependency and should expect to be rebased.
+
+Once a released version exists, Polaris should require at least that
+version and should fail clearly, at setup, if an older `mache` is present.
+A run that silently loses placement would appear to work while
+oversubscribing the machine, which is the worst failure mode available
+here: no error, wrong results, and slower than serial.
 
 ### Implementation: The Polaris Side
 
@@ -333,9 +361,18 @@ Contributors:
 
 The mechanisms Phase A relies on were measured on Chrysalis, Perlmutter (CPU
 and GPU), Frontier and Aurora before this design was written; the results
-are summarized in [Task Parallelism in Polaris](task_parallelism.md). Phase
-A shall be validated by showing that the commands Polaris generates produce
-the same behavior on each of those machines.
+are summarized in [Task Parallelism in Polaris](task_parallelism.md). Those
+measurements used commands written by hand. Phase A shall be validated by
+showing that the commands `mache` *renders* produce the same behavior on
+each of those machines, which is a different claim and the one that gates
+merging `mache` pull request #470.
+
+That validation does not require the rest of Phase A. Building placements,
+rendering them through `get_parallel_command()` and launching them
+concurrently is enough to confirm the rendering, and keeping it separate
+means a failure is attributable to `mache` rather than ambiguous between
+`mache` and Polaris's placement construction. It should be done first, on
+all five machines.
 
 A single confined step shall be run on each machine and shall report that it
 sees only the cores and GPUs it was given. This is the check that catches a

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -116,15 +116,31 @@ minimum, in the same style as its existing CPU requirements.
 
 Memory is unlike cores and GPUs in that the batch system will not keep it
 for us. Asking a launch for a share of the node's memory was measured to
-change nothing, so a memory figure passed to the launcher would reserve
-nothing and prevent nothing. Memory is therefore a budget Polaris keeps
-itself: the only way one step's memory is protected from another's is that
-Polaris declines to start the second step. That decision is Phase B's, and
-so is the accounting behind it.
+reserve nothing, so nothing Polaris passes to a launcher will make room for
+a step or tell Polaris whether one fits. Memory is therefore a budget
+Polaris keeps itself: the only way one step's memory is protected from
+another's is that Polaris declines to start the second step. That decision
+is Phase B's, and so is the accounting behind it.
+
+What a memory figure passed to a launcher *does* do, on machines whose Slurm
+postdates the 20.11 change, is cap the launch: a step allowed 1024 MB and
+told to take 4 GB is killed at 960 MB on Perlmutter GPU and on Frontier,
+while the same launch runs to completion on Chrysalis. So such a figure is
+an enforced ceiling on some machines and inert on others, and is never a
+reservation anywhere. Whether Polaris should impose that ceiling is taken up
+in Phase B, and the answer there turns on the distinction the next paragraph
+draws.
 
 What Phase A shall provide is the declaration, its default, and its
-visibility to the step. A step that declares nothing shall be treated as
-needing memory in proportion to the cores it asked for -- the node's memory
+visibility to the step -- and shall keep a declared figure distinguishable
+from a defaulted one, because later phases treat them differently. A step
+that says a number has made a claim about itself and can be held to it. A
+step that says nothing is being estimated by the framework, and must not be
+held to the framework's estimate. Anything that reads a step's memory needs
+to be able to tell which it has.
+
+A step that declares nothing shall be treated as needing memory in
+proportion to the cores it asked for -- the node's memory
 divided by its cores, times the step's cores. This is deliberately the value
 that makes memory-aware packing arithmetically identical to packing on cores
 alone, so that introducing memory can never make Phase B schedule worse than
@@ -133,9 +149,16 @@ for the steps that exist today. Steps that have been measured, which is
 mostly the analysis work in Phase C, override the default with a real
 figure and are then scheduled on it.
 
-Because a step's memory need is not enforced anywhere, an under-declaring
-step running beside others is a real failure mode, and one that did not
-exist when Polaris ran a step at a time. Phase B addresses it.
+A declared figure is therefore a ceiling as well as a claim, wherever the
+machine can hold a step to one, and a step author should declare a peak with
+margin rather than a typical value. A figure that describes what a step
+usually needs will kill it on the day it needs more, on the machines that
+enforce and not on the others.
+
+An under-declaring step running beside others is a real failure mode, and
+one that did not exist when Polaris ran a step at a time. Phase B addresses
+it, and the declared-versus-defaulted distinction is what lets it do so
+without turning the framework's own estimate into a death sentence.
 
 Device memory needs no declaration of its own. GPUs are never divided
 between steps, so a step given a GPU is given that GPU's memory with it, and
@@ -646,19 +669,42 @@ first thing that would break if a site changed its scheduler
 configuration.
 
 While those machines are being visited, two further things should be
-settled, because both are cheap there and expensive to guess at.
-Nothing in this design asks the batch system to limit a step's memory, on
-the evidence that requesting memory changed nothing observable. That
-evidence shows memory was not the cause of the serialization; it does not
-show that a memory request is inert. The test is direct: launch a step with
-a small memory allowance, have it allocate several times that, and record
-whether it is killed. Two answers matter and both are useful. If nothing
-enforces, this design is on the right footing and the co-resident reporting
-in Phase B is the whole of the answer. If some machine does enforce, then
-two consequences follow at once -- a step could be capped there, and, by the
-same argument that applies to GPUs, a step that says nothing about memory
-may be read as claiming all of it, which would be the same trap in a second
-place.
+settled, because both are cheap there and expensive to guess at. The first
+has been answered and its result is recorded below; the second has not.
+The question was whether a memory request is inert. The evidence for
+assuming so showed only that memory was not the cause of the serialization,
+which is a different claim. The test was direct -- launch a step with a
+small allowance, have it allocate several times that, record whether it is
+killed -- and it has been run:
+
+| machine | 1024 MB allowed, 4 GB requested |
+| --- | --- |
+| Chrysalis (Slurm 20.02) | reached 4 GB, exited 0 -- not enforced |
+| Perlmutter GPU (Slurm 25.11) | killed at 960 MB |
+| Frontier (Slurm 25.11) | killed at 960 MB |
+
+A memory request is real on newer Slurm and inert on older. What follows for
+the design is in the requirement above and in Phase B.
+
+The second consequence that was anticipated does **not** occur, and can be
+retired rather than carried forward. By the argument that applies to GPUs, a
+step that says nothing about memory might have been read as claiming all of
+it. It is not: on both machines that enforce, four concurrent launches that
+said nothing about memory started within 40 ms of each other and ran their
+full duration. Aurora and Perlmutter CPU remain unmeasured.
+
+What is still open, and matters more than what was closed, is whether
+*placement itself* imposes a memory ceiling. The measurement above passed an
+explicit allowance. Placement on newer Slurm asks for exactly the resources
+a step needs rather than the job's, and memory is evidently a resource the
+scheduler tracks there, so a placed step may be given a share of the node's
+memory it never asked for and be killed at it -- with Polaris having said
+nothing about memory and its own accounting unaware of any limit. That would
+make placement impose a hidden ceiling that bites only the memory-hungry
+steps, which is the failure shape this design most wants to avoid. The check
+is a placed launch given no memory request at all, allocating hard, with an
+unplaced launch beside it to separate what placement causes from what the
+allocation causes. It should be added to the machine runs that remain.
 
 ### Testing and Validation: Measuring Each Machine's Memory
 

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -141,6 +141,18 @@ Device memory needs no declaration of its own. GPUs are never divided
 between steps, so a step given a GPU is given that GPU's memory with it, and
 the GPU count already accounts for it.
 
+Host memory on a GPU machine is the case where the proportional default is
+most likely to be wrong, and a step author should expect to declare rather
+than rely on it. A step that wants every GPU on a node and only a handful of
+cores to drive them gets, by the proportional rule, only that handful's
+share of the node's memory -- which is unlikely to be what it needs to stage
+data for the devices. Making the default depend on GPUs as well would
+destroy the property that makes it safe, since it is exactly its being
+proportional to cores that makes memory-aware packing reduce to packing on
+cores. The default is a floor for steps nobody has measured, not an estimate
+anyone should trust for a step whose memory has nothing to do with its core
+count.
+
 ### Requirement: Resource Views Describe What a Step Can Use
 
 Date last modified: 2026/08/23
@@ -173,7 +185,7 @@ against. A step told its cores and its memory can do that; a step told only
 its cores cannot, and the natural mistake is to derive memory from cores,
 which is wrong in exactly the case that matters.
 
-### Requirement: A Step Says Whether Its Cores May Span Nodes
+### Requirement: A Step Says Whether Its Resources May Span Nodes
 
 Date last modified: 2026/08/23
 
@@ -182,12 +194,19 @@ Contributors:
 - Xylar Asay-Davis
 - Claude
 
-Whether a step's cores may be drawn from more than one node shall be a
+Whether a step's resources may be drawn from more than one node shall be a
 property the step declares, and shall not be inferred from whether the step
 uses MPI.
 
-The two are not the same question, and treating them as the same is what
-this requirement exists to prevent. An MPI step spans nodes because its
+This covers cores and GPUs together, as one property rather than two. A step
+that reaches other nodes reaches them by one mechanism, and that mechanism
+carries whatever the work needs; a step that cannot reach them cannot reach
+either. No case has been identified that wants the two to differ, and
+splitting them would invite a step to claim GPUs on nodes its cores cannot
+reach.
+
+MPI and spanning are not the same question, and treating them as the same is
+what this requirement exists to prevent. An MPI step spans nodes because its
 launcher spreads its ranks. A single-process Python step that does its work
 in its own threads cannot span nodes, because there is no mechanism by which
 it would reach them. A single-process Python step that hands its work to a
@@ -195,6 +214,12 @@ distributed worker pool spans nodes perfectly well -- the pool is exactly
 the mechanism the thread-based step lacks -- and it does so while remaining
 one process asking for one task. "Not MPI" covers the last two cases, which
 want opposite answers.
+
+Such a step's workers may use GPUs as readily as cores, and when they do,
+the GPUs come from the nodes the workers are on rather than from the node
+the step's own process happens to occupy. Nothing about a step being
+single-process confines its GPUs to one node once its work is somewhere
+else.
 
 Steps that do not say shall be treated as confined to a node, which is what
 every non-MPI step in Polaris is today. This is also the safe direction: a
@@ -209,7 +234,8 @@ today, because a step that names a minimum has said in advance which
 reductions are acceptable. A step whose *minimum* cannot be met within a
 node shall be an error when the run is set up, naming what it needs, what a
 node holds, and the property that would let it span -- not quietly reduced
-to what fits.
+to what fits. This applies to a step asking for more GPUs than a node has
+exactly as it applies to cores.
 
 This is deliberately the rule Polaris already follows, extended rather than
 replaced, and it leaves today's steps alone. The two steps that currently
@@ -251,6 +277,11 @@ than how it is launched, and both are constructed to leave existing steps
 where they are: the memory default reproduces core-only packing exactly, and
 the node-span rule reduces to today's target-and-minimum behavior for every
 step now in Polaris. Neither should show up as a difference in a run.
+
+This requirement is also what the migration of existing non-MPI steps onto
+the new fields is checked against. A step restated in different words shall
+receive the same resources and produce the same outputs, and any step for
+which that is not true has been restated wrongly.
 
 ## Algorithm Design
 
@@ -338,11 +369,23 @@ memory each. Tracking memory as its own quantity avoids both, and is
 consistent with the decision already made for GPUs, which this design
 likewise declines to express in CPU-shaped terms.
 
-Non-MPI steps are worth calling out. A single-process Python step has no
-meaningful "number of ranks"; what it has is a number of cores it can use
-and an amount of memory it needs. Expressing that through MPI-shaped fields
-is how Polaris ends up telling a Python step it has 192 cores across three
-nodes. Non-MPI steps should describe cores and memory directly.
+GPUs need no separate treatment for non-MPI steps, and it is worth saying so
+rather than leaving it to be inferred. A per-step total is already the shape
+a single-process step wants, so the same `gpus` and `min_gpus` serve both
+kinds of step and nothing further is required. The measurement that forced
+GPUs into that shape -- a per-rank count does not confine a launch -- happens
+to have put them where a step with no ranks can use them. Cores are the
+exception rather than GPUs being an omission: they are described per rank
+for historical reasons, and are the one resource a non-MPI step therefore
+cannot state.
+
+Non-MPI steps are worth calling out for that reason. A single-process Python
+step has no meaningful "number of ranks"; what it has is a number of cores
+it can use and an amount of memory it needs. Expressing that through
+MPI-shaped fields is how Polaris ends up telling a Python step it has 192
+cores across three nodes. Non-MPI steps should describe cores and memory
+directly, and their GPUs through the same per-step total every other step
+uses.
 
 That matters more once such a step is allowed to span nodes. A step that
 wants two hundred cores from a distributed pool is, in MPI-shaped terms, one
@@ -369,11 +412,13 @@ and placing them are one act.
 Two cases in this design separate them. Memory is reserved and never placed,
 because no launcher acts on it. A step that delegates its work to a
 distributed pool is the mirror image: what Polaris launches is a driver
-process needing about one core, while the cores the step claims are consumed
-by pool workers, which are separate launches, started elsewhere, and shared
-with other steps. Placing two hundred cores on that driver would confine
-them to a process that will not use them, while the workers that will are
-somewhere else entirely.
+process needing about one core, while the cores the step claims -- and the
+GPUs, where its workers use them -- are consumed by pool workers, which are
+separate launches, started elsewhere, and shared with other steps. Placing
+two hundred cores on that driver would confine them to a process that will
+not use them, while the workers that will are somewhere else entirely, and
+placing GPUs on it would reserve devices on the one node whose work is
+smallest.
 
 The distinction to carry forward is that **placement is what the launcher
 acts on and a reservation is what the scheduler tracks**. They coincide for
@@ -478,13 +523,36 @@ Contributors:
   not a ceiling it is held to.
 - `Step` gains a way to say how many cores and how much memory a non-MPI
   step needs, without going through MPI task counts.
-- `Step` gains a property saying whether its cores may be drawn from more
-  than one node, false by default for a non-MPI step and true for an MPI
-  one. `constrain_resources()` uses it in place of the node-sized cap it
-  applies today: a step that may span is bounded by the allocation, and a
-  step that may not and asks for more than a node holds is an error rather
-  than a silent reduction. Nothing in Polaris sets the property to true in
-  Phase A; it exists so that Phase C does not have to remove a rule.
+- `Step` gains a property saying whether its resources -- cores and GPUs
+  alike -- may be drawn from more than one node, false by default for a
+  non-MPI step and true for an MPI one. `constrain_resources()` uses it in
+  place of the node-sized cap it applies today: a step that may span is
+  bounded by the allocation, and a step that may not and asks for more than
+  a node holds is an error rather than a silent reduction. Nothing in
+  Polaris sets the property to true in Phase A; it exists so that Phase C
+  does not have to remove a rule.
+- No non-MPI GPU field is added, because `gpus` and `min_gpus` already are
+  one. Deprecating `gpus_per_task` is what completes this: it is the only
+  GPU field with a shape a non-MPI step cannot use.
+- The non-MPI steps that exist today are moved onto the new fields, as a
+  commit of its own at the end of the Phase A series rather than mixed into
+  the framework change. Nothing forces this: the two spellings mean the same
+  thing for a step confined to a node, and the framework should accept
+  either. It is done in Phase A anyway because Phase A is the only phase
+  whose acceptance criterion is that behavior does not change, which is
+  precisely how a translation of this kind is checked, and because leaving
+  both spellings live means the Phase B scheduler is the first thing to meet
+  them -- where a misread declaration shows up as a packing bug rather than
+  as a wrong number on a page.
+- That migration is smaller than it sounds and needs more judgment than it
+  sounds. Of the non-model steps that declare resources, most name one core
+  and one task, which is the default and can simply go. Four genuinely want
+  to state cores directly. The remainder set `ntasks=1` while being MPI
+  steps that happen to run at width one -- the WOA23 steps, the topography
+  remapping step, and the shared mapping-file step -- and moving those would
+  be wrong, since `ntasks` is the field that means what they mean. This has
+  to be decided per step rather than swept, and is the reason it is its own
+  commit and not a mechanical pass.
 - The code that builds a step's parallel command passes a placement through
   to `mache` when one has been assigned, and passes none when it has not,
   preserving today's behavior.

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -803,6 +803,26 @@ machine's configured figure is wrong, or that the machine has become
 heterogeneous since it was measured, and both are things a caller needs to
 learn about from a message rather than from an exhausted node.
 
+**The configured figure plans; the allocation's own nodes account.** These
+are two uses with different requirements and only one of them has to be
+predicted in advance. Sizing a job script happens before any node has been
+assigned, so it can only use a configured number. Deciding what fits happens
+inside the allocation, where the nodes are known and can simply be asked
+what they have -- which is better than any configured value, because it is
+the truth for the nodes in hand rather than an estimate of a machine.
+
+Polaris shall therefore read the memory of the nodes it was actually given,
+once, at the start of a run, and the scheduler shall account against those
+figures rather than against the configured one. Where they disagree the
+disagreement shall be reported, because it means the configuration is stale
+or the machine has changed, and neither should be discovered silently.
+
+This does not make the configured figure unnecessary; it makes it a
+planning estimate rather than a promise, which is what it can honestly be.
+It also retires heterogeneity as a thing to chase: a machine whose nodes
+differ is simply a run whose nodes differ, observed rather than predicted,
+and a configured value that has gone stale can no longer over-admit.
+
 ### Testing and Validation: No Regression
 
 Date last modified: 2026/08/23

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -491,10 +491,14 @@ supports this, so no change to Polaris's deployment machinery is needed:
 
 This is a temporary state and should be treated as one. Phase A should not
 be merged into Polaris while it depends on an unreleased branch. The order
-is: Polaris testing confirms the rendering works, `mache` merges and
-releases, Polaris pins the released version, and only then does Phase A
-land. Anything built on Phase A in the meantime is developed against a
-moving dependency and should expect to be rebased.
+is: Polaris testing confirms the rendering works and measures each machine's
+memory, `mache` takes both -- the confirmation and the corrected memory
+figures -- then merges and releases, Polaris pins the released version, and
+only then does Phase A land. Folding the memory corrections into the same
+release is worth a little care in sequencing, since the alternative is
+shipping estimates and correcting them in a second release that nothing
+forces anyone to make. Anything built on Phase A in the meantime is
+developed against a moving dependency and should expect to be rebased.
 
 Once a released version exists, Polaris should require at least that
 version and should fail clearly, at setup, if an older `mache` is present.
@@ -641,8 +645,8 @@ keeping as a small standing test rather than a one-off, since it is the
 first thing that would break if a site changed its scheduler
 configuration.
 
-While those machines are being visited, one further question should be
-settled, because it is cheap to answer there and expensive to guess at.
+While those machines are being visited, two further things should be
+settled, because both are cheap there and expensive to guess at.
 Nothing in this design asks the batch system to limit a step's memory, on
 the evidence that requesting memory changed nothing observable. That
 evidence shows memory was not the cause of the serialization; it does not
@@ -655,6 +659,50 @@ two consequences follow at once -- a step could be capped there, and, by the
 same argument that applies to GPUs, a step that says nothing about memory
 may be read as claiming all of it, which would be the same trap in a second
 place.
+
+### Testing and Validation: Measuring Each Machine's Memory
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The per-node memory `mache` reports is a number nobody has been able to
+measure. Whoever adds `memory_per_node` to the machine configs is not on
+those machines, and the figure that matters -- what a job may actually
+allocate -- is not what a vendor specification says, not what site
+documentation says, and not what a login node reports. The values that ship
+with `mache` will be estimates.
+
+Polaris's validation is the only occasion on which anyone is on all five of
+those machines with a reason to look, so measuring the real values is part
+of it. For each of Chrysalis, Perlmutter CPU, Perlmutter GPU, Frontier and
+Aurora, a job shall record what the batch system says a node has, and the
+corrections shall be returned to `mache` as a change to its machine configs.
+
+Two figures are worth recording rather than one, because they answer
+different questions. What the scheduler believes a node has is what a
+scheduler would pack against, and is what the config option should hold: on
+Slurm that is the node's real memory as `scontrol` or `sinfo` reports it,
+and on PBS it is the equivalent node attribute. What a process can actually
+allocate before it is refused is the figure that decides whether the first
+is honest. Where the two disagree, the smaller one is the one Polaris must
+not exceed, and the disagreement is itself worth reporting.
+
+Until a machine has been measured its value should be treated as
+provisional, and estimates should err low: a figure that is too high costs a
+job killed for exhausting a node, while one that is too low costs only work
+that could have been packed. Those are not comparable, so the unverified
+direction to be wrong in is downwards.
+
+This is a small task with an unusual failure mode: it is easy to omit and
+nothing fails when it is. A run with an over-estimated node memory looks
+entirely normal until a suite happens to pack tightly enough to exhaust a
+node, at which point the failure appears far from its cause and looks like a
+step's bug. Recording which machines have been measured, in the `mache`
+configs themselves, is what makes the omission visible.
 
 ### Testing and Validation: No Regression
 

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -663,10 +663,35 @@ all five machines.
 
 A single confined step shall be run on each machine and shall report that it
 sees only the cores and GPUs it was given. This is the check that catches a
-placement which is constructed correctly but not honored, and it is worth
-keeping as a small standing test rather than a one-off, since it is the
-first thing that would break if a site changed its scheduler
-configuration.
+placement which is constructed correctly but not honored, and it is the
+first thing that would break if a site changed its scheduler configuration.
+
+Something of it shall keep running after Phase A, but not the harness that
+produced it. The harness exists to answer a question and is not part of what
+Polaris ships; it is removed once the question is answered, and anything
+worth keeping has to be moved somewhere permanent **before** that rather
+than after. Two things are worth keeping, and neither needs an allocation to
+be remembered.
+
+The first is a test that needs no batch system at all. A single-node
+launcher confines a launch with ordinary process affinity, which is enough
+to build several disjoint placements, render each through `mache`, run them
+at once and read back what each could see. That exercises the rendering
+end to end and runs anywhere, so it belongs with the ordinary tests and
+guards against a rendering regression on every commit. It cannot tell
+whether a real scheduler honors a placement, which is the other tier.
+
+The second is not a test at all. Phase A assigns no placements -- the serial
+path passes none, deliberately -- so any check here has to construct one for
+itself, which makes it a diagnostic rather than an observation of Polaris
+doing its job. From Phase B onwards every placed step has a placement to
+verify, and a step that checks it received what it was given costs almost
+nothing and runs on every machine on every run. That is the standing check
+on real machines, and it should replace this one rather than sit beside it.
+
+What must not happen is an allocation-gated test that exists and is never
+run. A check that requires someone to remember to run `pytest` inside a job
+is a check that reports nothing for as long as nobody does.
 
 While those machines are being visited, two further things should be
 settled, because both are cheap there and expensive to guess at. The first

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -597,12 +597,24 @@ Contributors:
   system reports.
 - Nothing about memory reaches `mache`'s `ResourcePlacement`. That type
   describes where a launch runs -- which nodes, which cores, which GPUs --
-  and every field in it is rendered into the launch command. A memory field
-  would render to nothing on every machine Polaris supports. If the
-  enforcement question below is answered and some machine does honor a
-  memory request, adding the field then is an additive change; adding it
-  now would widen an unmerged pull request to carry something no machine
-  reads.
+  and every field in it is rendered into the launch command. Memory is not
+  a location and does not belong there.
+
+  The enforcement question that was open when this was first written has
+  since been answered, and machines do honor a memory request, so a cap
+  does now reach the launcher -- as a separate optional argument to
+  `get_parallel_command()` rather than as a field on the placement. Keeping
+  the two apart is deliberate: a placement still says only where a launch
+  runs, and a cap is a different kind of statement that the signature
+  should distinguish rather than blend. `mache` reports separately whether
+  a machine can enforce one, so Polaris can say in a run log that caps are
+  not enforced here rather than quietly believe it has a safety net.
+- Polaris passes that cap for a step that declared a memory figure, and
+  omits it entirely for a step carrying the proportional default, which is
+  what makes the argument optional rather than always supplied. This is the
+  only place the declared-versus-defaulted distinction reaches outside
+  Polaris, and it is the reason Phase A must keep the two separable rather
+  than resolving the default eagerly into one number.
 
 ### Implementation: Boundaries
 

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -492,42 +492,45 @@ it. Its design is *Design Document: parallel placement*, at
 `docs/design/parallel_placement.md` in the `mache` repository. It is a
 separate repository, so this cannot be a cross-reference.
 
-That work exists: **`mache` pull request #470**, which adds a
+That work was **`mache` pull request #470**, which adds a
 `ResourcePlacement` type and the optional argument, renders it for Slurm
-both before and after 20.11, for PBS with PALS and for a single node, and
-adds a test that renders a placement against every shipped machine config.
-It is not merged. Xylar's condition for merging it is that Polaris testing
-first confirms the rendered commands behave as intended on real machines,
-so Phase A and that pull request unblock each other and should be worked on
-together.
+both before and after 20.11, for PBS with PALS and for a single node, adds
+an optional memory cap, and tests the rendering against every shipped
+machine config. Its condition for merging was that Polaris testing first
+confirm the rendered commands behave as intended on real machines, so it and
+Phase A unblocked each other and were worked on together. **It is merged,
+and released as `mache` 3.12.0.**
 
-Until a released `mache` provides this, Polaris must deploy against the
-pull request branch rather than a released version. `deploy.py` already
-supports this, so no change to Polaris's deployment machinery is needed:
+The sequencing that release was held to is worth recording, because it was
+deliberate and the alternative was easy to drift into. The order was:
+Polaris testing confirms the rendering *and* measures each machine's memory,
+`mache` takes both, then merges and releases, Polaris pins that release, and
+only then does Phase A land. Folding the memory corrections into the same
+release mattered because the alternative is shipping estimates and
+correcting them in a second release that nothing forces anyone to make.
+That held: 3.12.0 carries the placement work, the memory cap, and the
+surveyed `memory_per_node` figures together.
+
+While the work was unreleased, Polaris deployed against the pull request
+branch, which `deploy.py` already supported and which therefore needed no
+change to Polaris's deployment machinery:
 
 ```
 ./deploy.py --mache-fork xylar/mache --mache-branch parallel-placement ...
 ```
 
 `deploy.py` and `deploy/cli_spec.json` are contract files shared with
-`mache` and must not be edited in Polaris to accommodate this.
+`mache` and must not be edited in Polaris to accommodate anything of this
+kind. That was always a temporary state, and it ends here: Phase A must not
+merge while depending on an unreleased branch, and no longer has to.
 
-This is a temporary state and should be treated as one. Phase A should not
-be merged into Polaris while it depends on an unreleased branch. The order
-is: Polaris testing confirms the rendering works and measures each machine's
-memory, `mache` takes both -- the confirmation and the corrected memory
-figures -- then merges and releases, Polaris pins the released version, and
-only then does Phase A land. Folding the memory corrections into the same
-release is worth a little care in sequencing, since the alternative is
-shipping estimates and correcting them in a second release that nothing
-forces anyone to make. Anything built on Phase A in the meantime is
-developed against a moving dependency and should expect to be rebased.
-
-Once a released version exists, Polaris should require at least that
-version and should fail clearly, at setup, if an older `mache` is present.
-A run that silently loses placement would appear to work while
-oversubscribing the machine, which is the worst failure mode available
-here: no error, wrong results, and slower than serial.
+Polaris shall now require `mache` 3.12.0 or later, and shall fail clearly,
+at setup, if an older one is present. Until the release existed the check
+had to be on the capability rather than on a version, because there was no
+version to name; it becomes an ordinary requirement. What it guards against
+is the reason it is stated at all: a run that silently lost placement would
+appear to work while oversubscribing the machine, which is the worst failure
+available here -- no error, wrong results, and slower than serial.
 
 ### Implementation: The Polaris Side
 

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -1,0 +1,338 @@
+# Task Parallelism Phase A: Placement
+
+Creation date: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+## Summary
+
+Today, when Polaris runs a step that uses MPI, it launches it across the
+whole allocation. That is correct when only one step runs at a time, and it
+is the single largest obstacle to ever running two steps at once: two steps
+that each believe they own the machine will either collide or, more often,
+queue behind one another.
+
+Phase A gives Polaris the ability to run a step on a **named part** of its
+allocation -- these nodes, these cores, these GPUs -- and gives steps a way
+to describe what they need, in terms the batch system can act on.
+
+Phase A does not run anything concurrently. At the end of it, Polaris still
+executes one step at a time and produces identical results. What changes is
+that the machinery for saying "run this here" exists and is known to work on
+every machine Polaris supports.
+
+Most of the work is not in Polaris. Polaris does not build the command that
+launches parallel work; `mache` does, through its `ParallelSystem` classes.
+`mache` is a contract shared with other software, so the launcher change must
+land there first. That change has its own design document in the `mache`
+repository; this document describes what Polaris needs from it and what
+changes on the Polaris side.
+
+Success in Phase A means Polaris can construct a correct launch command for a
+step confined to a given subset of the allocation, on Slurm and on PBS, for
+CPU-only and GPU steps, and that `polaris serial` behaves exactly as before.
+
+## Requirements
+
+### Requirement: Confine a Step to Part of the Allocation
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Polaris shall be able to launch a step so that it runs on a specified subset
+of the allocation's nodes and cores, rather than on all of them.
+
+The subset shall be expressible in terms Polaris already understands: which
+nodes, how many cores, and how many GPUs. Polaris shall not need to know
+machine-specific syntax in order to express it.
+
+### Requirement: Isolation Enforced by the Batch System
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+When two steps are confined to non-overlapping subsets, the batch system
+shall be what keeps them apart, not Polaris.
+
+We prototyped an alternative in which Polaris pinned processes itself using
+CPU affinity masks. It works, but it is a weaker guarantee: a step that
+ignores its mask is not prevented from doing so, and the mechanism differs
+per machine. Measurements showed the batch system can do this properly on
+every supported machine, so it should.
+
+The exception is machines running Slurm older than 20.11, such as Chrysalis,
+where the necessary options do not exist. There, Polaris shall fall back to
+explicit CPU binding, and shall record that it has done so.
+
+### Requirement: Steps Declare GPUs as a Per-Step Total
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A step that uses GPUs shall declare how many GPUs **the step** needs, not how
+many each MPI rank needs.
+
+This differs from how CPU resources are described today, where `ntasks` and
+`cpus_per_task` are per-rank quantities, and the difference is not
+cosmetic. Measurements on both GPU machines showed that requesting GPUs
+per-rank does not confine a step at all, while requesting a per-step total
+does. A step that does not declare GPUs shall be understood to need none.
+
+### Requirement: Steps Declare Memory
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A step shall be able to declare how much memory it needs, as a target and a
+minimum, in the same style as its existing CPU requirements.
+
+Phase A only requires that the declaration exist and be carried through to
+the launcher. Using it to decide how many steps may run at once belongs to
+Phase B. Memory matters most for the analysis work in Phase C, where a
+single step may need a large fraction of a node.
+
+### Requirement: Resource Views Describe What a Step Can Use
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The resource information given to a step shall describe the resources that
+step can actually use.
+
+A step confined to one node shall be told about one node's resources. A
+non-MPI Python step cannot use cores on other nodes without a distributed
+launcher, so telling it the allocation-wide core count invites it to size
+itself wrongly. Any resources withheld from a step shall be genuinely
+withheld, not merely subtracted from a number.
+
+### Requirement: Portability Across Supported Machines
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Placement shall work on all machines Polaris supports for parallel work:
+Slurm systems both older and newer than the 20.11 change in how job steps
+reserve resources, and PBS systems using the PALS launcher.
+
+Where a machine cannot support placement, Polaris shall detect this and say
+so, rather than silently running steps on the whole allocation.
+
+### Requirement: No Change to Existing Behavior
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+`polaris serial` shall behave exactly as it does today. A step that does not
+ask to be confined shall be launched as it is now.
+
+## Algorithm Design
+
+### Algorithm Design: What Placement Means to the Launcher
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The launcher should accept an optional description of where a step is to
+run, alongside the existing task and CPU counts. In substance that
+description is:
+
+- the nodes the step may use;
+- how many cores it may use on each;
+- how many GPUs it needs in total.
+
+Each supported system can express all three, though they say it differently.
+On newer Slurm it is a matter of asking for exactly the resources requested
+rather than inheriting the job's; on PBS with PALS it is a host list plus an
+explicit core list; on older Slurm, where the modern options do not exist, it
+is an explicit CPU mask, which is the fallback noted above.
+
+The important design point is that Polaris should describe the *placement*,
+never the flags. Which flags implement it is the launcher's business, and
+they differ enough between machines -- and between Slurm versions on the same
+kind of machine -- that leaking them into Polaris would spread
+machine-specific knowledge through the scheduler.
+
+### Algorithm Design: Describing Step Resources
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Polaris steps today describe CPU needs per MPI rank: `ntasks` how many ranks,
+`cpus_per_task` how many cores each, with `min_tasks` and `min_cpus_per_task`
+giving the scheduler room to run a step smaller when resources are tight.
+That target-and-minimum pattern is a good one and should be kept.
+
+GPUs should be added as a per-step total with a matching minimum, for the
+reason given in the requirements. Memory should be added the same way.
+
+Non-MPI steps are worth calling out. A single-process Python step has no
+meaningful "number of ranks"; what it has is a number of cores it can use
+and an amount of memory it needs. Expressing that through MPI-shaped fields
+is how Polaris ends up telling a Python step it has 192 cores across three
+nodes. Non-MPI steps should describe cores and memory directly.
+
+### Algorithm Design: Detecting What a Machine Supports
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Placement support is a property of the machine and of the version of its
+batch system, and it must be decided at run time rather than baked into
+configuration, because the same machine can change underneath us.
+
+The launcher should determine, once per run, which placement mechanism
+applies, and report it. Three outcomes matter: full placement with batch-system
+enforcement; placement by explicit CPU binding, on older Slurm; and no
+placement, which Polaris should treat as "concurrency is not available here"
+rather than as an error.
+
+## Implementation
+
+### Implementation: The mache Side
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+`mache.parallel.ParallelSystem.get_parallel_command()` gains an optional
+placement argument, and each subclass renders it appropriately. This is the
+contract change, and it must land in `mache` and be released before Polaris
+can depend on it. Its design is
+`docs/design/parallel_placement.md` in the `mache` repository.
+
+Polaris should depend on the `mache` version that provides it and should
+fail clearly, at setup, if an older `mache` is present -- a run that silently
+loses placement would appear to work while oversubscribing the machine.
+
+### Implementation: The Polaris Side
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+- `Step` gains `gpus` and `min_gpus` as per-step totals, and `memory` and
+  `min_memory`. The existing `gpus_per_task` should be deprecated in favor
+  of the total, since it does not do what its name suggests when steps run
+  concurrently.
+- `Step` gains a way to say how many cores and how much memory a non-MPI
+  step needs, without going through MPI task counts.
+- The code that builds a step's parallel command passes a placement through
+  to `mache` when one has been assigned, and passes none when it has not,
+  preserving today's behavior.
+- The resource information handed to a step is built from its placement, so
+  that a confined step sees only what it was given.
+
+### Implementation: Boundaries
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Nothing in Phase A decides *which* subset a step should get. There is no
+scheduler yet; the only caller is the existing serial path, which assigns no
+placement. Keeping that boundary makes Phase A reviewable on its own and
+means a mistake in it shows up as a wrong command rather than as a wrong
+schedule.
+
+## Testing
+
+### Testing and Validation: Command Construction
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Unit tests shall check the command built for a given placement on each
+supported system, including: a step confined to one node, a step spanning
+several, a step needing GPUs, a step needing none, and a step with no
+placement at all, which shall produce today's command unchanged.
+
+These tests need no allocation and shall run in ordinary CI.
+
+### Testing and Validation: Real Machines
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The launcher spike in `utils/launcher_spike/` already demonstrates that the
+underlying mechanisms work on Chrysalis, Perlmutter (CPU and GPU), Frontier
+and Aurora. Phase A shall be validated by showing that the commands Polaris
+now generates match the ones the spike proved, on each machine.
+
+A single confined step shall be run on each machine and shall report that it
+sees only the cores and GPUs it was given. This is the same check the spike
+payload performs, and it is the one that catches a placement that is
+constructed correctly but not honored.
+
+### Testing and Validation: No Regression
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A representative suite shall be run with `polaris serial` and compared
+against a baseline, to confirm that adding the placement machinery has not
+changed behavior when placement is not used. Since Phase A adds no
+concurrency, any difference in results is a bug rather than a trade-off.

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -260,7 +260,9 @@ Contributors:
 placement argument, and each subclass renders it appropriately. This is the
 contract change, and it must land in `mache` and be released before Polaris
 can depend on it. Its design is
-`docs/design/parallel_placement.md` in the `mache` repository.
+*Design Document: parallel placement*, at `docs/design/parallel_placement.md`
+in the `mache` repository. It is a separate repository, so this cannot be a
+cross-reference.
 
 Polaris should depend on the `mache` version that provides it and should
 fail clearly, at setup, if an older `mache` is present -- a run that silently
@@ -329,15 +331,18 @@ Contributors:
 - Xylar Asay-Davis
 - Claude
 
-The launcher spike in `utils/launcher_spike/` already demonstrates that the
-underlying mechanisms work on Chrysalis, Perlmutter (CPU and GPU), Frontier
-and Aurora. Phase A shall be validated by showing that the commands Polaris
-now generates match the ones the spike proved, on each machine.
+The mechanisms Phase A relies on were measured on Chrysalis, Perlmutter (CPU
+and GPU), Frontier and Aurora before this design was written; the results
+are summarized in [Task Parallelism in Polaris](task_parallelism.md). Phase
+A shall be validated by showing that the commands Polaris generates produce
+the same behavior on each of those machines.
 
 A single confined step shall be run on each machine and shall report that it
-sees only the cores and GPUs it was given. This is the same check the spike
-payload performs, and it is the one that catches a placement that is
-constructed correctly but not honored.
+sees only the cores and GPUs it was given. This is the check that catches a
+placement which is constructed correctly but not honored, and it is worth
+keeping as a small standing test rather than a one-off, since it is the
+first thing that would break if a site changed its scheduler
+configuration.
 
 ### Testing and Validation: No Regression
 

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -114,10 +114,32 @@ Contributors:
 A step shall be able to declare how much memory it needs, as a target and a
 minimum, in the same style as its existing CPU requirements.
 
-Phase A only requires that the declaration exist and be carried through to
-the launcher. Using it to decide how many steps may run at once belongs to
-Phase B. Memory matters most for the analysis work in Phase C, where a
-single step may need a large fraction of a node.
+Memory is unlike cores and GPUs in that the batch system will not keep it
+for us. Asking a launch for a share of the node's memory was measured to
+change nothing, so a memory figure passed to the launcher would reserve
+nothing and prevent nothing. Memory is therefore a budget Polaris keeps
+itself: the only way one step's memory is protected from another's is that
+Polaris declines to start the second step. That decision is Phase B's, and
+so is the accounting behind it.
+
+What Phase A shall provide is the declaration, its default, and its
+visibility to the step. A step that declares nothing shall be treated as
+needing memory in proportion to the cores it asked for -- the node's memory
+divided by its cores, times the step's cores. This is deliberately the value
+that makes memory-aware packing arithmetically identical to packing on cores
+alone, so that introducing memory can never make Phase B schedule worse than
+it would have without it, and so that no per-step number has to be invented
+for the steps that exist today. Steps that have been measured, which is
+mostly the analysis work in Phase C, override the default with a real
+figure and are then scheduled on it.
+
+Because a step's memory need is not enforced anywhere, an under-declaring
+step running beside others is a real failure mode, and one that did not
+exist when Polaris ran a step at a time. Phase B addresses it.
+
+Device memory needs no declaration of its own. GPUs are never divided
+between steps, so a step given a GPU is given that GPU's memory with it, and
+the GPU count already accounts for it.
 
 ### Requirement: Resource Views Describe What a Step Can Use
 
@@ -131,11 +153,70 @@ Contributors:
 The resource information given to a step shall describe the resources that
 step can actually use.
 
-A step confined to one node shall be told about one node's resources. A
-non-MPI Python step cannot use cores on other nodes without a distributed
-launcher, so telling it the allocation-wide core count invites it to size
-itself wrongly. Any resources withheld from a step shall be genuinely
-withheld, not merely subtracted from a number.
+A step confined to one node shall be told about one node's resources, and a
+step whose work may span nodes shall be told about all of the resources it
+was given. Telling a step that runs its work in its own process about cores
+on nodes it will never reach invites it to size itself wrongly; telling a
+step that distributes its work about one node's worth understates what it
+has. The view shall describe how a step's resources are distributed, not
+only how many there are, since that is the part a step sizing itself needs
+and the part a single number cannot carry.
+
+Any resources withheld from a step shall be genuinely withheld, not merely
+subtracted from a number.
+
+Memory shall be part of that view. It is the one resource where the number a
+step is told is the only thing standing between it and the node's limit,
+because nothing below Polaris will stop it, and it is the number a step that
+sizes something for itself -- a worker pool, a chunk size -- has to size
+against. A step told its cores and its memory can do that; a step told only
+its cores cannot, and the natural mistake is to derive memory from cores,
+which is wrong in exactly the case that matters.
+
+### Requirement: A Step Says Whether Its Cores May Span Nodes
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Whether a step's cores may be drawn from more than one node shall be a
+property the step declares, and shall not be inferred from whether the step
+uses MPI.
+
+The two are not the same question, and treating them as the same is what
+this requirement exists to prevent. An MPI step spans nodes because its
+launcher spreads its ranks. A single-process Python step that does its work
+in its own threads cannot span nodes, because there is no mechanism by which
+it would reach them. A single-process Python step that hands its work to a
+distributed worker pool spans nodes perfectly well -- the pool is exactly
+the mechanism the thread-based step lacks -- and it does so while remaining
+one process asking for one task. "Not MPI" covers the last two cases, which
+want opposite answers.
+
+Steps that do not say shall be treated as confined to a node, which is what
+every non-MPI step in Polaris is today. This is also the safe direction: a
+request that a node can satisfy is satisfiable on any allocation that could
+have satisfied a larger one.
+
+Where a step cannot be given what it asked for, the existing
+target-and-minimum rule shall decide what happens, with the node boundary
+as one more thing that can make a request unsatisfiable. A step confined to
+a node may be reduced silently towards its target, exactly as it may be
+today, because a step that names a minimum has said in advance which
+reductions are acceptable. A step whose *minimum* cannot be met within a
+node shall be an error when the run is set up, naming what it needs, what a
+node holds, and the property that would let it span -- not quietly reduced
+to what fits.
+
+This is deliberately the rule Polaris already follows, extended rather than
+replaced, and it leaves today's steps alone. The two steps that currently
+ask for more cores than some machines have per node both name a minimum of
+one, so they are reduced as they always were. What changes is only that the
+bound is the allocation for a step that may span, and that a step that may
+not span and cannot fit says so instead of shrinking in silence.
 
 ### Requirement: Portability Across Supported Machines
 
@@ -164,6 +245,12 @@ Contributors:
 
 `polaris serial` shall behave exactly as it does today. A step that does not
 ask to be confined shall be launched as it is now.
+
+Two of the requirements above change what a step is told or permitted rather
+than how it is launched, and both are constructed to leave existing steps
+where they are: the memory default reproduces core-only packing exactly, and
+the node-span rule reduces to today's target-and-minimum behavior for every
+step now in Polaris. Neither should show up as a difference in a run.
 
 ## Algorithm Design
 
@@ -217,14 +304,88 @@ That target-and-minimum pattern is a good one and should be kept.
 GPUs should be added as a per-step total with a matching minimum, for the
 reason given in the requirements, defaulting to none so that the great
 majority of steps need say nothing and still get an explicit "no GPUs"
-passed to the launcher on their behalf. Memory should be added the same
-way.
+passed to the launcher on their behalf.
+
+Memory follows the same target-and-minimum pattern but does not follow the
+same path afterwards. GPUs go to the launcher because the launcher acts on
+them; memory goes to the scheduler and to the step, because those are the
+only two things that act on it. It is worth being explicit that this is not
+an omission: a memory figure rendered into a launch command would be
+decoration, and worse than decoration, because it would suggest an
+enforcement that does not happen.
+
+Memory's default differs from the GPU default in kind. "No GPUs" is a true
+statement about a step that uses no GPUs. There is no equivalent true
+statement about memory -- every step uses some -- so the default has to be
+an assumption, and the assumption chosen is the step's proportional share of
+the node: cores requested, times the node's memory divided by the node's
+cores. Its merit is not that it is accurate for any particular step; it is
+that a run in which every step defaults packs exactly as a run with no
+memory accounting at all, so the mechanism is inert until someone supplies a
+measured number.
+
+An alternative was considered and rejected: converting memory into an
+equivalent number of cores and packing on cores alone, so that a step
+needing a large fraction of the node's memory reserves a matching fraction
+of its cores. It has the appeal of resting on the one resource the batch
+system does enforce. But it over-reserves whenever a step's ratio of memory
+to cores differs from the node's, and it does so worst for steps that want
+much memory and few cores, which is precisely the analysis work that
+motivated declaring memory at all. It would also hand such a step *more*
+cores than it asked for, so a step that sizes a worker pool from its cores
+would respond to needing more memory by creating more workers with less
+memory each. Tracking memory as its own quantity avoids both, and is
+consistent with the decision already made for GPUs, which this design
+likewise declines to express in CPU-shaped terms.
 
 Non-MPI steps are worth calling out. A single-process Python step has no
 meaningful "number of ranks"; what it has is a number of cores it can use
 and an amount of memory it needs. Expressing that through MPI-shaped fields
 is how Polaris ends up telling a Python step it has 192 cores across three
 nodes. Non-MPI steps should describe cores and memory directly.
+
+That matters more once such a step is allowed to span nodes. A step that
+wants two hundred cores from a distributed pool is, in MPI-shaped terms, one
+task with two hundred CPUs each -- a sentence no launcher can act on, since
+one process cannot be given two hundred cores on a node that has a hundred
+and twenty-eight. Written directly, as two hundred cores that may come from
+several nodes, it says something true and actionable. The MPI-shaped fields
+are not merely awkward here; they cannot express the case at all.
+
+### Algorithm Design: Reservations Are Not Always Placements
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+For most steps, the resources Polaris reserves and the resources it confines
+the step to are the same set, described once and used twice. An MPI step
+given ninety-six cores is launched on those ninety-six cores; reserving them
+and placing them are one act.
+
+Two cases in this design separate them. Memory is reserved and never placed,
+because no launcher acts on it. A step that delegates its work to a
+distributed pool is the mirror image: what Polaris launches is a driver
+process needing about one core, while the cores the step claims are consumed
+by pool workers, which are separate launches, started elsewhere, and shared
+with other steps. Placing two hundred cores on that driver would confine
+them to a process that will not use them, while the workers that will are
+somewhere else entirely.
+
+The distinction to carry forward is that **placement is what the launcher
+acts on and a reservation is what the scheduler tracks**. They coincide for
+ordinary steps. Where they do not, the scheduler's accounting is the one
+that has to be right, because it is what stops the machine being
+oversubscribed; the placement is only ever a description of where a
+particular launch goes.
+
+Phase A implements no delegation -- there is no pool until Phase C, and no
+scheduler until Phase B. What Phase A must not do is build the two ideas as
+one thing, because separating them afterwards means revisiting every place
+that assumed a step's cores and its launch describe the same set.
 
 ### Algorithm Design: Detecting What a Machine Supports
 
@@ -305,17 +466,48 @@ Contributors:
 - Xylar Asay-Davis
 - Claude
 
-- `Step` gains `gpus` and `min_gpus` as per-step totals, and `memory` and
-  `min_memory`. The existing `gpus_per_task` should be deprecated in favor
-  of the total, since it does not do what its name suggests when steps run
-  concurrently.
+- `Step` gains `gpus` and `min_gpus` as per-step totals. The existing
+  `gpus_per_task` should be deprecated in favor of the total, since it does
+  not do what its name suggests when steps run concurrently.
+- `Step` gains `memory` and `min_memory`. `Step` already carries a
+  `max_memory` attribute, documented as a placeholder for task parallelism
+  and unused by anything. This is that placeholder being redeemed, not a
+  second mechanism beside it, and the existing attribute should be
+  reconciled rather than left alongside. Its units, megabytes, are worth
+  keeping; its name is not, since what a step declares is what it needs and
+  not a ceiling it is held to.
 - `Step` gains a way to say how many cores and how much memory a non-MPI
   step needs, without going through MPI task counts.
+- `Step` gains a property saying whether its cores may be drawn from more
+  than one node, false by default for a non-MPI step and true for an MPI
+  one. `constrain_resources()` uses it in place of the node-sized cap it
+  applies today: a step that may span is bounded by the allocation, and a
+  step that may not and asks for more than a node holds is an error rather
+  than a silent reduction. Nothing in Polaris sets the property to true in
+  Phase A; it exists so that Phase C does not have to remove a rule.
 - The code that builds a step's parallel command passes a placement through
   to `mache` when one has been assigned, and passes none when it has not,
   preserving today's behavior.
 - The resource information handed to a step is built from its placement, so
-  that a confined step sees only what it was given.
+  that a confined step sees only what it was given, and includes memory
+  alongside cores, nodes and GPUs.
+- The per-node memory a machine has becomes a `[parallel]` configuration
+  option in `mache`, beside the `cores_per_node` and `gpus_per_node` that
+  are already there. That is a separate and much smaller change than pull
+  request #470: it describes a machine rather than altering an interface,
+  and it does not touch `ResourcePlacement`. It should be a configured
+  quantity rather than one read from the running node, both because Polaris
+  needs it before a compute node is in hand and because what belongs in it
+  is the memory a job may actually use, which is not what the operating
+  system reports.
+- Nothing about memory reaches `mache`'s `ResourcePlacement`. That type
+  describes where a launch runs -- which nodes, which cores, which GPUs --
+  and every field in it is rendered into the launch command. A memory field
+  would render to nothing on every machine Polaris supports. If the
+  enforcement question below is answered and some machine does honor a
+  memory request, adding the field then is an additive change; adding it
+  now would widen an unmerged pull request to carry something no machine
+  reads.
 
 ### Implementation: Boundaries
 
@@ -380,6 +572,21 @@ placement which is constructed correctly but not honored, and it is worth
 keeping as a small standing test rather than a one-off, since it is the
 first thing that would break if a site changed its scheduler
 configuration.
+
+While those machines are being visited, one further question should be
+settled, because it is cheap to answer there and expensive to guess at.
+Nothing in this design asks the batch system to limit a step's memory, on
+the evidence that requesting memory changed nothing observable. That
+evidence shows memory was not the cause of the serialization; it does not
+show that a memory request is inert. The test is direct: launch a step with
+a small memory allowance, have it allocate several times that, and record
+whether it is killed. Two answers matter and both are useful. If nothing
+enforces, this design is on the right footing and the co-resident reporting
+in Phase B is the whole of the answer. If some machine does enforce, then
+two consequences follow at once -- a step could be capped there, and, by the
+same argument that applies to GPUs, a step that says nothing about memory
+may be read as claiming all of it, which would be the same trap in a second
+place.
 
 ### Testing and Validation: No Regression
 

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -75,7 +75,7 @@ The exception is machines running Slurm older than 20.11, such as Chrysalis,
 where the necessary options do not exist. There, Polaris shall fall back to
 explicit CPU binding, and shall record that it has done so.
 
-### Requirement: Steps Declare GPUs as a Per-Step Total
+### Requirement: A Step's GPU Need Is Always Stated Explicitly
 
 Date last modified: 2026/08/23
 
@@ -84,14 +84,23 @@ Contributors:
 - Xylar Asay-Davis
 - Claude
 
-A step that uses GPUs shall declare how many GPUs **the step** needs, not how
-many each MPI rank needs.
+A Polaris step uses no GPUs unless it declares otherwise. That premise does
+not change, and most steps will continue to declare nothing.
 
-This differs from how CPU resources are described today, where `ntasks` and
-`cpus_per_task` are per-rank quantities, and the difference is not
-cosmetic. Measurements on both GPU machines showed that requesting GPUs
-per-rank does not confine a step at all, while requesting a per-step total
-does. A step that does not declare GPUs shall be understood to need none.
+What must change is that Polaris shall state a step's GPU need to the
+launcher in every case, **including when it is zero**. Passing nothing is
+not the same as passing zero: the batch system treats an unstated GPU
+requirement as a claim on the node's GPUs and reserves all of them, which
+prevents any other step from starting. Because most Polaris steps use no
+GPUs, explicitly requesting none is the ordinary case rather than a special
+one.
+
+A step that does want GPUs shall declare how many **the step** needs, not
+how many each MPI rank needs. This differs from how CPU resources are
+described today, where `ntasks` and `cpus_per_task` are per-rank
+quantities, and the difference is not cosmetic: measurements on both GPU
+machines showed the per-rank form does not confine a step at all, while a
+per-step total does.
 
 ### Requirement: Steps Declare Memory
 
@@ -173,7 +182,11 @@ description is:
 
 - the nodes the step may use;
 - how many cores it may use on each;
-- how many GPUs it needs in total.
+- how many GPUs it needs in total, which is normally none.
+
+All three are always present. There is no "unspecified" for GPUs, because
+an unspecified GPU requirement is what the batch system reads as a claim on
+all of them.
 
 Each supported system can express all three, though they say it differently.
 On newer Slurm it is a matter of asking for exactly the resources requested
@@ -202,7 +215,10 @@ giving the scheduler room to run a step smaller when resources are tight.
 That target-and-minimum pattern is a good one and should be kept.
 
 GPUs should be added as a per-step total with a matching minimum, for the
-reason given in the requirements. Memory should be added the same way.
+reason given in the requirements, defaulting to none so that the great
+majority of steps need say nothing and still get an explicit "no GPUs"
+passed to the launcher on their behalf. Memory should be added the same
+way.
 
 Non-MPI steps are worth calling out. A single-process Python step has no
 meaningful "number of ranks"; what it has is a number of cores it can use

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -524,13 +524,22 @@ change to Polaris's deployment machinery:
 kind. That was always a temporary state, and it ends here: Phase A must not
 merge while depending on an unreleased branch, and no longer has to.
 
-Polaris shall now require `mache` 3.12.0 or later, and shall fail clearly,
-at setup, if an older one is present. Until the release existed the check
-had to be on the capability rather than on a version, because there was no
-version to name; it becomes an ordinary requirement. What it guards against
-is the reason it is stated at all: a run that silently lost placement would
-appear to work while oversubscribing the machine, which is the worst failure
-available here -- no error, wrong results, and slower than serial.
+Polaris shall require `mache` 3.12.0 or later, and shall fail clearly if an
+older one is present. Those are two separate mechanisms and it is worth
+saying which does what.
+
+The version requirement belongs in the deployment pin, which is what governs
+any environment built the ordinary way. The check in the running code is a
+backstop for an environment that was not, and it shall test the *capability*
+-- whether this `mache` accepts a placement at all -- rather than compare
+version numbers. The capability is the thing that matters, and a version is
+only a proxy for it: a proxy that would reject a development build or a fork
+that can place, and accept a release that could not.
+
+What either guards against is the reason they exist: a run that silently
+lost placement would appear to work while oversubscribing the machine, which
+is the worst failure available here -- no error, wrong results, and slower
+than serial.
 
 ### Implementation: The Polaris Side
 

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -681,12 +681,39 @@ sees only the cores and GPUs it was given. This is the check that catches a
 placement which is constructed correctly but not honored, and it is the
 first thing that would break if a site changed its scheduler configuration.
 
-Something of it shall keep running after Phase A, but not the harness that
-produced it. The harness exists to answer a question and is not part of what
-Polaris ships; it is removed once the question is answered, and anything
-worth keeping has to be moved somewhere permanent **before** that rather
-than after. Two things are worth keeping, and neither needs an allocation to
-be remembered.
+One combination that neither the harness nor the unit tests reach has been
+checked separately, because it is the one Phase B relies on most. The
+harness confines synthetic payloads; the unit tests give a step a placement
+and inspect what would be launched. Neither runs a *real* step under a
+placement Polaris built from that step's own declarations. That was done
+once, on Chrysalis, with an Omega forward step declaring four tasks of one
+core:
+
+| given | rendered launch | ran |
+| --- | --- | --- |
+| no placement | `-n 4 --cpu-bind=cores -m plane=64` | yes |
+| four cores | `-n 4 -w <node>` + a four-bit mask | yes |
+| two cores | `-n 2 -w <node>` + a two-bit mask | yes |
+
+The third row is the one that establishes anything. A step asking for four
+tasks came out as two, on a node holding sixty-four cores, which is only
+possible if the resources it was constrained against were the placement
+rather than the allocation. The second row cannot show that, because four
+is what the step asked for either way -- a distinction worth keeping in mind
+if this is ever repeated, since the obvious test is the uninformative one.
+
+The placed and unplaced runs at the same width produced bit-identical
+output, which is the other thing worth confirming: a placement changes where
+a step runs and not what it computes. This was the cpu-binding fallback
+rather than the reservation path, Chrysalis running Slurm 20.02, so it
+exercised the weaker of the two mechanisms.
+
+Something of all this shall keep running after Phase A, but not the harness
+or the scaffold that produced it. Both exist to answer a question and are
+not part of what Polaris ships; they are removed once the question is
+answered, and anything worth keeping has to be moved somewhere permanent
+**before** that rather than after. Two things are worth keeping, and neither
+needs an allocation to be remembered.
 
 The first is a test that needs no batch system at all. A single-node
 launcher confines a launch with ordinary process affinity, which is enough

--- a/docs/design_docs/task_parallelism_phase_a.md
+++ b/docs/design_docs/task_parallelism_phase_a.md
@@ -797,8 +797,23 @@ was not one. The small node was a Perlmutter *GPU* node: the run had been
 labelled from the deployment's machine name rather than from the node it
 landed on, and three hardware signals agree it was misfiled -- the job held
 four GPUs, its hyperthread siblings were 64 apart rather than 128, and its
-memory matched a GPU node. There is at present no evidence that any machine
-Polaris targets is heterogeneous in memory.
+memory matched a GPU node. Perlmutter CPU is homogeneous, and its two genuine
+samples agree.
+
+**Aurora, however, is heterogeneous, and that is measured rather than
+inferred.** Its scheduler was asked what every one of its 10,624 nodes has,
+which is a survey and not a sample: about 89% report roughly 1135 GiB, 11%
+report roughly 1007 GiB, and a handful sit between. The smallest is 1,030,518
+MB against a median of 1,162,460 -- so a figure taken from the majority would
+be about 13% too high for one node in nine, and a step packed against it
+would be over-admitted whenever it landed on a small one.
+
+The two episodes are worth reading together, because they point the same way
+for opposite reasons. The Perlmutter reading was withdrawn because two
+samples of different machines were compared as though they were one machine.
+The Aurora figure stands because nothing was sampled at all -- every node was
+asked. The rule that survives both is the one already stated: where nodes
+differ the smallest binds, and a single sample cannot establish the number.
 
 The episode is worth keeping for what it says about the measurements
 generally, which is that they are labelled by configuration and confirmed by

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -99,12 +99,19 @@ as impossible before the run starts.
 
 The memory a node is credited with shall be what that node reports, not what
 its machine's configuration estimates. Phase A requires the allocation's
-nodes to be read at the start of a run for this reason: nodes within one
-machine have been measured to differ twofold in memory at identical core
-counts, so a single configured figure will over-admit on the smaller ones,
-and over-admitting memory is the failure that kills a job rather than the
-one that slows it. Nodes shall therefore be tracked individually where they
-differ, rather than as so many copies of one node.
+nodes to be read at the start of a run, because a configured figure is an
+estimate of a machine while the scheduler is packing particular nodes, and
+over-admitting memory is the failure that kills a job rather than the one
+that slows it. Nodes shall be tracked individually rather than as so many
+copies of one node, which costs nothing if they turn out to be identical and
+is the only correct answer if they are not.
+
+No machine Polaris targets is currently known to be heterogeneous in memory.
+This is not written for a case that has been observed; it is written because
+the configured figure is the weaker source of truth in every case, and
+reading the nodes removes a whole class of error -- a stale configuration, a
+machine that has changed, a job that is not on the machine it was thought to
+be -- without requiring any of them to be anticipated.
 
 A step that has not said its resources may span nodes shall have its cores
 and its GPUs drawn from a single node. This is a packing constraint rather

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -203,9 +203,58 @@ The list of neighbors and their declarations is what turns an inexplicable
 failure into a short investigation, and, in the common case where one
 neighbor's declaration is obviously too small, into an obvious fix.
 
-Polaris shall not attempt to prevent this by capping steps. Nothing measured
-so far can cap them, and even where a cap is available it converts a rare
-failure into a routine one.
+### Requirement: A Declared Memory Figure May Be Enforced
+
+Date last modified: 2026/08/24
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Where the machine can hold a launch to a memory figure, Polaris shall do so
+for a step that declared one, and shall not for a step that did not.
+
+Measurement settled that this is possible on newer Slurm and not on older:
+a launch allowed 1024 MB and told to take 4 GB is killed at 960 MB on
+Perlmutter GPU and on Frontier, and runs to completion on Chrysalis. PALS
+appears to offer no per-launch memory size at all, so Aurora is expected not
+to enforce either.
+
+The reason to use it is that an unenforced declaration is invisible when it
+is wrong. It does not fail; it quietly makes the scheduler's accounting a
+fiction, and the error surfaces much later as an exhausted node that someone
+has to trace back, or never surfaces while costing throughput the whole
+time. Holding a step to its own number turns that into an immediate,
+attributable failure, and the fix -- correct the number -- improves packing
+on every machine, including the ones that cannot enforce.
+
+The reason to use it only for a declared figure is that most steps will
+never declare one. They take the proportional default, which is deliberately
+a rough guess and is known to be poor for steps whose memory has little to
+do with their core count. Capping a step at the framework's estimate of it
+would not produce better estimates; it would require every step to carry a
+measured figure before it could run, which is the burden Phase A was built
+to avoid, and it would arrive as a wave of failures in steps nobody had
+touched. A step that stated a number is making a claim and can fairly be
+held to it. A step that said nothing is being guessed at, and the framework
+should carry the risk of its own guess.
+
+Enforcement will therefore be uneven across machines, and that is accepted.
+It replaces silent divergence with loud divergence, which is the better of
+the two, and it reaches only steps whose authors opted in by declaring.
+
+Polaris shall not rely on enforcement in place of its own accounting.
+Admission control works on every machine; capping does not, and the
+reporting required above is needed regardless.
+
+One question is still open and may change the shape of this. Placement on
+newer Slurm asks for exactly what a step needs rather than the job's
+resources, so a placed step may already receive a memory ceiling nobody set.
+If it does, the choice is not whether to impose a cap but whether Polaris
+names the number or lets the scheduler pick one it never reports. That
+measurement is described in Phase A and should be taken before this
+requirement is implemented.
 
 ### Requirement: Results Match Serial Execution
 

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -93,11 +93,34 @@ Contributors:
 Polaris shall run as many ready steps as the allocation's resources allow,
 and no more.
 
-Cores, GPUs, nodes and memory shall all be accounted for. Memory matters here
-even though most steps today use little of it, because getting it wrong means
-a job that dies rather than a job that runs slowly. A step whose minimum
-requirements cannot be met by the whole allocation shall be reported as
-impossible before the run starts.
+Cores, GPUs, nodes and memory shall all be accounted for. A step whose
+minimum requirements cannot be met by the whole allocation shall be reported
+as impossible before the run starts.
+
+A step that has not said its cores may span nodes shall have them drawn from
+a single node. This is a packing constraint rather than a total: an
+allocation with cores free on several nodes and none of them holding enough
+may be unable to start such a step while showing plenty free, and the pool
+has to be able to say so rather than deadlocking or overcommitting. A step
+that may span is bounded only by what the allocation holds.
+
+Memory is accounted for differently from the rest, and the difference should
+be understood rather than smoothed over. Cores, GPUs and nodes are handed to
+the launcher, which keeps steps off each other's; memory is not, because
+nothing below Polaris will act on it. The pool's memory accounting is
+therefore admission control and nothing more: it decides what may start, and
+a step that starts and then uses more than it declared is not stopped by
+anything. This is the correct amount of mechanism, since the alternative --
+a step killed part-way through for exceeding a figure someone estimated --
+trades a rare failure for a routine one. But it means memory accounting is
+only as good as the declarations, and the design should say so rather than
+imply a guarantee it does not have.
+
+Since a step that declares no memory is taken to want its proportional share
+of the node, a run in which nothing declares memory packs exactly as it
+would with no memory accounting at all -- the two constraints reduce to the
+same inequality. Memory accounting can therefore only ever remove a
+schedule that a measured declaration says would not have fit.
 
 Where a step declares both a target and a minimum, Polaris may run it at less
 than its target in order to fit more work, but never below its minimum.
@@ -149,6 +172,38 @@ shall not prevent unrelated work from continuing.
 
 Completed steps shall still be skipped on rerun, cached steps shall still be
 honored, and a rerun after a failure shall resume from what succeeded.
+
+### Requirement: A Step Killed by the Node Is Reported as Such
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Running steps concurrently introduces a failure that serial Polaris does not
+have. Memory is not enforced by anything, so a step that uses more than it
+declared exhausts the node, and the operating system then kills whichever
+process it chooses. The step that dies need not be the step at fault, and a
+step that was correct in isolation can fail because of a neighbor.
+
+Polaris shall recognize this case rather than presenting it as an ordinary
+step failure. A step terminated by a signal rather than by its own exit
+shall be reported as terminated, and the report shall name every step that
+was resident on the same node at the time, together with what each of them
+had declared.
+
+Naming the co-resident set is the most that can honestly be said, and saying
+it is the point: the victim is identifiable and the culprit is not, so a
+report that blames only the victim sends whoever reads it to the wrong step.
+The list of neighbors and their declarations is what turns an inexplicable
+failure into a short investigation, and, in the common case where one
+neighbor's declaration is obviously too small, into an obvious fix.
+
+Polaris shall not attempt to prevent this by capping steps. Nothing measured
+so far can cap them, and even where a cap is available it converts a rare
+failure into a routine one.
 
 ### Requirement: Results Match Serial Execution
 
@@ -322,7 +377,12 @@ Contributors:
 
 - a graph builder, producing the step graph and rejecting invalid ones;
 - a resource pool, tracking free nodes, cores, GPUs and memory, and handing
-  out and taking back reservations;
+  out and taking back reservations. What it hands out is a reservation, which
+  for an ordinary step is also the placement its launch is given, and for the
+  cases described in Phase A -- memory, and a step that delegates its work --
+  is not. The pool's accounting is what keeps the machine from being
+  oversubscribed and must cover everything a step claims, whether or not any
+  of it reaches a launcher;
 - an executor, starting a step as a subprocess with its placement and
   reporting completion;
 - a scheduler, owning the loop above;
@@ -381,7 +441,25 @@ fits, a step run at its minimum rather than its target, and a step whose
 minimum exceeds the allocation, which shall be reported before the run.
 
 Memory shall be covered explicitly, including the case where cores are
-available but memory is not.
+available but memory is not, and the case where a step declares memory
+smaller than its proportional share and is packed on the smaller figure.
+
+The node-span constraint shall be covered too, in particular the case that
+distinguishes it from a simple total: enough cores free across the
+allocation, not enough on any one node, and a step that may not span. It
+shall wait rather than start, and a step that may span shall start on the
+same allocation.
+
+One property is worth testing as a property rather than as a case: a set of
+steps that all take the default declaration shall produce exactly the
+schedule that packing on cores alone produces. This is the guarantee that
+introducing memory cannot degrade an existing suite, and it is cheap to
+check against a core-only reference for a range of generated step sets.
+
+Because the co-resident report is what a developer will have to work from
+when a node runs out of memory, it shall be tested too: a step killed by a
+signal shall be reported as terminated rather than failed, and shall name
+the steps that were on its node with what they declared.
 
 ### Testing and Validation: Concurrency and Isolation
 

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -97,6 +97,15 @@ Cores, GPUs, nodes and memory shall all be accounted for. A step whose
 minimum requirements cannot be met by the whole allocation shall be reported
 as impossible before the run starts.
 
+The memory a node is credited with shall be what that node reports, not what
+its machine's configuration estimates. Phase A requires the allocation's
+nodes to be read at the start of a run for this reason: nodes within one
+machine have been measured to differ twofold in memory at identical core
+counts, so a single configured figure will over-admit on the smaller ones,
+and over-admitting memory is the failure that kills a job rather than the
+one that slows it. Nodes shall therefore be tracked individually where they
+differ, rather than as so many copies of one node.
+
 A step that has not said its resources may span nodes shall have its cores
 and its GPUs drawn from a single node. This is a packing constraint rather
 than a total: an allocation with cores free on several nodes and none of

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -527,6 +527,20 @@ consume other steps' outputs and fail deliberately, and shall verify that
 independent steps genuinely overlap in time, that a failure blocks only its
 dependents, and that a rerun resumes correctly.
 
+A placed step shall check that it received what it was given, and shall say
+so when it did not. This is the standing check on real machines that Phase A
+could not have: Phase A places nothing, so verifying placement there needed
+a harness built for the purpose, while here every step has a placement
+already and confirming it costs almost nothing. It runs on every machine on
+every run, which is what makes it useful -- the thing it guards against is a
+site changing its scheduler configuration underneath us, and that will not
+announce itself.
+
+A mismatch shall be reported rather than corrected. A step given fewer cores
+than it was promised is running in a way the scheduler's accounting does not
+describe, and continuing quietly is how a run ends up oversubscribed and
+slower than serial with nothing in the log to say why.
+
 Overlap shall be checked from recorded start and end times, not inferred
 from wall time. A test that concludes "it was faster, so it must have run
 concurrently" will pass on a machine where nothing overlapped at all.

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -348,8 +348,8 @@ directory, external side effects, or anything else that makes running beside
 another step wrong.
 
 This is the same metadata the analysis conformance checks in
-`task_parallel_analysis_steps.md` need, and it should be one mechanism, not
-two.
+*Task-Parallel-Safe Analysis Steps in Polaris* needs, and it should be one
+mechanism, not two.
 
 ## Testing
 
@@ -429,5 +429,7 @@ Contributors:
 
 Validation shall cover Chrysalis, Perlmutter (CPU and GPU), Frontier and
 Aurora, since these differ in exactly the way that matters: two eras of Slurm,
-a PBS system, and GPU and non-GPU nodes. The launcher spike established that
-each can do what Phase B needs; this validation confirms Polaris does it.
+a PBS system, and GPU and non-GPU nodes. Each was measured to support what
+Phase B needs, as recorded in
+[Task Parallelism in Polaris](task_parallelism.md); this validation confirms
+Polaris does it.

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -97,12 +97,14 @@ Cores, GPUs, nodes and memory shall all be accounted for. A step whose
 minimum requirements cannot be met by the whole allocation shall be reported
 as impossible before the run starts.
 
-A step that has not said its cores may span nodes shall have them drawn from
-a single node. This is a packing constraint rather than a total: an
-allocation with cores free on several nodes and none of them holding enough
-may be unable to start such a step while showing plenty free, and the pool
-has to be able to say so rather than deadlocking or overcommitting. A step
-that may span is bounded only by what the allocation holds.
+A step that has not said its resources may span nodes shall have its cores
+and its GPUs drawn from a single node. This is a packing constraint rather
+than a total: an allocation with cores free on several nodes and none of
+them holding enough may be unable to start such a step while showing plenty
+free, and the pool has to be able to say so rather than deadlocking or
+overcommitting. The same applies to GPUs, and a step needing both must find
+both on one node rather than each somewhere. A step that may span is bounded
+only by what the allocation holds.
 
 Memory is accounted for differently from the rest, and the difference should
 be understood rather than smoothed over. Cores, GPUs and nodes are handed to
@@ -444,9 +446,10 @@ Memory shall be covered explicitly, including the case where cores are
 available but memory is not, and the case where a step declares memory
 smaller than its proportional share and is packed on the smaller figure.
 
-The node-span constraint shall be covered too, in particular the case that
-distinguishes it from a simple total: enough cores free across the
-allocation, not enough on any one node, and a step that may not span. It
+The node-span constraint shall be covered too, in particular the cases that
+distinguish it from a simple total: enough cores free across the allocation,
+not enough on any one node, and a step that may not span; and a step needing
+both cores and GPUs where each is available but not together on one node. It
 shall wait rather than start, and a step that may span shall start on the
 same allocation.
 

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -1,0 +1,433 @@
+# Task Parallelism Phase B: Concurrency
+
+Creation date: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+## Summary
+
+Phase B makes Polaris run independent steps at the same time.
+
+Phase A gave Polaris the ability to confine a step to part of its allocation.
+Phase B adds the parts that decide what to run and when: a graph of which
+steps depend on which, a record of which resources are in use, and an
+executor that runs each step in its own process.
+
+MPI steps and Python steps are treated the same way. This is worth stating
+plainly because earlier designs staged them separately, running Python work
+concurrently while MPI steps waited their turn. That separation existed
+because we could not confine an MPI step to part of the allocation. Phase A
+removes that reason, and with it the need for a barrier between the two kinds
+of work, the machinery to switch between modes, and the cost of switching.
+
+Each step runs in its own operating-system process. Polaris already knows how
+to do this: `polaris serial` can run a single step in a fresh process from
+its pickle file, and that is the unit the scheduler dispatches. Running a step
+in its own process means it cannot disturb another step by changing the
+working directory, setting a module-level default or writing to a global
+logger -- all of which Polaris steps legitimately do today.
+
+This is where the regression-suite speedup arrives. On a recent `omega_pr`
+run on Chrysalis, three nodes, 12:26 total: the MPI work amounts to roughly
+236 s of core-time on 192 cores, against a dependency floor of about 106 s,
+so something in the range of 2.5-3x is the expectation on the same
+allocation. That number is an estimate from one run's timings and should be
+treated as a target to measure against, not a promise.
+
+Success in Phase B means a suite's independent steps run together, results
+match serial execution exactly, a failure stops only the work that depended
+on it, and reruns still skip completed steps.
+
+## Requirements
+
+### Requirement: A Concurrent Execution Path
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Polaris shall provide a way to run a suite, task or step with concurrency,
+alongside the existing `polaris serial`.
+
+`polaris serial` shall remain available and unchanged. Setup shall provide an
+opt-in way to generate job scripts that use the concurrent path; the serial
+path shall remain the default until the concurrent one has been used enough
+to trust.
+
+### Requirement: Scheduling from Declared Dependencies
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Polaris shall decide what may run from explicitly declared step
+dependencies and from declared input and output files, not from the order in
+which steps happen to be listed.
+
+If a suite relies on listed order without declaring a real dependency, it is
+acceptable for the concurrent path to expose that as a failure. Invalid
+graphs -- cycles, or an input no selected step produces and which does not
+already exist -- shall be rejected before anything runs, rather than
+discovered partway through.
+
+Steps shared between tasks shall be recognized as one step and run once.
+
+### Requirement: Resource-Aware Scheduling
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Polaris shall run as many ready steps as the allocation's resources allow,
+and no more.
+
+Cores, GPUs, nodes and memory shall all be accounted for. Memory matters here
+even though most steps today use little of it, because getting it wrong means
+a job that dies rather than a job that runs slowly. A step whose minimum
+requirements cannot be met by the whole allocation shall be reported as
+impossible before the run starts.
+
+Where a step declares both a target and a minimum, Polaris may run it at less
+than its target in order to fit more work, but never below its minimum.
+
+### Requirement: Each Step in Its Own Process
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Each step shall run in its own process, isolated from other running steps.
+
+Polaris steps mutate process-wide state as a matter of course: the framework
+changes the working directory into each step's work directory, and sets
+library-level defaults for NetCDF output. These are correct today and would
+be races if two steps shared a process. Process isolation makes them
+harmless without requiring every existing step to be rewritten.
+
+### Requirement: Deterministic Ordering
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+When several steps could run, the choice among them shall be repeatable.
+
+Two runs of the same work with the same resources should make the same
+choices. The chosen order need not match what `polaris serial` did, but it
+must not vary from run to run, or debugging a concurrent run becomes
+guesswork.
+
+### Requirement: Failure Isolation and Restart
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A step that fails shall prevent the steps that depend on it from running, and
+shall not prevent unrelated work from continuing.
+
+Completed steps shall still be skipped on rerun, cached steps shall still be
+honored, and a rerun after a failure shall resume from what succeeded.
+
+### Requirement: Results Match Serial Execution
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+For deterministic workflows, running concurrently shall produce the same
+final outputs as running serially.
+
+### Requirement: The Run Can Be Understood Afterwards
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A concurrent run shall record enough to reconstruct what happened: which
+steps ran when, what resources each held, what each was waiting for, and how
+the total compares with running serially.
+
+This is not optional polish. A concurrent run that is slower than expected
+is otherwise very hard to diagnose, because the interesting question --
+why was nothing running at this moment -- cannot be answered from step logs.
+
+### Requirement: Do Not Poll the Batch System
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Polaris shall not repeatedly query the batch system to find out how running
+steps are getting on.
+
+NERSC asks that jobs keep batch-system queries to one or two a minute in
+aggregate, and a scheduler that polls per step per second would breach that
+badly at scale. Polaris shall learn that a step has finished from the process
+it started, not by asking the queue.
+
+## Algorithm Design
+
+### Algorithm Design: The Scheduling Loop
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The loop is conventional and should stay that way:
+
+1. Mark ready any step whose dependencies have all succeeded.
+2. Among ready steps, in a stable order, take each that fits in the
+   resources currently free and start it.
+3. Wait for any running step to finish.
+4. Release its resources, record the outcome, and repeat.
+
+The stable order should come from setup order -- suite, then task, then step
+within task -- which is easy to explain and close to what users already
+expect. Steps that cannot fit right now are simply skipped over until they
+can; there is no need for a more elaborate policy in Phase B, and a simple
+one is much easier to reason about when a schedule looks wrong.
+
+The one policy choice worth making deliberately is whether to hold resources
+free for a large step that cannot currently fit, rather than filling the gap
+with small ones and starving it. Phase B should not do this: it should fill
+the gap, and rely on the largest steps being started early by the stable
+order. If starvation shows up in practice, that is the point to add a rule,
+with evidence for it.
+
+### Algorithm Design: Running a Step in Its Own Process
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Polaris already has exactly the right unit. `polaris serial` run inside a
+step's work directory loads `step.pickle` and executes that one step, with
+configuration, parallel system, resources, logging and completion markers all
+handled. The scheduler starts that as a subprocess, with the step's placement
+in its environment, and waits for it.
+
+This has a property worth spelling out: the *same* mechanism serves MPI and
+non-MPI steps. An MPI step's subprocess goes on to launch its model through
+the parallel command; a Python step's subprocess simply runs Python. The
+scheduler does not need two executors, two policies or a barrier between
+them.
+
+The alternative we considered and rejected was to run steps as functions
+inside a pool of worker processes. It is a good fit for fine-grained Python
+work -- and Phase C adds exactly that, for exactly that reason -- but it is a
+poor fit for whole Polaris steps, which are coarse, mutate process state and
+launch their own subprocesses.
+
+### Algorithm Design: Building the Graph
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Edges come from two places: dependencies a step declares directly, and files
+one selected step produces that another consumes. Listed order contributes
+nothing except as the tie-break for choosing among ready steps.
+
+Steps that are already complete, or cached, participate in validation as
+satisfied nodes: their outputs are available for others to depend on, but
+they are not run.
+
+The graph should be validated before any step starts. An unsatisfiable input
+discovered at minute forty of a suite is much more expensive than the same
+error reported at second one.
+
+### Algorithm Design: Knowing When a Step Has Finished
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The scheduler waits on the processes it started. When one exits, its exit
+status says whether the step succeeded, and Polaris's existing completion
+markers confirm it. Nothing asks the batch system anything.
+
+## Implementation
+
+### Implementation: Shared Step Lifecycle
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The per-step lifecycle -- runtime input checks, dependency loading,
+`runtime_setup()`, `run()`, output checks, validation, completion markers --
+currently lives inside `polaris/run/serial.py`. It should be moved into a
+shared module that both the serial and concurrent paths call, with no change
+in behavior.
+
+This is worth landing as its own change, ahead of the scheduler, because it
+is a pure refactor and reviewable as one. Earlier task-parallel work already
+did this and the result was sound; it is the piece of that work most worth
+carrying forward.
+
+### Implementation: New Modules
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+- a graph builder, producing the step graph and rejecting invalid ones;
+- a resource pool, tracking free nodes, cores, GPUs and memory, and handing
+  out and taking back reservations;
+- an executor, starting a step as a subprocess with its placement and
+  reporting completion;
+- a scheduler, owning the loop above;
+- an event stream, recording scheduling decisions as structured records.
+
+These should be small and separately testable. The scheduler in the earlier
+attempt grew past three thousand lines, largely because worker-pool lifecycle
+and mode-switching policy lived inside it; with a subprocess executor there
+is no lifecycle to manage and the loop stays short.
+
+### Implementation: Step Eligibility
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Steps should be eligible for concurrency by default, with a way for a step
+author to mark one unsafe -- for shared mutable state outside its work
+directory, external side effects, or anything else that makes running beside
+another step wrong.
+
+This is the same metadata the analysis conformance checks in
+`task_parallel_analysis_steps.md` need, and it should be one mechanism, not
+two.
+
+## Testing
+
+### Testing and Validation: Graph and Scheduling
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Unit tests shall cover graph construction from explicit and file
+dependencies, shared steps, cycles, unsatisfiable inputs, cached and
+completed steps, and the stability of ready-step ordering. These use
+synthetic steps and need no allocation.
+
+### Testing and Validation: Resource Accounting
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Unit tests shall cover packing: steps that all fit, steps where only a subset
+fits, a step run at its minimum rather than its target, and a step whose
+minimum exceeds the allocation, which shall be reported before the run.
+
+Memory shall be covered explicitly, including the case where cores are
+available but memory is not.
+
+### Testing and Validation: Concurrency and Isolation
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Integration tests shall use synthetic steps that sleep, produce outputs,
+consume other steps' outputs and fail deliberately, and shall verify that
+independent steps genuinely overlap in time, that a failure blocks only its
+dependents, and that a rerun resumes correctly.
+
+Overlap shall be checked from recorded start and end times, not inferred
+from wall time. A test that concludes "it was faster, so it must have run
+concurrently" will pass on a machine where nothing overlapped at all.
+
+### Testing and Validation: Equivalence and Speedup
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A representative suite shall be run concurrently and compared against a
+serial baseline; outputs shall match.
+
+Wall time shall be recorded and compared, on each supported machine, but no
+particular speedup shall be required to declare Phase B correct. Correctness
+and isolation are the bar. Speedup below expectation is a reason to look at
+the event stream, not a reason to hold the phase.
+
+### Testing and Validation: Cross-Machine
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Validation shall cover Chrysalis, Perlmutter (CPU and GPU), Frontier and
+Aurora, since these differ in exactly the way that matters: two eras of Slurm,
+a PBS system, and GPU and non-GPU nodes. The launcher spike established that
+each can do what Phase B needs; this validation confirms Polaris does it.

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -248,13 +248,20 @@ Polaris shall not rely on enforcement in place of its own accounting.
 Admission control works on every machine; capping does not, and the
 reporting required above is needed regardless.
 
-One question is still open and may change the shape of this. Placement on
-newer Slurm asks for exactly what a step needs rather than the job's
-resources, so a placed step may already receive a memory ceiling nobody set.
-If it does, the choice is not whether to impose a cap but whether Polaris
-names the number or lets the scheduler pick one it never reports. That
-measurement is described in Phase A and should be taken before this
-requirement is implemented.
+A question that could have reshaped this has been answered and did not.
+Placement on newer Slurm asks for exactly what a step needs rather than the
+job's resources, so a placed step might have received a memory ceiling
+nobody set -- in which case the choice would not have been whether to cap
+but whether Polaris names the number or lets the scheduler pick one it never
+reports. It does not: on Perlmutter CPU and on Frontier, a placed
+single-core launch and an unplaced control, neither mentioning memory, both
+allocated twice what a single core's proportional share would be and neither
+was touched. The amount was chosen to be what would bite if placement scaled
+memory with cores.
+
+That bounds rather than settles -- it shows no ceiling below the amount
+tried, and Perlmutter GPU was not tested on this point -- but it removes the
+mechanism that would have forced Polaris's hand.
 
 ### Requirement: Results Match Serial Execution
 

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -106,12 +106,20 @@ that slows it. Nodes shall be tracked individually rather than as so many
 copies of one node, which costs nothing if they turn out to be identical and
 is the only correct answer if they are not.
 
-No machine Polaris targets is currently known to be heterogeneous in memory.
-This is not written for a case that has been observed; it is written because
-the configured figure is the weaker source of truth in every case, and
-reading the nodes removes a whole class of error -- a stale configuration, a
-machine that has changed, a job that is not on the machine it was thought to
-be -- without requiring any of them to be anticipated.
+This was written before any machine was known to be heterogeneous, on the
+argument that the configured figure is the weaker source of truth in every
+case and that reading the nodes removes a whole class of error -- a stale
+configuration, a machine that has changed, a job that is not on the machine
+it was thought to be -- without requiring any of them to be anticipated.
+That argument still stands on its own.
+
+It no longer has to. Aurora is heterogeneous, from a survey of all 10,624 of
+its nodes: about one in nine holds roughly 1007 GiB where the majority holds
+1135, so a figure taken from the majority would over-admit by about 13%
+whenever a step landed on a small node. A run that packs against what its
+own nodes report cannot make that mistake; a run that packs against one
+number per machine can only avoid it by using the smallest, and thereby
+wasting the difference everywhere else.
 
 A step that has not said its resources may span nodes shall have its cores
 and its GPUs drawn from a single node. This is a packing constraint rather

--- a/docs/design_docs/task_parallelism_phase_b.md
+++ b/docs/design_docs/task_parallelism_phase_b.md
@@ -482,8 +482,11 @@ directory, external side effects, or anything else that makes running beside
 another step wrong.
 
 This is the same metadata the analysis conformance checks in
-*Task-Parallel-Safe Analysis Steps in Polaris* needs, and it should be one
-mechanism, not two.
+[Task-Parallel-Safe Analysis Steps in Polaris](task_parallel_analysis_steps.md)
+needs, and it should be one mechanism, not two. That document has since
+landed and its rules are in the developer guide under
+{ref}`dev-task-parallelism`; the shared mechanism does not exist yet, and
+building it twice is what this is written to prevent.
 
 ## Testing
 

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -159,7 +159,7 @@ writes to a shared path is unsafe there in a way it is not unsafe in its own
 process.
 
 The properties this requires are set out in
-`docs/design_docs/task_parallel_analysis_steps.md`, which should be adopted
+*Task-Parallel-Safe Analysis Steps in Polaris*, which should be adopted
 before analysis steps are written. Phase C depends on those rules being
 followed; it cannot enforce them after the fact.
 

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -158,6 +158,7 @@ count is. Nothing extra is needed to express it -- `gpus` is already a
 per-step total -- but the pool has to account for it, and a step that
 distributes GPU work should not have GPUs reserved on the node its driver
 happens to sit on.
+
 Reading the bound off "is it an MPI step" instead would have made this phase
 begin by undoing a rule, which is why the property exists ahead of anything
 that sets it.
@@ -177,12 +178,32 @@ should not be the assumed shape of every analysis step, and no step should
 be written to span nodes before measurement shows it needs to. But it should
 be available, and the requirements below are written so that it is.
 
+It should be available in particular because nothing has yet demanded it,
+and that fact carries less weight than it appears to. The instrumented
+analysis run contained no Python task needing more than a node -- the
+largest held 53.9 GiB where the node had 251 -- and it would be easy to read
+that as evidence the case is hypothetical. It is not evidence of that. The
+program measured had no way to express such a task: its parallelism is
+fork-based and confined to one node, and the only work in it that spans
+nodes at all is MPI, meaning `ncclimo` and the generation of mapping files.
+Any analysis that would have needed more than a node was therefore never
+written, or was restructured until it fitted, or was handed to one of those
+two. A tool produces no examples of what it cannot express, and the absence
+of such tasks describes the tool rather than the science.
+
+So the door stays open deliberately. Every Polaris step that is not MPI has
+always been bounded by one process on one node, and this phase is the first
+opportunity to lift that bound rather than a proposal to add a capability
+nobody asked for. Declining to lift it because nothing has hit it would
+preserve a limitation by default, on the strength of a measurement that
+could not have found a counterexample.
+
 The case that genuinely stays hard is a computation that cannot be
 partitioned at all -- one needing global, random access to a single array
 larger than a node. Neither chunking nor distribution helps there, and the
 answer is to restructure the computation. Analysis work is mostly reductions
-over dimensions that partition cleanly, so this should be rare; if the
-measurement turns one up, it is worth examining on its own rather than
+over dimensions that partition cleanly, so this should be rare; if one turns
+up, it is worth examining on its own rather than
 treating as a requirement on the framework.
 
 Success in Phase C means a Python step can distribute work across more than

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -159,6 +159,20 @@ per-step total -- but the pool has to account for it, and a step that
 distributes GPU work should not have GPUs reserved on the node its driver
 happens to sit on.
 
+This phase is also where one open question from Phase A stops being
+harmless. On PBS with PALS, a launch that needs no GPUs is given an empty
+vendor visibility variable, and whether the runtime reads that as "no
+devices" or as "no mask, every device" has not been established -- a clean
+Aurora run does not settle it, because there the check reads back the same
+value the launcher wrote. Through Phase A and Phase B it does not matter:
+nothing on PALS reserves GPUs, so concurrency is unaffected either way and
+the worst case is a step seeing hardware it said it did not want. Here,
+where several workers on one node may each be assigned different devices,
+whether that assignment confines anything is the difference between
+isolation and two workers quietly sharing a device. It should be answered
+before pool workers are given GPUs on that machine, and answering it takes
+two commands in an allocation rather than any machinery.
+
 Reading the bound off "is it an MPI step" instead would have made this phase
 begin by undoing a rule, which is why the property exists ahead of anything
 that sets it.

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -40,13 +40,44 @@ If that shows analysis tasks are coarse -- minutes each, tens of them -- then
 Phase B already handles them and Phase C reduces to writing analysis steps
 that declare their resources properly. If it shows they are fine-grained --
 seconds each, hundreds or thousands -- then a pool is necessary and this
-phase proceeds as written. If it shows the largest single task does not fit
-in one node's memory, then the constraint is not concurrency at all, and the
-right response is out-of-core computation rather than more nodes.
+phase proceeds as written.
 
-This document is written for the middle case because it is the one the
+This document is written for the second case because it is the one the
 existing evidence points at, but the numbers that would size the pool are
 deliberately left unset. They should come from measurement.
+
+### A task larger than one node
+
+Nothing here restricts a step to a single node, and the design should not
+acquire that restriction by accident.
+
+Polaris already runs steps that span nodes: every MPI model run does. What
+is bounded to one node is a **non-MPI step running in its own process**, as
+in Phase B -- that is a property of processes, not a decision Polaris made.
+
+For the pool, a computation whose data exceed one node's memory is not a
+separate problem needing separate machinery. Working in chunks and spreading
+those chunks across the workers' combined memory are the same facility, and
+a pool built on a distributed array framework provides both. A step that
+needs more memory than one node has can take a lease spanning several and
+work across their combined memory, using the same submit-and-collect
+interface as any other step.
+
+The cost is not zero: moving data between nodes is slower than staying
+within one, the work has to be written in terms of array operations the
+framework can partition rather than as monolithic in-memory arrays, and
+diagnosing a distributed computation is harder than a local one. So this
+should not be the assumed shape of every analysis step, and no step should
+be written to span nodes before measurement shows it needs to. But it should
+be available, and the requirements below are written so that it is.
+
+The case that genuinely stays hard is a computation that cannot be
+partitioned at all -- one needing global, random access to a single array
+larger than a node. Neither chunking nor distribution helps there, and the
+answer is to restructure the computation. Analysis work is mostly reductions
+over dimensions that partition cleanly, so this should be rare; if the
+measurement turns one up, it is worth examining on its own rather than
+treating as a requirement on the framework.
 
 Success in Phase C means a Python step can distribute work across more than
 one node, that this is faster than the same work on one node, and that
@@ -69,6 +100,13 @@ one node of the allocation.
 This is the requirement that distinguishes Phase C from what MPAS-Analysis
 can already do. A capability limited to a single node would not address the
 problem that motivates the phase.
+
+This covers two things that should not be conflated: many independent pieces
+of work running at once on different nodes, and a single computation whose
+data are spread across the memory of several nodes. Both shall be possible.
+The second is not expected to be common, but designing it out would be a
+mistake, and a pool built on a distributed array framework gives it without
+additional machinery.
 
 ### Requirement: The Pool Occupies a Known Share
 

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -1,0 +1,330 @@
+# Task Parallelism Phase C: Python Worker Pool
+
+Creation date: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+## Summary
+
+Phase B runs each step in its own process. That is the right unit for a
+Polaris step, which typically does minutes of work. It is the wrong unit for
+work made of many small pieces: if a piece takes two seconds, spending a
+second starting a process for it wastes half the machine.
+
+Phase C adds a second executor for that case: a pool of worker processes,
+spread across the allocation's nodes, that a step can send many small pieces
+of work to.
+
+The motivating workload is analysis. Polaris is to gain analysis capability
+equivalent to MPAS-Analysis, and MPAS-Analysis already does this kind of
+work in parallel -- but with Python's `multiprocessing`, which cannot reach
+beyond one node. At high resolution, which is Omega's target, one node is not
+enough. Lifting that ceiling is the point of this phase.
+
+Phase C stands on Phase A and Phase B. The pool occupies a defined part of
+the allocation, so ordinary steps continue to run in the rest; the
+scheduler from Phase B accounts for the pool's share as it would any other
+reservation. Making that share change as the amount of Python work changes is
+Phase D.
+
+### This phase may turn out to be unnecessary in its current form
+
+Whether a pool is needed at all is an empirical question, and the measurement
+is not yet in. We are instrumenting a high-resolution MPAS-Analysis run for
+per-task duration, peak memory and dependency-graph width.
+
+If that shows analysis tasks are coarse -- minutes each, tens of them -- then
+Phase B already handles them and Phase C reduces to writing analysis steps
+that declare their resources properly. If it shows they are fine-grained --
+seconds each, hundreds or thousands -- then a pool is necessary and this
+phase proceeds as written. If it shows the largest single task does not fit
+in one node's memory, then the constraint is not concurrency at all, and the
+right response is out-of-core computation rather than more nodes.
+
+This document is written for the middle case because it is the one the
+existing evidence points at, but the numbers that would size the pool are
+deliberately left unset. They should come from measurement.
+
+Success in Phase C means a Python step can distribute work across more than
+one node, that this is faster than the same work on one node, and that
+results are unchanged.
+
+## Requirements
+
+### Requirement: Python Work Across More Than One Node
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A step shall be able to distribute Python work across workers on more than
+one node of the allocation.
+
+This is the requirement that distinguishes Phase C from what MPAS-Analysis
+can already do. A capability limited to a single node would not address the
+problem that motivates the phase.
+
+### Requirement: The Pool Occupies a Known Share
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The pool shall be confined to a defined set of resources, and the scheduler
+shall know about that reservation.
+
+An earlier attempt launched a worker pool without bounding it, which claimed
+the whole allocation and prevented model runs from starting at all. With
+Phase A the pool is placed like anything else, and the scheduler simply sees
+fewer free resources while it exists.
+
+### Requirement: Steps Ask for Workers Explicitly
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A step shall have to opt in to using the pool, and shall declare how many
+workers it wants and needs.
+
+Ordinary steps shall continue to run as their own process, as in Phase B.
+Adding a pool shall not change how any existing step runs.
+
+### Requirement: Work Sent to the Pool Must Be Safe to Run There
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Work dispatched to a worker shall not depend on process state that the worker
+does not have, and shall not disturb state that other work in the same worker
+relies on.
+
+A worker process runs many pieces of work over its lifetime, possibly
+several at once, and never ran the setup that a fresh Polaris process runs.
+Work that changes the working directory, sets a library-level default or
+writes to a shared path is unsafe there in a way it is not unsafe in its own
+process.
+
+The properties this requires are set out in
+`docs/design_docs/task_parallel_analysis_steps.md`, which should be adopted
+before analysis steps are written. Phase C depends on those rules being
+followed; it cannot enforce them after the fact.
+
+### Requirement: Failures Are Attributable
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+When work sent to the pool fails, it shall be clear which piece of work
+failed and why, and the failure shall be reported as a failure of the step
+that submitted it.
+
+A worker that dies shall not silently reduce the pool. Losing workers
+quietly turns a crash into a mysterious slowdown.
+
+### Requirement: The Pool's Cost Is Visible
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The time spent starting and stopping the pool, and the resources it held
+while idle, shall be recorded.
+
+A pool is only worth having if the work it enables outweighs what it costs.
+Earlier measurements found a worker pool spending around 9% of a suite's wall
+time on its own lifecycle, which is the sort of thing that must be visible
+rather than inferred.
+
+## Algorithm Design
+
+### Algorithm Design: What the Pool Is
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The pool is a set of worker processes, at least one per node it spans, started
+once and reused. A step that opts in is given a handle to it and a lease
+saying how many workers it may use, submits pieces of work, and collects
+results.
+
+Starting the pool is a single launch, confined by Phase A placement. That is
+important for two reasons: it is one launch rather than one per piece of
+work, which is the whole point of pooling; and being confined means the rest
+of the allocation stays usable.
+
+Dask Distributed is the natural implementation. It is what the scientific
+Python ecosystem uses for this, it is what MPAS-Analysis's xarray-based work
+would already be at home in, and earlier Polaris work established that it can
+be started across an allocation's nodes. The design should not depend on that
+choice: what a step sees should be "submit work, get results", so the
+underlying mechanism can be replaced.
+
+### Algorithm Design: Sizing the Pool
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The pool should be sized from the work that is ready to run, not from the
+allocation. If three analysis steps are ready and together they want twelve
+workers, twelve is the number, regardless of how many nodes are free.
+
+Phase C may size the pool once, when the first step that needs it runs, and
+keep it until the run ends. That is simple and adequate while Python work is
+a small part of a suite. It is also the thing Phase D fixes, because a pool
+sized once holds its share even after the Python work is finished.
+
+The numbers that make this concrete -- how many workers, how much memory each
+-- depend on the analysis measurement described above.
+
+### Algorithm Design: Two Executors, One Scheduler
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The scheduler from Phase B does not change shape. It still decides what may
+run and what resources each thing gets. What changes is that a step may be
+executed in one of two ways: as its own process, or, if it opted in, by being
+given the pool.
+
+Keeping the decision "what runs next" separate from "how it is executed" is
+what prevents the scheduler from acquiring the mode-switching complexity that
+made the earlier attempt hard to reason about.
+
+## Implementation
+
+### Implementation: Pool Lifecycle
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+- a module owning the pool: starting it with a placement, handing out
+  leases, shutting it down, and reporting its cost;
+- a step hook -- a separate method from `run()` -- through which a step
+  receives the pool and its lease. Keeping it separate means the meaning of
+  `run()` is unchanged for every existing step.
+
+The pool must be shut down cleanly at the end of a run, including when the
+run fails, or its workers outlive the job.
+
+### Implementation: Worker Environment
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A worker process starts without any of the setup a Polaris process performs.
+Anything the work needs must travel with it. Earlier work discovered this the
+hard way: NetCDF output settings were configured in the main process, so work
+running in workers silently wrote files in a different format, which showed
+up as a step taking fifty seconds instead of ten.
+
+Rather than replicating Polaris's startup inside each worker, the work sent
+to a worker should carry what it needs. This is the same discipline the
+analysis groundrules require, and it is the reason those rules matter more
+here than anywhere else.
+
+## Testing
+
+### Testing and Validation: Multi-Node Distribution
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A test shall submit work to the pool and verify from the results which node
+each piece ran on, confirming that more than one node was used. This is the
+central claim of the phase and should be checked directly rather than
+inferred from timing.
+
+### Testing and Validation: Safety of Work Sent to Workers
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Tests shall include work that deliberately violates the rules -- changes the
+working directory, mutates a library default, writes outside its work
+directory -- and confirm the conformance checks catch it.
+
+A test shall run two pieces of work in one worker at the same time and
+confirm that neither affects the other's results.
+
+### Testing and Validation: Failure Handling
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Tests shall cover work that raises, work that exits the worker process
+outright, and a worker lost mid-run. In each case the submitting step shall
+fail with an attributable error, and the run shall not hang.
+
+### Testing and Validation: Is It Worth It
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Validation shall compare the same analysis workload run three ways: as
+ordinary Phase B steps, through the pool on one node, and through the pool on
+several. The comparison shall include the pool's own lifecycle cost.
+
+If the pool does not beat Phase B steps on the real workload, that is a
+finding, and it should be recorded rather than worked around. The measurement
+that decides this is the same instrumented MPAS-Analysis run that sizes the
+pool.

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -52,8 +52,20 @@ Nothing here restricts a step to a single node, and the design should not
 acquire that restriction by accident.
 
 Polaris already runs steps that span nodes: every MPI model run does. What
-is bounded to one node is a **non-MPI step running in its own process**, as
-in Phase B -- that is a property of processes, not a decision Polaris made.
+is bounded to one node is a **non-MPI step running in its own process** --
+that is a property of processes, not a decision Polaris made. A step that
+hands its work to the pool is not in that category, because the pool is
+precisely the mechanism such a step lacks.
+
+Phase A provides the property this turns on: a step declares whether its
+cores may be drawn from more than one node, defaulting to no. A step using
+the pool declares that they may, and this phase is where anything first
+does. Its cores are then a reservation rather than a placement, in the sense
+Phase A draws: Polaris launches the step's driver, which needs about one
+core, and accounts the rest against the pool's share of the allocation.
+Reading the bound off "is it an MPI step" instead would have made this phase
+begin by undoing a rule, which is why the property exists ahead of anything
+that sets it.
 
 For the pool, a computation whose data exceed one node's memory is not a
 separate problem needing separate machinery. Working in chunks and spreading
@@ -250,6 +262,15 @@ wrongly, the symptom is workers dying and work silently retrying, which
 reads as a mysterious slowdown. Worker memory limits must be derived from
 the resources the pool was actually given, and worker restarts must be
 reported, not absorbed.
+
+This is the case the memory declaration introduced in Phase A exists for.
+The pool's memory is the memory its steps declared, divided among its
+workers, and it must be taken from the declaration rather than inferred from
+the worker count: the analysis steps this phase is for are the ones whose
+memory bears no fixed relation to their cores, and deriving one from the
+other gets them wrong in the direction that hurts. Steps that reach this
+phase should be carrying measured figures rather than the proportional
+default, which is what the measurement described above is for.
 
 **Large results should not travel back through the pool.** Analysis tasks
 that produce files should write them and return paths. Returning large

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -58,10 +58,9 @@ in Phase B -- that is a property of processes, not a decision Polaris made.
 For the pool, a computation whose data exceed one node's memory is not a
 separate problem needing separate machinery. Working in chunks and spreading
 those chunks across the workers' combined memory are the same facility, and
-a pool built on a distributed array framework provides both. A step that
-needs more memory than one node has can take a lease spanning several and
-work across their combined memory, using the same submit-and-collect
-interface as any other step.
+the distributed-array layer that provides it sits on the same pool. A step
+that needs more memory than one node has can take a lease spanning several
+and work across their combined memory.
 
 The cost is not zero: moving data between nodes is slower than staying
 within one, the work has to be written in terms of array operations the
@@ -105,8 +104,8 @@ This covers two things that should not be conflated: many independent pieces
 of work running at once on different nodes, and a single computation whose
 data are spread across the memory of several nodes. Both shall be possible.
 The second is not expected to be common, but designing it out would be a
-mistake, and a pool built on a distributed array framework gives it without
-additional machinery.
+mistake, and it comes without additional machinery from the same framework
+that provides the first.
 
 ### Requirement: The Pool Occupies a Known Share
 
@@ -218,12 +217,58 @@ important for two reasons: it is one launch rather than one per piece of
 work, which is the whole point of pooling; and being confined means the rest
 of the allocation stays usable.
 
-Dask Distributed is the natural implementation. It is what the scientific
-Python ecosystem uses for this, it is what MPAS-Analysis's xarray-based work
-would already be at home in, and earlier Polaris work established that it can
-be started across an allocation's nodes. The design should not depend on that
-choice: what a step sees should be "submit work, get results", so the
-underlying mechanism can be replaced.
+Dask Distributed is the natural implementation. What matters for Polaris is
+that its core is a **general task scheduler**, not an array library: a step
+submits arbitrary Python callables and collects results, and can say which
+workers a piece of work may run on and what resources it needs. Distributed
+arrays are one thing built on top of that scheduler, available when a step
+wants them, and irrelevant when it does not. The primary use here is the
+general form -- many independent analysis tasks -- and the design should be
+read that way.
+
+Earlier Polaris work established that such a pool can be started across an
+allocation's nodes. The design should not depend on the choice of framework:
+what a step sees should be "submit work, get results", so the underlying
+mechanism can be replaced.
+
+### Algorithm Design: Where a Pool Disappoints
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The risks in adopting a pool are operational rather than conceptual, and are
+worth naming so they are designed for rather than discovered.
+
+**Worker memory is managed by the pool, not by the batch system.** Workers
+spill, pause and eventually restart themselves when they approach their
+memory limit. If a step's tasks are memory-hungry and the limits are set
+wrongly, the symptom is workers dying and work silently retrying, which
+reads as a mysterious slowdown. Worker memory limits must be derived from
+the resources the pool was actually given, and worker restarts must be
+reported, not absorbed.
+
+**Large results should not travel back through the pool.** Analysis tasks
+that produce files should write them and return paths. Returning large
+arrays moves them across the network and through the process that
+coordinates the pool, which is the classic way to turn a fast distributed
+computation into a slow one.
+
+**Pure-Python work needs separate processes, not threads.** A worker that
+runs several tasks as threads will serialize anything holding Python's
+global interpreter lock. Work that is numerical and releases the lock is
+fine; work that is Python-level loops is not. The pool's shape -- how many
+worker processes, how many threads each -- must follow from what the tasks
+actually do.
+
+**There is a floor on useful task size.** Each task carries a small
+scheduling cost. It is far below the duration of any realistic analysis
+task, so it should not matter here, but it is the reason a pool is the wrong
+answer for very short work and worth confirming against the measured task
+durations rather than assumed.
 
 ### Algorithm Design: Sizing the Pool
 

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -58,11 +58,19 @@ hands its work to the pool is not in that category, because the pool is
 precisely the mechanism such a step lacks.
 
 Phase A provides the property this turns on: a step declares whether its
-cores may be drawn from more than one node, defaulting to no. A step using
-the pool declares that they may, and this phase is where anything first
-does. Its cores are then a reservation rather than a placement, in the sense
-Phase A draws: Polaris launches the step's driver, which needs about one
-core, and accounts the rest against the pool's share of the allocation.
+resources may be drawn from more than one node, defaulting to no. A step
+using the pool declares that they may, and this phase is where anything
+first does. Its cores are then a reservation rather than a placement, in the
+sense Phase A draws: Polaris launches the step's driver, which needs about
+one core, and accounts the rest against the pool's share of the allocation.
+
+The property covers GPUs on the same terms, and this is where that matters.
+A pool whose workers use GPUs draws them from the nodes those workers are
+on, so a step's GPU count is a claim against the pool exactly as its core
+count is. Nothing extra is needed to express it -- `gpus` is already a
+per-step total -- but the pool has to account for it, and a step that
+distributes GPU work should not have GPUs reserved on the node its driver
+happens to sit on.
 Reading the bound off "is it an MPI step" instead would have made this phase
 begin by undoing a rule, which is why the property exists ahead of anything
 that sets it.

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -30,21 +30,108 @@ scheduler from Phase B accounts for the pool's share as it would any other
 reservation. Making that share change as the amount of Python work changes is
 Phase D.
 
-### This phase may turn out to be unnecessary in its current form
+### What the measurement showed
 
-Whether a pool is needed at all is an empirical question, and the measurement
-is not yet in. We are instrumenting a high-resolution MPAS-Analysis run for
-per-task duration, peak memory and dependency-graph width.
+Whether a pool is needed at all was an empirical question, and it has been
+answered. A high-resolution MPAS-Analysis run was instrumented for per-task
+duration, peak memory and dependency-graph width, and run cold on one node:
+1231 tasks, none failed, 7h29m.
 
-If that shows analysis tasks are coarse -- minutes each, tens of them -- then
-Phase B already handles them and Phase C reduces to writing analysis steps
-that declare their resources properly. If it shows they are fine-grained --
-seconds each, hundreds or thousands -- then a pool is necessary and this
-phase proceeds as written.
+The question this phase turned on was whether analysis work is coarse --
+minutes each, tens of them, in which case Phase B already handles it -- or
+fine-grained, in which case a pool is needed. It is fine-grained. The median
+task is 5.2 seconds and 49% run in under five, at the resolution that
+matters. This document proceeds as written.
 
-This document is written for the second case because it is the one the
-existing evidence points at, but the numbers that would size the pool are
-deliberately left unset. They should come from measurement.
+Two of that measurement's headline numbers should not be carried into this
+design without their qualification, and the qualification is the same for
+both.
+
+**The measured ceiling on what more nodes could buy was 1.29x, and it is a
+statement about three particular tasks.** The run's critical path was 5h49m
+of a 7h29m makespan, and a single transect-remapping task was 82% of it;
+three such tasks are the whole tail. They are known not to be written for
+high resolution, and they are among the things Polaris would reimplement
+rather than inherit. Taking the reported figures at face value, and assuming
+the three are independent rather than chained, removing the largest raises
+the ceiling from about 6.5x to about 11x and removing all three to about
+36x. Those are arithmetic on someone else's summary rather than a
+reanalysis, so they should be read as an order of magnitude. The conclusion
+that survives is directional and sufficient: the measured headroom is a
+lower bound taken on the least favorable available version of the workload,
+not an estimate of what task parallelism is worth.
+
+**The reported narrowing of the dependency graph with resolution is the same
+finding again, not a second one.** Mean graph width, as reported, is
+arithmetically serial work divided by critical path -- which is the speedup
+ceiling. Both runs confirm it: 2255 minutes over 349 gives 6.46 against a
+reported width of 6.5, and the low-resolution run gives 30.4 against a
+reported 30. So "the graph got narrower as resolution rose" restates the
+serial tail and inherits its fragility. The structural comparison is peak
+width, which went from 251 to 170 -- a modest narrowing rather than a
+collapse. This matters because an intrinsically narrow graph would be a real
+argument against this phase, and the evidence does not support one.
+
+### What the measurement showed about memory
+
+The memory result is the one that bears on how a pool is built, and it
+arrived in two parts, the second correcting the first.
+
+Every task in that run inherited 7.85 GiB by forking. Taken at face value
+that is an argument for a pool on memory grounds alone -- 26 times the
+median task's own data, unaffordable per task and cheap per worker,
+independent of how long tasks run. Measured directly, the baseline splits
+into **0.40 GiB of Python imports and 7.45 GiB of data loaded before
+forking**. The import half is identical at both resolutions; the data half
+scales with the problem, which is what identifies it.
+
+Only the 0.40 GiB generalizes. It is a property of the scientific Python
+stack rather than of any workload, and every worker in any pool pays it. The
+7.45 GiB was an artifact of one program loading its inputs in a parent
+process and forking, which a reimplementation does not inherit.
+
+So the pool is still the right shape, but the reason has to be stated
+correctly rather than at its most convenient. Paying interpreter start and
+0.40 GiB of imports once per worker instead of once per task is worth it
+against a 5.2 second median; that is a claim about startup cost, and it does
+depend on the duration distribution. The stronger memory argument does not
+survive its own measurement.
+
+The correction matters a second time. Because those tasks *inherited* their
+inputs, the per-task memory figures exclude them, so they are not what a
+worker holding its own inputs would need. What a worker needs is imports,
+plus whatever of the shared inputs its work actually touches, plus its own
+data -- and the middle term was never measured because forking made it free.
+
+### Sizing a pool, and what not to assume while doing it
+
+The question that sizes a pool is therefore **how much read-only input a
+step needs resident**, and it is deliberately phrased that way rather than
+in terms of any particular kind of input. If steps can work on subsets,
+memory stops binding and a pool is limited by cores. If each step needs all
+of it, the same node supports far fewer workers than it has cores. Polaris
+can measure this as soon as it has one real step of the kind, and should,
+before choosing a pool size.
+
+Two things follow that are easy to get wrong in opposite directions.
+
+**The pool must not be designed around a shared dataset.** Analysis happens
+to be a workload where many tasks read from one large input, and it is
+tempting to build for that. Most Polaris workflows have no such thing, and a
+pool that assumes one -- in how it starts workers, in how it accounts for
+their memory, or in what it expects a task to be given -- would be a pool
+that serves one purpose well and the general case badly. Task parallelism is
+the general facility; analysis is its first demanding customer, not its
+specification.
+
+**But a worker's memory should not be assumed private either.** Where many
+tasks on a node do read the same large input, holding one copy per node
+rather than one per worker is the distributed equivalent of what forking
+gives for free, and the difference is large enough to change how many
+workers fit. This is worth leaving room for and is not worth building now:
+nothing has been measured that needs it, and the measurement that would
+justify it is the one described above. It is recorded here so that it is not
+rediscovered late, and so that nothing in the pool's design forecloses it.
 
 ### A task larger than one node
 
@@ -278,7 +365,9 @@ the worker count: the analysis steps this phase is for are the ones whose
 memory bears no fixed relation to their cores, and deriving one from the
 other gets them wrong in the direction that hurts. Steps that reach this
 phase should be carrying measured figures rather than the proportional
-default, which is what the measurement described above is for.
+default. What a step declares is what it will hold resident -- its own data
+and whatever of its inputs it keeps -- and not what an equivalent forking
+program would have needed, which is smaller for the reason given above.
 
 **Large results should not travel back through the pool.** Analysis tasks
 that produce files should write them and return paths. Returning large
@@ -318,7 +407,11 @@ a small part of a suite. It is also the thing Phase D fixes, because a pool
 sized once holds its share even after the Python work is finished.
 
 The numbers that make this concrete -- how many workers, how much memory each
--- depend on the analysis measurement described above.
+-- follow from how much read-only input a step needs resident, which is the
+open question stated above and which Polaris can answer with one real step
+of the kind. Until it is answered, a pool should be sized from what its
+steps declare and should report what it chose, rather than carrying a
+default that would be a guess dressed as a number.
 
 ### Algorithm Design: Two Executors, One Scheduler
 
@@ -437,6 +530,13 @@ ordinary Phase B steps, through the pool on one node, and through the pool on
 several. The comparison shall include the pool's own lifecycle cost.
 
 If the pool does not beat Phase B steps on the real workload, that is a
-finding, and it should be recorded rather than worked around. The measurement
-that decides this is the same instrumented MPAS-Analysis run that sizes the
-pool.
+finding, and it should be recorded rather than worked around.
+
+The measurement already in hand does not decide this, and it is worth being
+clear about why. It was taken on one program, on one node, using fork, with
+a critical path dominated by tasks that would be rewritten before they ever
+ran here. It establishes that the work is fine-grained and that a worker's
+resident inputs are the quantity to watch. It does not establish what a pool
+is worth, because the version of the workload that would run under one does
+not exist yet. The comparison has to be made against Polaris's own steps,
+and this phase should not claim a speedup it has not measured on them.

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -159,19 +159,38 @@ per-step total -- but the pool has to account for it, and a step that
 distributes GPU work should not have GPUs reserved on the node its driver
 happens to sit on.
 
-This phase is also where one open question from Phase A stops being
-harmless. On PBS with PALS, a launch that needs no GPUs is given an empty
-vendor visibility variable, and whether the runtime reads that as "no
-devices" or as "no mask, every device" has not been established -- a clean
-Aurora run does not settle it, because there the check reads back the same
-value the launcher wrote. Through Phase A and Phase B it does not matter:
-nothing on PALS reserves GPUs, so concurrency is unaffected either way and
-the worst case is a step seeing hardware it said it did not want. Here,
-where several workers on one node may each be assigned different devices,
-whether that assignment confines anything is the difference between
-isolation and two workers quietly sharing a device. It should be answered
-before pool workers are given GPUs on that machine, and answering it takes
-two commands in an allocation rather than any machinery.
+This phase is also where a limitation carried harmlessly through Phase A and
+Phase B stops being harmless. On PBS with PALS, a launch that needs no GPUs
+is given an empty vendor visibility variable, and it has now been measured
+that the runtime reads an empty value as "no mask", meaning every device. So
+the explicit "no GPUs" is a no-op there: a worker that declares no GPUs on
+that machine can still see all of them.
+
+Through Phase A and Phase B this costs nothing, because nothing on PALS
+reserves GPUs and the worst case is a step seeing hardware it declined. Here
+it splits into two cases that behave differently, and only one of them
+works.
+
+A worker assigned *some* devices is confined: a mask naming a subset was
+measured to do exactly that. A worker assigned *no* devices is not confined
+at all. So a pool mixing GPU and CPU-only workers on one node gets isolation
+between the GPU workers and none for the CPU-only ones, which is the
+opposite of the intuition that asking for nothing is the safe case.
+
+A candidate fix is to name an out-of-range device rather than an empty
+value. It is untested, and should be tested rather than assumed: the runtime
+may equally refuse it, warn, or fall back to every device. It is one launch
+on the pattern that answered the first question.
+
+One further thing is unestablished and matters more here than anywhere else.
+That machine's configuration describes twelve GPUs per node, which are
+tiles, while the runtime presents six cards under the device hierarchy it
+runs with; a mask naming three tiles yielded two devices, which is
+consistent. What has not been tried is a mask naming a *single* tile, which
+is the unit a scheduler handing out twelve of them would actually assign.
+Whether two workers masked to different tiles of the same card are isolated
+from each other, or merely both see that card, is the question this phase
+rests on, and it is not answered by what has been measured so far.
 
 Reading the bound off "is it an MPI step" instead would have made this phase
 begin by undoing a rule, which is why the property exists ahead of anything

--- a/docs/design_docs/task_parallelism_phase_c.md
+++ b/docs/design_docs/task_parallelism_phase_c.md
@@ -301,9 +301,10 @@ writes to a shared path is unsafe there in a way it is not unsafe in its own
 process.
 
 The properties this requires are set out in
-*Task-Parallel-Safe Analysis Steps in Polaris*, which should be adopted
-before analysis steps are written. Phase C depends on those rules being
-followed; it cannot enforce them after the fact.
+[Task-Parallel-Safe Analysis Steps in Polaris](task_parallel_analysis_steps.md),
+which should be adopted before analysis steps are written, and are written
+up for step authors under {ref}`dev-task-parallelism`. Phase C depends on
+those rules being followed; it cannot enforce them after the fact.
 
 ### Requirement: Failures Are Attributable
 

--- a/docs/design_docs/task_parallelism_phase_d.md
+++ b/docs/design_docs/task_parallelism_phase_d.md
@@ -1,0 +1,267 @@
+# Task Parallelism Phase D: Coexistence and Elasticity
+
+Creation date: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+## Summary
+
+Phase C gives the worker pool a fixed share of the allocation for the life of
+the run. That is simple, and it is wrong in one specific way: once the Python
+work is finished, the pool goes on holding its share, and those nodes sit
+idle while model runs queue for resources that are right there.
+
+Phase D makes the pool's share change with the work. When Python work is
+ready, the pool grows; when it drains, the pool gives nodes back and ordinary
+steps use them.
+
+This is the phase that makes a mixed suite -- model runs and analysis in the
+same job -- use the machine properly. It is also the phase most likely to be
+unnecessary, and that should be tested before it is built: if suites in
+practice do their analysis at the end, after the model runs are done, then a
+pool that appears late and holds resources until the job ends costs nothing,
+and Phase D is optimisation without a problem to solve.
+
+Success in Phase D means a suite mixing model runs and analysis finishes in
+close to the time the work itself requires, with no long stretch where part
+of the allocation is reserved but idle.
+
+## Requirements
+
+### Requirement: The Pool Gives Resources Back
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+When there is less ready Python work than the pool is sized for, the pool
+shall shrink and the freed resources shall become available to other steps.
+
+When the Python work is finished entirely, the pool shall release everything.
+
+### Requirement: The Pool Grows When Needed
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+When ready Python work exceeds what the current pool can handle, and
+resources are free, the pool shall grow.
+
+Growing shall not take resources from steps that are already running.
+
+### Requirement: Changes Are Not Constant
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The pool shall not resize continuously in response to small fluctuations.
+
+Adding and removing workers is not free. An earlier design that switched
+execution modes at every opportunity spent a significant fraction of its
+wall time doing so. The scheduler shall require a change to be worth making
+before making it.
+
+### Requirement: A Rule for Competing Work
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+When ready model steps and ready Python work both want the same free
+resources, Polaris shall apply a stated rule rather than whichever the loop
+happens to reach first.
+
+The rule shall be simple enough to explain in a sentence and shall be
+recorded in the run's event stream when it is applied, so that a schedule
+that looks wrong can be understood.
+
+### Requirement: Resizing Is Safe
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Shrinking the pool shall not interrupt work already running on the workers
+being removed.
+
+A worker shall be allowed to finish what it holds before it is stopped, and
+the resources it occupied shall not be offered to another step until it has
+actually gone.
+
+### Requirement: Elasticity Is Visible
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Every resize shall be recorded, with what triggered it and what it cost, and
+the run summary shall report how much of the allocation was idle and for how
+long.
+
+Idle time is the quantity this phase exists to reduce, so it must be
+measurable before and after.
+
+## Algorithm Design
+
+### Algorithm Design: Deciding the Size
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The scheduler already holds the dependency graph, so it knows not only what
+Python work is ready now but how much is still to come. The pool's target
+size should be the number of workers the ready Python work can actually use,
+capped by what the allocation can spare.
+
+Resizing should happen in whole nodes. A pool spanning three nodes releasing
+"half a node" leaves a fragment too small to run a model step in, which is
+the shape of free resource that looks available and is useless.
+
+Two guards keep this from thrashing. A change should have to be worth more
+than it costs -- the cost being one launch per node added, which measurement
+puts at a fraction of a second to a second -- and a resize should not be
+followed immediately by its opposite.
+
+### Algorithm Design: When Both Kinds of Work Are Waiting
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+The rule proposed is: **prefer the work on the critical path, and break ties
+in favour of model steps.**
+
+Model steps tend to be longer and to have more work depending on them, so
+starting one late delays more. Python work tends to be shorter and more
+plentiful, which makes it good for filling gaps. The scheduler can estimate
+the critical path from the graph, so this is not guesswork.
+
+This is a proposal, not a conclusion. It should be revisited once there is a
+real mixed suite to measure, and the alternative -- simple first-ready
+ordering -- should be measured against it rather than assumed worse.
+
+### Algorithm Design: Shrinking Without Interrupting
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Shrinking should be cooperative: mark the workers to be removed as accepting
+no new work, wait for what they hold to finish, then stop them and return
+their resources to the pool. The scheduler must not count those resources as
+free until the workers have actually exited, or it will place a step on top
+of one still shutting down.
+
+## Implementation
+
+### Implementation: What Changes
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Phase D changes the pool module from Phase C and the scheduler loop from
+Phase B, and adds nothing structurally new:
+
+- the pool gains grow and drain operations, and a notion of workers that are
+  finishing but not yet gone;
+- the resource pool distinguishes resources that are free from resources that
+  will be free shortly;
+- the scheduler consults a target pool size each time round the loop, and
+  applies the competing-work rule when both kinds are ready.
+
+### Implementation: Order of Work
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Shrinking should be implemented before growing. Shrinking is what recovers
+the idle resources that motivate the phase; growing is an optimisation on top
+of it, and a pool that only ever shrinks is still correct.
+
+## Testing
+
+### Testing and Validation: Resize Behavior
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Tests with synthetic work shall cover: Python work draining to nothing, and
+the pool releasing everything; Python work appearing when the pool is at zero;
+a burst of work followed immediately by a lull, which shall not produce a
+resize followed by its opposite; and a shrink while work is still running,
+which shall wait for it.
+
+### Testing and Validation: Idle Time
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+A mixed synthetic suite -- model-like steps and Python-like work,
+interleaved so that a fixed pool would clearly waste resources -- shall be run
+with a fixed pool and with an elastic one. Total allocation-seconds idle
+shall fall, and results shall be identical.
+
+This test is also what decides whether Phase D is worth building at all. It
+should be written first, run against Phase C, and the answer recorded.
+
+### Testing and Validation: Real Mixed Workload
+
+Date last modified: 2026/08/23
+
+Contributors:
+
+- Xylar Asay-Davis
+- Claude
+
+Once a real suite exists that mixes model runs and analysis, it shall be run
+with a fixed and an elastic pool and the wall times compared, on at least one
+Slurm and one PBS machine.


### PR DESCRIPTION
Design documents for task parallelism in Polaris, as four phases that are each independently useful:

- **Phase A — Placement.** Run a step on a named part of the allocation, and let steps declare what they need. No concurrency; Polaris still runs one step at a time and produces identical results.
- **Phase B — Concurrency.** A scheduler that runs independent steps at once, each in its own process.
- **Phase C — A worker pool.** A second executor for Python work too fine-grained to give a process of its own. This is what lifts the single-node ceiling that constrains MPAS-Analysis today.
- **Phase D — Coexistence and elasticity.** Let the pool and ordinary steps share an allocation, and let the pool grow and shrink.

Most of the Phase A work is in `mache`, which owns how Polaris launches parallel work. That landed as [mache #470](https://github.com/E3SM-Project/mache/pull/470), released as mache 3.12.0.

## The design rests on measurement, and the measurements are in the documents

Placement was verified on Chrysalis, Perlmutter CPU and GPU, Frontier and Aurora, first with commands written by hand and then with the commands `mache` actually renders. That second round found two real defects, both fixed in `mache`: PALS rejects `--env-remove`, which stopped every placed launch on Aurora, and a `gpu_bind` of `none` alongside an explicit GPU request left three of four concurrent launches on Perlmutter GPU with no GPU at all, exiting zero.

The results live in the umbrella document rather than in the harnesses that produced them, deliberately: a harness built to answer a question is not part of what Polaris ships, and an earlier version of these documents pointed at a README on a branch that was never going to merge.

## Several conclusions changed on evidence, and the documents say so

Worth knowing before reading, because the reasoning reverses in places:

- **Memory is enforced on newer Slurm**, contradicting the original assumption that a memory request is inert. Polaris will therefore cap a step that *declared* a figure and never one carrying the framework's proportional default — capping a guess would make every step carry a measured number before it could run.
- **An empty `ZE_AFFINITY_MASK` hides nothing.** Level Zero reads it as "no mask", so `mache`'s explicit "no GPUs" on PALS is a no-op. Harmless through Phases A and B; an isolation question in Phase C.
- **One finding was withdrawn.** An apparent memory heterogeneity on Perlmutter CPU turned out to be a mislabelled run — a Perlmutter *GPU* node recorded under the wrong machine name. Aurora, by contrast, is genuinely heterogeneous, from a survey of all 10,624 nodes. The documents argue both, and the distinction is which was a sample and which was a survey.

## Not in this PR

No implementation. Phase A's code is a separate branch and will rebase onto this once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
