### PR TITLE
Add `validate_vars` to the mesh and topography steps

### DIFF
--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -49,6 +49,31 @@ _RECONSTRUCTION_INPUT_VARS: dict[ReconstructionType, tuple[str, ...]] = {
 }
 
 
+def get_reconstruction_validate_vars(
+    location: ReconstructionType = 'cell',
+) -> list[str]:
+    """
+    Get the variables in a reconstruction-weights file that should be
+    compared against a baseline
+
+    Parameters
+    ----------
+    location : {'cell', 'vertex'}, optional
+        The location the reconstruction weights were computed at
+
+    Returns
+    -------
+    validate_vars : list of str
+        The names of the reconstruction variables at ``location``
+    """
+    field_names = _RECONSTRUCTION_FIELD_NAMES[location]
+    return [
+        field_names['n_edges'],
+        field_names['stencil'],
+        field_names['weights'],
+    ]
+
+
 def select_reconstruction_vars(
     ds: xr.Dataset, location: ReconstructionType = 'cell'
 ) -> xr.Dataset:

--- a/polaris/mesh/spherical/__init__.py
+++ b/polaris/mesh/spherical/__init__.py
@@ -15,8 +15,15 @@ from mpas_tools.viz.paraview_extractor import extract_vtk
 
 from polaris import Step
 from polaris.constants import get_constant
-from polaris.mesh.reconstruct import compute_reconstruction_weights
+from polaris.mesh.reconstruct import (
+    compute_reconstruction_weights,
+    get_reconstruction_validate_vars,
+)
 from polaris.mesh.spherical.quality import check_cell_polygon_quality
+from polaris.mesh.validate import (
+    CELL_WIDTH_VALIDATE_VARS,
+    MPAS_MESH_VALIDATE_VARS,
+)
 from polaris.model_step import make_graph_file
 
 
@@ -92,16 +99,22 @@ class SphericalBaseStep(Step):
         """
         config = self.config
         section = config['spherical_mesh']
-        for option in [
-            'jigsaw_mesh_filename',
-            'mpas_mesh_filename',
-            'cell_width_filename',
-        ]:
+        validate_vars = {
+            'jigsaw_mesh_filename': None,
+            'mpas_mesh_filename': MPAS_MESH_VALIDATE_VARS,
+            'cell_width_filename': CELL_WIDTH_VALIDATE_VARS,
+        }
+        for option, variables in validate_vars.items():
             filename = section.get(option)
-            self.add_output_file(filename=filename)
+            self.add_output_file(filename=filename, validate_vars=variables)
         if section.getboolean('generate_reconstruction_weights'):
             filename = section.get('reconstruction_weights_filename')
-            self.add_output_file(filename=filename)
+            self.add_output_file(
+                filename=filename,
+                validate_vars=get_reconstruction_validate_vars(
+                    location='cell'
+                ),
+            )
         self.add_output_file(filename='graph.info')
 
     def run(self):

--- a/polaris/mesh/spherical/coastline.py
+++ b/polaris/mesh/spherical/coastline.py
@@ -12,6 +12,9 @@ from polaris.mesh.spherical.critical_transects import CriticalTransects
 CONVENTIONS = ('calving_front', 'grounding_line', 'bedrock_zero')
 EARTH_RADIUS = get_constant('mean_radius')
 
+#: variables in a coastline file to compare against a baseline
+COASTLINE_VALIDATE_VARS = ['ocean_mask', 'signed_distance']
+
 
 def build_coastline_datasets(
     ds_topo,

--- a/polaris/mesh/validate.py
+++ b/polaris/mesh/validate.py
@@ -1,0 +1,52 @@
+"""
+Lists of variables used to compare mesh files against a baseline.
+
+These lists are kept in a dependency-light module so that both framework
+steps (e.g. :py:class:`polaris.mesh.spherical.SphericalBaseStep`) and task
+steps that cull or otherwise derive MPAS meshes can share them.
+"""
+
+#: Variables in an MPAS mesh file to compare against a baseline.  Only
+#: variables present in both a base mesh and a culled mesh are included, so
+#: that the same list can be used for either.
+MPAS_MESH_VALIDATE_VARS = [
+    'latCell',
+    'lonCell',
+    'xCell',
+    'yCell',
+    'zCell',
+    'areaCell',
+    'indexToCellID',
+    'nEdgesOnCell',
+    'cellsOnCell',
+    'edgesOnCell',
+    'verticesOnCell',
+    'meshDensity',
+    'latEdge',
+    'lonEdge',
+    'xEdge',
+    'yEdge',
+    'zEdge',
+    'dcEdge',
+    'dvEdge',
+    'angleEdge',
+    'indexToEdgeID',
+    'nEdgesOnEdge',
+    'cellsOnEdge',
+    'edgesOnEdge',
+    'verticesOnEdge',
+    'weightsOnEdge',
+    'latVertex',
+    'lonVertex',
+    'xVertex',
+    'yVertex',
+    'zVertex',
+    'areaTriangle',
+    'kiteAreasOnVertex',
+    'indexToVertexID',
+    'cellsOnVertex',
+    'edgesOnVertex',
+]
+
+#: Variables in a lon/lat cell-width file to compare against a baseline
+CELL_WIDTH_VALIDATE_VARS = ['cellWidth']

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -13,6 +13,20 @@ from polaris.archive import extract_zip_member
 from polaris.e3sm.init.topo import format_lat_lon_resolution_name
 from polaris.step import Step
 
+#: variables in a combined topography file to compare against a baseline.
+#: ``ocean_mask`` is deliberately left out.  The combine step writes it, but
+#: the cached combined topography files that tasks use by default were
+#: generated before it was added, so it is absent from the file a run
+#: actually reads and from everything derived from it.  Add it back here
+#: once those cached files have been regenerated.
+COMBINE_TOPO_VALIDATE_VARS = [
+    'base_elevation',
+    'ice_draft',
+    'ice_thickness',
+    'ice_mask',
+    'grounded_mask',
+]
+
 
 class CombineStep(Step):
     """
