### PR TITLE
Scaffolding for Omega analysis

### DIFF
--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -395,6 +395,20 @@ Pruning shall be safe to the extent that it can be: it shall report what it
 would remove before removing it, and removing the intermediates shall never
 remove something that cannot be recomputed from the simulation output.
 
+A third operation was proposed and belongs here rather than where it was
+suggested: **removing a step's input symlinks once it has completed.**  Every
+step links the simulation files it reads into its own directory and records
+them with `log_inputs`, so the log preserves what a symlink says.  It should
+not happen automatically at the end of a step, for two reasons.  Polaris checks
+that a step's declared inputs exist before running it, so a step whose links
+were removed can no longer be re-run in place, and re-running one step is a
+real workflow.  And a live symlink is better provenance than a log line: it can
+be followed, listed and opened, which is what someone opening an old work
+directory wants.  The bytes are not the argument either way --- a one-year
+QU240 analysis makes 64 of them --- so this belongs in the deliberate prune,
+for an analysis being archived after its simulation is gone, where dangling
+links are noise.  Raised by @cbegeman in review of the scaffolding.
+
 Two things Phase 1 does are what make this implementable later, and neither is
 an accident:
 

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -19,6 +19,71 @@
 
 ## Tasks
 
+### analysis
+
+```{eval-rst}
+.. currentmodule:: polaris.tasks.ocean.analysis
+
+.. autosummary::
+   :toctree: generated/
+
+   add_analysis_tasks
+
+   AnalysisTask
+   AnalysisTask.configure
+   AnalysisTask.year_range
+
+   ClimatologyMapsTask
+   GlobalStatsTask
+   HeatContentSeriesTask
+   MocTask
+
+   analysis_step.AnalysisStep
+   analysis_step.AnalysisStep.get_sim_files
+   analysis_step.AnalysisStep.add_sim_input_file
+   analysis_step.AnalysisStep.add_sim_input_files
+   analysis_step.AnalysisStep.log_inputs
+
+   climatology.Climatology
+   climatology.Climatology.setup
+   climatology.Climatology.run
+
+   climatology_maps.ClimatologyMaps
+   climatology_maps.ClimatologyMaps.setup
+   climatology_maps.ClimatologyMaps.run
+   climatology_maps.get_field_groups
+
+   global_stats.GlobalStatsTimeSeries
+   global_stats.GlobalStatsTimeSeries.setup
+   global_stats.GlobalStatsTimeSeries.run
+
+   heat_content_series.HeatContentSeries
+   heat_content_series.HeatContentSeries.setup
+   heat_content_series.HeatContentSeries.run
+
+   moc.Moc
+   moc.Moc.setup
+   moc.Moc.run
+
+   sim_files.SimFile
+   sim_files.AnalysisStream
+   sim_files.OmegaConfig
+   sim_files.OmegaConfig.stream_status
+   sim_files.OmegaConfig.stream_filename
+   sim_files.OmegaConfig.analysis_group_status
+   sim_files.OmegaConfig.analysis_streams
+   sim_files.SimulationFiles
+   sim_files.SimulationFiles.mesh_filename
+   sim_files.SimulationFiles.vert_coord_filename
+   sim_files.SimulationFiles.monthly_mean_files
+   sim_files.SimulationFiles.global_stats_files
+   sim_files.SimulationFiles.moc_files
+   sim_files.read_omega_config
+   sim_files.expand_template
+   sim_files.check_files_exist
+   sim_files.year_range_key
+```
+
 ### baroclinic_channel
 
 ```{eval-rst}

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -938,3 +938,89 @@ density, which is horizontally constant and increases with depth.
 The {py:func}`polaris.ocean.rpe.compute_rpe()` is used to compute the RPE as
 a function of time in a series of one or more output files.  The RPE is stored
 in `rpe.csv` and also returned as a numpy array for plotting and analysis.
+
+(dev-ocean-analysis)=
+
+## Analysis of completed simulations
+
+The package `polaris.tasks.ocean.analysis` contains the tasks of the
+`omega_analysis` suite, which analyze a simulation that has already been run
+rather than running one.  {ref}`ocean-analysis` describes the suite from a
+user's point of view.  Three pieces of it are shared machinery that a new
+analysis product builds on.
+
+### Locating the simulation's files
+
+`polaris.tasks.ocean.analysis.sim_files` is a leaf module --- it does not
+import {py:class}`polaris.Step` --- so that it can be unit tested and reused
+by every step that reads simulation output.
+
+{py:class}`polaris.tasks.ocean.analysis.sim_files.SimulationFiles` is the
+entry point.  It resolves the mesh, the vertical coordinate and the lists of
+monthly-mean, global-statistics and MOC files covering a range of years, and
+reports where each path came from.  Underneath it,
+{py:class}`polaris.tasks.ocean.analysis.sim_files.OmegaConfig` reads the
+simulation's own Omega configuration and answers questions about it
+defensively: a missing stream, a stream that names no file, and an analysis
+group that is turned off are told apart rather than raising from inside a
+lookup.  This is the one place Polaris depends on the *shape* of Omega's
+configuration rather than on its output.
+
+Two details are worth knowing before adding a product:
+
+- File-name templates are expanded by
+  {py:func}`polaris.tasks.ocean.analysis.sim_files.expand_template`, which
+  substitutes `$Y` and `$M`.  A template with no `$M` gives one file per year,
+  and one with no date at all gives a single file --- which is the real case
+  for Omega's analysis output.  These templates come from the Omega
+  configuration and never from a Polaris config file, because Polaris config
+  files use extended interpolation and a bare `$` in a value is an error.
+- Omega builds the file name of an analysis group's output stream as
+  `<prefix>_<period><TimeStats|Instants><template>`.  A group can write both
+  time means and snapshots under different names, so
+  {py:meth}`polaris.tasks.ocean.analysis.sim_files.OmegaConfig.analysis_streams`
+  returns each stream with its period and whether it is a time reduction, and
+  the caller must not assume either spelling.
+
+### Steps
+
+{py:class}`polaris.tasks.ocean.analysis.analysis_step.AnalysisStep` extends
+{py:class}`polaris.ocean.model.OceanIOStep` with the year range every analysis
+step has and with the input handling every one of them needs:
+`get_sim_files()` to resolve the simulation, `add_sim_input_file()` and
+`add_sim_input_files()` to link its files into the step's work directory, and
+`log_inputs()` to report what was read.
+
+Analysis steps follow {ref}`dev-task-parallelism` from the start, since it is
+cheap while the code is being written and expensive to retrofit.  In
+particular, every file a step opens in `run()` goes through
+{py:meth}`polaris.Step.work_path()` rather than a bare relative filename,
+temporary files go in the step's own work directory, and a step declares the
+parallelism it will actually start as `cpus_per_task` rather than sizing
+itself to the machine.
+
+### Range-keyed steps
+
+Every step lives at a subdirectory named for the range of years it covers ---
+`climatology/0021-0040`, `global_stats/0001-0060` --- built with
+{py:func}`polaris.tasks.ocean.analysis.sim_files.year_range_key`.
+
+That is what gives the suite its re-analysis behavior, and it needs no
+framework support.  A setup with a new range creates steps in directories that
+have never run and so run; a setup with the same range lands on directories
+that are already complete and recomputes nothing; and two ranges never share a
+directory, so an earlier range's results cannot be clobbered or mislabelled.
+
+A task's subdirectory is fixed when the component is constructed, but its
+steps are not: `polaris setup` merges the user's config into each task and
+then calls `configure()` before adding configs to steps, precisely so that
+steps created there are handled.  The analysis tasks therefore discard and
+rebuild their step lists from the config options, in the same way the cosine
+bell tasks do for resolutions.  Construction itself must read nothing but the
+packaged defaults, since `polaris list` builds every task in every component;
+the simulation's Omega configuration is not read until step setup.
+
+Steps are created with
+{py:meth}`polaris.Component.get_or_create_shared_step()`, so a step several
+tasks want --- the climatology, which every field group of `climatology_maps`
+reads --- is built once for a range no matter how many of them ask for it.

--- a/docs/users_guide/ocean/suites.md
+++ b/docs/users_guide/ocean/suites.md
@@ -91,6 +91,36 @@ ocean/spherical/icos/cosine_bell/decomp
 ocean/spherical/icos/cosine_bell/restart
 ```
 
+(ocean-suite-omega-analysis)=
+
+## omega_analysis suite
+
+The `omega_analysis` suite analyzes a simulation that has already been run,
+rather than running one.  It is pointed at a completed Omega simulation
+through a config file and produces plots and the netCDF data behind them.  See
+{ref}`ocean-analysis` for the config file it needs and for what each task
+produces.
+
+Unlike the other suites here, it needs neither an Omega nor an MPAS-Ocean
+build, since no model is run, and it can be run on the machine where the
+simulation output lives without copying that output.  Because there is no
+build to detect the model from, `--model omega` is required and no
+`-p`/`--component_path` is given:
+
+```bash
+polaris suite -c ocean -t omega_analysis -w <work_dir> -f analysis.cfg \
+    --model omega
+```
+
+The tasks in the suite are:
+
+```none
+ocean/analysis/climatology_maps
+ocean/analysis/heat_content_series
+ocean/analysis/global_stats
+ocean/analysis/moc
+```
+
 (ocean-suite-framework-pr)=
 
 ## framework_pr suite

--- a/docs/users_guide/ocean/tasks/analysis.md
+++ b/docs/users_guide/ocean/tasks/analysis.md
@@ -1,0 +1,207 @@
+(ocean-analysis)=
+
+# analysis
+
+The `analysis` task group analyzes a simulation that has **already been run**,
+rather than running one.  Its tasks are pointed at a completed Omega
+simulation through a config file and produce plots and the netCDF data behind
+them.
+
+This makes it unlike the other pages in this section.  There is no mesh, no
+vertical grid, no initial condition, no forcing and no time step to describe,
+because no model is run: everything the analysis needs it reads from the
+simulation's own output.
+
+Analysis products are added over time; {ref}`ocean-analysis-products` lists
+what is available so far.
+
+## supported models
+
+**Omega only.**  The analysis locates a simulation's output by reading the
+simulation's own Omega configuration file, which is also how it learns the
+mesh, the vertical coordinate and the output streams.  MPAS-Ocean describes
+its output with namelists and streams files instead, and reading those would
+require a translator into the same form, which does not exist.  A setup with
+`[ocean] model` set to `mpas-ocean` reports that rather than failing later.
+
+Neither an Omega nor an MPAS-Ocean build is needed, since no model is run.
+
+(ocean-analysis-config)=
+
+## pointing the analysis at a simulation
+
+The user supplies a config file describing the simulation to analyze.  In the
+common case it needs three things: where the simulation is, and the two ranges
+of simulation years to analyze.
+
+```cfg
+[ocean_analysis]
+
+# the simulation's own Omega configuration file
+omega_config_filename = /path/to/run/omega.yml
+
+# a short name used in plot titles and file names
+simulation_name = my_run
+
+
+[ocean_analysis_climatology]
+
+# the first and last year of the climatology, inclusive
+start_year = 21
+end_year = 40
+
+
+[ocean_analysis_time_series]
+
+# the first and last year of the time series, inclusive
+start_year = 1
+end_year = 60
+```
+
+`omega_config_filename` is **required** and is the only description of where
+the simulation's output lives.  Polaris reads the mesh, the vertical
+coordinate and the output streams from it, so none of them have to be restated
+by hand.  An Omega run always writes this file; it is in the run directory.
+
+The two year ranges are independent.  The climatology range governs the
+map-view products and the MOC; the time-series range governs the global
+statistics and ocean heat content time series.  Changing one does not disturb
+the other.
+
+A few further options in `[ocean_analysis]` are worth knowing about, though
+most simulations need none of them:
+
+`simulation_path`
+: The directory that relative file names in the Omega configuration are
+  resolved against.  Defaults to the directory containing that file, which is
+  the run directory.  Set it if the output has moved since the run.
+
+`mesh_filename`, `vert_coord_filename`
+: The horizontal mesh and vertical-coordinate files, absolute or relative to
+  `simulation_path`.  Each defaults to the file the Omega configuration names.
+  Set one if it has moved.
+
+`output_path`
+: Where plots and their netCDF files are published for browsing.  Defaults to
+  `<work_dir>/analysis_output`.  Point it somewhere web-servable to share the
+  results.
+
+The remaining sections --- `[ocean_analysis_climatology]`,
+`[ocean_analysis_ohc]`, `[ocean_analysis_time_series]` and
+`[ocean_analysis_moc]` --- describe what each product computes and plots.  See
+the comments in `polaris/tasks/ocean/analysis/analysis.cfg` for the full list
+with its defaults.
+
+## running the analysis
+
+```bash
+polaris suite -c ocean -t omega_analysis -w <work_dir> -f analysis.cfg \
+    --model omega
+polaris serial
+```
+
+Two things about that command differ from most Polaris suites:
+
+- **`--model omega` is required** (or `model = omega` in an `[ocean]` section
+  of the config file).  Polaris normally detects the model by finding a build,
+  and there is no build here.
+- **No `-p`/`--component_path`**, for the same reason.
+
+The suite can be run on the machine where the simulation output lives, without
+copying that output.
+
+To run a single product rather than the whole suite, set up that task on its
+own:
+
+```bash
+polaris setup -t ocean/analysis/global_stats -w <work_dir> -f analysis.cfg \
+    --model omega
+```
+
+## where the results go
+
+Two directory trees, with two audiences.
+
+The **work directory** is built for predictability and for finding a step's
+log, not for browsing.  It follows one rule, `<product>/<period>`, with a
+third level only for the one product that is chunked by field group:
+
+```none
+ocean/analysis/
+├── climatology/0021-0040/                (shared: ncclimo)
+├── climatology_maps/0021-0040/
+│   ├── temperature/ salinity/ velocity/
+│   ├── ssh/ mixed_layer_depth/
+│   └── heat_content/
+├── heat_content_series/0001-0060/
+├── global_stats/0001-0060/
+└── moc/0021-0040/
+```
+
+The range in each path is the zero-padded first and last year, matching the
+convention `ncclimo` uses in its own file names.
+
+The **staging tree** under `output_path` is where results are published for
+browsing, with descriptive file names that carry the product, the field, the
+season, the vertical reduction and the range.
+
+## analyzing the same simulation more than once
+
+Every product lives at a directory named for the range it covers, and that is
+what makes re-analysis behave sensibly:
+
+- **A new range recomputes.**  It creates steps in directories that have never
+  run, so they run.  Nothing has to be deleted and no flag has to be passed.
+- **An unchanged range recomputes nothing.**  Those directories are already
+  complete.
+- **An earlier range's results survive.**  Two ranges never share a directory,
+  so analyzing years 21--40 leaves the results for years 1--20 in place.  This
+  also makes it impossible to get a plot labelled with one range whose
+  contents came from another.
+
+Re-running `polaris setup` rewrites the suite pickle at the root of the work
+directory, so the range most recently set up is the one `polaris serial` will
+run.  Step directories from earlier ranges are untouched, so returning to an
+earlier range means re-running setup with that range's config.
+
+Analyzing many ranges accumulates step directories and intermediate files,
+which is what makes re-analyzing an earlier range nearly free.  It is worth
+knowing about on a filesystem with a quota; the climatology files dominate.
+
+(ocean-analysis-products)=
+
+## products
+
+The suite is being built up product by product.  What exists so far:
+
+| task | product | status |
+| --- | --- | --- |
+| `climatology_maps` | map-view climatologies, one step per field group | not yet implemented |
+| `global_stats` | time series of the simulation's global statistics | not yet implemented |
+| `heat_content_series` | time series of globally integrated ocean heat content | not yet implemented |
+| `moc` | latitude-elevation plot of the meridional overturning circulation | not yet implemented |
+
+Each task currently resolves the simulation files it will read, links them
+into its work directory and reports them in its log, which is enough to check
+that a simulation is being located correctly.
+
+The `moc` task additionally depends on a diagnostic that Omega computes in
+situ and does not yet provide.  A simulation without it is an ordinary case:
+the step reports that no MOC output was written and produces nothing, rather
+than failing the suite.
+
+## troubleshooting
+
+**`invalid interpolation syntax`** while reading the config file.  Polaris
+config files use extended interpolation, so a bare `$` in a value is an error.
+File-name templates containing `$Y` and `$M` belong in the simulation's Omega
+configuration, not in a Polaris config file, and there is no option that takes
+one.
+
+**Missing input files at setup.**  The analysis checks that every file it will
+read exists before anything runs, and reports the years and months that are
+absent together with the Omega stream that named them.  The usual cause is a
+year range that reaches beyond the simulation.
+
+**`Could not detect ocean model`.**  `--model omega` was not passed and there
+is no `[ocean] model` option in the config file.

