### PR TITLE
Read CF time units in `get_days_since_start()`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,28 @@ These instructions apply to the whole repository unless a deeper
 - Prefer starting from the existing template instead of creating task
   documentation pages from scratch.
 
+## GitHub pull requests and issues
+
+- Do not hard-wrap. Write each paragraph and each bullet as a single
+  line, however long. GitHub wraps them for display, and hard breaks
+  make later edits show up as reflowed paragraphs in the diff.
+- Start with a paragraph summarizing what the pull request or issue is
+  about, then use sections for the detail.
+- Keep the description in a file at the root of the worktree for the
+  branch it describes, and never commit it. It is a draft to paste into
+  GitHub, not part of the branch's content.
+- Follow `.github/pull_request_template.md`: the description goes at
+  the top, keep only the checklist lines that apply, and use closing
+  keywords for any issue the pull request fixes.
+- Do not list individual commits in a pull request description. The
+  commits are already on the pull request; describe what the change
+  accomplishes as a whole instead.
+- Do not describe testing in a pull request description. Testing goes
+  in its own `Testing` comment on the pull request, which is what the
+  template's checklist asks for.
+- An issue should say what happens, what was expected instead, and
+  enough about the configuration and commands used to reproduce it.
+
 ## Supported machines
 
 - `docs/developers_guide/supported_machines.yaml` is the source of the

--- a/polaris/ocean/model/time.py
+++ b/polaris/ocean/model/time.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 import cftime
@@ -24,7 +25,7 @@ def get_days_since_start(ds):
         if 'Time' in ds['Time'].coords:
             t_arr = cftime.date2num(
                 ds['Time'].values,
-                units=ds['Time'].Units.replace('seconds', 'days'),
+                units=_get_days_since_units(ds['Time']),
                 calendar=ds['Time'].dt.calendar,
                 has_year_zero=True,
             )
@@ -70,3 +71,41 @@ def get_time_interval_string(days=None, seconds=None):
     seconds_str = time.strftime('%H:%M:%S', time.gmtime(sec_part))
     time_str = f'{day_part:04d}_{seconds_str}.{int(sec_decimal * 1e3):03d}'
     return time_str
+
+
+def _get_days_since_units(da):
+    """
+    Get CF time units of the form ``days since <reference>`` for a time
+    variable, taking the reference date from the CF ``units`` attribute
+    whatever units it is expressed in.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        A time variable.  When times have been decoded, xarray has moved
+        ``units`` from ``attrs`` into ``encoding``, so both are checked.
+
+    Returns
+    -------
+    units : str
+        The CF units with the time unit replaced by ``days``
+    """
+    name = da.name if da.name is not None else 'time'
+    if 'units' in da.encoding:
+        units = da.encoding['units']
+    elif 'units' in da.attrs:
+        units = da.attrs['units']
+    else:
+        raise ValueError(
+            f"Could not find CF 'units' for time variable '{name}' in "
+            f'either its encoding or its attributes'
+        )
+
+    match = re.match(r'\s*\S+\s+since\s+(?P<reference>.+)', units)
+    if match is None:
+        raise ValueError(
+            f"CF 'units' for time variable '{name}' are not of the form "
+            f"'<units> since <reference>': '{units}'"
+        )
+
+    return f'days since {match.group("reference").strip()}'