@@ -300,6 +314,7 @@ class CombineStep(Step):
 
         # Start over with empty outputs
         self.outputs = []
+        self.validate_vars = dict()
 
         # Build output filenames
         res_name = self.resolution_name
@@ -318,7 +333,10 @@ class CombineStep(Step):
             self.exodus_filename = None
 
         self.add_output_file(filename=self.dst_scrip_filename)
-        self.add_output_file(filename=self.combined_filename)
+        self.add_output_file(
+            filename=self.combined_filename,
+            validate_vars=COMBINE_TOPO_VALIDATE_VARS,
+        )
         if self.exodus_filename is not None:
             self.add_output_file(filename=self.exodus_filename)
 

--- a/polaris/tasks/e3sm/init/topo/cull/cull.py
+++ b/polaris/tasks/e3sm/init/topo/cull/cull.py
@@ -9,11 +9,22 @@ from mpas_tools.mesh.cull import map_culled_to_base
 from pyremap import MpasCellMeshDescriptor
 
 from polaris import Step
-from polaris.mesh.reconstruct import compute_reconstruction_weights
+from polaris.mesh.reconstruct import (
+    compute_reconstruction_weights,
+    get_reconstruction_validate_vars,
+)
+from polaris.mesh.validate import MPAS_MESH_VALIDATE_VARS
 from polaris.model_step import make_graph_file
 
 CULL_PREFIXES = ['ocean', 'ocean_no_cavities', 'land']
 SCRIP_PREFIXES = ['ocean', 'ocean_no_cavities', 'land']
+
+#: variables in a culled-to-base map file to compare against a baseline
+MAP_CULLED_TO_BASE_VALIDATE_VARS = [
+    'mapCulledToBaseCell',
+    'mapCulledToBaseEdge',
+    'mapCulledToBaseVertex',
+]
 
 
 class CullMeshStep(Step):
@@ -69,14 +80,23 @@ class CullMeshStep(Step):
         self.cull_mask_step = cull_mask_step
 
         for prefix in CULL_PREFIXES:
-            self.add_output_file(filename=f'culled_{prefix}_mesh.nc')
-            self.add_output_file(filename=f'{prefix}_map_culled_to_base.nc')
+            self.add_output_file(
+                filename=f'culled_{prefix}_mesh.nc',
+                validate_vars=MPAS_MESH_VALIDATE_VARS,
+            )
+            self.add_output_file(
+                filename=f'{prefix}_map_culled_to_base.nc',
+                validate_vars=MAP_CULLED_TO_BASE_VALIDATE_VARS,
+            )
             if prefix in SCRIP_PREFIXES:
                 self.add_output_file(filename=f'culled_{prefix}_mesh.scrip.nc')
             if prefix.startswith('ocean'):
                 self.add_output_file(filename=f'culled_{prefix}_graph.info')
                 self.add_output_file(
-                    filename=f'culled_{prefix}_reconstruction_weights.nc'
+                    filename=f'culled_{prefix}_reconstruction_weights.nc',
+                    validate_vars=get_reconstruction_validate_vars(
+                        location='cell'
+                    ),
                 )
 
     def setup(self):