--- a/docs/users_guide/ocean/tasks/index.md
+++ b/docs/users_guide/ocean/tasks/index.md
@@ -5,6 +5,7 @@
 ```{toctree}
 :titlesonly: true
 
+analysis
 baroclinic_channel
 barotropic_channel
 barotropic_gyre

--- a/polaris/suites/ocean/omega_analysis.txt
+++ b/polaris/suites/ocean/omega_analysis.txt
@@ -1,0 +1,4 @@
+ocean/analysis/climatology_maps
+ocean/analysis/heat_content_series
+ocean/analysis/global_stats
+ocean/analysis/moc

--- a/polaris/tasks/ocean/add_tasks.py
+++ b/polaris/tasks/ocean/add_tasks.py
@@ -1,3 +1,4 @@
+from polaris.tasks.ocean.analysis import add_analysis_tasks
 from polaris.tasks.ocean.baroclinic_channel import add_baroclinic_channel_tasks
 from polaris.tasks.ocean.barotropic_channel import add_barotropic_channel_tasks
 from polaris.tasks.ocean.barotropic_gyre import add_barotropic_gyre_tasks
@@ -50,6 +51,9 @@ def add_ocean_tasks(component):
 
     # single column tasks
     add_single_column_tasks(component=component)
+
+    # analysis of a completed simulation, which runs no model
+    add_analysis_tasks(component=component)
 
     # spherical tasks
     add_customizable_viz_tasks(component=component)

--- a/polaris/tasks/ocean/analysis/__init__.py
+++ b/polaris/tasks/ocean/analysis/__init__.py
@@ -1,0 +1,293 @@
+from polaris import Task
+from polaris.config import PolarisConfigParser
+from polaris.tasks.ocean.analysis.climatology import Climatology as Climatology
+from polaris.tasks.ocean.analysis.climatology_maps import (
+    ClimatologyMaps as ClimatologyMaps,
+)
+from polaris.tasks.ocean.analysis.climatology_maps import get_field_groups
+from polaris.tasks.ocean.analysis.global_stats import (
+    GlobalStatsTimeSeries as GlobalStatsTimeSeries,
+)
+from polaris.tasks.ocean.analysis.heat_content_series import (
+    HeatContentSeries as HeatContentSeries,
+)
+from polaris.tasks.ocean.analysis.moc import Moc as Moc
+from polaris.tasks.ocean.analysis.sim_files import year_range_key
+
+
+def add_analysis_tasks(component):
+    """
+    Add the tasks that analyze a completed Omega simulation
+
+    Parameters
+    ----------
+    component : polaris.tasks.ocean.Ocean
+        The ocean component the tasks will be added to
+    """
+    filepath = f'{component.name}/analysis/analysis.cfg'
+    config = PolarisConfigParser(filepath=filepath)
+    config.add_from_package('polaris.tasks.ocean.analysis', 'analysis.cfg')
+
+    for task_cls in [
+        ClimatologyMapsTask,
+        GlobalStatsTask,
+        HeatContentSeriesTask,
+        MocTask,
+    ]:
+        component.add_task(task_cls(component=component, config=config))
+
+
+class AnalysisTask(Task):
+    """
+    A task of the ocean analysis suite
+
+    A task is a thin grouping over shared steps and introduces no directory
+    level of its own.  Its steps are built from config options rather than
+    fixed at construction, so that a user who asks for a different range of
+    years gets steps in different directories -- which have never run, and so
+    run -- without having to delete anything or pass a flag.
+
+    Attributes
+    ----------
+    range_section : str
+        The config section holding the ``start_year`` and ``end_year`` this
+        task's steps are keyed on
+    """
+
+    def __init__(self, component, config, name, range_section):
+        """
+        Create the task and its steps
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the task belongs to
+
+        config : polaris.config.PolarisConfigParser
+            The config parser shared by every analysis task
+
+        name : str
+            The name of the task, which is also its subdirectory under
+            ``analysis``
+
+        range_section : str
+            The config section holding the ``start_year`` and ``end_year``
+            this task's steps are keyed on
+        """
+        super().__init__(
+            component=component, name=name, subdir=f'analysis/{name}'
+        )
+        self.range_section = range_section
+        self.set_shared_config(config, link='analysis.cfg')
+        self._setup_steps()
+
+    def configure(self):
+        """
+        Build the steps again now that the user's config file has been read
+
+        ``polaris setup`` merges the user's config into the task and then
+        calls this before adding configs to steps, precisely so that steps
+        created here are handled.
+        """
+        super().configure()
+        self._setup_steps()
+
+    def year_range(self):
+        """
+        Get the range of simulation years this task's steps cover
+
+        Returns
+        -------
+        start_year : int
+            The first year of the range, inclusive
+
+        end_year : int
+            The last year of the range, inclusive
+        """
+        section = self.config[self.range_section]
+        return section.getint('start_year'), section.getint('end_year')
+
+    def _setup_steps(self):
+        """Discard the task's steps and build them from the config options"""
+        raise NotImplementedError(
+            f'{type(self).__name__} does not define _setup_steps()'
+        )
+
+    def _remove_all_steps(self):
+        """Start fresh with no steps"""
+        for step in list(self.steps.values()):
+            self.remove_step(step)
+
+    def _add_shared_step(self, step_cls, subdir, symlink=None, **kwargs):
+        """Add a shared step at a subdirectory computed from the range"""
+        step = self.component.get_or_create_shared_step(
+            step_cls=step_cls,
+            subdir=subdir,
+            config=self.config,
+            config_filename=self.config_filename,
+            **kwargs,
+        )
+        self.add_step(step, symlink=symlink)
+        return step
+
+
+class ClimatologyMapsTask(AnalysisTask):
+    """
+    A task that plots map-view climatologies of the simulation's fields
+
+    It has one step per field group, plus the shared climatology every field
+    group reads, so that adding a field costs that field and not the others.
+    """
+
+    def __init__(self, component, config):
+        """
+        Create the climatology maps task
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the task belongs to
+
+        config : polaris.config.PolarisConfigParser
+            The config parser shared by every analysis task
+        """
+        super().__init__(
+            component=component,
+            config=config,
+            name='climatology_maps',
+            range_section='ocean_analysis_climatology',
+        )
+
+    def _setup_steps(self):
+        start_year, end_year = self.year_range()
+        key = year_range_key(start_year, end_year)
+
+        self._remove_all_steps()
+
+        self._add_shared_step(
+            step_cls=Climatology,
+            subdir=f'analysis/climatology/{key}',
+            symlink='climatology',
+            start_year=start_year,
+            end_year=end_year,
+        )
+
+        fields = self.config.getlist('ocean_analysis_climatology', 'fields')
+        for group, group_fields in get_field_groups(fields).items():
+            self._add_shared_step(
+                step_cls=ClimatologyMaps,
+                subdir=f'analysis/climatology_maps/{key}/{group}',
+                field_group=group,
+                fields=group_fields,
+                start_year=start_year,
+                end_year=end_year,
+            )
+
+
+class GlobalStatsTask(AnalysisTask):
+    """
+    A task that plots time series of the simulation's global statistics
+    """
+
+    def __init__(self, component, config):
+        """
+        Create the global statistics task
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the task belongs to
+
+        config : polaris.config.PolarisConfigParser
+            The config parser shared by every analysis task
+        """
+        super().__init__(
+            component=component,
+            config=config,
+            name='global_stats',
+            range_section='ocean_analysis_time_series',
+        )
+
+    def _setup_steps(self):
+        start_year, end_year = self.year_range()
+        key = year_range_key(start_year, end_year)
+        self._remove_all_steps()
+        self._add_shared_step(
+            step_cls=GlobalStatsTimeSeries,
+            subdir=f'analysis/global_stats/{key}',
+            start_year=start_year,
+            end_year=end_year,
+        )
+
+
+class HeatContentSeriesTask(AnalysisTask):
+    """
+    A task that plots the time series of globally integrated ocean heat
+    content
+    """
+
+    def __init__(self, component, config):
+        """
+        Create the ocean heat content time series task
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the task belongs to
+
+        config : polaris.config.PolarisConfigParser
+            The config parser shared by every analysis task
+        """
+        super().__init__(
+            component=component,
+            config=config,
+            name='heat_content_series',
+            range_section='ocean_analysis_time_series',
+        )
+
+    def _setup_steps(self):
+        start_year, end_year = self.year_range()
+        key = year_range_key(start_year, end_year)
+        self._remove_all_steps()
+        self._add_shared_step(
+            step_cls=HeatContentSeries,
+            subdir=f'analysis/heat_content_series/{key}',
+            start_year=start_year,
+            end_year=end_year,
+        )
+
+
+class MocTask(AnalysisTask):
+    """
+    A task that plots the global meridional overturning circulation
+    """
+
+    def __init__(self, component, config):
+        """
+        Create the MOC task
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the task belongs to
+
+        config : polaris.config.PolarisConfigParser
+            The config parser shared by every analysis task
+        """
+        super().__init__(
+            component=component,
+            config=config,
+            name='moc',
+            range_section='ocean_analysis_climatology',
+        )
+
+    def _setup_steps(self):
+        start_year, end_year = self.year_range()
+        key = year_range_key(start_year, end_year)
+        self._remove_all_steps()
+        self._add_shared_step(
+            step_cls=Moc,
+            subdir=f'analysis/moc/{key}',
+            start_year=start_year,
+            end_year=end_year,
+        )

--- a/polaris/tasks/ocean/analysis/analysis.cfg
+++ b/polaris/tasks/ocean/analysis/analysis.cfg
@@ -55,7 +55,7 @@ plot_seasons = ANN, DJF, JJA
 
 # The fields for which climatology maps are produced, using MPAS-Ocean
 # (Polaris standard) names
-fields = temperature, salinity, velocityZonal, velocityMeridional,
+fields = temperature, salinity, velocityZonal, velocityMeridional, ssh,
          mixedLayerDepth
 
 # The elevations at which fields with a vertical dimension are plotted.

--- a/polaris/tasks/ocean/analysis/analysis.cfg
+++ b/polaris/tasks/ocean/analysis/analysis.cfg
@@ -1,0 +1,219 @@
+# options describing the simulation to be analyzed and where results go
+[ocean_analysis]
+
+# The absolute path to the simulation's Omega configuration file.  This is the
+# analysis' only description of where the simulation's output lives: Polaris
+# reads the mesh, the output streams and their file-name templates from it, so
+# that none of them have to be restated here.  It is required, since an Omega
+# run always has one.  MPAS-Ocean output is not supported; reading it would
+# need a translator from its namelists and streams into the same form.
+omega_config_filename =
+
+# The absolute path to the directory containing the simulation's output.
+# Defaults to the directory containing the Omega configuration file, which is
+# what its relative file names are resolved against.
+simulation_path =
+
+# A short name for the simulation, used in plot titles and file names
+simulation_name = omega
+
+# Where to publish plots and their netCDF files for browsing, organized by
+# product and date range.  Defaults to <work_dir>/analysis_output.  Point this
+# somewhere web-servable if you want to share the results.
+output_path =
+
+# The horizontal mesh file, absolute or relative to simulation_path.  Defaults
+# to the mesh the Omega config names.
+mesh_filename =
+
+# The vertical-coordinate file (Omega only), absolute or relative to
+# simulation_path
+vert_coord_filename =
+
+# Inherit results from earlier analyses of the same simulation in this work
+# directory.  Set to False to recompute everything from the monthly means.
+reuse_previous = True
+
+# Re-run the plotting steps even when their range is unchanged, to pick up
+# changes to colormaps and other plot styling.  Intermediate results --
+# climatologies and accumulator caches -- are still reused.
+replot = False
+
+
+# options for the climatology and the maps made from it
+[ocean_analysis_climatology]
+
+# The first and last year of the climatology, inclusive
+start_year = 1
+end_year = 10
+
+# The seasons to compute, in addition to the 12 monthly climatologies
+seasons = ANN, DJF, MAM, JJA, SON
+
+# The seasons to plot; may include the monthly climatologies JAN through DEC
+plot_seasons = ANN, DJF, JJA
+
+# The fields for which climatology maps are produced, using MPAS-Ocean
+# (Polaris standard) names
+fields = temperature, salinity, velocityZonal, velocityMeridional,
+         mixedLayerDepth
+
+# The elevations at which fields with a vertical dimension are plotted.
+# Elevations are in m, positive up, so values within the ocean are negative:
+#   top      the topmost valid layer of each column (the sea surface)
+#   bottom   the bottommost valid layer of each column (the seafloor)
+#   <z>      an elevation in m, linearly interpolated
+#   k<index> a fixed, zero-based vertical index
+elevations = top, -100.0, -500.0, -2000.0, bottom
+
+# Whether to compute mixed-layer depth offline from monthly-mean temperature
+# and salinity, for simulations whose output does not include it
+compute_mixed_layer_depth = False
+
+# The density threshold used when computing mixed-layer depth offline, in
+# kg m-3, relative to a reference elevation of -10 m
+mixed_layer_depth_threshold = 0.03
+
+
+# options for vertically integrated ocean heat content
+[ocean_analysis_ohc]
+
+# The elevation ranges over which heat content is integrated, given as
+# <top>:<bottom> in m, positive up.  "bottom" means the seafloor.  These are
+# geometric elevations, matching the convention used by MPAS-Analysis and by
+# observational heat content products; the integral itself is mass-weighted.
+elevation_ranges = top:-700.0, -700.0:-2000.0, -2000.0:bottom, top:bottom
+
+# The specific heat capacity used to convert conservative temperature to heat
+# content.  By default, this comes from the Physical Constants Dictionary.
+# The reference density is not a config option; see the algorithm design.
+#seawater_specific_heat_capacity = 3996.0
+
+
+# options for the global time series
+[ocean_analysis_time_series]
+
+# The first and last year of the time series, inclusive
+start_year = 1
+end_year = 10
+
+# The fields from the model's global statistics output to plot.  Fields the
+# simulation did not write are skipped with a message, not an error.
+fields = temperature, salinity, normalVelocity, kineticEnergyCell, ssh
+
+# The statistics to plot for each field.  As with fields, missing statistics
+# are skipped.
+stats = mean, min, max, std
+
+
+# options for the meridional overturning circulation plot
+[ocean_analysis_moc]
+
+# The contour interval in Sv
+contour_interval = 2.0
+
+# The maximum absolute value of the color map in Sv; the color map is
+# symmetric about zero
+#max_streamfunction = 30.0
+
+
+# Options for maps of one field.  The section is named for the field with the
+# field name in lower case with underscores, so that maps of velocityZonal are
+# configured by [ocean_analysis_map_velocity_zonal].
+
+# options for temperature maps
+[ocean_analysis_map_temperature]
+
+# colormap options
+# colormap
+colormap_name = cmo.thermal
+
+# the type of norm used in the colormap
+norm_type = linear
+
+# A dictionary with keywords for the norm
+norm_args = {'vmin': -2., 'vmax': 32.}
+
+
+# options for salinity maps
+[ocean_analysis_map_salinity]
+
+# colormap options
+# colormap
+colormap_name = cmo.haline
+
+# the type of norm used in the colormap
+norm_type = linear
+
+# A dictionary with keywords for the norm
+norm_args = {'vmin': 30., 'vmax': 37.}
+
+
+# options for zonal velocity maps
+[ocean_analysis_map_velocity_zonal]
+
+# colormap options
+# colormap
+colormap_name = cmo.balance
+
+# the type of norm used in the colormap
+norm_type = linear
+
+# A dictionary with keywords for the norm
+norm_args = {'vmin': -0.5, 'vmax': 0.5}
+
+
+# options for meridional velocity maps
+[ocean_analysis_map_velocity_meridional]
+
+# colormap options
+# colormap
+colormap_name = cmo.balance
+
+# the type of norm used in the colormap
+norm_type = linear
+
+# A dictionary with keywords for the norm
+norm_args = {'vmin': -0.5, 'vmax': 0.5}
+
+
+# options for sea surface height maps
+[ocean_analysis_map_ssh]
+
+# colormap options
+# colormap
+colormap_name = cmo.balance
+
+# the type of norm used in the colormap
+norm_type = linear
+
+# A dictionary with keywords for the norm
+norm_args = {'vmin': -2., 'vmax': 2.}
+
+
+# options for mixed-layer depth maps
+[ocean_analysis_map_mixed_layer_depth]
+
+# colormap options
+# colormap
+colormap_name = cmo.deep
+
+# the type of norm used in the colormap
+norm_type = linear
+
+# A dictionary with keywords for the norm
+norm_args = {'vmin': 0., 'vmax': 500.}
+
+
+# options for ocean heat content maps
+[ocean_analysis_map_heat_content]
+
+# colormap options
+# colormap
+colormap_name = cmo.thermal
+
+# the type of norm used in the colormap
+norm_type = linear
+
+# A dictionary with keywords for the norm
+norm_args = {}

--- a/polaris/tasks/ocean/analysis/analysis_step.py
+++ b/polaris/tasks/ocean/analysis/analysis_step.py
@@ -1,0 +1,133 @@
+import os
+
+from polaris.ocean.model import OceanIOStep
+from polaris.tasks.ocean.analysis.sim_files import SimulationFiles
+
+
+class AnalysisStep(OceanIOStep):
+    """
+    A step of the ocean analysis suite
+
+    Every analysis step covers a range of simulation years and reads some of
+    the simulation's output, so both live here rather than being repeated by
+    each product.
+
+    Attributes
+    ----------
+    start_year : int
+        The first year of the range this step covers, inclusive
+
+    end_year : int
+        The last year of the range this step covers, inclusive
+
+    input_filenames : list of str
+        The local names of the simulation files symlinked into the step's
+        work directory, in the order they were added
+    """
+
+    def __init__(
+        self, component, name, subdir, start_year, end_year, **kwargs
+    ):
+        """
+        Create a new analysis step
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the step belongs to
+
+        name : str
+            The name of the step
+
+        subdir : str
+            The subdirectory for the step, which ends in the range key so
+            that a step covering a different range is a different step
+
+        start_year : int
+            The first year of the range this step covers, inclusive
+
+        end_year : int
+            The last year of the range this step covers, inclusive
+
+        kwargs
+            Keyword arguments passed on to
+            :py:class:`polaris.ocean.model.OceanIOStep`
+        """
+        super().__init__(
+            component=component, name=name, subdir=subdir, **kwargs
+        )
+        self.start_year = start_year
+        self.end_year = end_year
+        self.input_filenames: list = []
+
+    def get_sim_files(self):
+        """
+        Get the simulation's files, reporting where each path came from
+
+        This is called from ``setup()``, where a step has no logger yet, so
+        the report goes to the terminal along with the rest of what
+        ``polaris setup`` prints.
+
+        Returns
+        -------
+        sim_files : polaris.tasks.ocean.analysis.sim_files.SimulationFiles
+            The files of the simulation being analyzed
+        """
+        return SimulationFiles(self.config)
+
+    def add_sim_input_file(self, path, filename=None):
+        """
+        Symlink one file of simulation output into the step's work directory
+
+        Parameters
+        ----------
+        path : str
+            The absolute path to the file
+
+        filename : str, optional
+            The local name of the symlink; defaults to the base name of
+            ``path``
+
+        Returns
+        -------
+        filename : str
+            The local name of the symlink
+        """
+        if filename is None:
+            filename = os.path.basename(path)
+        if filename in self.input_filenames:
+            raise ValueError(
+                f'Two files of simulation output would be linked into '
+                f'{self.name} as "{filename}".  The second is {path}.'
+            )
+        self.add_input_file(filename=filename, target=path)
+        self.input_filenames.append(filename)
+        return filename
+
+    def add_sim_input_files(self, sim_files):
+        """
+        Symlink a list of simulation files into the step's work directory
+
+        Parameters
+        ----------
+        sim_files : list of polaris.tasks.ocean.analysis.sim_files.SimFile
+            The files to link, as returned by the methods of
+            :py:class:`~polaris.tasks.ocean.analysis.sim_files.SimulationFiles`
+        """
+        for sim_file in sim_files:
+            self.add_sim_input_file(sim_file.path)
+
+    def log_inputs(self):
+        """
+        Report the simulation files this step reads
+
+        This is what the steps do in place of their product while the suite
+        is being scaffolded, and it is worth keeping afterwards: it is the
+        record of what a step actually read, in the step's own log.
+        """
+        self.logger.info(
+            f'{self.name}: years {self.start_year} through {self.end_year}, '
+            f'{len(self.input_filenames)} input files'
+        )
+        for filename in self.input_filenames:
+            self.logger.info(f'  {self.work_path(filename)}')

--- a/polaris/tasks/ocean/analysis/analysis_step.py
+++ b/polaris/tasks/ocean/analysis/analysis_step.py
@@ -73,7 +73,13 @@ class AnalysisStep(OceanIOStep):
         sim_files : polaris.tasks.ocean.analysis.sim_files.SimulationFiles
             The files of the simulation being analyzed
         """
-        return SimulationFiles(self.config)
+        sim_files = SimulationFiles(self.config)
+        print(
+            f'{self.name} ({self.start_year}-{self.end_year}): simulation at '
+            f'{sim_files.simulation_path} '
+            f'(from {sim_files.simulation_path_source})'
+        )
+        return sim_files
 
     def add_sim_input_file(self, path, filename=None):
         """

--- a/polaris/tasks/ocean/analysis/climatology.py
+++ b/polaris/tasks/ocean/analysis/climatology.py
@@ -1,0 +1,59 @@
+from polaris.tasks.ocean.analysis.analysis_step import AnalysisStep
+
+# ``ncclimo`` in background mode runs one process per month, so this is what
+# the step will start and therefore what it declares.  The pool is sized from
+# this number and never from the size of the machine.
+NCCLIMO_PROCESSES = 12
+
+
+class Climatology(AnalysisStep):
+    """
+    A step that computes monthly, seasonal and annual climatologies of the
+    simulation's monthly-mean output with ``ncclimo``
+
+    The climatology is shared: every field group of ``climatology_maps`` reads
+    it, so it runs once for a range no matter how many products want it.
+    """
+
+    def __init__(self, component, subdir, start_year, end_year):
+        """
+        Create the climatology step
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the step belongs to
+
+        subdir : str
+            The subdirectory for the step
+
+        start_year : int
+            The first year of the climatology, inclusive
+
+        end_year : int
+            The last year of the climatology, inclusive
+        """
+        super().__init__(
+            component=component,
+            name='climatology',
+            subdir=subdir,
+            start_year=start_year,
+            end_year=end_year,
+            ntasks=1,
+            cpus_per_task=NCCLIMO_PROCESSES,
+        )
+
+    def setup(self):
+        """
+        Link the monthly means the climatology is computed from
+        """
+        sim_files = self.get_sim_files()
+        self.add_sim_input_files(
+            sim_files.monthly_mean_files(self.start_year, self.end_year)
+        )
+
+    def run(self):
+        """
+        Report the monthly means; the climatology itself is not computed yet
+        """
+        self.log_inputs()

--- a/polaris/tasks/ocean/analysis/climatology_maps.py
+++ b/polaris/tasks/ocean/analysis/climatology_maps.py
@@ -1,10 +1,21 @@
 from polaris.tasks.ocean.analysis.analysis_step import AnalysisStep
 
-# The field groups maps are chunked into.  A group is the unit because things
-# computed together belong together: the two velocity components share one
-# vector reconstruction, and heat content over several elevation ranges shares
-# one set of layer weights.  Heat content reads no field of its own, since it
-# is derived from temperature and the layer masses.
+# The field groups maps are chunked into.
+#
+# A group is the unit of *shared computation*, and therefore the unit of work:
+# one step per group.  The two velocity components share one vector
+# reconstruction, and heat content over several elevation ranges shares one set
+# of layer weights, so each is worth computing once.  Temperature, salinity and
+# ssh are groups of one only because they share nothing.
+#
+# It is deliberately not a presentation grouping.  How products are gathered
+# for a reader is carried by the manifest's ``group`` and ``gallery`` facets,
+# which the publication layer adds, so that re-chunking the work does not
+# rearrange the gallery.  A group of two fields can appear as two galleries,
+# and two groups can appear under one heading.
+#
+# Heat content reads no field of its own, since it is derived from temperature
+# and the layer masses.
 FIELD_GROUPS = {
     'temperature': ('temperature',),
     'salinity': ('salinity',),
@@ -61,7 +72,8 @@ class ClimatologyMaps(AnalysisStep):
     Attributes
     ----------
     field_group : str
-        The name of the field group this step covers
+        The name of the field group this step covers, which is the unit of
+        shared computation rather than a heading products are gathered under
 
     fields : list of str
         The fields of that group that were requested

--- a/polaris/tasks/ocean/analysis/climatology_maps.py
+++ b/polaris/tasks/ocean/analysis/climatology_maps.py
@@ -1,0 +1,138 @@
+from polaris.tasks.ocean.analysis.analysis_step import AnalysisStep
+
+# The field groups maps are chunked into.  A group is the unit because things
+# computed together belong together: the two velocity components share one
+# vector reconstruction, and heat content over several elevation ranges shares
+# one set of layer weights.  Heat content reads no field of its own, since it
+# is derived from temperature and the layer masses.
+FIELD_GROUPS = {
+    'temperature': ('temperature',),
+    'salinity': ('salinity',),
+    'velocity': ('velocityZonal', 'velocityMeridional'),
+    'ssh': ('ssh',),
+    'mixed_layer_depth': ('mixedLayerDepth',),
+    'heat_content': (),
+}
+
+# Heat content is a field group of the maps rather than a product of its own,
+# and it is not one of the fields a user lists, so it is always present
+DERIVED_FIELD_GROUPS = ('heat_content',)
+
+
+def get_field_groups(fields):
+    """
+    Get the field groups that cover a list of requested fields
+
+    Parameters
+    ----------
+    fields : list of str
+        The fields to plot, using MPAS-Ocean names, as listed in the
+        ``[ocean_analysis_climatology] fields`` config option
+
+    Returns
+    -------
+    field_groups : dict
+        A mapping from the name of each group that is needed to the fields of
+        that group that were requested, in the order the groups are defined
+
+    Raises
+    ------
+    ValueError
+        If a requested field belongs to no group
+    """
+    requested: dict = {}
+    for field in fields:
+        group = _group_for_field(field)
+        requested.setdefault(group, []).append(field)
+
+    field_groups = {}
+    for group, group_fields in FIELD_GROUPS.items():
+        if group in DERIVED_FIELD_GROUPS:
+            field_groups[group] = list(group_fields)
+        elif group in requested:
+            field_groups[group] = requested[group]
+    return field_groups
+
+
+class ClimatologyMaps(AnalysisStep):
+    """
+    A step that plots maps of one field group from the climatology
+
+    Attributes
+    ----------
+    field_group : str
+        The name of the field group this step covers
+
+    fields : list of str
+        The fields of that group that were requested
+    """
+
+    def __init__(
+        self, component, subdir, field_group, fields, start_year, end_year
+    ):
+        """
+        Create a climatology map step for one field group
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the step belongs to
+
+        subdir : str
+            The subdirectory for the step
+
+        field_group : str
+            The name of the field group this step covers
+
+        fields : list of str
+            The fields of that group that were requested
+
+        start_year : int
+            The first year of the climatology, inclusive
+
+        end_year : int
+            The last year of the climatology, inclusive
+        """
+        super().__init__(
+            component=component,
+            name=field_group,
+            subdir=subdir,
+            start_year=start_year,
+            end_year=end_year,
+            ntasks=1,
+            cpus_per_task=1,
+        )
+        self.field_group = field_group
+        self.fields = list(fields)
+
+    def setup(self):
+        """
+        Link the mesh the maps are plotted on
+        """
+        sim_files = self.get_sim_files()
+        self.add_sim_input_file(sim_files.mesh_filename(), 'mesh.nc')
+
+    def run(self):
+        """
+        Report the fields and inputs; no maps are plotted yet
+        """
+        self.logger.info(
+            f'field group {self.field_group}: '
+            f'{", ".join(self.fields) if self.fields else "derived"}'
+        )
+        self.log_inputs()
+
+
+def _group_for_field(field):
+    """Get the name of the group a field belongs to"""
+    for group, group_fields in FIELD_GROUPS.items():
+        if field in group_fields:
+            return group
+    known = sorted(
+        field for fields in FIELD_GROUPS.values() for field in fields
+    )
+    raise ValueError(
+        f'The field "{field}" in [ocean_analysis_climatology] fields belongs '
+        f'to no field group.  The fields that can be mapped are: '
+        f'{", ".join(known)}.'
+    )

--- a/polaris/tasks/ocean/analysis/global_stats.py
+++ b/polaris/tasks/ocean/analysis/global_stats.py
@@ -1,0 +1,51 @@
+from polaris.tasks.ocean.analysis.analysis_step import AnalysisStep
+
+
+class GlobalStatsTimeSeries(AnalysisStep):
+    """
+    A step that plots time series of the quantities in the simulation's global
+    statistics output
+    """
+
+    def __init__(self, component, subdir, start_year, end_year):
+        """
+        Create the global statistics time series step
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the step belongs to
+
+        subdir : str
+            The subdirectory for the step
+
+        start_year : int
+            The first year of the time series, inclusive
+
+        end_year : int
+            The last year of the time series, inclusive
+        """
+        super().__init__(
+            component=component,
+            name='global_stats',
+            subdir=subdir,
+            start_year=start_year,
+            end_year=end_year,
+            ntasks=1,
+            cpus_per_task=1,
+        )
+
+    def setup(self):
+        """
+        Link the simulation's global statistics output
+        """
+        sim_files = self.get_sim_files()
+        self.add_sim_input_files(
+            sim_files.global_stats_files(self.start_year, self.end_year)
+        )
+
+    def run(self):
+        """
+        Report the statistics files; no time series are plotted yet
+        """
+        self.log_inputs()

--- a/polaris/tasks/ocean/analysis/heat_content_series.py
+++ b/polaris/tasks/ocean/analysis/heat_content_series.py
@@ -1,0 +1,63 @@
+from polaris.tasks.ocean.analysis.analysis_step import AnalysisStep
+
+
+class HeatContentSeries(AnalysisStep):
+    """
+    A step that reduces each month of the simulation to globally integrated
+    ocean heat content over a set of elevation ranges, and plots the series
+
+    Reading a month at a time is what keeps this step's memory footprint
+    independent of the length of the record, and it is what makes a month the
+    unit that a later run can inherit.
+    """
+
+    def __init__(self, component, subdir, start_year, end_year):
+        """
+        Create the ocean heat content time series step
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the step belongs to
+
+        subdir : str
+            The subdirectory for the step
+
+        start_year : int
+            The first year of the time series, inclusive
+
+        end_year : int
+            The last year of the time series, inclusive
+        """
+        super().__init__(
+            component=component,
+            name='heat_content_series',
+            subdir=subdir,
+            start_year=start_year,
+            end_year=end_year,
+            ntasks=1,
+            cpus_per_task=1,
+        )
+
+    def setup(self):
+        """
+        Link the monthly means, the mesh and the vertical coordinate
+
+        The mesh supplies the cell areas of the global integral and the
+        vertical coordinate the indices of the top and bottom valid layer of
+        each column.
+        """
+        sim_files = self.get_sim_files()
+        self.add_sim_input_file(sim_files.mesh_filename(), 'mesh.nc')
+        self.add_sim_input_file(
+            sim_files.vert_coord_filename(), 'vert_coord.nc'
+        )
+        self.add_sim_input_files(
+            sim_files.monthly_mean_files(self.start_year, self.end_year)
+        )
+
+    def run(self):
+        """
+        Report the monthly means; no heat content is computed yet
+        """
+        self.log_inputs()

--- a/polaris/tasks/ocean/analysis/moc.py
+++ b/polaris/tasks/ocean/analysis/moc.py
@@ -1,0 +1,68 @@
+from polaris.tasks.ocean.analysis.analysis_step import AnalysisStep
+
+
+class Moc(AnalysisStep):
+    """
+    A step that time averages the meridional overturning circulation Omega
+    computes in situ and plots it against latitude and elevation
+
+    Attributes
+    ----------
+    has_moc_output : bool
+        Whether the simulation wrote MOC output at all
+    """
+
+    def __init__(self, component, subdir, start_year, end_year):
+        """
+        Create the MOC step
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component the step belongs to
+
+        subdir : str
+            The subdirectory for the step
+
+        start_year : int
+            The first year to average over, inclusive
+
+        end_year : int
+            The last year to average over, inclusive
+        """
+        super().__init__(
+            component=component,
+            name='moc',
+            subdir=subdir,
+            start_year=start_year,
+            end_year=end_year,
+            ntasks=1,
+            cpus_per_task=1,
+        )
+        self.has_moc_output = False
+
+    def setup(self):
+        """
+        Link the simulation's MOC output, if it wrote any
+
+        Omega's MOC diagnostic is new, so users will analyze simulations that
+        predate it.  That is reported rather than treated as a failure, and
+        the step goes on to produce nothing.
+        """
+        sim_files = self.get_sim_files()
+        moc_files = sim_files.moc_files(self.start_year, self.end_year)
+        self.has_moc_output = moc_files is not None
+        if moc_files is not None:
+            self.add_sim_input_files(moc_files)
+
+    def run(self):
+        """
+        Report the MOC output; no plot is made yet
+        """
+        if not self.has_moc_output:
+            self.logger.info(
+                'The simulation wrote no MOC output, so there is nothing to '
+                'plot.'
+            )
+            return
+        self.log_inputs()

--- a/polaris/tasks/ocean/analysis/sim_files.py
+++ b/polaris/tasks/ocean/analysis/sim_files.py
@@ -1,0 +1,203 @@
+"""
+Helpers for locating the output of the simulation being analyzed.
+
+This module is deliberately free of any dependence on
+:py:class:`polaris.Step`, so that it can be unit tested and reused by every
+analysis step that reads simulation output.
+"""
+
+import os
+from typing import NamedTuple, Optional
+
+
+class SimFile(NamedTuple):
+    """
+    One file of simulation output, together with the date it covers
+
+    Attributes
+    ----------
+    path : str
+        The absolute path to the file
+
+    year : int or None
+        The simulation year the file covers, or ``None`` if the file-name
+        template has no ``$Y`` in it
+
+    month : int or None
+        The month the file covers, or ``None`` if the file-name template has
+        no ``$M`` in it
+    """
+
+    path: str
+    year: Optional[int]
+    month: Optional[int]
+
+
+def year_range_key(start_year, end_year):
+    """
+    Get the key for a range of years, used both for step subdirectories and
+    for the names of published files
+
+    The zero-padded convention matches the one ``ncclimo`` already uses in its
+    output file names.
+
+    Parameters
+    ----------
+    start_year : int
+        The first year of the range, inclusive
+
+    end_year : int
+        The last year of the range, inclusive
+
+    Returns
+    -------
+    key : str
+        The range key, e.g. ``'0021-0040'``
+    """
+    return f'{start_year:04d}-{end_year:04d}'
+
+
+def expand_template(template, start_year, end_year, simulation_path=None):
+    """
+    Expand a file-name template over a range of years
+
+    ``$Y`` is replaced by the four-digit year and ``$M`` by the two-digit
+    month.  A template with no ``$M`` gives one file per year and a template
+    with neither gives a single file, which is the case for the analysis
+    output Omega writes to one file for a whole run.
+
+    Parameters
+    ----------
+    template : str
+        The file-name template, absolute or relative to ``simulation_path``
+
+    start_year : int
+        The first year to expand over, inclusive
+
+    end_year : int
+        The last year to expand over, inclusive
+
+    simulation_path : str, optional
+        The directory a relative template is resolved against
+
+    Returns
+    -------
+    sim_files : list of SimFile
+        The expanded files, in chronological order
+    """
+    _check_template(template)
+
+    if not os.path.isabs(template):
+        if simulation_path is None:
+            raise ValueError(
+                f'The file-name template "{template}" is relative but no '
+                f'simulation_path was given to resolve it against.'
+            )
+        template = os.path.join(simulation_path, template)
+    template = os.path.abspath(template)
+
+    if start_year > end_year:
+        raise ValueError(
+            f'The start year {start_year} is after the end year {end_year}.'
+        )
+
+    has_year = '$Y' in template
+    has_month = '$M' in template
+
+    if not has_year:
+        # a template with no date in it describes a single file covering the
+        # whole run
+        return [SimFile(path=template, year=None, month=None)]
+
+    sim_files = []
+    for year in range(start_year, end_year + 1):
+        path = template.replace('$Y', f'{year:04d}')
+        if not has_month:
+            sim_files.append(SimFile(path=path, year=year, month=None))
+            continue
+        for month in range(1, 13):
+            sim_files.append(
+                SimFile(
+                    path=path.replace('$M', f'{month:02d}'),
+                    year=year,
+                    month=month,
+                )
+            )
+
+    return sim_files
+
+
+def check_files_exist(sim_files, description, option_name):
+    """
+    Check that every expanded file exists, reporting the missing years and
+    months rather than a bare list of paths
+
+    Parameters
+    ----------
+    sim_files : list of SimFile
+        The files to check, as returned by :py:func:`expand_template`
+
+    description : str
+        A short description of what the files are, used in the error message,
+        e.g. ``'monthly-mean'``
+
+    option_name : str
+        The name of the config option in ``[ocean_analysis]`` that sets the
+        template these files came from, so that the error says what to fix
+
+    Raises
+    ------
+    FileNotFoundError
+        If any of the files is missing
+    """
+    missing = [sim_file for sim_file in sim_files if not _exists(sim_file)]
+    if not missing:
+        return
+
+    lines = [
+        f'{len(missing)} of {len(sim_files)} {description} files are missing:'
+    ]
+    lines.extend(_describe_missing(missing))
+    lines.append(
+        f'Check the year range and the [ocean_analysis] {option_name} '
+        f'option (or the Omega configuration file it defaults to).'
+    )
+    raise FileNotFoundError('\n'.join(lines))
+
+
+def _exists(sim_file):
+    """Whether a simulation file is present, following any symlink"""
+    return os.path.exists(sim_file.path)
+
+
+def _describe_missing(missing):
+    """Summarize missing files as one line per year"""
+    if missing[0].year is None:
+        return [f'  {sim_file.path}' for sim_file in missing]
+
+    by_year: dict = {}
+    for sim_file in missing:
+        by_year.setdefault(sim_file.year, []).append(sim_file.month)
+
+    lines = []
+    for year, months in sorted(by_year.items()):
+        if months[0] is None:
+            lines.append(f'  year {year:04d}')
+        else:
+            month_list = ', '.join(f'{month:02d}' for month in sorted(months))
+            lines.append(f'  year {year:04d}: months {month_list}')
+    return lines
+
+
+def _check_template(template):
+    """Complain about date fields we do not know how to expand"""
+    unsupported = [
+        field for field in ['$D', '$h', '$m', '$s'] if field in template
+    ]
+    if unsupported:
+        raise ValueError(
+            f'The file-name template "{template}" contains '
+            f'{", ".join(unsupported)}, which the analysis cannot expand.  '
+            f'Only $Y and $M are supported, since the analysis reads output '
+            f'written no more often than monthly.'
+        )

--- a/polaris/tasks/ocean/analysis/sim_files.py
+++ b/polaris/tasks/ocean/analysis/sim_files.py
@@ -7,6 +7,8 @@ analysis step that reads simulation output.
 """
 
 import os
+import re
+from glob import glob
 from typing import List, NamedTuple, Optional
 
 from polaris.yaml import PolarisYaml
@@ -129,7 +131,9 @@ def expand_template(template, start_year, end_year, simulation_path=None):
     return sim_files
 
 
-def check_files_exist(sim_files, description, source):
+def check_files_exist(
+    sim_files, description, source, template=None, simulation_path=None
+):
     """
     Check that every expanded file exists, reporting the missing years and
     months rather than a bare list of paths
@@ -148,6 +152,14 @@ def check_files_exist(sim_files, description, source):
         error says where to look, e.g. ``'the History stream in
         /path/omega.yml'``
 
+    template : str, optional
+        The template the files were expanded from.  Given it, the error also
+        says which years the simulation did write, which is usually the
+        answer the reader wants.
+
+    simulation_path : str, optional
+        The directory a relative template is resolved against
+
     Raises
     ------
     FileNotFoundError
@@ -161,11 +173,48 @@ def check_files_exist(sim_files, description, source):
         f'{len(missing)} of {len(sim_files)} {description} files are missing:'
     ]
     lines.extend(_describe_missing(missing))
-    lines.append(
-        f'They are named by {source}.  Check the year range and that the '
-        f'simulation wrote this output for those years.'
-    )
+    lines.append(f'They are named by {source}.')
+    available = _years_available(template, simulation_path)
+    if available:
+        first, last = available[0], available[-1]
+        gaps = len(available) < last - first + 1
+        span = f'{first}-{last}' + (', with gaps' if gaps else '')
+        lines.append(
+            f'The simulation wrote years {span}.  Set start_year and '
+            f'end_year within that range.'
+        )
+    else:
+        lines.append(
+            'Check the year range and that the simulation wrote this output '
+            'for those years.'
+        )
     raise FileNotFoundError('\n'.join(lines))
+
+
+def _years_available(template, simulation_path):
+    """
+    Find the years the simulation actually wrote, for the error message
+
+    This looks at the simulation directory, which the analysis otherwise
+    never does: a range is declared by the user rather than discovered, so
+    that the same request always means the same thing.  Discovering it here
+    only turns "some files are missing" into the answer the reader wants,
+    and nothing outside this error path depends on it.
+    """
+    if template is None or '$Y' not in template:
+        return []
+    if not os.path.isabs(template) and simulation_path is not None:
+        template = os.path.join(simulation_path, template)
+    pattern = template.replace('$Y', '[0-9]' * 4).replace('$M', '[0-9]' * 2)
+    matcher = re.escape(template)
+    matcher = matcher.replace(re.escape('$Y'), r'(?P<year>[0-9]{4})')
+    matcher = matcher.replace(re.escape('$M'), r'[0-9]{2}')
+    years = set()
+    for path in glob(pattern):
+        found = re.fullmatch(matcher, path)
+        if found:
+            years.add(int(found.group('year')))
+    return sorted(years)
 
 
 class AnalysisStream(NamedTuple):
@@ -681,7 +730,11 @@ class SimulationFiles:
             simulation_path=self.simulation_path,
         )
         check_files_exist(
-            sim_files=sim_files, description=description, source=source
+            sim_files=sim_files,
+            description=description,
+            source=source,
+            template=template,
+            simulation_path=self.simulation_path,
         )
         return sim_files
 

--- a/polaris/tasks/ocean/analysis/sim_files.py
+++ b/polaris/tasks/ocean/analysis/sim_files.py
@@ -405,6 +405,9 @@ class SimulationFiles:
     simulation_path : str
         The directory that relative file names are resolved against
 
+    simulation_path_source : str
+        Where ``simulation_path`` came from, for reporting
+
     simulation_name : str
         A short name for the simulation, used in plot titles and file names
     """
@@ -438,8 +441,6 @@ class SimulationFiles:
                 'Omega run always writes one.'
             )
         self.omega_config = read_omega_config(omega_config_filename)
-        self.log(f'simulation configuration: {self.omega_config.filename}')
-
         self.simulation_path = self._resolve_simulation_path()
         self.simulation_name = section.get('simulation_name')
 
@@ -582,9 +583,8 @@ class SimulationFiles:
         else:
             simulation_path = os.path.dirname(self.omega_config.filename)
             source = 'the directory of the Omega configuration file'
-        simulation_path = os.path.abspath(simulation_path)
-        self.log(f'simulation path: {simulation_path} (from {source})')
-        return simulation_path
+        self.simulation_path_source = source
+        return os.path.abspath(simulation_path)
 
     def _resolve_stream_path(self, option_name, stream_name, description):
         """
@@ -619,7 +619,7 @@ class SimulationFiles:
         value = self.omega_config.stream_filename(stream_name)
         assert value is not None
         self.log(
-            f'{description}: {value} '
+            f'  {description}: {value} '
             f"(from the Omega config's {stream_name} stream)"
         )
         return value
@@ -638,7 +638,7 @@ class SimulationFiles:
             else:
                 kind = 'time-mean' if stream.is_reduction else 'snapshot'
                 self.log(
-                    f'{description}: {stream.filename} (from the Omega '
+                    f'  {description}: {stream.filename} (from the Omega '
                     f"config's {group_name} group, the {stream.period} "
                     f'{kind} stream)'
                 )
@@ -649,7 +649,7 @@ class SimulationFiles:
                 f'The analysis needs the {description} of the simulation, '
                 f'but {reason}.'
             )
-        self.log(f'no {description} output: {reason}')
+        self.log(f'  no {description} output: {reason}')
         return None
 
     def _analysis_group_problem(self, group_name):

--- a/polaris/tasks/ocean/analysis/sim_files.py
+++ b/polaris/tasks/ocean/analysis/sim_files.py
@@ -7,7 +7,9 @@ analysis step that reads simulation output.
 """
 
 import os
-from typing import NamedTuple, Optional
+from typing import List, NamedTuple, Optional
+
+from polaris.yaml import PolarisYaml
 
 
 class SimFile(NamedTuple):
@@ -165,6 +167,222 @@ def check_files_exist(sim_files, description, option_name):
     raise FileNotFoundError('\n'.join(lines))
 
 
+class AnalysisStream(NamedTuple):
+    """
+    One output stream of an Omega analysis group
+
+    Attributes
+    ----------
+    filename : str
+        The file-name template Omega builds for the stream, which may contain
+        ``$Y`` and ``$M``
+
+    period : str
+        The period of the time reduction or of the snapshots, e.g. ``'1Month'``
+
+    is_reduction : bool
+        Whether the stream holds time means rather than snapshots
+    """
+
+    filename: str
+    period: str
+    is_reduction: bool
+
+
+class OmegaConfig:
+    """
+    The configuration file of the simulation being analyzed
+
+    Polaris reads the simulation's own Omega configuration so that the mesh,
+    the output streams and their file-name templates do not have to be
+    restated by hand.  This is the one place Polaris depends on the *shape* of
+    Omega's configuration rather than on its output, so every method here
+    reports what it did not find rather than raising from deep inside a
+    lookup.
+
+    Attributes
+    ----------
+    filename : str
+        The absolute path to the Omega configuration file
+
+    streams : dict
+        The contents of the ``IOStreams`` section
+
+    options : dict
+        The remaining options under the ``Omega`` section
+    """
+
+    def __init__(self, filename, streams, options):
+        self.filename = filename
+        self.streams = streams
+        self.options = options
+
+    def stream_status(self, stream_name):
+        """
+        Report whether an ``IOStreams`` entry can supply a file name
+
+        Parameters
+        ----------
+        stream_name : str
+            The name of the stream, e.g. ``'History'``
+
+        Returns
+        -------
+        status : str
+            ``'ok'``, ``'missing'`` if there is no such stream, or
+            ``'no_filename'`` if the stream is there but names no file (a
+            stream that uses a pointer file, for instance)
+        """
+        if stream_name not in self.streams:
+            return 'missing'
+        if not self.streams[stream_name].get('Filename'):
+            return 'no_filename'
+        return 'ok'
+
+    def stream_filename(self, stream_name):
+        """
+        Get the file name or file-name template of an ``IOStreams`` entry
+
+        Parameters
+        ----------
+        stream_name : str
+            The name of the stream, e.g. ``'History'``
+
+        Returns
+        -------
+        filename : str or None
+            The file name, or ``None`` if the stream is absent or names no
+            file
+        """
+        if self.stream_status(stream_name) != 'ok':
+            return None
+        return str(self.streams[stream_name]['Filename'])
+
+    def analysis_group_status(self, group_name):
+        """
+        Report whether an analysis group is writing output
+
+        Parameters
+        ----------
+        group_name : str
+            The name of the analysis group, e.g. ``'GlobalStats'``
+
+        Returns
+        -------
+        status : str
+            ``'ok'``, ``'missing'`` if the simulation has no such group, or
+            ``'disabled'`` if it has one that is turned off
+        """
+        groups = self.options.get('Analysis', {})
+        if group_name not in groups:
+            return 'missing'
+        if not groups[group_name].get('Enable', True):
+            return 'disabled'
+        return 'ok'
+
+    def analysis_streams(self, group_name):
+        """
+        Get the output streams an analysis group writes
+
+        The file names are reconstructed the way Omega's analysis manager
+        builds them, as ``<prefix>_<period><TimeStats|Instants><template>``.
+        Time reductions come first, since a time mean is what analysis wants
+        when a group writes both.
+
+        Parameters
+        ----------
+        group_name : str
+            The name of the analysis group, e.g. ``'GlobalStats'``
+
+        Returns
+        -------
+        streams : list of AnalysisStream
+            The streams the group writes, empty if the group is absent or
+            disabled
+        """
+        if self.analysis_group_status(group_name) != 'ok':
+            return []
+
+        group = self.options['Analysis'][group_name]
+        filename = group.get('Filename')
+        if not filename:
+            return []
+
+        streams: List[AnalysisStream] = []
+        for period in group.get('ReductionPeriod', []) or []:
+            streams.append(
+                AnalysisStream(
+                    filename=_omega_analysis_filename(
+                        str(filename), str(period), is_reduction=True
+                    ),
+                    period=str(period),
+                    is_reduction=True,
+                )
+            )
+        for period in group.get('SnapshotPeriod', []) or []:
+            streams.append(
+                AnalysisStream(
+                    filename=_omega_analysis_filename(
+                        str(filename), str(period), is_reduction=False
+                    ),
+                    period=str(period),
+                    is_reduction=False,
+                )
+            )
+        return streams
+
+
+def read_omega_config(filename):
+    """
+    Read the configuration file of the simulation being analyzed
+
+    Parameters
+    ----------
+    filename : str
+        The path to the simulation's Omega configuration file
+
+    Returns
+    -------
+    omega_config : OmegaConfig
+        The parsed configuration
+
+    Raises
+    ------
+    FileNotFoundError
+        If there is no file at ``filename``
+
+    ValueError
+        If the file does not look like an Omega configuration
+    """
+    filename = os.path.abspath(filename)
+    if not os.path.exists(filename):
+        raise FileNotFoundError(
+            f'No Omega configuration file at {filename}.  Set the '
+            f'[ocean_analysis] omega_config_filename option to the '
+            f'configuration file of the simulation being analyzed, or leave '
+            f'it empty and set the mesh and file-name template options by '
+            f'hand.'
+        )
+
+    try:
+        yaml = PolarisYaml.read(filename, streams_section='IOStreams')
+    except Exception as exception:
+        raise ValueError(
+            f'Could not parse {filename} as an Omega configuration file: '
+            f'{exception}'
+        ) from exception
+
+    if yaml.model != 'Omega':
+        raise ValueError(
+            f'{filename} does not look like an Omega configuration file: its '
+            f'top-level section is "{yaml.model}" rather than "Omega".'
+        )
+
+    return OmegaConfig(
+        filename=filename, streams=yaml.streams, options=yaml.configs
+    )
+
+
 def _exists(sim_file):
     """Whether a simulation file is present, following any symlink"""
     return os.path.exists(sim_file.path)
@@ -201,3 +419,30 @@ def _check_template(template):
             f'Only $Y and $M are supported, since the analysis reads output '
             f'written no more often than monthly.'
         )
+
+
+def _omega_analysis_filename(filename, period, is_reduction):
+    """
+    Build the file name Omega's analysis manager gives an output stream
+
+    This mirrors ``AnalysisGroup::createAnalysisGroupStreams()`` in Omega,
+    which splits the configured name at the first ``$``, absorbing a trailing
+    ``.`` or ``_`` from the prefix into the timestamp template, and then
+    inserts the period and the kind of output between the two.
+    """
+    position = filename.find('$')
+    if position == -1:
+        prefix = filename
+        template = ''
+    elif position == 0:
+        prefix = ''
+        template = filename
+    elif filename[position - 1] in ('.', '_'):
+        prefix = filename[: position - 1]
+        template = filename[position - 1 :]
+    else:
+        prefix = filename[:position]
+        template = filename[position:]
+
+    kind = 'TimeStats' if is_reduction else 'Instants'
+    return f'{prefix}_{period}{kind}{template}'

--- a/polaris/tasks/ocean/analysis/sim_files.py
+++ b/polaris/tasks/ocean/analysis/sim_files.py
@@ -129,7 +129,7 @@ def expand_template(template, start_year, end_year, simulation_path=None):
     return sim_files
 
 
-def check_files_exist(sim_files, description, option_name):
+def check_files_exist(sim_files, description, source):
     """
     Check that every expanded file exists, reporting the missing years and
     months rather than a bare list of paths
@@ -143,9 +143,10 @@ def check_files_exist(sim_files, description, option_name):
         A short description of what the files are, used in the error message,
         e.g. ``'monthly-mean'``
 
-    option_name : str
-        The name of the config option in ``[ocean_analysis]`` that sets the
-        template these files came from, so that the error says what to fix
+    source : str
+        A description of where the file-name template came from, so that the
+        error says where to look, e.g. ``'the History stream in
+        /path/omega.yml'``
 
     Raises
     ------
@@ -161,8 +162,8 @@ def check_files_exist(sim_files, description, option_name):
     ]
     lines.extend(_describe_missing(missing))
     lines.append(
-        f'Check the year range and the [ocean_analysis] {option_name} '
-        f'option (or the Omega configuration file it defaults to).'
+        f'They are named by {source}.  Check the year range and that the '
+        f'simulation wrote this output for those years.'
     )
     raise FileNotFoundError('\n'.join(lines))
 
@@ -383,6 +384,314 @@ def read_omega_config(filename):
     )
 
 
+class SimulationFiles:
+    """
+    The files of the simulation being analyzed
+
+    The simulation's own Omega configuration is the analysis' description of
+    where its output lives: the mesh, the vertical coordinate and every output
+    stream are read from it, so that none of them have to be restated in a
+    Polaris config file.  An Omega run always writes one, so its absence is an
+    error rather than a case to fall back from.
+
+    Attributes
+    ----------
+    config : polaris.config.PolarisConfigParser
+        The config options for the analysis
+
+    omega_config : OmegaConfig
+        The simulation's Omega configuration
+
+    simulation_path : str
+        The directory that relative file names are resolved against
+
+    simulation_name : str
+        A short name for the simulation, used in plot titles and file names
+    """
+
+    def __init__(self, config, log=print):
+        """
+        Resolve the simulation's paths from its Omega configuration
+
+        Parameters
+        ----------
+        config : polaris.config.PolarisConfigParser
+            The config options for the analysis
+
+        log : callable, optional
+            Where to report each resolved path and its source.  The default,
+            ``print``, is what a step wants during ``setup()``, where it has
+            no logger yet; at run time a step passes ``self.logger.info``.
+        """
+        self.config = config
+        self.log = log
+
+        _check_model(config)
+
+        section = config['ocean_analysis']
+        omega_config_filename = section.get('omega_config_filename').strip()
+        if not omega_config_filename:
+            raise ValueError(
+                'Set the [ocean_analysis] omega_config_filename option to '
+                "the simulation's Omega configuration file.  It is how the "
+                'analysis finds the mesh and the output streams, and an '
+                'Omega run always writes one.'
+            )
+        self.omega_config = read_omega_config(omega_config_filename)
+        self.log(f'simulation configuration: {self.omega_config.filename}')
+
+        self.simulation_path = self._resolve_simulation_path()
+        self.simulation_name = section.get('simulation_name')
+
+    def mesh_filename(self):
+        """
+        Get the horizontal mesh file
+
+        Returns
+        -------
+        filename : str
+            The absolute path to the mesh file
+        """
+        return self._resolve_stream_path(
+            option_name='mesh_filename',
+            stream_name='HorzMeshIn',
+            description='horizontal mesh',
+        )
+
+    def vert_coord_filename(self):
+        """
+        Get the vertical-coordinate file
+
+        Returns
+        -------
+        filename : str
+            The absolute path to the vertical-coordinate file
+        """
+        return self._resolve_stream_path(
+            option_name='vert_coord_filename',
+            stream_name='InitialVertCoord',
+            description='vertical coordinate',
+        )
+
+    def monthly_mean_files(self, start_year, end_year):
+        """
+        Get the monthly-mean output files covering a range of years
+
+        Parameters
+        ----------
+        start_year : int
+            The first year of the range, inclusive
+
+        end_year : int
+            The last year of the range, inclusive
+
+        Returns
+        -------
+        sim_files : list of SimFile
+            The monthly-mean files, which are known to exist
+        """
+        template = self._stream_template(
+            stream_name='History', description='monthly means'
+        )
+        return self._expand_and_check(
+            template=template,
+            start_year=start_year,
+            end_year=end_year,
+            description='monthly-mean',
+            source=f'the History stream in {self.omega_config.filename}',
+        )
+
+    def global_stats_files(self, start_year, end_year):
+        """
+        Get the global statistics output files covering a range of years
+
+        Parameters
+        ----------
+        start_year : int
+            The first year of the range, inclusive
+
+        end_year : int
+            The last year of the range, inclusive
+
+        Returns
+        -------
+        sim_files : list of SimFile
+            The global statistics files, which are known to exist
+        """
+        template = self._analysis_template(
+            group_name='GlobalStats',
+            description='global statistics',
+            required=True,
+        )
+        assert template is not None
+        return self._expand_and_check(
+            template=template,
+            start_year=start_year,
+            end_year=end_year,
+            description='global statistics',
+            source=(
+                f'the GlobalStats analysis group in '
+                f'{self.omega_config.filename}'
+            ),
+        )
+
+    def moc_files(self, start_year, end_year):
+        """
+        Get the meridional overturning circulation output files covering a
+        range of years
+
+        Omega's MOC diagnostic is new, so a simulation that does not write it
+        is an ordinary case rather than an error.
+
+        Parameters
+        ----------
+        start_year : int
+            The first year of the range, inclusive
+
+        end_year : int
+            The last year of the range, inclusive
+
+        Returns
+        -------
+        sim_files : list of SimFile or None
+            The MOC files, which are known to exist, or ``None`` if the
+            simulation does not write MOC output
+        """
+        template = self._analysis_template(
+            group_name='Moc',
+            description='meridional overturning circulation',
+            required=False,
+        )
+        if template is None:
+            return None
+        return self._expand_and_check(
+            template=template,
+            start_year=start_year,
+            end_year=end_year,
+            description='MOC',
+            source=f'the Moc analysis group in {self.omega_config.filename}',
+        )
+
+    def _resolve_simulation_path(self):
+        """Get the directory that relative file names are resolved against"""
+        simulation_path = self.config.get(
+            'ocean_analysis', 'simulation_path'
+        ).strip()
+        if simulation_path:
+            source = '[ocean_analysis] simulation_path'
+        else:
+            simulation_path = os.path.dirname(self.omega_config.filename)
+            source = 'the directory of the Omega configuration file'
+        simulation_path = os.path.abspath(simulation_path)
+        self.log(f'simulation path: {simulation_path} (from {source})')
+        return simulation_path
+
+    def _resolve_stream_path(self, option_name, stream_name, description):
+        """
+        Resolve a single file, either from a config option or from an Omega
+        ``IOStreams`` entry
+        """
+        value = self.config.get('ocean_analysis', option_name).strip()
+        if value:
+            self.log(
+                f'{description}: {value} (from [ocean_analysis] {option_name})'
+            )
+        else:
+            value = self._stream_template(stream_name, description)
+        return self._absolute(value)
+
+    def _stream_template(self, stream_name, description):
+        """Get a file name or template from an Omega ``IOStreams`` entry"""
+        status = self.omega_config.stream_status(stream_name)
+        if status == 'missing':
+            raise ValueError(
+                f'{self.omega_config.filename} has no {stream_name} stream, '
+                f'so the analysis cannot find the {description} of the '
+                f'simulation.'
+            )
+        if status == 'no_filename':
+            raise ValueError(
+                f'The {stream_name} stream in '
+                f'{self.omega_config.filename} names no file, so the '
+                f'analysis cannot find the {description} of the simulation.'
+            )
+
+        value = self.omega_config.stream_filename(stream_name)
+        assert value is not None
+        self.log(
+            f'{description}: {value} '
+            f"(from the Omega config's {stream_name} stream)"
+        )
+        return value
+
+    def _analysis_template(self, group_name, description, required):
+        """Get a file-name template from an Omega analysis group"""
+        reason = self._analysis_group_problem(group_name)
+        if reason is None:
+            streams = self.omega_config.analysis_streams(group_name)
+            stream = _preferred_analysis_stream(streams)
+            if stream is None:
+                reason = (
+                    f'the {group_name} analysis group in '
+                    f'{self.omega_config.filename} writes no output streams'
+                )
+            else:
+                kind = 'time-mean' if stream.is_reduction else 'snapshot'
+                self.log(
+                    f'{description}: {stream.filename} (from the Omega '
+                    f"config's {group_name} group, the {stream.period} "
+                    f'{kind} stream)'
+                )
+                return stream.filename
+
+        if required:
+            raise ValueError(
+                f'The analysis needs the {description} of the simulation, '
+                f'but {reason}.'
+            )
+        self.log(f'no {description} output: {reason}')
+        return None
+
+    def _analysis_group_problem(self, group_name):
+        """
+        Describe why an analysis group cannot supply a template, if it cannot
+        """
+        status = self.omega_config.analysis_group_status(group_name)
+        if status == 'missing':
+            return (
+                f'{self.omega_config.filename} has no {group_name} analysis '
+                f'group, so the simulation wrote no such output'
+            )
+        if status == 'disabled':
+            return (
+                f'the {group_name} analysis group in '
+                f'{self.omega_config.filename} is turned off, so the '
+                f'simulation wrote no such output'
+            )
+        return None
+
+    def _expand_and_check(
+        self, template, start_year, end_year, description, source
+    ):
+        """Expand a template over a year range and check that it all exists"""
+        sim_files = expand_template(
+            template=template,
+            start_year=start_year,
+            end_year=end_year,
+            simulation_path=self.simulation_path,
+        )
+        check_files_exist(
+            sim_files=sim_files, description=description, source=source
+        )
+        return sim_files
+
+    def _absolute(self, filename):
+        """Resolve a file name against the simulation path"""
+        if not os.path.isabs(filename):
+            filename = os.path.join(self.simulation_path, filename)
+        return os.path.abspath(filename)
+
+
 def _exists(sim_file):
     """Whether a simulation file is present, following any symlink"""
     return os.path.exists(sim_file.path)
@@ -446,3 +755,35 @@ def _omega_analysis_filename(filename, period, is_reduction):
 
     kind = 'TimeStats' if is_reduction else 'Instants'
     return f'{prefix}_{period}{kind}{template}'
+
+
+def _preferred_analysis_stream(streams):
+    """
+    Pick the analysis stream to read: a time mean if the group wrote one,
+    otherwise a snapshot
+    """
+    for stream in streams:
+        if stream.is_reduction:
+            return stream
+    if streams:
+        return streams[0]
+    return None
+
+
+def _check_model(config):
+    """
+    Complain unless the simulation was run with Omega
+
+    MPAS-Ocean output is not supported.  Reading it would need a translator
+    from its namelists and streams into the form this module reads, which is
+    a separate piece of work.
+    """
+    model = config.get('ocean', 'model')
+    if model != 'omega':
+        raise ValueError(
+            f'The analysis suite reads Omega output, but [ocean] model is '
+            f'"{model}".  Set --model omega at setup if the simulation was '
+            f'run with Omega.  MPAS-Ocean output is not supported: reading '
+            f'it would need a translator from its namelists and streams '
+            f'into the form the analysis reads.'
+        )

--- a/tests/ocean/analysis/test_analysis_tasks.py
+++ b/tests/ocean/analysis/test_analysis_tasks.py
@@ -1,0 +1,159 @@
+import pytest
+
+from polaris.tasks.ocean import Ocean
+from polaris.tasks.ocean.analysis import add_analysis_tasks
+from polaris.tasks.ocean.analysis.climatology_maps import get_field_groups
+
+TASK_SUBDIRS = [
+    'analysis/climatology_maps',
+    'analysis/global_stats',
+    'analysis/heat_content_series',
+    'analysis/moc',
+]
+
+FIELD_GROUPS = [
+    'temperature',
+    'salinity',
+    'velocity',
+    'ssh',
+    'mixed_layer_depth',
+    'heat_content',
+]
+
+
+def _make_component():
+    """A fresh ocean component with only the analysis tasks in it."""
+    component = Ocean()
+    add_analysis_tasks(component)
+    return component
+
+
+def _step_subdirs(component, task_subdir):
+    return [
+        step.subdir for step in component.tasks[task_subdir].steps.values()
+    ]
+
+
+def _set_range(component, section, start_year, end_year):
+    """Set a year range the way a user's config file would, and reconfigure."""
+    config = component.tasks['analysis/moc'].config
+    config.set(section, 'start_year', str(start_year), user=True)
+    config.set(section, 'end_year', str(end_year), user=True)
+    for task_subdir in TASK_SUBDIRS:
+        component.tasks[task_subdir].configure()
+
+
+def test_the_suite_has_one_task_per_product():
+    component = _make_component()
+    assert sorted(component.tasks) == sorted(TASK_SUBDIRS)
+
+
+def test_steps_land_at_range_keyed_subdirectories():
+    """The work tree is <product>/<range>, with a field group below the one
+    product that is chunked."""
+    component = _make_component()
+    _set_range(component, 'ocean_analysis_climatology', 21, 40)
+    _set_range(component, 'ocean_analysis_time_series', 1, 60)
+
+    assert _step_subdirs(component, 'analysis/climatology_maps') == [
+        'analysis/climatology/0021-0040',
+    ] + [
+        f'analysis/climatology_maps/0021-0040/{group}'
+        for group in FIELD_GROUPS
+    ]
+    assert _step_subdirs(component, 'analysis/global_stats') == [
+        'analysis/global_stats/0001-0060'
+    ]
+    assert _step_subdirs(component, 'analysis/heat_content_series') == [
+        'analysis/heat_content_series/0001-0060'
+    ]
+    assert _step_subdirs(component, 'analysis/moc') == [
+        'analysis/moc/0021-0040'
+    ]
+
+
+def test_changing_the_range_moves_the_steps():
+    """A new range is new directories, which have never run and so run."""
+    component = _make_component()
+    before = _step_subdirs(component, 'analysis/moc')
+    _set_range(component, 'ocean_analysis_climatology', 21, 40)
+    after = _step_subdirs(component, 'analysis/moc')
+    assert before == ['analysis/moc/0001-0010']
+    assert after == ['analysis/moc/0021-0040']
+    assert 'analysis/moc/0001-0010' not in component.steps
+
+
+def test_the_two_ranges_are_independent():
+    """Changing the climatology does not disturb the time series, or the
+    other way around."""
+    component = _make_component()
+    _set_range(component, 'ocean_analysis_climatology', 21, 40)
+    assert _step_subdirs(component, 'analysis/global_stats') == [
+        'analysis/global_stats/0001-0010'
+    ]
+
+    _set_range(component, 'ocean_analysis_time_series', 1, 60)
+    assert _step_subdirs(component, 'analysis/moc') == [
+        'analysis/moc/0021-0040'
+    ]
+
+
+def test_the_climatology_is_shared_by_every_field_group():
+    """One ncclimo call for a range, no matter how many maps read it."""
+    component = _make_component()
+    task = component.tasks['analysis/climatology_maps']
+    climatology = task.steps['climatology']
+    assert climatology.subdir == 'analysis/climatology/0001-0010'
+    assert component.steps['analysis/climatology/0001-0010'] is climatology
+    assert task.step_symlinks['climatology'] == 'climatology'
+
+
+def test_the_climatology_declares_ncclimo_s_processes():
+    """The pool is sized from what the step will start, not from the
+    machine."""
+    component = _make_component()
+    climatology = component.tasks['analysis/climatology_maps'].steps[
+        'climatology'
+    ]
+    assert climatology.ntasks == 1
+    assert climatology.cpus_per_task == 12
+
+
+def test_the_default_fields_cover_every_field_group():
+    component = _make_component()
+    config = component.tasks['analysis/climatology_maps'].config
+    fields = config.getlist('ocean_analysis_climatology', 'fields')
+    assert list(get_field_groups(fields)) == FIELD_GROUPS
+
+
+def test_fewer_fields_means_fewer_steps():
+    """The field list is an axis a user edits, so adding a field should cost
+    that field and not the others."""
+    component = _make_component()
+    config = component.tasks['analysis/climatology_maps'].config
+    config.set(
+        'ocean_analysis_climatology',
+        'fields',
+        'temperature, velocityZonal',
+        user=True,
+    )
+    component.tasks['analysis/climatology_maps'].configure()
+    assert _step_subdirs(component, 'analysis/climatology_maps') == [
+        'analysis/climatology/0001-0010',
+        'analysis/climatology_maps/0001-0010/temperature',
+        'analysis/climatology_maps/0001-0010/velocity',
+        'analysis/climatology_maps/0001-0010/heat_content',
+    ]
+
+
+def test_a_field_in_no_group_is_named_in_the_error():
+    with pytest.raises(ValueError, match='belongs to no field group'):
+        get_field_groups(['temperature', 'notAField'])
+
+
+def test_heat_content_is_a_group_even_though_it_is_derived():
+    """Heat content is a field group of the maps rather than a product of its
+    own, and it is not a field a user lists."""
+    groups = get_field_groups(['temperature'])
+    assert list(groups) == ['temperature', 'heat_content']
+    assert groups['heat_content'] == []

--- a/tests/ocean/analysis/test_sim_files.py
+++ b/tests/ocean/analysis/test_sim_files.py
@@ -1,0 +1,121 @@
+import os
+
+import pytest
+
+from polaris.tasks.ocean.analysis.sim_files import (
+    check_files_exist,
+    expand_template,
+    year_range_key,
+)
+
+
+def test_year_range_key_is_zero_padded():
+    """The range key matches the convention ncclimo uses in file names."""
+    assert year_range_key(21, 40) == '0021-0040'
+    assert year_range_key(1, 10) == '0001-0010'
+
+
+def test_expand_template_over_years_and_months(tmp_path):
+    """A template with $Y and $M gives one file per month, in order."""
+    sim_files = expand_template(
+        'output/ocn.hist.$Y-$M.nc', 3, 4, simulation_path=str(tmp_path)
+    )
+    assert len(sim_files) == 24
+    assert sim_files[0].path == os.path.join(
+        str(tmp_path), 'output/ocn.hist.0003-01.nc'
+    )
+    assert (sim_files[0].year, sim_files[0].month) == (3, 1)
+    assert sim_files[-1].path == os.path.join(
+        str(tmp_path), 'output/ocn.hist.0004-12.nc'
+    )
+    assert (sim_files[-1].year, sim_files[-1].month) == (4, 12)
+
+
+def test_expand_template_over_years_only(tmp_path):
+    """A template with $Y but no $M gives one file per year."""
+    sim_files = expand_template(
+        'stats.$Y.nc', 1, 3, simulation_path=str(tmp_path)
+    )
+    assert [sim_file.year for sim_file in sim_files] == [1, 2, 3]
+    assert all(sim_file.month is None for sim_file in sim_files)
+
+
+def test_expand_template_without_a_date(tmp_path):
+    """Omega writes a run's analysis output to a single, undated file."""
+    sim_files = expand_template(
+        'global_stats_1DayInstants', 1, 60, simulation_path=str(tmp_path)
+    )
+    assert len(sim_files) == 1
+    assert sim_files[0].path == os.path.join(
+        str(tmp_path), 'global_stats_1DayInstants'
+    )
+    assert sim_files[0].year is None
+    assert sim_files[0].month is None
+
+
+def test_expand_template_absolute_ignores_simulation_path(tmp_path):
+    """An absolute template is used as given."""
+    template = str(tmp_path / 'elsewhere' / 'ocn.hist.$Y-$M.nc')
+    sim_files = expand_template(template, 1, 1, simulation_path='/not/used')
+    assert sim_files[0].path == str(
+        tmp_path / 'elsewhere' / 'ocn.hist.0001-01.nc'
+    )
+
+
+def test_expand_template_relative_needs_a_simulation_path():
+    """A relative template with nothing to resolve it against is an error."""
+    with pytest.raises(ValueError, match='simulation_path'):
+        expand_template('ocn.hist.$Y-$M.nc', 1, 1)
+
+
+def test_expand_template_rejects_finer_date_fields(tmp_path):
+    """Date fields finer than a month cannot be expanded."""
+    with pytest.raises(ValueError, match=r'\$D'):
+        expand_template(
+            'restart/ocn.restart.$Y-$M-$D.nc',
+            1,
+            1,
+            simulation_path=str(tmp_path),
+        )
+
+
+def test_expand_template_rejects_a_reversed_range(tmp_path):
+    with pytest.raises(ValueError, match='after the end year'):
+        expand_template('ocn.hist.$Y.nc', 5, 2, simulation_path=str(tmp_path))
+
+
+def test_check_files_exist_passes_when_they_do(tmp_path):
+    for month in range(1, 13):
+        (tmp_path / f'ocn.hist.0001-{month:02d}.nc').touch()
+    sim_files = expand_template(
+        'ocn.hist.$Y-$M.nc', 1, 1, simulation_path=str(tmp_path)
+    )
+    check_files_exist(sim_files, 'monthly-mean', 'monthly_mean_template')
+
+
+def test_check_files_exist_names_the_missing_months(tmp_path):
+    """The error says which years and months are missing, and what to fix."""
+    for month in range(1, 13):
+        (tmp_path / f'ocn.hist.0001-{month:02d}.nc').touch()
+    (tmp_path / 'ocn.hist.0002-01.nc').touch()
+    sim_files = expand_template(
+        'ocn.hist.$Y-$M.nc', 1, 2, simulation_path=str(tmp_path)
+    )
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_files_exist(sim_files, 'monthly-mean', 'monthly_mean_template')
+    message = str(excinfo.value)
+    assert '11 of 24 monthly-mean files are missing' in message
+    assert 'year 0002: months 02, 03, 04' in message
+    assert 'year 0001' not in message
+    assert 'monthly_mean_template' in message
+
+
+def test_check_files_exist_reports_an_undated_file_by_path(tmp_path):
+    sim_files = expand_template(
+        'global_stats_1DayInstants', 1, 60, simulation_path=str(tmp_path)
+    )
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_files_exist(
+            sim_files, 'global statistics', 'global_stats_template'
+        )
+    assert 'global_stats_1DayInstants' in str(excinfo.value)

--- a/tests/ocean/analysis/test_sim_files.py
+++ b/tests/ocean/analysis/test_sim_files.py
@@ -113,6 +113,55 @@ def test_check_files_exist_names_the_missing_months(tmp_path):
     assert 'the History stream' in message
 
 
+def test_check_files_exist_says_which_years_the_simulation_wrote(tmp_path):
+    """Given the template, the error answers the question it raises."""
+    for year in (1, 2):
+        for month in range(1, 13):
+            (tmp_path / f'ocn.hist.{year:04d}-{month:02d}.nc').touch()
+    template = 'ocn.hist.$Y-$M.nc'
+    sim_files = expand_template(template, 1, 4, simulation_path=str(tmp_path))
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_files_exist(
+            sim_files,
+            'monthly-mean',
+            'the History stream',
+            template=template,
+            simulation_path=str(tmp_path),
+        )
+    message = str(excinfo.value)
+    assert 'The simulation wrote years 1-2.' in message
+    assert 'with gaps' not in message
+
+
+def test_check_files_exist_says_when_the_years_it_wrote_have_gaps(tmp_path):
+    """A hole in the middle is worth knowing about before setting a range."""
+    for year in (1, 3):
+        for month in range(1, 13):
+            (tmp_path / f'ocn.hist.{year:04d}-{month:02d}.nc').touch()
+    template = 'ocn.hist.$Y-$M.nc'
+    sim_files = expand_template(template, 1, 4, simulation_path=str(tmp_path))
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_files_exist(
+            sim_files,
+            'monthly-mean',
+            'the History stream',
+            template=template,
+            simulation_path=str(tmp_path),
+        )
+    assert 'years 1-3, with gaps' in str(excinfo.value)
+
+
+def test_check_files_exist_without_a_template_still_advises(tmp_path):
+    """The old advice stands when the caller gives no template."""
+    (tmp_path / 'ocn.hist.0001-01.nc').touch()
+    sim_files = expand_template(
+        'ocn.hist.$Y-$M.nc', 1, 1, simulation_path=str(tmp_path)
+    )
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_files_exist(sim_files, 'monthly-mean', 'the History stream')
+    assert 'Check the year range' in str(excinfo.value)
+
+
 def test_check_files_exist_reports_an_undated_file_by_path(tmp_path):
     sim_files = expand_template(
         'global_stats_1DayInstants', 1, 60, simulation_path=str(tmp_path)

--- a/tests/ocean/analysis/test_sim_files.py
+++ b/tests/ocean/analysis/test_sim_files.py
@@ -5,6 +5,7 @@ import pytest
 from polaris.tasks.ocean.analysis.sim_files import (
     check_files_exist,
     expand_template,
+    read_omega_config,
     year_range_key,
 )
 
@@ -119,3 +120,105 @@ def test_check_files_exist_reports_an_undated_file_by_path(tmp_path):
             sim_files, 'global statistics', 'global_stats_template'
         )
     assert 'global_stats_1DayInstants' in str(excinfo.value)
+
+
+OMEGA_CONFIG = """\
+Omega:
+  IOStreams:
+    HorzMeshIn:
+      Filename: mesh.nc
+      Mode: read
+    InitialVertCoord:
+      Filename: vert_coord.nc
+      Mode: read
+    RestartRead:
+      UsePointerFile: true
+      PointerFilename: ocn.pointer
+      Mode: read
+    History:
+      Filename: output/ocn.hist.$Y-$M.nc
+      Mode: write
+      Freq: 1
+      FreqUnits: months
+  Analysis:
+    GlobalStats:
+      Enable: true
+      Filename: global_stats
+      ReductionPeriod: [1Month]
+      SnapshotPeriod: [1Day]
+    Moc:
+      Enable: false
+      Filename: moc
+      ReductionPeriod: [1Month]
+    Timeseries:
+      Enable: true
+      Filename: analysis.$Y.$M
+      ReductionPeriod: [1Month]
+"""
+
+
+def _write_omega_config(tmp_path, text=OMEGA_CONFIG):
+    filename = tmp_path / 'omega.yml'
+    filename.write_text(text)
+    return str(filename)
+
+
+def test_read_omega_config_finds_streams(tmp_path):
+    """The mesh, vertical coordinate and monthly means come from the config."""
+    omega_config = read_omega_config(_write_omega_config(tmp_path))
+    assert omega_config.stream_filename('HorzMeshIn') == 'mesh.nc'
+    assert omega_config.stream_filename('InitialVertCoord') == 'vert_coord.nc'
+    assert (
+        omega_config.stream_filename('History') == 'output/ocn.hist.$Y-$M.nc'
+    )
+
+
+def test_read_omega_config_reports_what_it_cannot_supply(tmp_path):
+    """An absent stream and a pointer-file stream are told apart."""
+    omega_config = read_omega_config(_write_omega_config(tmp_path))
+    assert omega_config.stream_status('History') == 'ok'
+    assert omega_config.stream_status('Moc') == 'missing'
+    assert omega_config.stream_status('RestartRead') == 'no_filename'
+    assert omega_config.stream_filename('Moc') is None
+    assert omega_config.stream_filename('RestartRead') is None
+
+
+def test_read_omega_config_missing_file_names_the_option(tmp_path):
+    with pytest.raises(FileNotFoundError, match='omega_config_filename'):
+        read_omega_config(str(tmp_path / 'not_there.yml'))
+
+
+def test_read_omega_config_rejects_a_foreign_file(tmp_path):
+    filename = tmp_path / 'not_omega.yml'
+    filename.write_text('mpas-ocean:\n  streams: {}\n')
+    with pytest.raises(ValueError, match='does not look like an Omega'):
+        read_omega_config(str(filename))
+
+
+def test_analysis_group_status(tmp_path):
+    """A group can be absent, turned off, or writing."""
+    omega_config = read_omega_config(_write_omega_config(tmp_path))
+    assert omega_config.analysis_group_status('GlobalStats') == 'ok'
+    assert omega_config.analysis_group_status('Moc') == 'disabled'
+    assert omega_config.analysis_group_status('Bogus') == 'missing'
+    assert omega_config.analysis_streams('Moc') == []
+    assert omega_config.analysis_streams('Bogus') == []
+
+
+def test_analysis_streams_reconstruct_omega_file_names(tmp_path):
+    """Time reductions come first, and snapshots are named differently."""
+    omega_config = read_omega_config(_write_omega_config(tmp_path))
+    streams = omega_config.analysis_streams('GlobalStats')
+    assert [stream.filename for stream in streams] == [
+        'global_stats_1MonthTimeStats',
+        'global_stats_1DayInstants',
+    ]
+    assert [stream.is_reduction for stream in streams] == [True, False]
+    assert [stream.period for stream in streams] == ['1Month', '1Day']
+
+
+def test_analysis_streams_keep_a_timestamp_template(tmp_path):
+    """The separator before the first $ moves into the timestamp template."""
+    omega_config = read_omega_config(_write_omega_config(tmp_path))
+    streams = omega_config.analysis_streams('Timeseries')
+    assert streams[0].filename == 'analysis_1MonthTimeStats.$Y.$M'

--- a/tests/ocean/analysis/test_sim_files.py
+++ b/tests/ocean/analysis/test_sim_files.py
@@ -2,7 +2,9 @@ import os
 
 import pytest
 
+from polaris.config import PolarisConfigParser
 from polaris.tasks.ocean.analysis.sim_files import (
+    SimulationFiles,
     check_files_exist,
     expand_template,
     read_omega_config,
@@ -91,7 +93,7 @@ def test_check_files_exist_passes_when_they_do(tmp_path):
     sim_files = expand_template(
         'ocn.hist.$Y-$M.nc', 1, 1, simulation_path=str(tmp_path)
     )
-    check_files_exist(sim_files, 'monthly-mean', 'monthly_mean_template')
+    check_files_exist(sim_files, 'monthly-mean', 'the History stream')
 
 
 def test_check_files_exist_names_the_missing_months(tmp_path):
@@ -103,12 +105,12 @@ def test_check_files_exist_names_the_missing_months(tmp_path):
         'ocn.hist.$Y-$M.nc', 1, 2, simulation_path=str(tmp_path)
     )
     with pytest.raises(FileNotFoundError) as excinfo:
-        check_files_exist(sim_files, 'monthly-mean', 'monthly_mean_template')
+        check_files_exist(sim_files, 'monthly-mean', 'the History stream')
     message = str(excinfo.value)
     assert '11 of 24 monthly-mean files are missing' in message
     assert 'year 0002: months 02, 03, 04' in message
     assert 'year 0001' not in message
-    assert 'monthly_mean_template' in message
+    assert 'the History stream' in message
 
 
 def test_check_files_exist_reports_an_undated_file_by_path(tmp_path):
@@ -117,7 +119,7 @@ def test_check_files_exist_reports_an_undated_file_by_path(tmp_path):
     )
     with pytest.raises(FileNotFoundError) as excinfo:
         check_files_exist(
-            sim_files, 'global statistics', 'global_stats_template'
+            sim_files, 'global statistics', 'the GlobalStats group'
         )
     assert 'global_stats_1DayInstants' in str(excinfo.value)
 
@@ -222,3 +224,143 @@ def test_analysis_streams_keep_a_timestamp_template(tmp_path):
     omega_config = read_omega_config(_write_omega_config(tmp_path))
     streams = omega_config.analysis_streams('Timeseries')
     assert streams[0].filename == 'analysis_1MonthTimeStats.$Y.$M'
+
+
+def _make_config(model='omega', **options):
+    """Build a config with the analysis defaults and the given overrides."""
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.ocean', 'ocean.cfg')
+    config.add_from_package('polaris.tasks.ocean.analysis', 'analysis.cfg')
+    config.set('ocean', 'model', model)
+    for option, value in options.items():
+        config.set('ocean_analysis', option, value)
+    return config
+
+
+def _make_simulation(tmp_path, text=OMEGA_CONFIG):
+    """Write an Omega config and the output files it names."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    omega_config_filename = _write_omega_config(tmp_path, text)
+    (tmp_path / 'mesh.nc').touch()
+    (tmp_path / 'vert_coord.nc').touch()
+    (tmp_path / 'output').mkdir()
+    for month in range(1, 13):
+        (tmp_path / 'output' / f'ocn.hist.0001-{month:02d}.nc').touch()
+    (tmp_path / 'global_stats_1MonthTimeStats').touch()
+    return omega_config_filename
+
+
+def test_simulation_files_come_from_the_omega_config(tmp_path):
+    """The Omega config is the only description of where the output lives."""
+    omega_config_filename = _make_simulation(tmp_path)
+    config = _make_config(omega_config_filename=omega_config_filename)
+    messages: list = []
+    sim = SimulationFiles(config, log=messages.append)
+
+    assert sim.simulation_path == str(tmp_path)
+    assert sim.mesh_filename() == str(tmp_path / 'mesh.nc')
+    assert sim.vert_coord_filename() == str(tmp_path / 'vert_coord.nc')
+    monthly = sim.monthly_mean_files(1, 1)
+    assert len(monthly) == 12
+    assert monthly[0].path == str(tmp_path / 'output' / 'ocn.hist.0001-01.nc')
+    stats = sim.global_stats_files(1, 1)
+    assert [sim_file.path for sim_file in stats] == [
+        str(tmp_path / 'global_stats_1MonthTimeStats')
+    ]
+    assert any('HorzMeshIn stream' in message for message in messages)
+    assert any('1Month time-mean stream' in message for message in messages)
+
+
+def test_a_mesh_option_beats_the_omega_config(tmp_path):
+    """A mesh that has moved since the run can be pointed at by hand."""
+    omega_config_filename = _make_simulation(tmp_path)
+    elsewhere = tmp_path / 'elsewhere'
+    elsewhere.mkdir()
+    (elsewhere / 'moved_mesh.nc').touch()
+    config = _make_config(
+        omega_config_filename=omega_config_filename,
+        mesh_filename=str(elsewhere / 'moved_mesh.nc'),
+    )
+    messages: list = []
+    sim = SimulationFiles(config, log=messages.append)
+
+    assert sim.mesh_filename() == str(elsewhere / 'moved_mesh.nc')
+    assert any(
+        'from [ocean_analysis] mesh_filename' in message
+        for message in messages
+    )
+
+
+def test_simulation_path_can_be_set_by_hand(tmp_path):
+    """Output that has moved away from the config file is still reachable."""
+    config_dir = tmp_path / 'config'
+    config_dir.mkdir()
+    omega_config_filename = _write_omega_config(config_dir)
+    _make_simulation(tmp_path / 'run')
+    config = _make_config(
+        omega_config_filename=omega_config_filename,
+        simulation_path=str(tmp_path / 'run'),
+    )
+    sim = SimulationFiles(config, log=lambda message: None)
+    assert sim.mesh_filename() == str(tmp_path / 'run' / 'mesh.nc')
+
+
+def test_missing_moc_output_is_reported_not_raised(tmp_path):
+    """A simulation that predates Omega's MOC diagnostic is an ordinary
+    case."""
+    text = OMEGA_CONFIG.replace(
+        '    Moc:\n      Enable: false\n'
+        '      Filename: moc\n      ReductionPeriod: [1Month]\n',
+        '',
+    )
+    omega_config_filename = _make_simulation(tmp_path, text)
+    config = _make_config(omega_config_filename=omega_config_filename)
+    messages: list = []
+    sim = SimulationFiles(config, log=messages.append)
+
+    assert sim.moc_files(1, 1) is None
+    assert any(
+        'no meridional overturning circulation output' in message
+        for message in messages
+    )
+    assert any('no Moc analysis group' in message for message in messages)
+
+
+def test_a_disabled_moc_group_is_reported_not_raised(tmp_path):
+    omega_config_filename = _make_simulation(tmp_path)
+    config = _make_config(omega_config_filename=omega_config_filename)
+    messages: list = []
+    sim = SimulationFiles(config, log=messages.append)
+
+    assert sim.moc_files(1, 1) is None
+    assert any('is turned off' in message for message in messages)
+
+
+def test_missing_global_stats_output_is_an_error(tmp_path):
+    """Global statistics are required, so their absence is reported loudly."""
+    text = OMEGA_CONFIG.replace(
+        'GlobalStats:\n      Enable: true', 'GlobalStats:\n      Enable: false'
+    )
+    omega_config_filename = _make_simulation(tmp_path, text)
+    config = _make_config(omega_config_filename=omega_config_filename)
+    sim = SimulationFiles(config, log=lambda message: None)
+    with pytest.raises(ValueError, match='is turned off'):
+        sim.global_stats_files(1, 1)
+
+
+def test_an_omega_config_is_required(tmp_path):
+    """An Omega run always writes one, so its absence is an error."""
+    config = _make_config()
+    with pytest.raises(ValueError, match='omega_config_filename'):
+        SimulationFiles(config, log=lambda message: None)
+
+
+def test_mpas_ocean_is_not_supported(tmp_path):
+    """Reading MPAS-Ocean output would need a translator we have not
+    written."""
+    omega_config_filename = _make_simulation(tmp_path)
+    config = _make_config(
+        model='mpas-ocean', omega_config_filename=omega_config_filename
+    )
+    with pytest.raises(ValueError, match='MPAS-Ocean output is not'):
+        SimulationFiles(config, log=lambda message: None)


### PR DESCRIPTION
# Scaffolding for the omega_analysis suite

This is item 3 of the order of work in `ocean_analysis_initial.md`: the `polaris/tasks/ocean/analysis/` package, `analysis.cfg`, the reader for the simulation's Omega configuration, the range-keyed step subdirectories, the tasks with their `configure()` methods, and the `omega_analysis` suite. No diagnostic is computed yet. What lands here is the structure every later product plugs into, which is why it goes first: how a step finds the simulation's files, how a date range becomes a step subdirectory, and how a task rebuilds its steps from the user's config.

The steps are not empty. Each one resolves the simulation files it will read, symlinks them into its work directory, and reports them at run time. That is what establishes that the Omega configuration reader, the template expansion and the range keying hold together against a real simulation, rather than leaving each product to find that out separately later.

## One design change, made while implementing

The design had `monthly_mean_template` and its siblings as config options overriding what the simulation's Omega configuration says. They cannot be: Polaris config files use `ExtendedInterpolation`, so a bare `$Y` in a value raises `invalid interpolation syntax` and takes down the whole config combine, not merely that option. Escaping it as `$$Y` works and is a trap, since a template pasted out of `omega.yml` then fails confusingly.

The override layer is gone rather than escaped. An Omega run always writes an `omega.yml`, so it is required rather than a default to fall back from, and it is the analysis' only description of where the output lives. That removes the precedence rules, the reporting of which source won, and the one path by which a `$` could reach a config value. What stays in the config file are plain paths with no templating in them: `simulation_path`, `mesh_filename` and `vert_coord_filename`, for output or a mesh that has moved since the run.

MPAS-Ocean support goes with it. Reading MPAS-Ocean output means translating its namelists and streams into the form this reads, which is separate work; a step set up against one now says so rather than failing obscurely later. This costs the deliverable nothing, since the design already develops and validates against Omega output only. The design PR has been updated to match, including the out-of-scope entry.

## What it does today

Every step lives at a subdirectory named for the range it covers, so a setup with a new range creates steps in directories that have never run and therefore run, while a setup with the same range lands on directories that are complete and recomputes nothing. That is the whole of the repeated-analysis requirement, and it needs no framework change. It also makes it structurally impossible to get a plot labelled with one range whose contents came from another.

The climatology and time-series ranges are separate config sections and move independently: changing the climatology moves the maps and the MOC and leaves the two time series where they were. The climatology step is shared, so one `ncclimo` call covers a range no matter how many map field groups pull it in.

Reading Omega's configuration is done defensively, since this is the one place Polaris depends on the *shape* of that file rather than on its output. A missing stream, a stream that names no file, and an analysis group that is turned off are told apart and reported. The names of an analysis group's output streams are reconstructed the way Omega's analysis manager builds them, as `<prefix>_<period><TimeStats|Instants><template>`, because a group can write time means and snapshots under different names and today's simulations write only snapshots.

## Testing

36 new unit tests cover template expansion over a year range, the missing-years report, the Omega configuration reader, and the step tree each task builds — that the two ranges are independent, that a changed range leaves no step behind, and that one climatology is shared by every field group. The full suite is 451 passed; the 6 errors in `tests/ocean/single_column/test_init.py` are `MpasCellCuller.x` not being on `PATH` outside a load-script shell and reproduce identically on `main`.

Run end to end against the one-year QU240 Omega mock-up. A single config option resolves the mesh and vertical coordinate from the `HorzMeshIn` and `InitialVertCoord` streams, twelve monthly means from `History`, and `global_stats_1DayInstants` — a name the reader reconstructs from the `GlobalStats` group and which matches the file on disk exactly. The MOC step reports that the run predates Omega's MOC diagnostic and produces nothing instead of failing the suite. Re-running recomputes nothing, and a second range set up into the same work directory left the first range's directory and completion marker untouched.

Asking for a year the mock-up does not have gives:

```
12 of 24 monthly-mean files are missing:
  year 0002: months 01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 11, 12
