### PR TITLE
Update MPAS to Omega conversion script to include ERA5 based forcing

### DIFF
--- a/docs/developers_guide/ocean/convert_mpaso_ic_to_omega.md
+++ b/docs/developers_guide/ocean/convert_mpaso_ic_to_omega.md
@@ -6,7 +6,8 @@ The script `utils/omega/convert_mpaso_ic_to_omega.py` is a developer utility
 for converting an MPAS-Ocean initial-condition file into an Omega-formatted
 initial-condition file.  It is primarily intended for cases where a developer
 already has an MPAS-Ocean initial condition and needs a corresponding Omega
-file with the expected variable names, a `PseudoThickness` field, and optional
+file with the expected variable names, a `PseudoThickness` field, optional
+idealized or ERA5 based surface forcing, and optional
 tracer conversion for the requested equation of state.
 
 The script complements the model-variable mapping described in
@@ -35,9 +36,11 @@ The converter performs the following operations:
 5. It computes `PseudoThickness` from `layerThickness`, the reference seawater
    density, and specific volume.
 6. It zeros any numeric fields whose names contain `velocity`.
-7. It renames dimensions and variables using
+7. It optionally adds idealized surface stress forcing or surface stress, 
+   net heat flux and surface freshwater forcing from a 20 year average of ERA5.
+8. It renames dimensions and variables using
    `polaris/ocean/model/mpaso_to_omega.yaml`.
-8. It writes the converted Omega file with
+9. It writes the converted Omega file with
    {py:func}`mpas_tools.io.write_netcdf`.
 
 If `--visualization` is supplied, the script also writes diagnostic figures for
@@ -73,6 +76,19 @@ python utils/omega/convert_mpaso_ic_to_omega.py \
     --input-file /path/to/ocean.nc \
     --output-file /path/to/ocean.omega.nc \
     --eos-type linear
+```
+
+To generate a file with ERA5 based forcing, use:
+
+```bash
+python utils/omega/convert_mpaso_ic_to_omega.py \
+    --input-file /path/to/ocean.nc \
+    --output-file /path/to/ocean.omega.nc \
+    --eos-type teos10 \
+    --include-realistic-forcing \
+    --forcing-file /path/to/forcing/file.nc \
+    --forcing-scrip-file /era5_0.25deg_scrip.nc \
+    --remap-method bilinear 
 ```
 
 The script appends an EOS suffix automatically unless it is already present:

--- a/docs/developers_guide/ocean/convert_mpaso_ic_to_omega.md
+++ b/docs/developers_guide/ocean/convert_mpaso_ic_to_omega.md
@@ -113,7 +113,7 @@ python utils/omega/convert_mpaso_ic_to_omega.py \
     --forcing-scrip-file /path/to/era5_0.25deg_scrip.nc \
 ```
 
-The forcing file generation uses bilinear remapping by default if you wish to use another method (e.g., conservative) add `--remap-method conservative` to the command.
+The forcing file generation uses conservative remapping by default; if you wish to use another method add `--remap-method bilinear` to the command.
 
 The script appends an EOS suffix automatically unless it is already present:
 

--- a/docs/developers_guide/ocean/convert_mpaso_ic_to_omega.md
+++ b/docs/developers_guide/ocean/convert_mpaso_ic_to_omega.md
@@ -77,8 +77,31 @@ python utils/omega/convert_mpaso_ic_to_omega.py \
     --output-file /path/to/ocean.omega.nc \
     --eos-type linear
 ```
+There are two options for forcing; idealized and a 1990-2010 annual average climatology of ERA5 net surface heat flux, freshwater flux, and momentum fluxes.  The idealized forcing includes surface stress only.  A cubic spline is fit to the following specified stresses
 
-To generate a file with ERA5 based forcing, use:
+| Latitude ($^o$N) | Sfc Stress (Pa) | 
+| :--------------: | :-------------: |
+| -70              | 0.0             |
+| -45              | 0.2             |
+| -15              | -0.1            |
+| 0                | -0.02           |
+| 15               | -0.1            |
+| 45               |  0.1            |
+| 70               | 0.0             |
+
+To add this sfc stress to the omega initial condition, add the `--include-idealized-sfc-stress` to the python invocation above.
+
+To instead generate a file with ERA5 based forcing, use:
+
+```bash
+python utils/omega/convert_mpaso_ic_to_omega.py \
+  --input-file /path/to/ocean_ic_file.nc \
+  --output-file /path/to/ocean.omega.nc \
+  --eos-type teos10 \
+  --include-realistic-forcing
+```
+
+On supported machines, this will download the ERA5 forcing file and SCRIP file for interpolation.  If you are running on a non-supported machine you can download the files separately and use the following:
 
 ```bash
 python utils/omega/convert_mpaso_ic_to_omega.py \