--- a/polaris/tasks/e3sm/init/topo/cull/mask.py
+++ b/polaris/tasks/e3sm/init/topo/cull/mask.py
@@ -23,6 +23,14 @@ from polaris.tasks.e3sm.init.topo.cull.dc_edge_diagnostics import (
     check_ocean_dc_edge,
 )
 
+#: variables in the cull-masks file to compare against a baseline
+CULL_MASKS_VALIDATE_VARS = [
+    'oceanCullMask',
+    'oceanNoCavitiesCullMask',
+    'landCullMask',
+    'landIceMask',
+]
+
 
 class CullMaskStep(Step):
     """
@@ -97,7 +105,10 @@ class CullMaskStep(Step):
             package='polaris.tasks.e3sm.init.topo.cull.mask',
         )
 
-        self.add_output_file(filename='cull_masks.nc')
+        self.add_output_file(
+            filename='cull_masks.nc',
+            validate_vars=CULL_MASKS_VALIDATE_VARS,
+        )
         self._critical_transects = None
 
     def setup(self):

--- a/polaris/tasks/e3sm/init/topo/remap/mask.py
+++ b/polaris/tasks/e3sm/init/topo/remap/mask.py
@@ -4,6 +4,28 @@ import xarray as xr
 
 from polaris import Step
 from polaris.mesh.spherical.coastline import CONVENTIONS
+from polaris.tasks.e3sm.init.topo.combine.step import (
+    COMBINE_TOPO_VALIDATE_VARS,
+)
+
+
+def get_masked_topo_validate_vars():
+    """
+    Get the variables in the masked topography file that should be compared
+    against a baseline
+
+    Returns
+    -------
+    validate_vars : list of str
+        The ocean and land masks along with the masked topography variables
+        that :py:class:`MaskTopoStep` adds to the combined topography
+    """
+    validate_vars = ['ocean_mask', 'land_mask']
+    for prefix in ['land', 'ocean']:
+        validate_vars.extend(
+            f'{prefix}_masked_{var}' for var in COMBINE_TOPO_VALIDATE_VARS
+        )
+    return validate_vars
 
 
 class MaskTopoStep(Step):
@@ -38,7 +60,10 @@ class MaskTopoStep(Step):
         """
         super().__init__(component, name=name, subdir=subdir)
         self.combine_topo_step = combine_topo_step
-        self.add_output_file(filename='topography_masked.nc')
+        self.add_output_file(
+            filename='topography_masked.nc',
+            validate_vars=get_masked_topo_validate_vars(),
+        )
 
     def setup(self):
         """

--- a/polaris/tasks/e3sm/init/topo/remap/remap.py
+++ b/polaris/tasks/e3sm/init/topo/remap/remap.py
@@ -8,6 +8,42 @@ from pyremap import MpasCellMeshDescriptor
 
 from polaris import Step
 from polaris.io import symlink
+from polaris.tasks.e3sm.init.topo.combine.step import (
+    COMBINE_TOPO_VALIDATE_VARS,
+)
+
+
+def get_remapped_topo_validate_vars():
+    """
+    Get the variables in the remapped topography file that should be compared
+    against a baseline
+
+    Returns
+    -------
+    validate_vars : list of str
+        The remapped topography variables and fractions, both unmasked and
+        masked by the ocean and land fractions
+    """
+    validate_vars = [_frac_name(var) for var in COMBINE_TOPO_VALIDATE_VARS]
+    # the ocean and land masks that the mask-topography step adds become
+    # fractions, too
+    validate_vars.extend(['ocean_frac', 'land_frac'])
+    for prefix in ['land', 'ocean']:
+        validate_vars.extend(
+            f'{prefix}_masked_{_frac_name(var)}'
+            for var in COMBINE_TOPO_VALIDATE_VARS
+        )
+    return validate_vars
+
+
+def _frac_name(var):
+    """
+    Get the name a variable takes after remapping, where masks become
+    fractions
+    """
+    if var.endswith('mask'):
+        return f'{var[:-4]}frac'
+    return var
 
 
 class RemapTopoStep(Step):
@@ -100,7 +136,10 @@ class RemapTopoStep(Step):
         self.smoothing = smoothing
         self.unsmoothed_topo = unsmoothed_topo
 
-        self.add_output_file(filename='topography_remapped.nc')
+        self.add_output_file(
+            filename='topography_remapped.nc',
+            validate_vars=get_remapped_topo_validate_vars(),
+        )
         self.expand_distance = 0.0
         self.expand_factor = 1.0
         self.do_remapping = True

--- a/polaris/tasks/mesh/spherical/unified/coastline/compute.py
+++ b/polaris/tasks/mesh/spherical/unified/coastline/compute.py
@@ -3,6 +3,7 @@ import os
 import xarray as xr
 
 from polaris.mesh.spherical.coastline import (
+    COASTLINE_VALIDATE_VARS,
     CONVENTIONS,
     _write_netcdf_with_fill_values,
     build_coastline_dataset,
@@ -69,7 +70,9 @@ class ComputeCoastlineStep(Step):
             ),
         )
         for filename in self.output_filenames.values():
-            self.add_output_file(filename=filename)
+            self.add_output_file(
+                filename=filename, validate_vars=COASTLINE_VALIDATE_VARS
+            )
 
     def run(self):
         """