They are named by the History stream in .../omega.yml.  Check the year range and that the simulation wrote this output for those years.
```

Regression tested with the `omega_pr` suite against `main`, both sides sharing one Omega build at `7d4d8bf` so that polaris was the only variable: 22 of 22 tasks passed, with 108 baseline comparisons passing and none failing.

## Notes for review

The four new tasks are in no existing suite and run no model, so nothing in `omega_pr` or `omega_nightly` reaches them. The one thing they do touch is component construction, which every `polaris setup` and `polaris list` performs — construction reads only the packaged defaults, and the simulation's Omega configuration is not read until step setup.

Setup is noisy: each step reports the simulation it found and which Omega stream named each of its files. That is deliberate for now, and temporary. Polaris deliberately writes almost nothing during setup so that the user sees the suite rather than the internals of individual steps, and ten analysis steps reporting their inputs dilutes exactly that. It earns its keep while the Omega configuration reader is new, since it is how a wrong file list gets diagnosed today; before the deliverable it moves into each step's own log at run time, where `self.logger` exists. Noted in the design so it does not harden into a habit as products are added.

Documentation covers the spine and not the products. `docs/users_guide/ocean/tasks/analysis.md` describes how to point the suite at a simulation, how to run it, where results go and what re-analyzing a different range does — the half that is stable now and that no later product will own. A table lists the four tasks as not yet implemented, which is one edit per product PR. The per-product descriptions and the full config-option reference are deliberately left for later, the first because describing plots that do not exist would be worse than saying nothing, the second because `analysis.cfg` already carries every option with its comment. The page departs from `tasks/template.md` and says why: the template is built around a task that runs a model, and this one runs none.

There is also an `omega_analysis` section in `docs/users_guide/ocean/suites.md`, a Developer's Guide section on the shared machinery, and the API listing.

The task classes take a `Task` suffix — `ClimatologyMapsTask`, `GlobalStatsTask`, `HeatContentSeriesTask`, `MocTask` — because the design already names `Climatology`, `ClimatologyMaps` and `HeatContentSeries` for the *steps*. This follows the existing `RemapTopoTask`/`CullTopoTask` precedent.
## This is one of five remaining PRs, reviewed in order

The work is a chain in dependency order. GitHub cannot base a cross-fork PR on another fork branch, so every one of these is based on `main` and its diff contains everything below it. Reviewing them in order is what keeps each diff small — review only the commits this branch adds.

| order | PR | branch | what it adds |
| --- | --- | --- | --- |
| 1 | #726 | `add-omega-analysis-scaffolding` | the suite, tasks and step structure |
| 2 | #736 | `add-omega-analysis-publisher` | manifests, the staging tree, the gallery |
| 3 | #729 | `add-omega-analysis-global-stats` | global statistics time series |
| 4 | #730 | `add-omega-analysis-climatology-maps` | the ncclimo climatology and its maps |
| 5 | #737 | `add-omega-analysis-heat-content` | ocean heat content, maps and time series |

Two are already merged: #706, the design documents, and #735, the vertical reduction kernel.

A gallery generated by the whole chain against the QU240 mock-up is published here, which is the quickest way to see what the suite produces: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/xasaydavis/omega_analysis_qu240_mockup_20260830/