@@ -86,10 +109,11 @@ python utils/omega/convert_mpaso_ic_to_omega.py \
     --output-file /path/to/ocean.omega.nc \
     --eos-type teos10 \
     --include-realistic-forcing \
-    --forcing-file /path/to/forcing/file.nc \
-    --forcing-scrip-file /era5_0.25deg_scrip.nc \
-    --remap-method bilinear 
+    --forcing-file /path/to/forcing_file.nc \
+    --forcing-scrip-file /path/to/era5_0.25deg_scrip.nc \
 ```
+
+The forcing file generation uses bilinear remapping by default if you wish to use another method (e.g., conservative) add `--remap-method conservative` to the command.
 
 The script appends an EOS suffix automatically unless it is already present:
 

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import subprocess
 from pathlib import Path
 
 import gsw
@@ -12,6 +13,13 @@ from scipy.interpolate import CubicSpline
 
 from polaris.constants import get_constant
 from polaris.mesh.info import is_spherical
+
+FORCING_VARIABLES = [
+    'windStressZonal',
+    'windStressMeridional',
+    'LatentHeatFlux',
+    'EvaporationFlux',
+]
 
 
 def parse_args():
@@ -46,16 +54,46 @@ def parse_args():
         ),
     )
     parser.add_argument(
-        '--include-wind-stress',
+        '--include-idealized-sfc-stress',
         action='store_true',
-        help=('Include wind stress fields.'),
+        help=('Include surface stress fields.'),
+    )
+    parser.add_argument(
+        '--include-realistic-forcing',
+        action='store_true',
+        help=(
+            'Include stress, heat, and evaporative fluxes '
+            'from averaged ERA5 data 1990-2010.'
+        ),
+    )
+    parser.add_argument(
+        '--forcing-file',
+        default=None,
+        help=(
+            'Time-averaged ERA5 forcing file.  Required with '
+            '--include-realistic-forcing.'
+        ),
+    )
+    parser.add_argument(
+        '--forcing-scrip-file',
+        default=None,
+        help=(
+            'SCRIP file describing the ERA5 forcing grid.  Required with '
+            '--include-realistic-forcing.'
+        ),
+    )
+    parser.add_argument(
+        '--remap-method',
+        choices=['conserve', 'bilinear'],
+        default='conserve',
+        help='Horizontal remapping method for surface fluxes.',
     )
     parser.add_argument(
         '--visualization',
         action='store_true',
         help=(
             'Generate temperature/salinity difference slices and '
-            'surface wind stress visualizations figures and save '
+            'surface stress visualizations figures and save '
             'next to the output NetCDF file. Figures are not '
             "generated for planar meshes (i.e., on_a_sphere = 'NO')."
         ),
@@ -67,9 +105,20 @@ def convert_to_omega(
     input_file,
     output_file,
     eos_type,
-    include_wind_stress=True,
+    include_realistic_forcing=False,
+    include_idealized_sfc_stress=False,
+    forcing_file=None,
+    forcing_scrip_file=None,
+    remap_method='conserve',
     visualization=False,
 ):
+    _check_forcing_args(
+        include_realistic_forcing,
+        include_idealized_sfc_stress,
+        forcing_file,
+        forcing_scrip_file,
+    )
+
     with xr.open_dataset(input_file, decode_times=False) as ds_in:
         ds_input = ds_in.load()
 
@@ -85,12 +134,18 @@ def convert_to_omega(
     mpas_velocity_fields = _zero_velocity_fields(ds_mpas_zero)
     if spherical:
         _rescale_sphere_radius(ds_mpas_zero)
-    if include_wind_stress:
-        _add_wind_stress(
-            ds_mpas_zero,
-            zonal_name='windStressZonal',
-            meridional_name='windStressMeridional',
+    if include_realistic_forcing:
+        ds_forcing = _remap_forcing_to_mpas(
+            mpas_file=input_file,
+            forcing_file=forcing_file,
+            forcing_scrip_file=forcing_scrip_file,
+            remap_method=remap_method,
         )
+    else:
+        ds_forcing = None
+    _apply_surface_forcing(
+        ds_mpas_zero, ds_forcing, include_idealized_sfc_stress
+    )
     _keep_selected_global_attrs(ds_mpas_zero)
 
     write_netcdf(
@@ -105,8 +160,8 @@ def convert_to_omega(
             'Rescaled MPAS earth radius, coordinates, and areas based on '
             'earth radius in pcd.yaml'
         )
-    if include_wind_stress:
-        print('Added windStressZonal and windStressMeridional fields')
+    if include_idealized_sfc_stress:
+        print('Added SfcStressZonal and SfcStressMeridional fields')
     if mpas_velocity_fields:
         print(f'Zeroed velocity fields: {", ".join(mpas_velocity_fields)}')
     else:
@@ -144,13 +199,10 @@ def convert_to_omega(
     velocity_fields = _zero_velocity_fields(ds_omega)
     if spherical:
         _rescale_sphere_radius(ds_omega)
-    if include_wind_stress:
-        _add_wind_stress(
-            ds_omega,
-            zonal_name='SfcStressZonal',
-            meridional_name='SfcStressMeridional',
-        )
+    _apply_surface_forcing(ds_omega, ds_forcing, include_idealized_sfc_stress)
+
     _add_surface_pressure(ds_omega)
+
     if visualization and spherical:
         _save_percent_difference_visualizations(
             ds_original=ds_mpas_zero,
@@ -190,7 +242,7 @@ def convert_to_omega(
         'Renamed variables to Omega names based on mpaso_to_omega.yaml mapping'
     )
     print('Renamed refLayerThickness to RefPseudoThickness for Omega output')
-    if include_wind_stress:
+    if include_idealized_sfc_stress:
         print('Added SfcStressZonal and SfcStressMeridional fields')
     else:
         print('Skipped SfcStressZonal and SfcStressMeridional fields')
@@ -198,6 +250,37 @@ def convert_to_omega(
     print('Removed unnecessary global attributes')
     if visualization:
         print('Saved temperature/salinity percent-difference visualizations')
+
+
+def _apply_surface_forcing(ds, ds_forcing, include_idealized_sfc_stress):
+    if ds_forcing is not None:
+        _add_surface_forcing(ds, ds_forcing)
+    elif include_idealized_sfc_stress:
+        _add_sfc_stress(
+            ds,
+            zonal_name='SfcStressZonal',
+            meridional_name='SfcStressMeridional',
+        )
+
+
+def _check_forcing_args(
+    include_realistic_forcing,
+    include_idealized_sfc_stress,
+    forcing_file,
+    forcing_scrip_file,
+):
+    if not include_realistic_forcing:
+        return
+    if include_idealized_sfc_stress:
+        raise ValueError(
+            'Only one of include_realistic_forcing and '
+            'include_idealized_sfc_stress may be requested'
+        )
+    if forcing_file is None or forcing_scrip_file is None:
+        raise ValueError(
+            'include_realistic_forcing requires both forcing_file and '
+            'forcing_scrip_file'
+        )
 
 
 def _to_degrees(angle):
@@ -570,7 +653,7 @@ def _rename_resting_thickness_for_omega(ds):
     return ds
 
 
-def _add_wind_stress(ds, zonal_name, meridional_name):
+def _add_sfc_stress(ds, zonal_name, meridional_name):
     # Fixed latitude-value pairs for cubic interpolation
     # These can be modified by editing the arrays below
     fixed_latitudes = np.array(
@@ -583,12 +666,12 @@ def _add_wind_stress(ds, zonal_name, meridional_name):
     # Create cubic spline interpolation function
     cs = CubicSpline(fixed_latitudes, fixed_values, bc_type='natural')
 
-    # Interpolate wind stress zonal values at each cell's latitude
-    wind_stress_zonal_values = cs(lat)
+    # Interpolate surface stress zonal values at each cell's latitude
+    sfc_stress_zonal_values = cs(lat)
 
     # Zero out values outside the range of fixed_latitudes
     outside = (lat < fixed_latitudes[0]) | (lat > fixed_latitudes[-1])
-    wind_stress_zonal_values[outside] = 0.0
+    sfc_stress_zonal_values[outside] = 0.0
 
     # Detect which time dimension name exists in the dataset
     ncell_dim = 'NCells' if 'NCells' in ds.dims else 'nCells'
@@ -597,12 +680,12 @@ def _add_wind_stress(ds, zonal_name, meridional_name):
     # Create the field with (time_dim, nCells) dimensions
     n_time = ds.sizes[time_dim]
     n_cells = ds.sizes[ncell_dim]
-    wind_stress_zonal = np.tile(
-        wind_stress_zonal_values[np.newaxis, :], (n_time, 1)
+    sfc_stress_zonal = np.tile(
+        sfc_stress_zonal_values[np.newaxis, :], (n_time, 1)
     )
 
     ds[zonal_name] = xr.DataArray(
-        data=wind_stress_zonal,
+        data=sfc_stress_zonal,
         dims=[time_dim, ncell_dim],
         attrs={
             'long_name': 'surface zonal wind stress',
@@ -611,10 +694,10 @@ def _add_wind_stress(ds, zonal_name, meridional_name):
         },
     )
 
-    # Create meridional wind stress field (set to zero)
-    wind_stress_merid = np.zeros((n_time, n_cells))
+    # Create meridional surface stress field (set to zero)
+    sfc_stress_merid = np.zeros((n_time, n_cells))
     ds[meridional_name] = xr.DataArray(
-        data=wind_stress_merid,
+        data=sfc_stress_merid,
         dims=[time_dim, ncell_dim],
         attrs={
             'long_name': 'surface meridional wind stress',
@@ -643,6 +726,93 @@ def _add_surface_pressure(ds):
             'standard_name': '',
         },
     )
+
+
+def _remap_forcing_to_mpas(
+    mpas_file,
+    forcing_file,
+    forcing_scrip_file,
+    remap_method='conserve',
+):
+    mpas_path = Path(mpas_file)
+    work_dir = mpas_path.parent
+
+    mpas_scrip = work_dir / 'mpas.scrip.nc'
+    remapped_file = work_dir / 'forcing.mpas.nc'
+
+    # Generate the destination SCRIP grid from the MPAS mesh
+    subprocess.run(
+        [
+            'scrip_from_mpas',
+            '-m',
+            str(mpas_file),
+            '-s',
+            str(mpas_scrip),
+        ],
+        check=True,
+    )
+
+    # Remap only the four forcing variables
+    subprocess.run(
+        [
+            'ncremap',
+            '-a',
+            remap_method,
+            '-s',
+            str(forcing_scrip_file),
+            '-g',
+            str(mpas_scrip),
+            '-v',
+            ','.join(FORCING_VARIABLES),
+            '-i',
+            str(forcing_file),
+            '-o',
+            str(remapped_file),
+        ],
+        check=True,
+    )
+
+    with xr.open_dataset(remapped_file, decode_times=False) as ds:
+        ds_forcing = ds.load()
+
+    return ds_forcing
+
+
+def _add_surface_forcing(ds_omega, ds_forcing):
+    ncell_dim = 'NCells' if 'NCells' in ds_omega.dims else 'nCells'
+    time_dim = 'Time' if 'Time' in ds_omega.dims else 'time'
+
+    n_cells = ds_omega.sizes[ncell_dim]
+    n_time = ds_omega.sizes[time_dim]
+
+    for input_name in FORCING_VARIABLES:
+        if input_name not in ds_forcing:
+            raise ValueError(
+                f'{input_name} not found in remapped forcing file'
+            )
+
+        field = ds_forcing[input_name].squeeze(drop=True)
+
+        if field.size != n_cells:
+            raise ValueError(
+                f'{input_name} contains {field.size} values, '
+                f'but MPAS mesh has {n_cells} cells'
+            )
+
+        values = field.values.reshape(n_cells)
+
+        # Omega IC has a Time dimension, even though the forcing has
+        # only one time-averaged state.
+        values = values[None, :]
+
+        if n_time != 1:
+            values = values.repeat(n_time, axis=0)
+
+        ds_omega[input_name] = xr.DataArray(
+            values,
+            dims=(time_dim, ncell_dim),
+            attrs=ds_forcing[input_name].attrs,
+        )
 
 
 def _select_visualization_levels(ds_original, count=5):
@@ -915,11 +1085,15 @@ def _save_percent_difference_visualizations(
 def main():
     args = parse_args()
     convert_to_omega(
-        args.input_file,
-        args.output_file,
-        args.eos_type,
-        args.include_wind_stress,
-        args.visualization,
+        input_file=args.input_file,
+        output_file=args.output_file,
+        eos_type=args.eos_type,
+        include_realistic_forcing=args.include_realistic_forcing,
+        include_idealized_sfc_stress=args.include_idealized_sfc_stress,
+        forcing_file=args.forcing_file,
+        forcing_scrip_file=args.forcing_scrip_file,
+        remap_method=args.remap_method,
+        visualization=args.visualization,
     )
 
 

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -179,8 +179,8 @@ def _prepare_mpas_zero(
     elif include_idealized_sfc_stress:
         _add_sfc_stress(
             ds_mpas_zero,
-            zonal_name='SfcStressZonal',
-            meridional_name='SfcStressMeridional',
+            zonal_name='windStressZonal',
+            meridional_name='windStressMeridional',
         )
 
     _keep_selected_global_attrs(ds_mpas_zero)
@@ -198,7 +198,7 @@ def _prepare_mpas_zero(
             'based on earth radius in pcd.yaml'
         )
     if include_idealized_sfc_stress:
-        print('Added SfcStressZonal and SfcStressMeridional fields')
+        print('Added windStressZonal and windStressMeridional fields')
 
     v_msg = (
         f'Zeroed velocity fields: {", ".join(mpas_velocity_fields)}'

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -218,7 +218,7 @@ def convert_to_omega(
     include_realistic_forcing=False,
     forcing_file=None,
     forcing_scrip_file=None,
-    remap_method='bilinear',
+    remap_method='conserve',
     include_idealized_sfc_stress=False,
     visualization=False,
 ):

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 import subprocess
 from pathlib import Path
 
@@ -11,9 +12,12 @@ from mpas_tools.io import write_netcdf
 from ruamel.yaml import YAML
 from scipy.interpolate import CubicSpline
 
+from polaris.config import PolarisConfigParser
 from polaris.constants import get_constant
+from polaris.io import download
 from polaris.mesh.info import is_spherical
 
+# These should probably move to a config file
 FORCING_VARIABLES = [
     'windStressZonal',
     'windStressMeridional',
@@ -70,16 +74,16 @@ def parse_args():
         '--forcing-file',
         default=None,
         help=(
-            'Time-averaged ERA5 forcing file.  Required with '
-            '--include-realistic-forcing.'
+            'Optional local ERA5 forcing file. If not supplied, the file is '
+            'downloaded from the Polaris data repository.'
         ),
     )
     parser.add_argument(
         '--forcing-scrip-file',
         default=None,
         help=(
-            'SCRIP file describing the ERA5 forcing grid.  Required with '
-            '--include-realistic-forcing.'
+            'Optional local ERA5 SCRIP file. If not supplied, the file is '
+            'downloaded from the Polaris data repository.'
         ),
     )
     parser.add_argument(
@@ -101,95 +105,177 @@ def parse_args():
     return parser.parse_args()
 
 
-def convert_to_omega(
-    input_file,
+def _print_summary(
     output_file,
     eos_type,
-    include_realistic_forcing=False,
-    include_idealized_sfc_stress=False,
-    forcing_file=None,
-    forcing_scrip_file=None,
-    remap_method='conserve',
-    visualization=False,
+    velocity_fields,
+    include_idealized_sfc_stress,
+    visualization,
 ):
-    _check_forcing_args(
-        include_realistic_forcing,
-        include_idealized_sfc_stress,
-        forcing_file,
-        forcing_scrip_file,
+    """Handles all the long-form stdout reporting for Omega."""
+    print(f'Wrote {output_file}')
+
+    if eos_type == 'teos10':
+        print(
+            'Converted to Omega TEOS-10 temperature: '
+            'potential -> conservative\n'
+            'Converted to Omega TEOS-10 salinity: '
+            'practical -> absolute'
+        )
+    else:
+        print(
+            'Kept temperature and salinity unchanged '
+            '(potential temp/practical salinity)'
+        )
+
+    v_msg = (
+        f'Zeroed velocity fields: {", ".join(velocity_fields)}'
+        if velocity_fields
+        else 'No velocity fields found to zero'
+    )
+    sfc_msg = (
+        'Added SfcStressZonal and SfcStressMeridional fields'
+        if include_idealized_sfc_stress
+        else 'Skipped SfcStressZonal and SfcStressMeridional fields'
     )
 
-    with xr.open_dataset(input_file, decode_times=False) as ds_in:
-        ds_input = ds_in.load()
+    print(
+        f'Added Omega variable PseudoThickness\n'
+        f'Rescaled Omega earth radius, coordinates, and areas\n'
+        f'{v_msg}\n'
+        f'Renamed variables to Omega names based on '
+        f'mpaso_to_omega.yaml\n'
+        f'Renamed refLayerThickness to RefPseudoThickness for '
+        f'Omega output\n'
+        f'{sfc_msg}\n'
+        f'Added SurfacePressure field\n'
+        f'Removed unnecessary global attributes'
+    )
 
-    spherical = is_spherical(ds_input)
-    _check_sphere_radius(ds_input, spherical)
+    if visualization:
+        print('Saved temperature/salinity percent-difference visualizations')
 
-    output_file = _append_eos_suffix(output_file, eos_type)
 
+def _prepare_mpas_zero(
+    ds_input,
+    input_file,
+    spherical,
+    include_realistic_forcing,
+    ds_forcing,
+    include_idealized_sfc_stress,
+):
+    """Generates and writes the baseline zero-velocity MPAS dataset."""
     input_path = Path(input_file)
     zero_velocity_mpas_file = str(input_path.with_suffix('')) + '.mpas.nc'
 
     ds_mpas_zero = ds_input.copy(deep=True)
     mpas_velocity_fields = _zero_velocity_fields(ds_mpas_zero)
+
     if spherical:
         _rescale_sphere_radius(ds_mpas_zero)
-    if include_realistic_forcing:
-        ds_forcing = _remap_forcing_to_mpas(
-            mpas_file=input_file,
-            forcing_file=forcing_file,
-            forcing_scrip_file=forcing_scrip_file,
-            remap_method=remap_method,
-        )
-    else:
-        ds_forcing = None
-    _apply_surface_forcing(
-        ds_mpas_zero, ds_forcing, include_idealized_sfc_stress
-    )
-    _keep_selected_global_attrs(ds_mpas_zero)
 
+    if include_realistic_forcing:
+        _add_surface_forcing(ds_mpas_zero, ds_forcing)
+    elif include_idealized_sfc_stress:
+        _add_sfc_stress(
+            ds_mpas_zero,
+            zonal_name='SfcStressZonal',
+            meridional_name='SfcStressMeridional',
+        )
+
+    _keep_selected_global_attrs(ds_mpas_zero)
     write_netcdf(
         ds_mpas_zero,
         zero_velocity_mpas_file,
         format='NETCDF3_64BIT_DATA',
         engine='netcdf4',
     )
+
     print(f'Wrote {zero_velocity_mpas_file}')
     if spherical:
         print(
-            'Rescaled MPAS earth radius, coordinates, and areas based on '
-            'earth radius in pcd.yaml'
+            'Rescaled MPAS earth radius, coordinates, and areas '
+            'based on earth radius in pcd.yaml'
         )
     if include_idealized_sfc_stress:
         print('Added SfcStressZonal and SfcStressMeridional fields')
-    if mpas_velocity_fields:
-        print(f'Zeroed velocity fields: {", ".join(mpas_velocity_fields)}')
-    else:
-        print('No velocity fields found to zero')
+
+    v_msg = (
+        f'Zeroed velocity fields: {", ".join(mpas_velocity_fields)}'
+        if mpas_velocity_fields
+        else 'No velocity fields found to zero'
+    )
+    print(v_msg)
     print('Removed unnecessary global attributes')
 
-    required_vars = ['layerThickness']
-    missing = [
-        name for name in required_vars if name not in ds_input.variables
-    ]
-    if missing:
-        raise ValueError(f'Missing required variables: {missing}')
+    return ds_mpas_zero
 
-    # Keep the original input dataset untouched; all Omega transforms
-    # happen on a separate working copy.
-    ds_omega = ds_input.copy(deep=True)
 
-    # Create valid mask with shape (Time, nCells, nVertLevels)
-    layer_thickness_valid = ds_omega['layerThickness'].values > 0.0
-    if layer_thickness_valid.ndim == 2:
-        # Broadcast (nCells, nVertLevels) to (nTime, nCells, nVertLevels)
-        valid = np.tile(
-            layer_thickness_valid[np.newaxis, :, :],
-            (ds_omega.sizes['Time'], 1, 1),
+def convert_to_omega(
+    input_file,
+    output_file,
+    eos_type,
+    include_realistic_forcing=False,
+    forcing_file=None,
+    forcing_scrip_file=None,
+    remap_method='bilinear',
+    include_idealized_sfc_stress=False,
+    visualization=False,
+):
+    """Main function with low complexity and strict 79 line limits."""
+    _check_forcing_args(
+        include_realistic_forcing, include_idealized_sfc_stress
+    )
+
+    # 1. Setup forcing dependencies up front
+    ds_forcing = None
+    if include_realistic_forcing:
+        if forcing_file is None or forcing_scrip_file is None:
+            downloaded = _get_realistic_forcing_files()
+            downloaded_forcing, downloaded_scrip = downloaded
+            forcing_file = forcing_file or downloaded_forcing
+            forcing_scrip_file = forcing_scrip_file or downloaded_scrip
+
+        ds_forcing = _remap_forcing_to_mpas(
+            mpas_file=input_file,
+            forcing_file=forcing_file,
+            forcing_scrip_file=forcing_scrip_file,
+            remap_method=remap_method,
         )
-    else:
-        valid = layer_thickness_valid
 
+    # 2. Load and validate
+    with xr.open_dataset(input_file, decode_times=False) as ds_in:
+        ds_input = ds_in.load()
+
+    if 'layerThickness' not in ds_input.variables:
+        raise ValueError("Missing required variables: ['layerThickness']")
+
+    spherical = is_spherical(ds_input)
+    _check_sphere_radius(ds_input, spherical)
+
+    output_file = _append_eos_suffix(output_file, eos_type)
+
+    # 3. Create baseline dataset
+    ds_mpas_zero = _prepare_mpas_zero(
+        ds_input,
+        input_file,
+        spherical,
+        include_realistic_forcing,
+        ds_forcing,
+        include_idealized_sfc_stress,
+    )
+
+    # 4. Initialize working copy and broadcast mask
+    ds_omega = ds_input.copy(deep=True)
+    lt_vals = ds_omega['layerThickness'].values > 0.0
+    valid = (
+        np.tile(lt_vals[np.newaxis, :, :], (ds_omega.sizes['Time'], 1, 1))
+        if lt_vals.ndim == 2
+        else lt_vals
+    )
+
+    # 5. Physics and state transitions
+    spec_vol = None
     if eos_type == 'teos10':
         spec_vol = _convert_teos10_tracers(ds_omega, valid)
     elif eos_type == 'linear':
@@ -197,9 +283,19 @@ def convert_to_omega(
 
     _add_pseudo_thickness(ds_omega, valid, spec_vol)
     velocity_fields = _zero_velocity_fields(ds_omega)
+
     if spherical:
         _rescale_sphere_radius(ds_omega)
-    _apply_surface_forcing(ds_omega, ds_forcing, include_idealized_sfc_stress)
+
+    # 6. Apply surface stresses
+    if include_realistic_forcing:
+        _add_surface_forcing(ds_omega, ds_forcing)
+    elif include_idealized_sfc_stress:
+        _add_sfc_stress(
+            ds_omega,
+            zonal_name='SfcStressZonal',
+            meridional_name='SfcStressMeridional',
+        )
 
     _add_surface_pressure(ds_omega)
 
@@ -210,76 +306,36 @@ def convert_to_omega(
             output_file=output_file,
         )
 
+    # 7. Map variables and export final netCDF
     ds_omega = _map_mpaso_to_omega(ds_omega)
     ds_omega = _rename_resting_thickness_for_omega(ds_omega)
     _keep_selected_global_attrs(ds_omega)
 
     write_netcdf(
-        ds_omega, output_file, format='NETCDF3_64BIT_DATA', engine='netcdf4'
+        ds_omega,
+        output_file,
+        format='NETCDF3_64BIT_DATA',
+        engine='netcdf4',
     )
 
-    print(f'Wrote {output_file}')
-    if eos_type == 'teos10':
-        print(
-            'Converted to Omega TEOS-10 temperature: potential -> conservative'
-        )
-        print('Converted to Omega TEOS-10 salinity: practical -> absolute')
-    else:
-        print(
-            'Kept temperature and salinity unchanged '
-            '(potential temperature and practical salinity)'
-        )
-    print('Added Omega variable PseudoThickness')
-    print(
-        'Rescaled Omega earth radius, coordinates, and areas based on '
-        'earth radius in pcd.yaml'
+    # 8. Report execution summary
+    _print_summary(
+        output_file,
+        eos_type,
+        velocity_fields,
+        include_idealized_sfc_stress,
+        visualization,
     )
-    if velocity_fields:
-        print(f'Zeroed velocity fields: {", ".join(velocity_fields)}')
-    else:
-        print('No velocity fields found to zero')
-    print(
-        'Renamed variables to Omega names based on mpaso_to_omega.yaml mapping'
-    )
-    print('Renamed refLayerThickness to RefPseudoThickness for Omega output')
-    if include_idealized_sfc_stress:
-        print('Added SfcStressZonal and SfcStressMeridional fields')
-    else:
-        print('Skipped SfcStressZonal and SfcStressMeridional fields')
-    print('Added SurfacePressure field')
-    print('Removed unnecessary global attributes')
-    if visualization:
-        print('Saved temperature/salinity percent-difference visualizations')
-
-
-def _apply_surface_forcing(ds, ds_forcing, include_idealized_sfc_stress):
-    if ds_forcing is not None:
-        _add_surface_forcing(ds, ds_forcing)
-    elif include_idealized_sfc_stress:
-        _add_sfc_stress(
-            ds,
-            zonal_name='SfcStressZonal',
-            meridional_name='SfcStressMeridional',
-        )
 
 
 def _check_forcing_args(
     include_realistic_forcing,
     include_idealized_sfc_stress,
-    forcing_file,
-    forcing_scrip_file,
 ):
-    if not include_realistic_forcing:
-        return
-    if include_idealized_sfc_stress:
+    if include_realistic_forcing and include_idealized_sfc_stress:
         raise ValueError(
             'Only one of include_realistic_forcing and '
             'include_idealized_sfc_stress may be requested'
-        )
-    if forcing_file is None or forcing_scrip_file is None:
-        raise ValueError(
-            'include_realistic_forcing requires both forcing_file and '
-            'forcing_scrip_file'
         )
 
 
@@ -291,6 +347,77 @@ def _to_degrees(angle):
     if max_abs <= 2.0 * get_constant('pi') + 1.0e-12:
         return angle * get_constant('radian')
     return angle
+
+
+def _get_polaris_config():
+    config = PolarisConfigParser()
+    config.add_from_package('polaris', 'default.cfg')
+
+    machine = os.environ.get('POLARIS_MACHINE')
+    if machine is not None:
+        config.add_from_package(
+            'mache.machines',
+            f'{machine}.cfg',
+            exception=False,
+        )
+        config.add_from_package(
+            'polaris.machines',
+            f'{machine}.cfg',
+            exception=False,
+        )
+
+    if not config.has_option('paths', 'database_root'):
+        raise ValueError(
+            'No Polaris database_root is configured. Source a Polaris '
+            'machine load script or provide local --forcing-file and '
+            '--forcing-scrip-file arguments.'
+        )
+    return config
+
+
+def _get_realistic_forcing_files():
+
+    config = _get_polaris_config()
+
+    database_root = config.get('paths', 'database_root')
+    base_url = config.get('download', 'server_base_url')
+
+    database_path = os.path.join(
+        database_root,
+        'ocean/realistic_global/forcing',
+    )
+
+    forcing_path = os.path.join(
+        database_path,
+        'era5_forcing_1990-2010_average_0.25x0.25_degree.20260820.nc',
+    )
+    scrip_path = os.path.join(
+        database_path,
+        'era5_0.25x0.25_degree_scrip.20260820.nc',
+    )
+
+    forcing_url = (
+        f'{base_url}/ocean/realistic_global/forcing/era5_forcing_'
+        '1990-2010_average_0.25x0.25_degree.20260820.nc'
+    )
+    scrip_url = (
+        f'{base_url}/ocean/realistic_global/forcing/'
+        'era5_0.25x0.25_degree_scrip.20260820.nc'
+    )
+
+    forcing_file = download(
+        forcing_url,
+        forcing_path,
+        config,
+    )
+
+    forcing_scrip_file = download(
+        scrip_url,
+        scrip_path,
+        config,
+    )
+
+    return forcing_file, forcing_scrip_file
 
 
 def _append_eos_suffix(output_file, eos_type):


### PR DESCRIPTION
This PR updates the convert_mpaso_ic_to_omega.py to include injection of forcing from ERA5 averaged between 1990-2010.  It includes a net surface heat flux and freshwater flux and surface wind stresses.  The ERA5 climatology has been uploaded to the Polaris input repository `polaris/ocean/realistic_global/forcing` along with the SCRIP file needed to remap to an MPASO input grid.  This has been tested in an EC30to60 configuration with Omega.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