--- a/polaris/tasks/mesh/spherical/unified/coastline/remap.py
+++ b/polaris/tasks/mesh/spherical/unified/coastline/remap.py
@@ -5,6 +5,7 @@ import xarray as xr
 from scipy import ndimage
 
 from polaris.mesh.spherical.coastline import (
+    COASTLINE_VALIDATE_VARS,
     CONVENTIONS,
     _write_netcdf_with_fill_values,
 )
@@ -77,7 +78,9 @@ class RemapCoastlineStep(Step):
                 work_dir_target=os.path.join(fine_step.path, filename),
             )
         for filename in self.output_filenames.values():
-            self.add_output_file(filename=filename)
+            self.add_output_file(
+                filename=filename, validate_vars=COASTLINE_VALIDATE_VARS
+            )
 
     def run(self):
         """

--- a/polaris/tasks/mesh/spherical/unified/river/clip.py
+++ b/polaris/tasks/mesh/spherical/unified/river/clip.py
@@ -11,6 +11,7 @@ from polaris.mesh.spherical.unified.river.geojson import (
 )
 from polaris.step import Step
 from polaris.tasks.mesh.spherical.unified.river.rasterize import (
+    RIVER_NETWORK_VALIDATE_VARS,
     build_river_network_dataset,
 )
 from polaris.tasks.mesh.spherical.unified.river.simplify import (
@@ -76,7 +77,10 @@ class ClipRiverNetworkStep(Step):
             ),
         )
         self.add_output_file(filename=self.clipped_filename)
-        self.add_output_file(filename=self.masks_filename)
+        self.add_output_file(
+            filename=self.masks_filename,
+            validate_vars=RIVER_NETWORK_VALIDATE_VARS,
+        )
 
     def run(self):
         """

--- a/polaris/tasks/mesh/spherical/unified/river/rasterize.py
+++ b/polaris/tasks/mesh/spherical/unified/river/rasterize.py
@@ -15,6 +15,9 @@ from polaris.tasks.mesh.spherical.unified.river.simplify import (
     read_river_segments_from_feature_collection,
 )
 