--- a/tests/ocean/test_time.py
+++ b/tests/ocean/test_time.py
@@ -1,0 +1,105 @@
+import cftime
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_allclose
+
+from polaris.ocean.model.time import get_days_since_start
+
+# days since the reference date below that the test datasets sample
+DAYS = np.array([0.0, 1.5, 10.25])
+
+REFERENCE = '0001-01-01 00:00:00'
+
+CALENDAR = 'noleap'
+
+# seconds, hours and days per day, for building the units under test
+PER_DAY = {'seconds': 86400.0, 'hours': 24.0, 'days': 1.0}
+
+
+def _make_dataset(units='seconds', omega_attrs=False, with_units=True):
+    """
+    An Omega-like dataset with a decoded ``Time`` coordinate.  Times are
+    cftime dates, so ``units`` belongs in ``encoding`` as xarray would
+    leave it after decoding; ``Units`` is Omega's capitalized duplicate.
+    """
+    dates = cftime.num2date(
+        DAYS * PER_DAY[units],
+        units=f'{units} since {REFERENCE}',
+        calendar=CALENDAR,
+    )
+    time = xr.DataArray(dates, dims=('Time',), name='Time')
+    if with_units:
+        time.encoding['units'] = f'{units} since {REFERENCE}'
+    time.encoding['calendar'] = CALENDAR
+    if omega_attrs:
+        time.attrs['Units'] = f'{units} since {REFERENCE}'
+    ds = xr.Dataset(coords={'Time': time})
+    ds['SomeField'] = xr.DataArray(np.zeros(len(DAYS)), dims=('Time',))
+    return ds
+
+
+def _round_trip(ds, tmp_path):
+    """Write with xarray and read back, as any test that generates its own
+    input would."""
+    path = tmp_path / 'output.nc'
+    ds.to_netcdf(path)
+    return xr.open_dataset(path)
+
+
+def test_xarray_round_trip(tmp_path):
+    """A file xarray wrote has 'units' in encoding and no 'Units' at all.
+    This is the case that failed before the CF units were used."""
+    ds = _round_trip(_make_dataset(), tmp_path)
+    assert 'Units' not in ds['Time'].attrs
+    assert 'units' not in ds['Time'].attrs
+    assert ds['Time'].encoding['units'].startswith('seconds since')
+    assert_allclose(get_days_since_start(ds), DAYS)
+
+
+@pytest.mark.parametrize('units', ['seconds', 'hours', 'days'])
+def test_omega_style_file(units, tmp_path):
+    """An Omega file carries both 'Units' and the CF 'units'; the answer is
+    unchanged from what the capitalized attribute gave for the 'seconds'
+    that Omega writes, and is now right for other reference units too."""
+    ds = _round_trip(_make_dataset(units=units, omega_attrs=True), tmp_path)
+    assert ds['Time'].attrs['Units'] == f'{units} since {REFERENCE}'
+    assert_allclose(get_days_since_start(ds), DAYS)
+
+
+def test_undecoded_units_in_attrs():
+    """A dataset that has not been through decoding still has its CF units
+    in attrs."""
+    ds = _make_dataset()
+    units = ds['Time'].encoding.pop('units')
+    ds['Time'].attrs['units'] = units
+    assert_allclose(get_days_since_start(ds), DAYS)
+
+
+@pytest.mark.parametrize('units', ['seconds', 'hours', 'days'])
+def test_reference_units(units, tmp_path):
+    """The reference units are not assumed to be seconds."""
+    ds = _round_trip(_make_dataset(units=units), tmp_path)
+    assert_allclose(get_days_since_start(ds), DAYS)
+
+
+def test_missing_units_raises():
+    """A time variable with no CF units at all is named in the error."""
+    ds = _make_dataset(with_units=False)
+    with pytest.raises(ValueError, match="'units' for time variable 'Time'"):
+        get_days_since_start(ds)
+
+
+def test_malformed_units_raises():
+    """Units that are not '<units> since <reference>' are named too."""
+    ds = _make_dataset()
+    ds['Time'].encoding['units'] = 'seconds'
+    with pytest.raises(ValueError, match="time variable 'Time'"):
+        get_days_since_start(ds)
+
+
+def test_no_time_variable():
+    """The existing error for a dataset with no time variable is kept."""
+    ds = xr.Dataset({'SomeField': xr.DataArray(np.zeros(3), dims=('x',))})
+    with pytest.raises(ValueError, match='Could not find a time variable'):
+        get_days_since_start(ds)


### PR DESCRIPTION
`get_days_since_start()` took the time units for its `'Time'` branch from `ds['Time'].Units`, a capitalized attribute that Omega writes alongside the CF `units` but that is not part of CF. That only ever worked by accident, and only on files Omega wrote: when xarray decodes times it moves the CF `units` out of `.attrs` and into `.encoding`, but it does not recognize `Units`, so Omega's copy stays in `.attrs` and the attribute access happens to succeed. On any other decoded file, including one that xarray merely wrote back out, the line raised `AttributeError: 'DataArray' object has no attribute 'Units'`. This PR reads the CF units instead, and fixes a second latent problem in the same expression. The values returned for every file the function was already handling are unchanged.

### Reading the units from the CF source

The units now come from `ds['Time'].encoding['units']` when times have been decoded, falling back to `ds['Time'].attrs['units']` when they have not, and a `ValueError` naming the time variable is raised when neither has them. Omega's capitalized duplicates are no longer read anywhere in polaris.

### Not assuming the reference units are seconds

The units string was previously built with `.replace('seconds', 'days')`, which silently did nothing on a file whose units were `hours since ...` or `minutes since ...` and returned an answer in those units rather than in days. A new private helper parses the reference date out of whatever the CF units say and rebuilds them as `days since <reference>`, so the unit the file happens to use no longer changes the answer.

### What this does not change

The four branches of `get_days_since_start()` do not agree about what "since start" means: `daysSinceStartOfSim` is relative to the start of the simulation, while the `xtime` branch and the undecoded `'Time'` branch are relative to the first timestamp in the file and the decoded `'Time'` branch is relative to the file's reference date. Reconciling them would change plots across a dozen tasks, so none of it is touched here and every branch returns exactly what it returned before. A caller that needs an absolute simulation year should derive it from the decoded date instead.

### Contributor guidance for GitHub descriptions

A short section is added to `AGENTS.md` recording how pull request and issue descriptions should be written: no hard-wrapping inside a paragraph or bullet, a summary paragraph followed by sections, the description kept as an uncommitted draft at the root of the branch's worktree, `.github/pull_request_template.md` as the shape to follow, and no commit list or testing in the description since GitHub already shows the commits and testing belongs in its own `Testing` comment.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
No issue is open for this; add a closing keyword here if one is filed.
-->
