### PR TITLE
Update Omega submodule

### DIFF
--- a/utils/e3sm_update/test_e3sm_changes.py
+++ b/utils/e3sm_update/test_e3sm_changes.py
@@ -229,10 +229,14 @@ def print_and_run(commands, get_output=False):
     print_commands = commands.replace(' && ', '\n  ')
     print(f'  {print_commands}\n\n')
     if get_output:
-        output_raw = subprocess.check_output(commands, shell=True)
+        output_raw = subprocess.check_output(
+            commands, shell=True, executable='/bin/bash'
+        )
         output = output_raw.decode('utf-8').strip('\n')
     else:
-        subprocess.run(commands, check=True, shell=True)
+        subprocess.run(
+            commands, check=True, shell=True, executable='/bin/bash'
+        )
         output = None
 
     return output


### PR DESCRIPTION
This PR blesses the non-B4B behavior on Frontier (craygnu) due to the removal of vertical chunking in https://github.com/E3SM-Project/Omega/pull/473

This merge updates the e3sm_submodules/Omega submodule from [7d4d8bf](https://github.com/E3SM-Project/Omega/tree/7d4d8bfa2b3f46342704d41b7c1782d7b876e6a7) to [c72e3cf](https://github.com/E3SM-Project/Omega/tree/c72e3cfab5e1c62d00a27c729f57893157f4b67d).

This update includes the following Omega PRs (check mark indicates bit-for-bit with previous PR in the list:
- [x]  (ocn) https://github.com/E3SM-Project/Omega/pull/505
- [x]  (ocn) https://github.com/E3SM-Project/Omega/pull/494
- [x]  (ocn) https://github.com/E3SM-Project/Omega/pull/515
- [x]  (ocn) https://github.com/E3SM-Project/Omega/pull/520
- [x]  (ocn) https://github.com/E3SM-Project/Omega/pull/483
- [x]  (ocn) https://github.com/E3SM-Project/Omega/pull/511
- [x]  (fwk) https://github.com/E3SM-Project/Omega/pull/521
- [x] (ocn) https://github.com/E3SM-Project/Omega/pull/518
- [x] (ocn) https://github.com/E3SM-Project/Omega/pull/473
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