+#: variables in a rasterized river-network file to compare against a baseline
+RIVER_NETWORK_VALIDATE_VARS = ['river_channel_mask']
+
 
 class RasterizeRiverLatLonStep(Step):
     """
@@ -70,7 +73,10 @@ class RasterizeRiverLatLonStep(Step):
                 self.coastline_step.output_filenames[convention],
             ),
         )
-        self.add_output_file(filename=self.masks_filename)
+        self.add_output_file(
+            filename=self.masks_filename,
+            validate_vars=RIVER_NETWORK_VALIDATE_VARS,
+        )
 
     def run(self):
         """

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
@@ -19,6 +19,29 @@ from polaris.mesh.spherical.unified.effective_ocean import (
 from polaris.mesh.spherical.unified.resolutions import FINEST_RESOLUTION
 from polaris.step import Step
 
+#: variables always present in a sizing-field file that should be compared
+#: against a baseline
+SIZING_FIELD_VALIDATE_VARS = [
+    'cellWidth',
+    'signed_distance',
+    'background_cell_width',
+    'ocean_background_cell_width',
+    'land_river_cell_width',
+    'pre_coastline_cell_width',
+    'coastline_cell_width',
+    'coastal_transition_delta',
+    'river_channel_cell_width',
+    'active_control',
+]
+
+#: additional sizing-field variables written only when cull emulation is on
+CULL_EMULATION_VALIDATE_VARS = [
+    'effective_ocean_mask',
+    'emulated_ocean_mask',
+    'mesh_scale_ocean_fraction',
+    'passages_widened',
+]
+
 
 class BuildSizingFieldStep(Step):
     """
@@ -121,7 +144,13 @@ class BuildSizingFieldStep(Step):
             ),
         )
         self._get_mesh_family().setup_sizing_field_step(self)
-        self.add_output_file(filename=self.sizing_field_filename)
+        validate_vars = list(SIZING_FIELD_VALIDATE_VARS)
+        if self.config.getboolean('sizing_field', 'enable_cull_emulation'):
+            validate_vars.extend(CULL_EMULATION_VALIDATE_VARS)
+        self.add_output_file(
+            filename=self.sizing_field_filename,
+            validate_vars=validate_vars,
+        )
 
     def run(self):
         """

--- a/polaris/validate.py
+++ b/polaris/validate.py
@@ -200,6 +200,10 @@ def _compute_norms(
     da1 = _rename_duplicate_dims(da1)
     da2 = _rename_duplicate_dims(da2)
 
+    # boolean arrays don't support subtraction, so compare them as integers
+    da1 = _as_numeric(da1)
+    da2 = _as_numeric(da2)
+
     result = True
     diff = np.abs(da1 - da2).values.ravel()
     # skip entries where one field or both are a fill value
@@ -233,6 +237,13 @@ def _compute_norms(
         print(diff_str)
 
     return result
+
+
+def _as_numeric(da):
+    """Convert a boolean DataArray to integers so it can be differenced"""
+    if da.dtype == bool:
+        da = da.astype(int)
+    return da
 
 
 def _rename_duplicate_dims(da):

--- a/tests/e3sm/init/topo/test_cull_validate_vars.py
+++ b/tests/e3sm/init/topo/test_cull_validate_vars.py
@@ -1,0 +1,190 @@
+import os
+
+from polaris.component import Component
+from polaris.mesh.reconstruct import get_reconstruction_validate_vars
+from polaris.mesh.validate import MPAS_MESH_VALIDATE_VARS
+from polaris.tasks.e3sm.init import e3sm_init
+from polaris.tasks.e3sm.init.topo.cull.tasks import add_cull_topo_tasks
+from polaris.tasks.mesh import mesh as mesh_component
+
+UNIFIED_MESH_NAME = 'u.oi30.lr10'
+SIMPLE_MESH_NAME = 'qu240km'
+
+# The output files each step of the cull task compares against a baseline.
+# Steps without NetCDF outputs (e.g. the GeoJSON-only river-simplify step)
+# are absent, as are outputs that are re-encodings of files that are already
+# validated (SCRIP files and graph files).
+UNIFIED_VALIDATED_FILES = {
+    'combine_topo_bedmap3_gebco2023_lat_lon_0.03125_degree': [
+        'bedmap3_gebco2023_0.03125_degree.nc',
+    ],
+    'coastline_compute': [
+        'coastline_bedrock_zero.nc',
+        'coastline_calving_front.nc',
+        'coastline_grounding_line.nc',
+    ],
+    'coastline_remap': [
+        'coastline_bedrock_zero.nc',
+        'coastline_calving_front.nc',
+        'coastline_grounding_line.nc',
+    ],
+    'river_rasterize': ['river_network.nc'],
+    'river_clip': ['clipped_river_network.nc'],
+    'sizing_field': ['sizing_field.nc'],
+    'base_mesh': ['base_mesh.nc', 'cellWidthVsLatLon.nc'],
+    'combine_topo_bedmap3_gebco2023_cubed_sphere_ne3000': [
+        'bedmap3_gebco2023_ne3000.nc',
+    ],
+    'mask_topo': ['topography_masked.nc'],
+    'remap_unsmoothed': ['topography_remapped.nc'],
+    'remap_smoothed': ['topography_remapped.nc'],
+    'cull_mask': ['cull_masks.nc'],
+    'cull_mesh': [
+        'culled_land_mesh.nc',
+        'culled_ocean_mesh.nc',
+        'culled_ocean_no_cavities_mesh.nc',
+        'culled_ocean_no_cavities_reconstruction_weights.nc',
+        'culled_ocean_reconstruction_weights.nc',
+        'land_map_culled_to_base.nc',
+        'ocean_map_culled_to_base.nc',
+        'ocean_no_cavities_map_culled_to_base.nc',
+    ],
+}
+
+
+def test_unified_cull_task_steps_validate_netcdf_outputs(tmp_path):
+    steps = _setup_cull_task_steps(UNIFIED_MESH_NAME, tmp_path)
+
+    validated = {
+        name: sorted(step.validate_vars)
+        for name, step in steps.items()
+        if step.validate_vars
+    }
+    expected = {
+        name: sorted(filenames)
+        for name, filenames in UNIFIED_VALIDATED_FILES.items()
+    }
+    assert validated == expected
+
+
+def test_simple_base_mesh_validates_reconstruction_weights(tmp_path):
+    steps = _setup_cull_task_steps(SIMPLE_MESH_NAME, tmp_path)
+
+    base_mesh_step = steps['qu_base_mesh_240km']
+    assert (
+        base_mesh_step.validate_vars['base_mesh.nc'] == MPAS_MESH_VALIDATE_VARS
+    )
+    assert base_mesh_step.validate_vars['cellWidthVsLatLon.nc'] == [
+        'cellWidth'
+    ]
+    assert base_mesh_step.validate_vars[
+        'reconstruction_weights.nc'
+    ] == get_reconstruction_validate_vars(location='cell')
+
+
+def test_unified_base_mesh_skips_reconstruction_weights(tmp_path):
+    # unified meshes get culled, so the base mesh doesn't compute weights
+    steps = _setup_cull_task_steps(UNIFIED_MESH_NAME, tmp_path)
+
+    base_mesh_step = steps['base_mesh']
+    assert 'reconstruction_weights.nc' not in base_mesh_step.validate_vars
+
+
+def test_culled_meshes_validate_the_full_mesh(tmp_path):
+    steps = _setup_cull_task_steps(UNIFIED_MESH_NAME, tmp_path)
+
+    validate_vars = steps['cull_mesh'].validate_vars
+    for prefix in ['ocean', 'ocean_no_cavities', 'land']:
+        assert (
+            validate_vars[f'culled_{prefix}_mesh.nc']
+            == MPAS_MESH_VALIDATE_VARS
+        )
+        assert validate_vars[f'{prefix}_map_culled_to_base.nc'] == [
+            'mapCulledToBaseCell',
+            'mapCulledToBaseEdge',
+            'mapCulledToBaseVertex',
+        ]
+
+
+def test_sizing_field_validates_cull_emulation_fields(tmp_path):
+    steps = _setup_cull_task_steps(UNIFIED_MESH_NAME, tmp_path)
+
+    sizing_step = steps['sizing_field']
+    assert sizing_step.config.getboolean(
+        'sizing_field', 'enable_cull_emulation'
+    )
+    validate_vars = sizing_step.validate_vars['sizing_field.nc']
+    assert 'cellWidth' in validate_vars
+    for var in [
+        'effective_ocean_mask',
+        'emulated_ocean_mask',
+        'mesh_scale_ocean_fraction',
+        'passages_widened',
+    ]:
+        assert var in validate_vars
+
+
+def test_remapped_topo_validates_fractions_and_masked_fields(tmp_path):
+    steps = _setup_cull_task_steps(UNIFIED_MESH_NAME, tmp_path)
+
+    validate_vars = steps['remap_unsmoothed'].validate_vars[
+        'topography_remapped.nc'
+    ]
+    # masks have become fractions after remapping
+    assert 'ocean_mask' not in validate_vars
+    for var in [
+        'base_elevation',
+        'ocean_frac',
+        'land_frac',
+        'ocean_masked_base_elevation',
+        'land_masked_ice_frac',
+    ]:
+        assert var in validate_vars
+
+
+def test_topo_validate_vars_skip_the_combined_ocean_mask(tmp_path):
+    # the cached combined topography files predate ocean_mask, so neither it
+    # nor anything derived from it can be compared against a baseline
+    steps = _setup_cull_task_steps(UNIFIED_MESH_NAME, tmp_path)
+
+    combine_step = steps['combine_topo_bedmap3_gebco2023_cubed_sphere_ne3000']
+    combined_vars = combine_step.validate_vars['bedmap3_gebco2023_ne3000.nc']
+    assert 'ocean_mask' not in combined_vars
+
+    masked_vars = steps['mask_topo'].validate_vars['topography_masked.nc']
+    # the mask-topography step adds its own ocean mask, which is compared
+    assert 'ocean_mask' in masked_vars
+    for prefix in ['land', 'ocean']:
+        assert f'{prefix}_masked_ocean_mask' not in masked_vars
+
+    for name in ['remap_unsmoothed', 'remap_smoothed']:
+        remapped_vars = steps[name].validate_vars['topography_remapped.nc']
+        # the ocean mask that the mask-topography step adds becomes a
+        # fraction that is compared
+        assert 'ocean_frac' in remapped_vars
+        for prefix in ['land', 'ocean']:
+            assert f'{prefix}_masked_ocean_frac' not in remapped_vars
+
+
+def _setup_cull_task_steps(mesh_name, work_dir):
+    """
+    Build the cull task for ``mesh_name`` and set up each of its steps in
+    ``work_dir`` so that ``validate_vars`` added during setup are available
+    """
+    _reset_shared_components()
+
+    component = Component(name='e3sm/init')
+    add_cull_topo_tasks(component=component)
+    task = component.tasks[f'{mesh_name}/topo/cull']
+    for step in task.steps.values():
+        step.base_work_dir = str(work_dir)
+        step.work_dir = os.path.join(str(work_dir), step.subdir)
+        step.setup()
+    return task.steps
+
+
+def _reset_shared_components():
+    for component in [e3sm_init, mesh_component]:
+        component.tasks.clear()
+        component.steps.clear()
+        component.configs.clear()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,49 @@
+import logging
+
+import numpy as np
+import xarray as xr
+
+from polaris.validate import compare_variables
+
+
+def _make_datasets(values1, values2):
+    ds1 = xr.Dataset({'mask': ('nCells', np.array(values1))})
+    ds2 = xr.Dataset({'mask': ('nCells', np.array(values2))})
+    return ds1, ds2
+
+
+def _compare(ds1, ds2, tmp_path):
+    # the files have to exist but the datasets are passed in directly
+    filename1 = str(tmp_path / 'file1.nc')
+    filename2 = str(tmp_path / 'file2.nc')
+    for filename in [filename1, filename2]:
+        with open(filename, 'w'):
+            pass
+    return compare_variables(
+        component=None,
+        variables=['mask'],
+        filename1=filename1,
+        filename2=filename2,
+        logger=logging.getLogger('test_validate'),
+        config=None,
+        ds1=ds1,
+        ds2=ds2,
+    )
+
+
+def test_compare_variables_passes_for_identical_boolean_fields(tmp_path):
+    # booleans don't support subtraction, so they have to be converted
+    # before the norms are computed
+    values = [True, False, True, True]
+    ds1, ds2 = _make_datasets(values, values)
+    assert ds1.mask.dtype == bool
+
+    assert _compare(ds1, ds2, tmp_path)
+
+
+def test_compare_variables_fails_for_differing_boolean_fields(tmp_path):
+    ds1, ds2 = _make_datasets(
+        [True, False, True, True], [True, False, False, True]
+    )
+
+    assert not _compare(ds1, ds2, tmp_path)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Running `e3sm/init/u.oi30.lr10/topo/cull` against a baseline compared nothing. Baseline validation only happens for output files that were added with a list of `validate_vars`, and not one step in that task -- or in any of the upstream mesh, coastline, river, sizing-field or topography steps it sets up -- had one. The run reported success because there was nothing to fail.

This PR gives every NetCDF output of that task a list of variables to compare.

## What is validated

| Step | File(s) | Variables |
| --- | --- | --- |
| `combine_topo_*` (lat-lon and cubed sphere) | combined topography | 5 |
| `coastline_compute`, `coastline_remap` | three convention files each | 2 |
| `river_rasterize`, `river_clip` | rasterized river masks | 1 |
| `sizing_field` | `sizing_field.nc` | 14 |
| `base_mesh` | mesh, cell width, reconstruction weights | 36, 1, 3 |
| `mask_topo` | `topography_masked.nc` | 12 |
| `remap_unsmoothed`, `remap_smoothed` | `topography_remapped.nc` | 17 |
| `cull_mask` | `cull_masks.nc` | 4 |
| `cull_mesh` | three meshes, three culled-to-base maps, two weight files | 36, 3, 3 |

The lists that more than one step needs live next to the code that writes the fields: a new dependency-light `polaris.mesh.validate` holds the MPAS mesh and cell-width variables, `get_reconstruction_validate_vars()` sits beside the code that computes reconstruction weights, and the coastline list sits beside the code that builds coastline datasets. The mesh list contains only variables that a culled mesh also carries, so the same list serves both a base mesh and a culled one.

The masked and remapped topography names are derived from the combined-topography list rather than repeated, mirroring how those two steps build the names themselves, including the `mask` to `frac` rename that remapping applies. Adding a field to the combined topography therefore extends all three lists at once.

## What is deliberately left out

SCRIP files and graph files are not validated. Each is a re-encoding of a mesh or grid whose fields are already compared: `culled_*_mesh.scrip.nc` is generated from `culled_*_mesh.nc`, and the combine step's target SCRIP file is fixed by the configured resolution. A difference in either implies a difference in something the same step already reports.

`river_simplify` writes only GeoJSON and the visualization steps write only PNG and text, so there is nothing for `compare_variables()` to compare.

`ocean_dc_edge_diagnostics.nc` is not validated. It is not a declared output today, it is only written for unified meshes, and every field in it derives from `dcEdge`, `oceanCullMask` and the sizing field, all of which are now compared.

`ocean_mask` is not validated in the combined topography, and neither is anything derived from it. The combine step writes it, but the step is `default_cached = True` and the cached files in `cached_files.json` were generated in May 2025, before `ocean_mask` was added to the step in April 2026. The file a run actually reads therefore does not contain it, so listing it fails the comparison on the missing variable in both the run and the baseline. Regenerating those cache files is expensive and out of scope here, so the name is left out with a comment saying to add it back once they are regenerated. The `ocean_mask` and `land_mask` that `MaskTopoStep` computes itself are unaffected and are compared, as are the `ocean_frac` and `land_frac` they become after remapping. What is dropped is `{land,ocean}_masked_ocean_mask` and `{land,ocean}_masked_ocean_frac`.

## Two things worth knowing about the comparison

`history` is never listed. It appears both as a global attribute carrying a timestamp and, in `geometric_features` output, as a string data variable of provenance lines. Any list that includes it, or any comparison that sweeps all data variables, would report a difference on every run forever. Every variable in every list here was checked against real output and is numeric.

Fields that are mostly NaN are safe. `compare_variables()` filters the difference to finite entries, so NaN against NaN is dropped rather than reported, which matters for the `land_masked_*` and `ocean_masked_*` fields that are fill-valued outside their mask. The trade-off is that a NaN becoming a number is skipped, which is part of why the integer masks are validated alongside the fields they mask.

## What changes for existing users

`SphericalBaseStep.setup()` now validates, so every task that builds a spherical base mesh gains baseline comparison of the mesh, the lon/lat cell width and, where they are generated, the vector-reconstruction weights. That reaches well beyond the cull task, to the ocean spherical tasks as well. The JIGSAW `.msh` mesh and `graph.info` are not NetCDF and stay unvalidated.

`CombineStep` rebuilds its output list whenever the target resolution changes, so `validate_vars` is now cleared alongside `outputs`. Without that, an entry could survive pointing at a file name the step no longer produces, and the comparison would fail on a missing file.

Boolean fields can now be compared. `_compute_norms()` differences the two fields with `-`, which numpy refuses for boolean arrays, so any boolean in a `validate_vars` list raised a `TypeError` that aborted the whole task instead of reporting a result. `landIceMask` in `cull_masks.nc` is written as a boolean, so validating it crashed the cull task before its remaining steps could run. Boolean fields are converted to integers before differencing: a match gives a zero norm, a difference gives a count of the differing entries.

No output file, variable or numerical result changes. This PR only declares what to compare.

## Baselines

Baselines generated before this change are still usable: the files and fields were always written, only the comparison is new. A baseline comparison that previously passed by comparing nothing may now legitimately fail, which is the point.

## Testing

Every variable in every list was checked against the real outputs of two runs: the `u02.oi30.lr10` run in `unified-mesh-candidates/20260811` and a `u.oi240.lr240` cull run against a baseline on Chrysalis. Every declared variable is present in both, with matching names, and none is non-numeric. The `u.oi240.lr240` run is the one that surfaced the cached-`ocean_mask` and boolean-comparison problems described above.

Each step's `setup()` was exercised in process for both a unified mesh (`u.oi30.lr10`) and a simple one (`qu240km`) to confirm the lists that are built during setup actually land on the step.

Seven new tests pin the per-step mapping of validated files, so a new output added without `validate_vars` fails the test rather than silently comparing nothing, and one of them pins that `ocean_mask` stays out of the combined-topography list and its derivatives. Two more cover the boolean comparison: identical boolean fields pass and differing ones fail. The full suite passes -- 338 tests -- with the six pre-existing errors in `tests/ocean/single_column/test_init.py` that also fail on `main`.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
