### PR TITLE
Fixes to planar vector reconstruction

### DIFF
--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -5,7 +5,10 @@ import numpy as np
 import xarray as xr
 
 from polaris.mesh.info import is_planar
-from polaris.mesh.vector import compute_edge_normal_vec
+from polaris.mesh.vector import (
+    compute_edge_normal_vec,
+    get_coordinate_matrix,
+)
 
 # TODO: when python 3.11 is dropped add type alias
 ReconstructionType = Literal['cell', 'vertex']
@@ -551,10 +554,7 @@ def build_reconstruction_weights(
 
     # compute the normal vector for each edge in Cartesian coordinates
     cartesian_normal_vector = compute_edge_normal_vec(ds)
-    # build the edge coord vec (nEdges, R3)
-    cartesian_edge_coords = xr.concat(
-        [ds.xEdge, ds.yEdge, ds.zEdge], dim='R3'
-    ).T
+    cartesian_edge_coords = get_coordinate_matrix(ds, 'edge')
 
     # project the normal vector onto the tangent plane at the cell center
     local_normal_vector = project_edge_normal_to_tangent_plane(
@@ -574,7 +574,7 @@ def build_reconstruction_weights(
     # term is the field extrapolated there rather than the value at the
     # reconstruction point.
     if is_planar(ds):
-        local_edge_coords = local_edge_coords - _reconstruction_point_coords(
+        local_edge_coords = local_edge_coords - get_coordinate_matrix(
             ds, location
         )
 
@@ -851,18 +851,3 @@ def _add_reconstruct_attrs(
         attrs['units'] = units
     data_array.attrs.update(attrs)
     return data_array
-
-
-def _reconstruction_point_coords(
-    ds: xr.Dataset, location: ReconstructionType
-) -> xr.DataArray:
-    """
-    The Cartesian coordinates of each reconstruction point, shaped
-    (nCells or nVertices, R3) so they broadcast against the local edge
-    coordinates.
-    """
-    # e.g. "cell" -> "xCell", "vertex" -> "xVertex"
-    prefix = location.capitalize()
-    return xr.concat(
-        [ds[f'x{prefix}'], ds[f'y{prefix}'], ds[f'z{prefix}']], dim='R3'
-    ).T

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -408,7 +408,7 @@ def compute_lstsq_weights(
         MPAS mesh dataset
     local_edge_coords: xr.DataArray (nCells or nVertices, maxEdges2/NINE, R3)
         Edge coordinate vectors projected onto the local tangent plane at the
-        the reconstruction point
+        reconstruction point and relative to it
     stencil: xr.DataArray (nCells or nVertices, maxEdges2 or NINE)
         A two level stencil of edges neighboring the reconstruction point
 
@@ -422,23 +422,9 @@ def compute_lstsq_weights(
     planar = is_planar(ds)
 
     if planar:
-        # planar: use actual distance from reconstruction point as D
-        point_dim = local_edge_coords.dims[0]
-        if point_dim in ('nCells', 'NCells'):
-            ref_point = xr.concat([ds.xCell, ds.yCell], dim='R3').T
-        elif point_dim in ('nVertices', 'NVertices'):
-            ref_point = xr.concat([ds.xVertex, ds.yVertex], dim='R3').T
-        else:
-            raise ValueError(
-                'Could not infer the reconstruction point location from '
-                f"dimension '{point_dim}'. Expected 'nCells'/'NCells' or "
-                "'nVertices'/'NVertices'."
-            )
-        D = np.sqrt(
-            ((local_edge_coords.isel(R3=[0, 1]) - ref_point) ** 2).sum(
-                dim='R3'
-            )
-        )
+        # planar: the coordinates are already relative to the
+        # reconstruction point, so D is the in-plane distance from it
+        D = np.sqrt((local_edge_coords.isel(R3=[0, 1]) ** 2).sum(dim='R3'))
     else:
         # normalize the rotated z coord onto the unit sphere to match
         # Renka (1984): z_hat = 1 at the reconstruction point and
@@ -578,6 +564,19 @@ def build_reconstruction_weights(
     local_edge_coords = project_edge_normal_to_tangent_plane(
         cartesian_edge_coords, rotation_matrix, stencil
     )
+
+    # On a sphere, the rotation above carries the reconstruction point to
+    # (0, 0, sphere_radius), so the local edge coordinates are already
+    # relative to it and the constant term of the least-squares fit below
+    # is the value at the point.  A planar mesh rotates by the identity,
+    # which leaves the coordinates absolute, so translate them here.
+    # Otherwise the fit is anchored at the mesh origin and the constant
+    # term is the field extrapolated there rather than the value at the
+    # reconstruction point.
+    if is_planar(ds):
+        local_edge_coords = local_edge_coords - _reconstruction_point_coords(
+            ds, location
+        )
 
     # weight the LSTSQ matrix following Renka (1984) pg. 422
     w = compute_lstsq_weights(ds, local_edge_coords, stencil)
@@ -852,3 +851,18 @@ def _add_reconstruct_attrs(
         attrs['units'] = units
     data_array.attrs.update(attrs)
     return data_array
+
+
+def _reconstruction_point_coords(
+    ds: xr.Dataset, location: ReconstructionType
+) -> xr.DataArray:
+    """
+    The Cartesian coordinates of each reconstruction point, shaped
+    (nCells or nVertices, R3) so they broadcast against the local edge
+    coordinates.
+    """
+    # e.g. "cell" -> "xCell", "vertex" -> "xVertex"
+    prefix = location.capitalize()
+    return xr.concat(
+        [ds[f'x{prefix}'], ds[f'y{prefix}'], ds[f'z{prefix}']], dim='R3'
+    ).T

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -26,7 +26,11 @@ _RECONSTRUCTION_FIELD_NAMES: dict[ReconstructionType, dict[str, str]] = {
     },
 }
 
-# variables read by build_reconstruction_weights() for each location
+# Variables read by build_reconstruction_weights() for each location.  Both
+# locations need the cell coordinates and cellsOnEdge, because the edge-normal
+# vectors point from cell to cell.  Every connectivity array's dimension
+# (nCells, nEdges, nVertices) must also be reachable from these variables so
+# that fix_out_of_bounds_indices() can find its size.
 _RECONSTRUCTION_INPUT_VARS: dict[ReconstructionType, tuple[str, ...]] = {
     'cell': (
         'xCell',
@@ -43,6 +47,9 @@ _RECONSTRUCTION_INPUT_VARS: dict[ReconstructionType, tuple[str, ...]] = {
         'xVertex',
         'yVertex',
         'zVertex',
+        'xCell',
+        'yCell',
+        'zCell',
         'xEdge',
         'yEdge',
         'zEdge',
@@ -272,7 +279,9 @@ def construct_edgesOnVerticesOnVertex(ds: xr.Dataset) -> xr.DataArray:
         output_dtypes=[conn.dtype],
     )
 
-    # union of edgesOnVertex over the two-ring edge stencil for target vertex
+    # union of edgesOnVertex over that one-ring of vertices, which is the
+    # two-ring edge stencil for the target vertex
+    conn = ds.edgesOnVertex[neighbor_vertices - 1]
     conn = conn.where(neighbor_vertices != 0, 0)
 
     return xr.apply_ufunc(

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -313,20 +313,26 @@ def construct_rotation_matrix(
 
     # e.g. "cell" -> "xCell", "vertex" -> "xVertex"
     prefix = location.capitalize()
-    x_hat = ds[f'x{prefix}'] / ds.sphere_radius
-    y_hat = ds[f'y{prefix}'] / ds.sphere_radius
-    z_hat = ds[f'z{prefix}'] / ds.sphere_radius
 
     # infer the reconstruction-point dimension ("nCells" or "nVertices")
     # directly from the coordinate arrays, rather than hard-coding it
-    point_dim = x_hat.dims[0]
-    n_points = x_hat.sizes[point_dim]
+    point_coord = ds[f'x{prefix}']
+    point_dim = point_coord.dims[0]
+    n_points = point_coord.sizes[point_dim]
 
-    # return identity matrix for planar meshes
+    # A planar mesh already lies in the x-y plane, so the tangent plane at
+    # every reconstruction point is the mesh plane itself and there is no
+    # rotation to do.  This is checked before the normalization below,
+    # which planar meshes would divide by a sphere_radius of zero.
     if is_planar(ds):
         return xr.DataArray(
-            np.ones((n_points, 3, 3)), dims=(point_dim, 'd1', 'd2')
+            np.broadcast_to(np.eye(3), (n_points, 3, 3)).copy(),
+            dims=(point_dim, 'd1', 'd2'),
         )
+
+    x_hat = ds[f'x{prefix}'] / ds.sphere_radius
+    y_hat = ds[f'y{prefix}'] / ds.sphere_radius
+    z_hat = ds[f'z{prefix}'] / ds.sphere_radius
 
     c_y = np.sqrt(y_hat**2 + z_hat**2)
     s_y = x_hat

--- a/polaris/mesh/vector.py
+++ b/polaris/mesh/vector.py
@@ -1,5 +1,36 @@
+from typing import Literal
+
 import numpy as np
 import xarray as xr
+
+# TODO: when python 3.11 is dropped add type alias
+VariableLocationType = Literal['cell', 'edge', 'vertex']
+
+
+def get_coordinate_matrix(
+    ds: xr.Dataset, location: VariableLocationType = 'cell'
+) -> xr.DataArray:
+    """
+    Get the Cartesian coordinates of the mesh elements at a given location
+    as a single array
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        MPAS mesh Dataset
+    location : {'cell', 'edge', 'vertex'}, optional
+        The mesh location to get the coordinates of
+
+    Returns
+    -------
+    xr.DataArray (nCells or nEdges or nVertices, R3)
+        The Cartesian coordinates of each element at ``location``
+    """
+    # e.g. "cell" -> "xCell", "vertex" -> "xVertex"
+    suffix = location.capitalize()
+    return xr.concat(
+        [ds[f'x{suffix}'], ds[f'y{suffix}'], ds[f'z{suffix}']], dim='R3'
+    ).T
 
 
 def compute_edge_normal_vec(ds: xr.Dataset) -> xr.DataArray:
@@ -25,8 +56,8 @@ def compute_edge_normal_vec(ds: xr.Dataset) -> xr.DataArray:
         # formulas below are correct for non-periodic meshes as well
         period = np.array([0.0, 0.0, 0.0])
 
-    vec_cell = xr.concat([ds.xCell, ds.yCell, ds.zCell], dim='R3').T
-    vec_edge = xr.concat([ds.xEdge, ds.yEdge, ds.zEdge], dim='R3').T
+    vec_cell = get_coordinate_matrix(ds, 'cell')
+    vec_edge = get_coordinate_matrix(ds, 'edge')
 
     cell_1 = ds.cellsOnEdge.isel(TWO=0) - 1
     cell_2 = ds.cellsOnEdge.isel(TWO=1) - 1

--- a/tests/mesh/test_reconstruct.py
+++ b/tests/mesh/test_reconstruct.py
@@ -4,11 +4,13 @@ plane at a vector-reconstruction point.
 """
 
 import numpy as np
+import pytest
 import xarray as xr
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
 from polaris.mesh.reconstruct import (
     compute_reconstruction_weights,
+    construct_edgesOnVerticesOnVertex,
     construct_rotation_matrix,
     tangential_reconstruction,
 )
@@ -107,14 +109,20 @@ def periodic_hex_mesh(nx=12, ny=12, dc=1000.0):
     )
 
 
-def interior_cells(ds, margin):
+def point_coords(ds, location):
+    """The x and y coordinates of the reconstruction points."""
+    suffix = location.capitalize()
+    return ds[f'x{suffix}'], ds[f'y{suffix}']
+
+
+def interior_points(ds, margin, location='cell'):
     """
-    Cells far enough from the domain edge that their two-ring stencil does
-    not wrap around the periodic boundary.  A wrapped edge is a long way
-    from the cell in absolute coordinates, so a field defined in those
-    coordinates is discontinuous across the seam.
+    Reconstruction points far enough from the domain edge that their
+    two-ring stencil does not wrap around the periodic boundary.  A wrapped
+    edge is a long way from the point in absolute coordinates, so a field
+    defined in those coordinates is discontinuous across the seam.
     """
-    x, y = ds.xCell, ds.yCell
+    x, y = point_coords(ds, location)
     return (
         (x > margin)
         & (x < ds.x_period - margin)
@@ -123,12 +131,13 @@ def interior_cells(ds, margin):
     )
 
 
-def reconstruct_planar_field(ds, u_of_edge, v_of_edge):
+def reconstruct_planar_field(ds, u_of_edge, v_of_edge, location='cell'):
     """
-    Reconstruct a planar vector field at cell centers from its edge-normal
-    component, using weights built from the mesh itself.
+    Reconstruct a planar vector field at cell or vertex centers from its
+    edge-normal component, using weights built from the mesh itself.
     """
-    weights_ds = compute_reconstruction_weights(ds, 'cell')
+    suffix = location.capitalize()
+    weights_ds = compute_reconstruction_weights(ds, location)
     normal = compute_edge_normal_vec(ds)
     normal_velocity = normal.isel(R3=0) * u_of_edge(
         ds.xEdge, ds.yEdge
@@ -136,12 +145,13 @@ def reconstruct_planar_field(ds, u_of_edge, v_of_edge):
     return tangential_reconstruction(
         ds,
         normal_velocity,
-        stencil=weights_ds.reconstructStencilCell,
-        weights=weights_ds.reconstructWeightsCell,
+        stencil=weights_ds[f'reconstructStencil{suffix}'],
+        weights=weights_ds[f'reconstructWeights{suffix}'],
     )
 
 
-def test_planar_reconstruction_of_uniform_field_is_exact():
+@pytest.mark.parametrize('location', ['cell', 'vertex'])
+def test_planar_reconstruction_of_uniform_field_is_exact(location):
     """
     A spatially uniform field must come back exactly, with no out-of-plane
     component.  An all-ones rotation matrix collapsed the local frame to a
@@ -150,7 +160,10 @@ def test_planar_reconstruction_of_uniform_field_is_exact():
     ds = periodic_hex_mesh()
 
     u_x, u_y, u_z = reconstruct_planar_field(
-        ds, lambda x, y: 1.0 + 0.0 * x, lambda x, y: 0.5 + 0.0 * x
+        ds,
+        lambda x, y: 1.0 + 0.0 * x,
+        lambda x, y: 0.5 + 0.0 * x,
+        location=location,
     )
 
     np.testing.assert_allclose(u_x.values, 1.0, atol=1e-12)
@@ -158,7 +171,8 @@ def test_planar_reconstruction_of_uniform_field_is_exact():
     np.testing.assert_array_equal(u_z.values, 0.0)
 
 
-def test_planar_reconstruction_of_linear_field_is_exact():
+@pytest.mark.parametrize('location', ['cell', 'vertex'])
+def test_planar_reconstruction_of_linear_field_is_exact(location):
     """
     The least-squares basis includes the linear terms, so a linear field
     must also come back exactly.  It does so only if the local edge
@@ -174,19 +188,73 @@ def test_planar_reconstruction_of_linear_field_is_exact():
     def v_of(x, y):
         return -1.1 + 0.4e-3 * x + 2.0e-3 * y
 
-    u_x, u_y, _ = reconstruct_planar_field(ds, u_of, v_of)
+    u_x, u_y, _ = reconstruct_planar_field(ds, u_of, v_of, location=location)
 
-    inside = interior_cells(ds, margin=3.0 * ds.dc)
+    inside = interior_points(ds, margin=3.0 * ds.dc, location=location)
     assert int(inside.sum()) > 0
 
+    x, y = point_coords(ds, location)
     scale = max(abs(u_of(ds.x_period, ds.y_period)), 1.0)
     np.testing.assert_allclose(
-        u_x.where(inside, u_of(ds.xCell, ds.yCell)).values,
-        u_of(ds.xCell, ds.yCell).values,
+        u_x.where(inside, u_of(x, y)).values,
+        u_of(x, y).values,
         atol=1e-10 * scale,
     )
     np.testing.assert_allclose(
-        u_y.where(inside, v_of(ds.xCell, ds.yCell)).values,
-        v_of(ds.xCell, ds.yCell).values,
+        u_y.where(inside, v_of(x, y)).values,
+        v_of(x, y).values,
         atol=1e-10 * scale,
+    )
+
+
+def test_vertex_stencil_holds_edges_not_vertices():
+    """
+    The vertex stencil is the union of edgesOnVertex over the one-ring of
+    neighboring vertices.  Gathering that union from the wrong connectivity
+    array filled the stencil with vertex indices and leaked the TWO
+    dimension of verticesOnEdge into the result.
+    """
+    ds = periodic_hex_mesh()
+
+    stencil = construct_edgesOnVerticesOnVertex(ds)
+
+    assert stencil.dims == ('nVertices', 'NINE')
+    assert int(stencil.max()) <= ds.sizes['nEdges']
+
+    # every hex vertex has three edges of its own plus six more from its
+    # three neighbors, so the two-ring stencil is full
+    np.testing.assert_array_equal(
+        (stencil != 0).sum(dim='NINE').values, ds.sizes['vertexDegree'] * 3
+    )
+
+    # a vertex's own edges are always part of its stencil
+    for vertex in range(ds.sizes['nVertices']):
+        own = set(ds.edgesOnVertex.isel(nVertices=vertex).values.tolist())
+        assert own <= set(stencil.isel(nVertices=vertex).values.tolist())
+
+
+@pytest.mark.parametrize('location', ['cell', 'vertex'])
+def test_reconstruction_weights_have_expected_dims(location):
+    """
+    Trimming the mesh to the variables needed for reconstruction must keep
+    the dimensions of every connectivity array reachable.  Dropping the cell
+    coordinates from the vertex list left nCells undefined, so bounds
+    checking cellsOnEdge raised a KeyError.
+    """
+    ds = periodic_hex_mesh()
+    suffix = location.capitalize()
+    point_dim = 'nCells' if location == 'cell' else 'nVertices'
+    stencil_dim = 'maxEdges2' if location == 'cell' else 'NINE'
+
+    weights_ds = compute_reconstruction_weights(ds, location)
+
+    assert weights_ds[f'reconstructStencil{suffix}'].dims == (
+        point_dim,
+        stencil_dim,
+    )
+    assert weights_ds[f'nEdgesReconstructOn{suffix}'].dims == (point_dim,)
+    assert weights_ds[f'reconstructWeights{suffix}'].dims == (
+        point_dim,
+        'R3',
+        stencil_dim,
     )

--- a/tests/mesh/test_reconstruct.py
+++ b/tests/mesh/test_reconstruct.py
@@ -5,8 +5,14 @@ plane at a vector-reconstruction point.
 
 import numpy as np
 import xarray as xr
+from mpas_tools.planar_hex import make_planar_hex_mesh
 
-from polaris.mesh.reconstruct import construct_rotation_matrix
+from polaris.mesh.reconstruct import (
+    compute_reconstruction_weights,
+    construct_rotation_matrix,
+    tangential_reconstruction,
+)
+from polaris.mesh.vector import compute_edge_normal_vec
 
 
 def planar_mesh(n_cells=4):
@@ -92,3 +98,95 @@ def test_spherical_rotation_matrix_is_orthogonal():
         np.testing.assert_allclose(
             rotation[cell] @ rotation[cell].T, np.eye(3), atol=1e-12
         )
+
+
+def periodic_hex_mesh(nx=12, ny=12, dc=1000.0):
+    """A small doubly periodic planar hex mesh with full connectivity."""
+    return make_planar_hex_mesh(
+        nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=False
+    )
+
+
+def interior_cells(ds, margin):
+    """
+    Cells far enough from the domain edge that their two-ring stencil does
+    not wrap around the periodic boundary.  A wrapped edge is a long way
+    from the cell in absolute coordinates, so a field defined in those
+    coordinates is discontinuous across the seam.
+    """
+    x, y = ds.xCell, ds.yCell
+    return (
+        (x > margin)
+        & (x < ds.x_period - margin)
+        & (y > margin)
+        & (y < ds.y_period - margin)
+    )
+
+
+def reconstruct_planar_field(ds, u_of_edge, v_of_edge):
+    """
+    Reconstruct a planar vector field at cell centers from its edge-normal
+    component, using weights built from the mesh itself.
+    """
+    weights_ds = compute_reconstruction_weights(ds, 'cell')
+    normal = compute_edge_normal_vec(ds)
+    normal_velocity = normal.isel(R3=0) * u_of_edge(
+        ds.xEdge, ds.yEdge
+    ) + normal.isel(R3=1) * v_of_edge(ds.xEdge, ds.yEdge)
+    return tangential_reconstruction(
+        ds,
+        normal_velocity,
+        stencil=weights_ds.reconstructStencilCell,
+        weights=weights_ds.reconstructWeightsCell,
+    )
+
+
+def test_planar_reconstruction_of_uniform_field_is_exact():
+    """
+    A spatially uniform field must come back exactly, with no out-of-plane
+    component.  An all-ones rotation matrix collapsed the local frame to a
+    single direction and gave errors of order the field itself.
+    """
+    ds = periodic_hex_mesh()
+
+    u_x, u_y, u_z = reconstruct_planar_field(
+        ds, lambda x, y: 1.0 + 0.0 * x, lambda x, y: 0.5 + 0.0 * x
+    )
+
+    np.testing.assert_allclose(u_x.values, 1.0, atol=1e-12)
+    np.testing.assert_allclose(u_y.values, 0.5, atol=1e-12)
+    np.testing.assert_array_equal(u_z.values, 0.0)
+
+
+def test_planar_reconstruction_of_linear_field_is_exact():
+    """
+    The least-squares basis includes the linear terms, so a linear field
+    must also come back exactly.  It does so only if the local edge
+    coordinates are relative to the reconstruction point; in absolute
+    coordinates the fit is anchored at the mesh origin and returns the
+    field extrapolated there instead.
+    """
+    ds = periodic_hex_mesh()
+
+    def u_of(x, y):
+        return 0.2 + 1.3e-3 * x - 0.7e-3 * y
+
+    def v_of(x, y):
+        return -1.1 + 0.4e-3 * x + 2.0e-3 * y
+
+    u_x, u_y, _ = reconstruct_planar_field(ds, u_of, v_of)
+
+    inside = interior_cells(ds, margin=3.0 * ds.dc)
+    assert int(inside.sum()) > 0
+
+    scale = max(abs(u_of(ds.x_period, ds.y_period)), 1.0)
+    np.testing.assert_allclose(
+        u_x.where(inside, u_of(ds.xCell, ds.yCell)).values,
+        u_of(ds.xCell, ds.yCell).values,
+        atol=1e-10 * scale,
+    )
+    np.testing.assert_allclose(
+        u_y.where(inside, v_of(ds.xCell, ds.yCell)).values,
+        v_of(ds.xCell, ds.yCell).values,
+        atol=1e-10 * scale,
+    )

--- a/tests/mesh/test_reconstruct.py
+++ b/tests/mesh/test_reconstruct.py
@@ -1,0 +1,94 @@
+"""
+Tests for the rotation from Cartesian coordinates to the local tangent
+plane at a vector-reconstruction point.
+"""
+
+import numpy as np
+import xarray as xr
+
+from polaris.mesh.reconstruct import construct_rotation_matrix
+
+
+def planar_mesh(n_cells=4):
+    """A minimal planar mesh with the coordinates the rotation needs."""
+    x = np.linspace(0.0, 3.0e4, n_cells)
+    ds = xr.Dataset(
+        {
+            'xCell': ('nCells', x),
+            'yCell': ('nCells', x[::-1].copy()),
+            'zCell': ('nCells', np.zeros(n_cells)),
+        }
+    )
+    # planar MPAS meshes carry a sphere radius of zero
+    ds.attrs['on_a_sphere'] = 'NO'
+    ds.attrs['sphere_radius'] = 0.0
+    return ds
+
+
+def spherical_mesh():
+    """A minimal spherical mesh spanning a range of latitudes."""
+    radius = 6.371e6
+    lat = np.deg2rad(np.array([-80.0, -25.0, 0.0, 25.0, 80.0]))
+    lon = np.deg2rad(np.array([0.0, 45.0, 120.0, 200.0, 330.0]))
+    ds = xr.Dataset(
+        {
+            'xCell': ('nCells', radius * np.cos(lat) * np.cos(lon)),
+            'yCell': ('nCells', radius * np.cos(lat) * np.sin(lon)),
+            'zCell': ('nCells', radius * np.sin(lat)),
+        }
+    )
+    ds.attrs['on_a_sphere'] = 'YES'
+    ds.attrs['sphere_radius'] = radius
+    return ds
+
+
+def test_planar_rotation_matrix_is_identity():
+    """
+    A planar mesh already lies in the x-y plane, so the rotation to the
+    tangent plane must be the identity.  An all-ones matrix would collapse
+    the local frame to a single direction and silently produce wrong
+    reconstruction weights.
+    """
+    ds = planar_mesh()
+    rotation = construct_rotation_matrix(ds, 'cell')
+
+    assert rotation.dims == ('nCells', 'd1', 'd2')
+
+    expected = np.broadcast_to(np.eye(3), (ds.sizes['nCells'], 3, 3))
+    np.testing.assert_array_equal(rotation.values, expected)
+
+
+def test_planar_rotation_leaves_in_plane_vector_unchanged():
+    """The planar rotation must be a no-op on a vector in the mesh plane."""
+    ds = planar_mesh()
+    rotation = construct_rotation_matrix(ds, 'cell').values
+
+    vector = np.array([1.0, 0.5, 0.0])
+    for cell in range(ds.sizes['nCells']):
+        np.testing.assert_allclose(rotation[cell] @ vector, vector)
+
+
+def test_planar_rotation_does_not_divide_by_zero():
+    """
+    Planar meshes have sphere_radius of zero, so the rotation must not
+    normalize the coordinates by it.
+    """
+    ds = planar_mesh()
+    with np.errstate(divide='raise', invalid='raise'):
+        rotation = construct_rotation_matrix(ds, 'cell')
+
+    assert np.isfinite(rotation.values).all()
+
+
+def test_spherical_rotation_matrix_is_orthogonal():
+    """
+    The spherical rotation is a product of two rotations about the x and y
+    axes, so it must be orthogonal at every reconstruction point.
+    """
+    ds = spherical_mesh()
+    rotation = construct_rotation_matrix(ds, 'cell').values
+
+    for cell in range(ds.sizes['nCells']):
+        np.testing.assert_allclose(
+            rotation[cell] @ rotation[cell].T, np.eye(3), atol=1e-12
+        )

--- a/utils/omega/ctest/omega_ctest.py
+++ b/utils/omega/ctest/omega_ctest.py
@@ -129,7 +129,7 @@ def download_meshes(config):
 
     files = [
         'ocean.QU.240km.omega_vars.260807.nc',
-        'PlanarPeriodic48x48.omega_vars.260518.nc',
+        'PlanarPeriodic48x48.omega_vars.260825.nc',
         'cosine_bell_icos480.omega_vars.260807.nc',
     ]
 


### PR DESCRIPTION
Vector reconstruction produced silently wrong weights on every planar mesh. This fixes two planar-only bugs and regenerates the planar Omega CTest mesh so it carries usable reconstruction weights for the first time. It also fixes the vertex-centered reconstruction path, which turned out not to run at all, and picks up the cleanup @andrewdnolan asked for in review.

## The two planar bugs

**1. The rotation matrix was all ones instead of the identity.** `construct_rotation_matrix()` returned `np.ones((n_points, 3, 3))` for planar meshes, where both the comment and the caller expect the identity. That matrix is used in real matrix products — to project edge normals and edge coordinates onto the tangent plane, and again to rotate the weights back to Cartesian — so it collapsed the local frame onto a single direction.

The planar check also sat *below* the normalization by `sphere_radius`, which is zero for planar meshes, so the function divided by zero on a path whose result it then discarded. The check now happens first.

**2. The least-squares fit was anchored at the mesh origin, not the cell.** This one only becomes visible once the rotation is the identity. The basis in `build_reconstruction_weights()` uses `local_edge_coords` as its linear terms. On a sphere, `construct_rotation_matrix()` carries the reconstruction point to `(0, 0, sphere_radius)`, so those coordinates are *relative to* the point and the constant term of the fit — which is what the weights return — is the value *at* the point. A planar mesh rotates by the identity, so the coordinates stay absolute and the fit is anchored at `(0, 0)` instead. The constant term is then the field extrapolated to the mesh origin, which is correct only where the field has no gradient.

The fix translates the local edge coordinates onto the reconstruction point for planar meshes, matching what the rotation already does on a sphere. `compute_lstsq_weights()` was already subtracting the reconstruction point itself to get the planar distance weighting; that is now done once, up front, so its planar branch reduces to the distance from the origin and no longer has to infer the point location from the dimension name.

## Testing

Reconstructing a vector field on `PlanarPeriodic48x48` from its edge-normal component, interior cells only (a periodic mesh makes a field defined in absolute coordinates discontinuous across the seam):

| field | before | after bug 1 | after both |
|---|---|---|---|
| uniform `(1.0, 0.5)` | 2.56 | 2.0e-13 | 1.3e-15 |
| linear `(0.2 + 1.3x - 0.7y, -1.1 + 0.4x + 2.0y)` | — | 0.98, 1.75 | 1.6e-15, 2.6e-14 |
| spurious out-of-plane component | 2.21 | 0.0 | 0.0 |

The linear-field error tracked `|b·x + c·y|` exactly, which is the signature of anchoring at the origin.

**Spherical meshes are unaffected.** Weights recomputed on `ocean.QU.240km` are bit-identical to those in the published `ocean.QU.240km.omega_vars.260807.nc`, for all three fields (`reconstructStencilCell`, `nEdgesReconstructOnCell`, `reconstructWeightsCell`). Both changes are provably planar-only, so the two spherical CTest meshes did not need regenerating.

New unit and end-to-end tests in `tests/mesh/test_reconstruct.py`, which had no planar coverage at all before:

- the planar rotation is the identity, is a no-op on an in-plane vector, and does not divide by zero
- the spherical rotation is orthogonal at every point
- a uniform and a linear field reconstruct exactly on a periodic hex mesh, at cell centers and at vertices
- the vertex stencil holds edge indices, is full, and contains each vertex's own edges
- the weights come back with the dimensions the reconstruction expects, at both locations

Each new test was checked against the unfixed code: the two rotation tests and both end-to-end tests fail with the all-ones matrix, the linear-field test fails with the uncentered coordinates, and all four vertex tests fail with the old stencil gather. They are regression guards, not tests written to pass.

`pytest tests/` — 421 passed. `pre-commit` clean.

## New Omega CTest mesh

`PlanarPeriodic48x48.omega_vars.260518.nc` has no reconstruction fields, so Omega's planar CTests cannot exercise reconstruction at all. The two spherical CTest meshes gained them in the 260807 update; the planar one was left behind because the weights it would have gotten were wrong.

`utils/omega/ctest/omega_ctest.py` now points at `PlanarPeriodic48x48.omega_vars.260825.nc`, which is the same mesh with `NEdgesReconOnCell`, `ReconStencilCell` and `ReconWeightsCell` appended via `utils/omega/add_reconstruction_weights.py`, computed after both fixes above. No pre-existing variable changed. Names and shapes match the spherical CTest files. The file is in the Polaris database under `ocean/omega_ctest`, with a note in that directory's `provenance/README.md`.

Omega picks up the same datestamp in E3SM-Project/Omega#525.

## Vertex-centered reconstruction never ran

Reviewing the cleanup below turned up a third bug, unrelated to planar meshes: `compute_reconstruction_weights(ds, 'vertex')` could not run at all. Nothing in Polaris asks for vertex-centered weights yet, which is why this went unnoticed — the cell-centered path everything actually uses is fine.

Two things were wrong. `_RECONSTRUCTION_INPUT_VARS['vertex']` trimmed the mesh down to the vertex and edge coordinates, so the subset had no `nCells` dimension and bounds checking `cellsOnEdge` raised `KeyError: 'nCells'`. Had it gotten past that, `compute_edge_normal_vec()` would have failed on the missing cell coordinates. Both locations need the cell coordinates, because the edge-normal vectors point from cell to cell.

`construct_edgesOnVerticesOnVertex()` then built the two-ring stencil from the wrong array. It masked the one-ring `verticesOnEdge` gather in place instead of gathering `edgesOnVertex` over those neighboring vertices, so the stencil held vertex indices rather than edge indices, and the `TWO` dimension of `verticesOnEdge` leaked into both the stencil and the weights. The fix gathers `edgesOnVertex` over the one-ring, which is what the docstring already described.

With both fixed, the uniform- and linear-field tests are exact at vertices too, and each vertex's stencil is the expected nine edges. Cell-centered weights are bit-for-bit unchanged, verified by recomputing them with the pre-cleanup code on periodic and non-periodic hex meshes.

## Cleanup from review

Per @andrewdnolan's [review](https://github.com/E3SM-Project/polaris/pull/721#discussion_r3864705987), the Cartesian coordinates of cells, edges and vertices were being concatenated into an `(n, R3)` array by hand in three places. That now lives in `get_coordinate_matrix(ds, location)` in `polaris/mesh/vector.py`, alongside a `VariableLocationType` alias covering all three mesh locations, and it replaces the manual construction in `compute_edge_normal_vec()` and in the reconstruction weights, along with the private `_reconstruction_point_coords()` helper this PR had added.

`construct_rotation_matrix()` is left alone: it needs `x_hat`, `y_hat` and `z_hat` as separate scalars, so routing it through the matrix would make it harder to read, not easier.

This is a pure refactor — the weights it produces are bit-for-bit identical, checked by running the pre-cleanup and post-cleanup code side by side on periodic and non-periodic planar hex meshes and comparing the edge normals, stencils and weights at cell centers and at vertices. The vertex weights change only with the fix above, not with this refactor.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite
