### PR TITLE
Add global stats products to Omega analysis

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -85,6 +85,7 @@
    sim_files.SimulationFiles.vert_coord_filename
    sim_files.SimulationFiles.monthly_mean_files
    sim_files.SimulationFiles.global_stats_files
+   sim_files.SimulationFiles.global_stats_stream
    sim_files.SimulationFiles.moc_files
    sim_files.read_omega_config
    sim_files.expand_template
@@ -636,6 +637,31 @@
 
 ## Ocean Framework
 
+### Analysis plots
+
+```{eval-rst}
+.. currentmodule:: polaris.ocean.analysis_plots
+
+.. autosummary::
+   :toctree: generated/
+
+   plot_global_stats
+```
+
+### Global statistics
+
+```{eval-rst}
+.. currentmodule:: polaris.ocean.global_stats_names
+
+.. autosummary::
+   :toctree: generated/
+
+   available_stats
+   global_stats_var_names
+   discover_fields
+   select_global_stats
+```
+
 ### Conservation utilities
 
 ```{eval-rst}
@@ -715,6 +741,7 @@
    OceanIOStep
    OceanIOStep.setup
    OceanIOStep.process_inputs_and_outputs
+   OceanIOStep.add_produced_file
    OceanIOStep.add_horiz_mesh_input_file
    OceanIOStep.add_vert_coord_input_file
    OceanIOStep.add_init_input_file
@@ -738,6 +765,8 @@
    OceanModelFilesMixin
 
    get_days_since_start
+   get_simulation_years
+   days_per_year
    get_time_interval_string
 ```
 

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -946,7 +946,7 @@ in `rpe.csv` and also returned as a numpy array for plotting and analysis.
 The package `polaris.tasks.ocean.analysis` contains the tasks of the
 `omega_analysis` suite, which analyze a simulation that has already been run
 rather than running one.  {ref}`ocean-analysis` describes the suite from a
-user's point of view.  Three pieces of it are shared machinery that a new
+user's point of view.  Four pieces of it are shared machinery that a new
 analysis product builds on.
 
 ### Locating the simulation's files
@@ -982,6 +982,40 @@ Two details are worth knowing before adding a product:
   returns each stream with its period and whether it is a time reduction, and
   the caller must not assume either spelling.
 
+### Naming the models' global statistics
+
+Both ocean models write one variable per (field, statistic) pair in their
+global statistics output and name it after the two, so
+`polaris.ocean.global_stats_names` builds the names rather than listing them.
+It is a leaf module for the same reason `sim_files` is, and it lives under
+`polaris.ocean` rather than under the analysis package because the
+`realistic_global` `analysis_members` task reads the same kind of output from
+a forward step in its own task.
+
+Three things about it are worth knowing:
+
+- **The names are built, not mapped.**  `mpaso_to_omega.yaml` needs an entry
+  only for the field itself --- `ssh: SshCell` --- and the statistic and,
+  for one of Omega's time reductions, the period are appended.  Mapping the
+  composite names instead would take an entry per (field, statistic) and,
+  once Omega writes time means, one per (field, statistic, period).
+- **The two models do not compute the same statistics.**  MPAS-Ocean writes
+  a root-mean-square where Omega writes a standard deviation, and those are
+  different quantities, so neither model's list in
+  {py:data}`polaris.ocean.global_stats_names.GLOBAL_STATS` has an entry for
+  the other's.  A step that wants a standard deviation from MPAS-Ocean
+  derives one from the root-mean-square and the mean, which is a conversion
+  and belongs in the step.
+- **A step should not assume what a run wrote.**
+  {py:func}`polaris.ocean.global_stats_names.select_global_stats` intersects
+  the (field, statistic) pairs a step asks for with what a dataset holds,
+  reports each one that is absent and drops it, and raises only when *none*
+  of them is present --- which is a step reading the wrong thing rather than
+  a simulation writing a subset.
+  {py:func}`polaris.ocean.global_stats_names.discover_fields` goes the other
+  way, giving the fields a file holds statistics for, which is what a config
+  option that names no fields falls back to.
+
 ### Steps
 
 {py:class}`polaris.tasks.ocean.analysis.analysis_step.AnalysisStep` extends
@@ -998,6 +1032,13 @@ particular, every file a step opens in `run()` goes through
 temporary files go in the step's own work directory, and a step declares the
 parallelism it will actually start as `cpus_per_task` rather than sizing
 itself to the machine.
+
+Which products an analysis step makes is usually not known until it has read
+the simulation, since a run writes some subset of the fields that were asked
+for.  Such a step declares no per-field outputs at setup and instead calls
+{py:meth}`polaris.ocean.model.OceanIOStep.add_produced_file` as it writes
+each one.  That is also what keeps a plot and the netCDF file beside it from
+getting out of step with each other, since they are registered together.
 
 ### Range-keyed steps
 

--- a/docs/users_guide/ocean/tasks/analysis.md
+++ b/docs/users_guide/ocean/tasks/analysis.md
@@ -280,14 +280,14 @@ is the cheapest look at whether a simulation is drifting.
 For each field it produces two files in
 `ocean/analysis/global_stats/<range>/`:
 
-`global_stats_<field>.png`
+`<field>.png`
 : Two panels sharing a time axis in simulation years.  The upper one shows
   the statistics themselves, with the standard deviation as a shaded envelope
   around the mean.  The lower one shows the change in each statistic since
   the beginning of the series, since drift is usually what the reader is
   looking for and it is easy to miss at the scale of the absolute values.
 
-`global_stats_<field>.nc`
+`<field>.nc`
 : Exactly the data that were plotted --- one variable per statistic, the time
   axis in simulation years, and the field, the statistics, the simulation
   name and the year range as global attributes.  It is there so the numbers

--- a/docs/users_guide/ocean/tasks/analysis.md
+++ b/docs/users_guide/ocean/tasks/analysis.md
@@ -252,20 +252,72 @@ The suite is being built up product by product.  What exists so far:
 | task | product | status |
 | --- | --- | --- |
 | `climatology_maps` | map-view climatologies, one step per field group | not yet implemented |
-| `global_stats` | time series of the simulation's global statistics | not yet implemented |
+| `global_stats` | time series of the simulation's global statistics | {ref}`available <ocean-analysis-global-stats>` |
 | `heat_content_series` | time series of globally integrated ocean heat content | not yet implemented |
 | `moc` | latitude-elevation plot of the meridional overturning circulation | not yet implemented |
 | `publish` | the staging tree and the {ref}`gallery <ocean-analysis-gallery>` over it | implemented |
 
-Each task currently resolves the simulation files it will read, links them
-into its work directory and reports them in its log, which is enough to check
-that a simulation is being located correctly.  Until the products land, there
-is nothing for `publish` to publish and it generates an empty gallery.
+A task that is not yet implemented resolves the simulation files it will read,
+links them into its work directory and reports them in its log, which is
+enough to check that a simulation is being located correctly.  No step
+describes its products in a manifest yet, so `publish` generates an empty
+gallery.
 
 The `moc` task additionally depends on a diagnostic that Omega computes in
 situ and does not yet provide.  A simulation without it is an ordinary case:
 the step reports that no MOC output was written and produces nothing, rather
 than failing the suite.
+
+(ocean-analysis-global-stats)=
+
+### global statistics time series
+
+Omega's `GlobalStats` analysis group reduces each field it is given to a
+handful of numbers per output time --- the global mean, minimum, maximum and
+standard deviation.  The `global_stats` task plots those against time, which
+is the cheapest look at whether a simulation is drifting.
+
+For each field it produces two files in
+`ocean/analysis/global_stats/<range>/`:
+
+`global_stats_<field>.png`
+: Two panels sharing a time axis in simulation years.  The upper one shows
+  the statistics themselves, with the standard deviation as a shaded envelope
+  around the mean.  The lower one shows the change in each statistic since
+  the beginning of the series, since drift is usually what the reader is
+  looking for and it is easy to miss at the scale of the absolute values.
+
+`global_stats_<field>.nc`
+: Exactly the data that were plotted --- one variable per statistic, the time
+  axis in simulation years, and the field, the statistics, the simulation
+  name and the year range as global attributes.  It is there so the numbers
+  can be inspected, compared against another tool, or re-plotted without
+  re-reading the simulation.
+
+Two options in `[ocean_analysis_time_series]` govern it, alongside the
+`start_year` and `end_year` that every time series shares:
+
+`fields`
+: The fields to plot, using MPAS-Ocean (Polaris standard) names.  Leave it
+  empty to plot every field the simulation wrote statistics for.
+
+`stats`
+: The statistics to plot for each field: any of `mean`, `min`, `max` and
+  `std`.
+
+**A field or statistic the simulation did not write is skipped with a message
+in the step's log, not treated as an error.**  The defaults describe what we
+would like to see, and any given simulation will have written some subset of
+it --- which is no more under the user's control than it is under ours.  A
+field with no surviving statistics is dropped entirely.  Only a file with
+*none* of the requested variables stops the step, since that usually means
+the year range does not overlap the simulation rather than that a variable is
+missing.
+
+Omega can write these statistics either as snapshots or as time means over a
+period it is configured with, and it names the variables differently in the
+two cases.  Polaris reads the simulation's Omega configuration to find out
+which it wrote, so this needs no option of its own.
 
 ## troubleshooting
 

--- a/polaris/ocean/analysis_plots.py
+++ b/polaris/ocean/analysis_plots.py
@@ -86,8 +86,17 @@ def plot_global_stats(
                 label=STAT_LABELS['std'],
             )
 
-        axes[0].legend()
-        axes[1].legend()
+        # one legend for the figure, above the panels: it applies to both,
+        # and inside the axes it covers the data
+        handles, labels = axes[0].get_legend_handles_labels()
+        axes[0].legend(
+            handles,
+            labels,
+            loc='lower center',
+            bbox_to_anchor=(0.5, 1.02),
+            ncol=len(labels),
+            frameon=False,
+        )
         axes[0].set_xlabel(x_label)
         axes[1].set_xlabel(x_label)
         axes[0].set_ylabel(field_name)

--- a/polaris/ocean/analysis_plots.py
+++ b/polaris/ocean/analysis_plots.py
@@ -1,0 +1,99 @@
+"""
+Plots shared by the steps that analyze a completed simulation.
+
+The steps that make these plots read their data in very different ways --
+one from a forward step in its own task, another from a run that finished
+months ago -- so the plotting is kept here, free of any dependence on
+:py:class:`polaris.Step`, and each step passes in arrays it has already
+selected.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from polaris.viz import mplstyle_context
+
+# the label each statistic is given in the legend and in the netCDF file
+# beside the plot, using the Polaris-standard spelling of the statistic
+STAT_LABELS = {
+    'min': 'Min',
+    'max': 'Max',
+    'mean': 'Avg',
+    'std': 'SD',
+}
+
+# the line style each statistic is drawn with; the standard deviation is a
+# shaded envelope around the mean rather than a line
+_STAT_STYLES = [('min', ':k'), ('max', '--k'), ('mean', '-k')]
+
+
+def plot_global_stats(
+    time, stats, field_name, out_filename, x_label='Days', title=None
+):
+    """
+    Plot a time series of the global statistics of one field
+
+    Two panels share a time axis: the statistics themselves, with a
+    standard-deviation envelope around the mean, and the change in each
+    statistic since the beginning of the time series, which is where drift
+    shows up.
+
+    Parameters
+    ----------
+    time : numpy.ndarray
+        The time axis of the series
+
+    stats : dict of str to numpy.ndarray
+        The statistics to plot, keyed by ``'min'``, ``'max'``, ``'mean'`` and
+        ``'std'``.  Any subset may be given and a statistic that is absent is
+        omitted from the plot.  The envelope is drawn only when both
+        ``'mean'`` and ``'std'`` are present.
+
+    field_name : str
+        The name of the field, used to label the vertical axes
+
+    out_filename : str
+        The image file to write
+
+    x_label : str, optional
+        The label for the time axis
+
+    title : str, optional
+        A title for the figure
+    """
+    with mplstyle_context():
+        fig, axes = plt.subplots(
+            nrows=2, ncols=1, sharex=True, sharey=False, figsize=(5, 8)
+        )
+
+        for stat, style in _STAT_STYLES:
+            if stat not in stats:
+                continue
+            values = np.asarray(stats[stat])
+            label = STAT_LABELS[stat]
+            axes[0].plot(time, values, style, label=label)
+            axes[1].plot(time, values - values[0], style, label=label)
+
+        if 'mean' in stats and 'std' in stats:
+            mean = np.asarray(stats['mean'])
+            std = np.asarray(stats['std'])
+            axes[0].fill_between(
+                time,
+                mean + std,
+                mean - std,
+                color='k',
+                alpha=0.5,
+                label=STAT_LABELS['std'],
+            )
+
+        axes[0].legend()
+        axes[1].legend()
+        axes[0].set_xlabel(x_label)
+        axes[1].set_xlabel(x_label)
+        axes[0].set_ylabel(field_name)
+        axes[1].set_ylabel(f'{field_name} - {field_name} at t=0')
+        axes[0].set_xlim([min(time), max(time)])
+        if title is not None:
+            fig.suptitle(title)
+        fig.savefig(out_filename, bbox_inches='tight')
+        plt.close(fig)

--- a/polaris/ocean/global_stats_names.py
+++ b/polaris/ocean/global_stats_names.py
@@ -1,0 +1,247 @@
+"""
+The names of the variables in an ocean model's global statistics output.
+
+Both models write one variable per (field, statistic) pair and name it after
+the two, so the names are built from the fields and statistics that are
+wanted rather than listed one by one.  Building them is what lets a step ask
+for a field the map has never heard of, and what keeps the time reductions
+Omega can write from needing a name apiece.
+
+The two models do not compute quite the same statistics, and this module is
+where that is written down: MPAS-Ocean computes a root-mean-square where
+Omega computes a standard deviation.  Those are different quantities, so
+neither model's list has an entry for the other's, and a step that wants a
+standard deviation from MPAS-Ocean has to derive one.
+
+This module is deliberately free of any dependence on
+:py:class:`polaris.Step` and on the ocean component, so that it can be unit
+tested on its own.  A caller that has Polaris-standard field names passes a
+``field_map`` to say what each is called in the model that wrote the file.
+"""
+
+# the global statistics each ocean model computes, and the name each one is
+# written under.  The keys are the Polaris-standard names used in config
+# options; the lists differ because the models differ.
+GLOBAL_STATS = {
+    'mpas-ocean': {
+        'min': 'Min',
+        'max': 'Max',
+        'mean': 'Avg',
+        'rms': 'Rms',
+    },
+    'omega': {
+        'min': 'SpatialMin',
+        'max': 'SpatialMax',
+        'mean': 'SpatialMean',
+        'std': 'SpatialStdDev',
+    },
+}
+
+# how each statistic is described, for plot legends and netCDF metadata
+STAT_DESCRIPTIONS = {
+    'min': 'global minimum',
+    'max': 'global maximum',
+    'mean': 'global mean',
+    'std': 'global standard deviation',
+    'rms': 'global root-mean-square',
+}
+
+
+def available_stats(model):
+    """
+    Get the global statistics a model computes
+
+    Parameters
+    ----------
+    model : {'mpas-ocean', 'omega'}
+        The ocean model that wrote the output
+
+    Returns
+    -------
+    stats : list of str
+        The Polaris-standard name of each statistic the model computes
+
+    Raises
+    ------
+    ValueError
+        If ``model`` is not an ocean model Polaris knows about
+    """
+    if model not in GLOBAL_STATS:
+        known = ', '.join(GLOBAL_STATS)
+        raise ValueError(
+            f'Do not know what global statistics "{model}" computes.  The '
+            f'ocean models are: {known}.'
+        )
+    return list(GLOBAL_STATS[model])
+
+
+def global_stats_var_names(
+    fields, stats, model, field_map=None, time_mean_period=None
+):
+    """
+    Build the names of the global statistics variables to look for
+
+    Parameters
+    ----------
+    fields : list of str
+        The fields whose statistics are wanted.  These are the names the
+        caller uses to label its results; ``field_map`` says what the model
+        calls each of them.
+
+    stats : list of str
+        The statistics to look for, each of them one of
+        :py:func:`available_stats` for this model
+
+    model : {'mpas-ocean', 'omega'}
+        The ocean model that wrote the output
+
+    field_map : dict of str to str, optional
+        What the model calls each field, as
+        :py:meth:`polaris.tasks.ocean.Ocean.map_var_list_to_native_model`
+        gives it.  A field that is missing from the map keeps its own name,
+        which is the right answer for a field only one model has.
+
+    time_mean_period : str, optional
+        The period of the time reduction the variables were averaged over,
+        e.g. ``'1Month'``.  The default is the spelling used for snapshots,
+        which carry no period at all.
+
+    Returns
+    -------
+    var_names : dict of (str, str) to str
+        The variable name of each ``(field, stat)`` pair, in the order the
+        fields and the statistics were given
+
+    Raises
+    ------
+    ValueError
+        If a statistic is not one this model computes, or if a time mean is
+        asked of a model that writes none
+    """
+    model_stats = _model_stats(model, stats)
+    if time_mean_period is not None and model != 'omega':
+        raise ValueError(
+            f'{model} writes no time means of its global statistics, so '
+            f'there are no variables averaged over {time_mean_period}.'
+        )
+    if field_map is None:
+        field_map = {}
+
+    var_names = {}
+    for field in fields:
+        for stat in stats:
+            var_names[(field, stat)] = _var_name(
+                model_field=field_map.get(field, field),
+                stat_name=model_stats[stat],
+                model=model,
+                time_mean_period=time_mean_period,
+            )
+    return var_names
+
+
+def select_global_stats(
+    ds,
+    fields,
+    stats,
+    model,
+    field_map=None,
+    time_mean_period=None,
+    log=None,
+    source='the global statistics output',
+    hint=None,
+):
+    """
+    Intersect the requested (field, statistic) pairs with what a dataset holds
+
+    A simulation writes some subset of the fields and statistics that were
+    asked for, and which subset is not something the person asking controls,
+    so a pair that is absent is reported and dropped rather than raised on.
+    A field with no surviving statistics is dropped entirely.  Only a dataset
+    with *none* of the requested variables raises, since that is not a
+    simulation writing a subset but a step reading the wrong thing.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The global statistics, with the names the model gave them
+
+    fields, stats, model, field_map, time_mean_period
+        As for :py:func:`global_stats_var_names`
+
+    log : callable, optional
+        Where to report each pair that was dropped, typically
+        ``step.logger.info``.  The default reports nothing.
+
+    source : str, optional
+        A short description of what was read, for the message when nothing
+        was found
+
+    hint : str, optional
+        What to check when nothing was found, appended to that message
+
+    Returns
+    -------
+    found : dict of str to dict of str to str
+        The variable name of each statistic that is present, by field, in the
+        order the fields and the statistics were given
+
+    Raises
+    ------
+    ValueError
+        If none of the requested variables is in ``ds``
+    """
+    var_names = global_stats_var_names(
+        fields=fields,
+        stats=stats,
+        model=model,
+        field_map=field_map,
+        time_mean_period=time_mean_period,
+    )
+
+    found: dict = {}
+    for (field, stat), var_name in var_names.items():
+        if var_name in ds:
+            found.setdefault(field, {})[stat] = var_name
+        elif log is not None:
+            log(f'  no {var_name}: skipping the {stat} of {field}')
+
+    if log is not None:
+        for field in fields:
+            if field not in found:
+                log(f'  no statistics of {field} were written: skipping it')
+
+    if not found:
+        message = (
+            f'None of the {len(var_names)} global statistics variables that '
+            f'were asked for is in {source}.'
+        )
+        if hint is not None:
+            message = f'{message}  {hint}'
+        raise ValueError(message)
+
+    return found
+
+
+def _model_stats(model, stats):
+    """Get a model's statistics, complaining about any it does not compute"""
+    # raises for a model Polaris does not know about
+    known = available_stats(model)
+
+    unknown = [stat for stat in stats if stat not in known]
+    if unknown:
+        raise ValueError(
+            f'{model} does not compute the global '
+            f'{", ".join(unknown)} of a field.  The statistics it computes '
+            f'are: {", ".join(known)}.'
+        )
+    return GLOBAL_STATS[model]
+
+
+def _var_name(model_field, stat_name, model, time_mean_period):
+    """Build one global statistics variable name"""
+    if model == 'omega':
+        name = f'{model_field}_{stat_name}'
+        if time_mean_period is not None:
+            name = f'{name}_TimeMean{time_mean_period}'
+        return name
+    return f'{model_field}{stat_name}'

--- a/polaris/ocean/global_stats_names.py
+++ b/polaris/ocean/global_stats_names.py
@@ -139,6 +139,51 @@ def global_stats_var_names(
     return var_names
 
 
+def discover_fields(ds, model, time_mean_period=None):
+    """
+    Get the fields a dataset holds global statistics for
+
+    This is the inverse of the name construction: a variable whose name ends
+    in one of the statistics the model computes is a statistic of whatever
+    comes before it.  It is what lets a step plot what a simulation wrote
+    rather than what someone thought it would write.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The global statistics, with the names the model gave them
+
+    model : {'mpas-ocean', 'omega'}
+        The ocean model that wrote the output
+
+    time_mean_period : str, optional
+        The period of the time reduction to look for.  The default finds the
+        snapshots, and a dataset holding both is not searched for the wrong
+        one.
+
+    Returns
+    -------
+    fields : list of str
+        The model's own name for each field, in the order its variables
+        appear in the dataset, without repeats
+    """
+    # raises for a model Polaris does not know about
+    available_stats(model)
+    stat_names = GLOBAL_STATS[model]
+
+    fields = []
+    for var_name in ds.data_vars:
+        field = _field_name(
+            var_name=str(var_name),
+            stat_names=stat_names.values(),
+            model=model,
+            time_mean_period=time_mean_period,
+        )
+        if field is not None and field not in fields:
+            fields.append(field)
+    return fields
+
+
 def select_global_stats(
     ds,
     fields,
@@ -165,8 +210,12 @@ def select_global_stats(
     ds : xarray.Dataset
         The global statistics, with the names the model gave them
 
-    fields, stats, model, field_map, time_mean_period
+    fields, model, field_map, time_mean_period
         As for :py:func:`global_stats_var_names`
+
+    stats : list of str or None
+        The statistics to look for, or ``None`` for every statistic this
+        model computes
 
     log : callable, optional
         Where to report each pair that was dropped, typically
@@ -190,6 +239,8 @@ def select_global_stats(
     ValueError
         If none of the requested variables is in ``ds``
     """
+    if not stats:
+        stats = available_stats(model)
     var_names = global_stats_var_names(
         fields=fields,
         stats=stats,
@@ -245,3 +296,21 @@ def _var_name(model_field, stat_name, model, time_mean_period):
             name = f'{name}_TimeMean{time_mean_period}'
         return name
     return f'{model_field}{stat_name}'
+
+
+def _field_name(var_name, stat_names, model, time_mean_period):
+    """Get the field one global statistics variable is a statistic of"""
+    if model == 'omega':
+        suffix = (
+            '' if time_mean_period is None else f'_TimeMean{time_mean_period}'
+        )
+        for stat_name in stat_names:
+            ending = f'_{stat_name}{suffix}'
+            if var_name.endswith(ending):
+                return var_name[: -len(ending)]
+        return None
+
+    for stat_name in stat_names:
+        if var_name.endswith(stat_name):
+            return var_name[: -len(stat_name)]
+    return None

--- a/polaris/ocean/model/__init__.py
+++ b/polaris/ocean/model/__init__.py
@@ -5,8 +5,12 @@ from polaris.ocean.model.ocean_model_files_mixin import (
 from polaris.ocean.model.ocean_model_step import (
     OceanModelStep as OceanModelStep,
 )
+from polaris.ocean.model.time import days_per_year as days_per_year
 from polaris.ocean.model.time import (
     get_days_since_start as get_days_since_start,
+)
+from polaris.ocean.model.time import (
+    get_simulation_years as get_simulation_years,
 )
 from polaris.ocean.model.time import (
     get_time_interval_string as get_time_interval_string,

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -98,23 +98,16 @@ variables:
   # eos
   BruntVaisalaFreqTop: BruntVaisalaFreqSq
 
-  # global stats daily variables
-  normalVelocityMax: NormalVelocity_SpatialMax
-  normalVelocityMin: NormalVelocity_SpatialMin
-  normalVelocityAvg: NormalVelocity_SpatialMean
-  normalVelocityRms: NormalVelocity_SpatialStdDev
-  layerThicknessMax: PseudoThickness_SpatialMax
-  layerThicknessMin: PseudoThickness_SpatialMin
-  layerThicknessAvg: PseudoThickness_SpatialMean
-  layerThicknessRms: PseudoThickness_SpatialStdDev
-  temperatureMax: Temperature_SpatialMax
-  temperatureMin: Temperature_SpatialMin
-  temperatureAvg: Temperature_SpatialMean
-  temperatureRms: Temperature_SpatialStdDev
-  salinityMax: Salinity_SpatialMax
-  salinityMin: Salinity_SpatialMin
-  salinityAvg: Salinity_SpatialMean
-  salinityRms: Salinity_SpatialStdDev
+  # Note: the variables in each model's global statistics output are not
+  #       mapped here.  Both models name a statistic after the field and the
+  #       statistic, so the names are built from the two in
+  #       polaris/ocean/global_stats_names.py, which needs an entry only for
+  #       the field itself.  Mapping the composite names instead would take
+  #       one entry per (field, statistic), and one per (field, statistic,
+  #       period) once Omega writes time means.  It would also have to claim
+  #       that MPAS-Ocean's Rms and Omega's SpatialStdDev are the same
+  #       quantity, which they are not: one is a root-mean-square and the
+  #       other a standard deviation.
 
 config:
 - section:

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -33,6 +33,24 @@ class OceanIOStep(OceanModelFilesMixin, Step):
         self._resolve_model_file_placeholders()
         super().process_inputs_and_outputs()
 
+    def add_produced_file(self, filename):
+        """
+        Register a file the step has just written as one of its outputs
+
+        Most outputs are known at setup, but a step that plots what a
+        simulation wrote does not know which plots it will make until it has
+        read the simulation, since a run writes some subset of the fields it
+        was asked for.  Such a step registers each product as it writes it,
+        which also keeps a plot and the data beside it from getting out of
+        step with each other.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the file, relative to the step's work directory
+        """
+        self.outputs.append(self.work_path(filename))
+
     def add_output_files_for_ocean_model_input(
         self,
         horiz_mesh_filename=None,

--- a/polaris/ocean/model/time.py
+++ b/polaris/ocean/model/time.py
@@ -38,6 +38,86 @@ def get_days_since_start(ds):
     return t_arr
 
 
+# the number of days in a year of each calendar cftime supports; the mixed
+# Julian/Gregorian calendars use the mean Gregorian year, which is what a
+# time axis in years wants
+DAYS_PER_YEAR = {
+    'noleap': 365.0,
+    '365_day': 365.0,
+    'all_leap': 366.0,
+    '366_day': 366.0,
+    '360_day': 360.0,
+    'julian': 365.25,
+    'standard': 365.2425,
+    'gregorian': 365.2425,
+    'proleptic_gregorian': 365.2425,
+}
+
+
+def days_per_year(calendar):
+    """
+    Get the length of a year in days in a given calendar
+
+    Parameters
+    ----------
+    calendar : str
+        The name of a CF calendar, as ``xarray.DataArray.dt.calendar`` gives
+        it
+
+    Returns
+    -------
+    days : float
+        The number of days in a year of that calendar
+
+    Raises
+    ------
+    ValueError
+        If the calendar is not one of those CF defines
+    """
+    if calendar not in DAYS_PER_YEAR:
+        known = ', '.join(DAYS_PER_YEAR)
+        raise ValueError(
+            f'Do not know the length of a year in the "{calendar}" '
+            f'calendar.  The calendars supported are: {known}.'
+        )
+    return DAYS_PER_YEAR[calendar]
+
+
+def get_simulation_years(ds, time_var='Time'):
+    """
+    Get the time axis of a dataset in decimal simulation years
+
+    The year comes from the calendar date itself rather than from an elapsed
+    time, so that a series covering years 21 through 40 is plotted at 21
+    through 41 -- the years the user asked for -- whatever reference date the
+    model happened to write its time coordinate against.  It also depends on
+    no attribute of the time variable beyond its calendar, so a file that has
+    been read and written again is handled the same as one straight from the
+    model.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset with a decoded time coordinate
+
+    time_var : str, optional
+        The name of the time coordinate
+
+    Returns
+    -------
+    years : numpy.ndarray
+        The decimal simulation year of each time in the dataset
+    """
+    times = ds[time_var]
+    length = days_per_year(times.dt.calendar)
+    seconds = (
+        times.dt.hour * 3600 + times.dt.minute * 60 + times.dt.second
+    ).values.astype(float)
+    day_of_year = times.dt.dayofyear.values.astype(float)
+    year = times.dt.year.values.astype(float)
+    return year + (day_of_year - 1.0 + seconds / 86400.0) / length
+
+
 def get_time_interval_string(days=None, seconds=None):
     """
     Convert a time interval in days and/or seconds to a string for use in a

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -576,16 +576,19 @@ class Ocean(Component):
         If the model is Omega, rename variables from their Omega names to
         the MPAS-Ocean equivalent
 
+        A variable with no entry in the map keeps its own name, which is the
+        right answer for a field only Omega has.
+
         Parameters
         ----------
         var_list : list of str
-            A list of MPAS-Ocean variable names
+            A list of variable names native to the ocean model being run
 
         Returns
         -------
         renamed_vars : list of str
-            The same list with variables renamed as appropriate for the
-            ocean model being run
+            The same list, in the same order, with variables renamed to their
+            MPAS-Ocean equivalents
         """
         renamed_vars = var_list
         model = self.model
@@ -593,11 +596,10 @@ class Ocean(Component):
             # switch keys and values in mpaso_to_omega maps to get
             # omega to mpaso maps
             assert self.mpaso_to_omega_var_map is not None
-            renamed_vars = [
-                v
-                for v, k in self.mpaso_to_omega_var_map.items()
-                if k in var_list
-            ]
+            omega_to_mpaso = {
+                k: v for v, k in self.mpaso_to_omega_var_map.items()
+            }
+            renamed_vars = [omega_to_mpaso.get(v, v) for v in var_list]
         return renamed_vars
 
     def open_model_dataset(

--- a/polaris/tasks/ocean/analysis/analysis.cfg
+++ b/polaris/tasks/ocean/analysis/analysis.cfg
@@ -114,12 +114,14 @@ elevation_ranges = top:-700.0, -700.0:-2000.0, -2000.0:bottom, top:bottom
 start_year = 1
 end_year = 10
 
-# The fields from the model's global statistics output to plot.  Fields the
-# simulation did not write are skipped with a message, not an error.
+# The fields from the model's global statistics output to plot, using
+# MPAS-Ocean (Polaris standard) names.  Leave this empty to plot every field
+# the simulation wrote statistics for.  Fields the simulation did not write
+# are skipped with a message, not an error.
 fields = temperature, salinity, normalVelocity, kineticEnergyCell, ssh
 
-# The statistics to plot for each field.  As with fields, missing statistics
-# are skipped.
+# The statistics to plot for each field: any of mean, min, max and std.  As
+# with fields, missing statistics are skipped.
 stats = mean, min, max, std
 
 

--- a/polaris/tasks/ocean/analysis/global_stats.py
+++ b/polaris/tasks/ocean/analysis/global_stats.py
@@ -141,7 +141,9 @@ class GlobalStatsTimeSeries(AnalysisStep):
             stat: ds[var_name].values.astype(float)
             for stat, var_name in field_stats.items()
         }
-        prefix = f'global_stats_{field}'
+        # the file is named for the field alone; the publish step prefixes
+        # the product group when it publishes it
+        prefix = field
         simulation_name = self.config.get('ocean_analysis', 'simulation_name')
 
         plot_global_stats(

--- a/polaris/tasks/ocean/analysis/global_stats.py
+++ b/polaris/tasks/ocean/analysis/global_stats.py
@@ -166,6 +166,20 @@ class GlobalStatsTimeSeries(AnalysisStep):
         )
         self.add_produced_file(f'{prefix}.nc')
 
+        # the group is the kind of product rather than the task that made
+        # it, so that every time series shares one section of the landing
+        # page.  One gallery for all of the global statistics: a page per
+        # field would be a page with one plot on it.
+        self.add_product(
+            plot=f'{prefix}.png',
+            data=f'{prefix}.nc',
+            group='time_series',
+            gallery='global_stats',
+            title=f'Global {field}',
+            field=field,
+            stats=sorted(field_stats),
+        )
+
         self.logger.info(
             f'  {field}: plotted the {", ".join(field_stats)} in {prefix}.png'
         )

--- a/polaris/tasks/ocean/analysis/global_stats.py
+++ b/polaris/tasks/ocean/analysis/global_stats.py
@@ -1,3 +1,12 @@
+import xarray as xr
+
+from polaris.ocean.analysis_plots import plot_global_stats
+from polaris.ocean.global_stats_names import (
+    STAT_DESCRIPTIONS,
+    discover_fields,
+    select_global_stats,
+)
+from polaris.ocean.model.time import get_simulation_years
 from polaris.tasks.ocean.analysis.analysis_step import AnalysisStep
 
 
@@ -5,6 +14,14 @@ class GlobalStatsTimeSeries(AnalysisStep):
     """
     A step that plots time series of the quantities in the simulation's global
     statistics output
+
+    Attributes
+    ----------
+    time_mean_period : str or None
+        The period the statistics were averaged over, if the simulation wrote
+        time means, or ``None`` if it wrote snapshots.  The two are spelled
+        differently in the file, so which one it is has to be known before the
+        variables can be looked up.
     """
 
     def __init__(self, component, subdir, start_year, end_year):
@@ -34,6 +51,7 @@ class GlobalStatsTimeSeries(AnalysisStep):
             ntasks=1,
             cpus_per_task=1,
         )
+        self.time_mean_period = None
 
     def setup(self):
         """
@@ -43,9 +61,168 @@ class GlobalStatsTimeSeries(AnalysisStep):
         self.add_sim_input_files(
             sim_files.global_stats_files(self.start_year, self.end_year)
         )
+        stream = sim_files.global_stats_stream()
+        assert stream is not None
+        self.time_mean_period = stream.period if stream.is_reduction else None
 
     def run(self):
         """
-        Report the statistics files; no time series are plotted yet
+        Plot a time series of each field's global statistics, and write the
+        data behind each plot beside it
         """
         self.log_inputs()
+
+        section = 'ocean_analysis_time_series'
+        stats = self.config.getlist(section, 'stats')
+
+        ds = self._open_stats()
+        fields = self._fields(ds)
+        found = select_global_stats(
+            ds=ds,
+            fields=fields,
+            stats=stats,
+            model='omega',
+            field_map=self._field_map(fields),
+            time_mean_period=self.time_mean_period,
+            log=self.logger.info,
+            source=', '.join(self.input_filenames),
+            hint=(
+                f'A simulation writes some subset of the fields and '
+                f'statistics [{section}] asks for, but none of them usually '
+                f'means that years {self.start_year} through '
+                f'{self.end_year} are not years the simulation covers, or '
+                f'that its GlobalStats analysis group named a stream other '
+                f'than the one it wrote.'
+            ),
+        )
+
+        time = get_simulation_years(ds)
+        for field, field_stats in found.items():
+            self._plot_field(ds, field, field_stats, time)
+
+    def _open_stats(self):
+        """
+        Open the global statistics files as one series
+
+        The variables keep the names Omega gave them, since those are the
+        names the analysis builds and looks for.
+        """
+        ds = xr.open_mfdataset(
+            [self.work_path(filename) for filename in self.input_filenames],
+            combine='nested',
+            concat_dim='time',
+        )
+        if 'Scalar' in ds.dims:
+            # Omega writes each global statistic as a field of one point
+            ds = ds.isel(Scalar=0)
+        # the rest of Polaris spells the time dimension the MPAS-Ocean way
+        return ds.rename({'time': 'Time'})
+
+    def _fields(self, ds):
+        """Get the fields to plot, in Polaris-standard names"""
+        fields = self.config.getlist('ocean_analysis_time_series', 'fields')
+        if fields:
+            return fields
+        # an empty option asks for whatever the simulation wrote
+        return self.component.map_var_list_from_native_model(
+            discover_fields(
+                ds, model='omega', time_mean_period=self.time_mean_period
+            )
+        )
+
+    def _field_map(self, fields):
+        """Get the name Omega gave each configured field"""
+        native = self.component.map_var_list_to_native_model(fields)
+        return dict(zip(fields, native, strict=True))
+
+    def _plot_field(self, ds, field, field_stats, time):
+        """Plot one field's statistics and write the data beside the plot"""
+        values = {
+            stat: ds[var_name].values.astype(float)
+            for stat, var_name in field_stats.items()
+        }
+        prefix = f'global_stats_{field}'
+        simulation_name = self.config.get('ocean_analysis', 'simulation_name')
+
+        plot_global_stats(
+            time=time,
+            stats=values,
+            field_name=_axis_label(ds, field, field_stats),
+            out_filename=self.work_path(f'{prefix}.png'),
+            x_label='Simulation years',
+            title=f'{simulation_name}: global {field}',
+        )
+        self.add_produced_file(f'{prefix}.png')
+
+        self._write_plot_data(
+            ds=ds,
+            field=field,
+            field_stats=field_stats,
+            time=time,
+            values=values,
+            out_filename=self.work_path(f'{prefix}.nc'),
+        )
+        self.add_produced_file(f'{prefix}.nc')
+
+        self.logger.info(
+            f'  {field}: plotted the {", ".join(field_stats)} in {prefix}.png'
+        )
+
+    def _write_plot_data(
+        self, ds, field, field_stats, time, values, out_filename
+    ):
+        """Write exactly what was plotted, so it can be checked again"""
+        units = _units(ds, field_stats)
+        ds_out = xr.Dataset()
+        ds_out['simulationYears'] = xr.DataArray(
+            time,
+            dims=('Time',),
+            attrs={
+                'long_name': 'simulation year, from the calendar date',
+                'units': 'years',
+            },
+        )
+        ds_out['Time'] = ds['Time']
+        for stat, var_name in field_stats.items():
+            ds_out[stat] = xr.DataArray(
+                values[stat],
+                dims=('Time',),
+                attrs={
+                    'long_name': f'{STAT_DESCRIPTIONS[stat]} of {field}',
+                    'units': units,
+                    'omega_name': var_name,
+                },
+            )
+        ds_out.attrs = {
+            'field': field,
+            'statistics': ', '.join(field_stats),
+            'simulation_name': self.config.get(
+                'ocean_analysis', 'simulation_name'
+            ),
+            'start_year': self.start_year,
+            'end_year': self.end_year,
+            'time_mean_period': (
+                'none; these are snapshots'
+                if self.time_mean_period is None
+                else self.time_mean_period
+            ),
+            'source_files': ', '.join(self.input_filenames),
+        }
+        ds_out.to_netcdf(out_filename)
+
+
+def _axis_label(ds, field, field_stats):
+    """Label the vertical axes with the field and its units, if it has any"""
+    units = _units(ds, field_stats)
+    if units:
+        return f'{field} ({units})'
+    return field
+
+
+def _units(ds, field_stats):
+    """Get the units the statistics of a field were written with"""
+    for var_name in field_stats.values():
+        units = ds[var_name].attrs.get('units', '')
+        if units:
+            return str(units)
+    return ''

--- a/polaris/tasks/ocean/analysis/sim_files.py
+++ b/polaris/tasks/ocean/analysis/sim_files.py
@@ -585,6 +585,23 @@ class SimulationFiles:
             ),
         )
 
+    def global_stats_stream(self):
+        """
+        Get the output stream the global statistics are read from
+
+        The names of the variables in the file depend on whether the stream
+        holds time means or snapshots, so a step that reads them needs the
+        stream and not just its file name.
+
+        Returns
+        -------
+        stream : AnalysisStream or None
+            The stream, or ``None`` if the simulation wrote no global
+            statistics
+        """
+        streams = self.omega_config.analysis_streams('GlobalStats')
+        return _preferred_analysis_stream(streams)
+
     def moc_files(self, start_year, end_year):
         """
         Get the meridional overturning circulation output files covering a

--- a/polaris/tasks/ocean/realistic_global/analysis_members/analysis_members.cfg
+++ b/polaris/tasks/ocean/realistic_global/analysis_members/analysis_members.cfg
@@ -7,3 +7,14 @@ eos_type = teos-10
 
 # Time step duration per kilometer [s]
 dt_per_km = 3.0
+
+
+# options for the plots of the global statistics the forward step wrote
+[analysis_members]
+
+# The fields to plot global statistics for, using MPAS-Ocean (Polaris
+# standard) names.  Leave this empty, as it is by default, to plot every
+# field the run wrote statistics for, which is what the models' own default
+# lists give.  A field the run did not write is skipped with a message, not
+# an error.
+fields =

--- a/polaris/tasks/ocean/realistic_global/analysis_members/stats_analysis.py
+++ b/polaris/tasks/ocean/realistic_global/analysis_members/stats_analysis.py
@@ -1,9 +1,8 @@
-import matplotlib.pyplot as plt
 import numpy as np
 
+from polaris.ocean.analysis_plots import plot_global_stats
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.model.time import get_days_since_start
-from polaris.viz import mplstyle_context
 
 
 class StatsAnalysis(OceanIOStep):
@@ -43,50 +42,29 @@ class StatsAnalysis(OceanIOStep):
             self.add_output_file(f'{variable_name}_stats.png')
 
     def run(self):
-        with mplstyle_context():
-            model = self.config.get('ocean', 'model')
-            ds = self.open_model_dataset('output.nc', self.config)
-            if 'Scalar' in ds.dims:
-                ds = ds.isel(Scalar=0)
-            time = get_days_since_start(ds)
-            for variable_name in self.variables:
-                fig, axes = plt.subplots(
-                    nrows=2, ncols=1, sharex=True, sharey=False, figsize=(5, 8)
-                )
-                suffix = 'Min'
-                var = ds[f'{variable_name}{suffix}']
-                axes[0].plot(time, var, ':k', label=suffix)
-                axes[1].plot(time, var - var[0], ':k', label=suffix)
-                suffix = 'Max'
-                var = ds[f'{variable_name}{suffix}']
-                axes[0].plot(time, var, '--k', label=suffix)
-                axes[1].plot(time, var - var[0], '--k', label=suffix)
-                suffix = 'Avg'
-                var_mean = ds[f'{variable_name}{suffix}']
-                axes[0].plot(time, var_mean, '-k', label=suffix)
-                axes[1].plot(time, var_mean - var_mean[0], '-k', label=suffix)
-                suffix = 'Rms'
-                if model == 'omega':
-                    var_std = ds[f'{variable_name}{suffix}'].values
-                else:
-                    var_rms = ds[f'{variable_name}{suffix}']
-                    var_std = np.sqrt(
-                        var_rms.values**2.0 - var_mean.values**2.0
-                    )
-                axes[0].fill_between(
-                    time,
-                    var_mean.values + var_std,
-                    var_mean.values - var_std,
-                    color='k',
-                    alpha=0.5,
-                    label='SD',
-                )
-                axes[0].legend()
-                axes[1].legend()
-                axes[0].set_xlabel('Days')
-                axes[1].set_xlabel('Days')
-                axes[0].set_ylabel(variable_name)
-                axes[1].set_ylabel(f'{variable_name} - {variable_name} at t=0')
-                axes[0].set_xlim([min(time), max(time)])
-                fig.savefig(f'{variable_name}_stats.png', bbox_inches='tight')
-                plt.close(fig)
+        model = self.config.get('ocean', 'model')
+        ds = self.open_model_dataset('output.nc', self.config)
+        if 'Scalar' in ds.dims:
+            ds = ds.isel(Scalar=0)
+        time = get_days_since_start(ds)
+        for variable_name in self.variables:
+            var_mean = ds[f'{variable_name}Avg'].values
+            var_rms = ds[f'{variable_name}Rms'].values
+            if model == 'omega':
+                # Omega's Rms is mapped from SpatialStdDev, so it already is
+                # a standard deviation
+                var_std = var_rms
+            else:
+                var_std = np.sqrt(var_rms**2.0 - var_mean**2.0)
+            stats = {
+                'min': ds[f'{variable_name}Min'].values,
+                'max': ds[f'{variable_name}Max'].values,
+                'mean': var_mean,
+                'std': var_std,
+            }
+            plot_global_stats(
+                time=time,
+                stats=stats,
+                field_name=variable_name,
+                out_filename=f'{variable_name}_stats.png',
+            )

--- a/polaris/tasks/ocean/realistic_global/analysis_members/stats_analysis.py
+++ b/polaris/tasks/ocean/realistic_global/analysis_members/stats_analysis.py
@@ -1,11 +1,21 @@
 import numpy as np
+import xarray as xr
 
 from polaris.ocean.analysis_plots import plot_global_stats
+from polaris.ocean.global_stats_names import (
+    discover_fields,
+    select_global_stats,
+)
 from polaris.ocean.model import OceanIOStep
 from polaris.ocean.model.time import get_days_since_start
 
 
 class StatsAnalysis(OceanIOStep):
+    """
+    A step that plots time series of the global statistics a forward step
+    wrote
+    """
+
     def __init__(
         self,
         component,
@@ -14,8 +24,6 @@ class StatsAnalysis(OceanIOStep):
         output_filename='global_stats.nc',
         name='global_stats',
     ):
-        # TODO this should be replaced with model-specific state variables
-        # read from yaml
         self.forward_step = forward_step
         self.output_filename = output_filename
         super().__init__(
@@ -23,9 +31,6 @@ class StatsAnalysis(OceanIOStep):
             name=name,
             indir=indir,
         )
-        if component.state_vars is None:
-            component._read_variables_yaml()
-        self.variables = component.state_vars
 
     def setup(self):
         model = self.config.get('ocean', 'model')
@@ -38,33 +43,73 @@ class StatsAnalysis(OceanIOStep):
             filename='output.nc',
             work_dir_target=target,
         )
-        for variable_name in self.variables:
-            self.add_output_file(f'{variable_name}_stats.png')
 
     def run(self):
         model = self.config.get('ocean', 'model')
-        ds = self.open_model_dataset('output.nc', self.config)
+        ds = xr.open_dataset(self.work_path('output.nc'))
         if 'Scalar' in ds.dims:
             ds = ds.isel(Scalar=0)
-        time = get_days_since_start(ds)
-        for variable_name in self.variables:
-            var_mean = ds[f'{variable_name}Avg'].values
-            var_rms = ds[f'{variable_name}Rms'].values
-            if model == 'omega':
-                # Omega's Rms is mapped from SpatialStdDev, so it already is
-                # a standard deviation
-                var_std = var_rms
-            else:
-                var_std = np.sqrt(var_rms**2.0 - var_mean**2.0)
-            stats = {
-                'min': ds[f'{variable_name}Min'].values,
-                'max': ds[f'{variable_name}Max'].values,
-                'mean': var_mean,
-                'std': var_std,
+
+        fields = self._fields(ds, model)
+        found = select_global_stats(
+            ds=ds,
+            fields=fields,
+            stats=None,
+            model=model,
+            field_map=self._field_map(fields, model),
+            log=self.logger.info,
+            source='output.nc',
+            hint=(
+                'Check that the global statistics analysis member was '
+                'enabled for the fields the plots are asked for.'
+            ),
+        )
+
+        ds_time = ds.rename({'time': 'Time'}) if 'time' in ds.dims else ds
+        time = get_days_since_start(ds_time)
+        for field, field_stats in found.items():
+            values = {
+                stat: ds[var_name].values.astype(float)
+                for stat, var_name in field_stats.items()
             }
+            _add_standard_deviation(values)
+            filename = f'{field}_stats.png'
             plot_global_stats(
                 time=time,
-                stats=stats,
-                field_name=variable_name,
-                out_filename=f'{variable_name}_stats.png',
+                stats=values,
+                field_name=field,
+                out_filename=self.work_path(filename),
             )
+            self.add_produced_file(filename)
+
+    def _fields(self, ds, model):
+        """Get the fields to plot, in Polaris-standard names"""
+        fields = self.config.getlist('analysis_members', 'fields')
+        if fields:
+            return fields
+        # the honest default: whatever the run wrote statistics for
+        return self.component.map_var_list_from_native_model(
+            discover_fields(ds, model=model)
+        )
+
+    def _field_map(self, fields, model):
+        """Get the name the model gave each field"""
+        native = self.component.map_var_list_to_native_model(fields)
+        return dict(zip(fields, native, strict=True))
+
+
+def _add_standard_deviation(values):
+    """
+    Get a standard deviation for the plot's envelope, deriving one from the
+    root-mean-square if that is what the model computed
+
+    MPAS-Ocean writes a root-mean-square where Omega writes a standard
+    deviation, so this is where the two are reconciled -- a conversion rather
+    than a difference of spelling, which is why it is not in the table of
+    names.
+    """
+    if 'std' in values or 'rms' not in values or 'mean' not in values:
+        return
+    mean = values['mean']
+    rms = values['rms']
+    values['std'] = np.sqrt(rms**2.0 - mean**2.0)

--- a/tests/ocean/analysis/test_global_stats_step.py
+++ b/tests/ocean/analysis/test_global_stats_step.py
@@ -153,7 +153,7 @@ def test_a_field_the_simulation_did_not_write_is_skipped(tmp_path):
     plotted = sorted(
         os.path.basename(o) for o in step.outputs if o.endswith('.png')
     )
-    assert plotted == ['global_stats_ssh.png', 'global_stats_temperature.png']
+    assert plotted == ['ssh.png', 'temperature.png']
 
 
 def test_a_statistic_the_simulation_did_not_write_is_skipped(tmp_path):
@@ -187,9 +187,9 @@ def test_an_empty_field_list_plots_what_the_simulation_wrote(tmp_path):
         os.path.basename(o) for o in step.outputs if o.endswith('.png')
     )
     assert plotted == [
-        'global_stats_PseudoThickness.png',
-        'global_stats_kineticEnergyCell.png',
-        'global_stats_temperature.png',
+        'PseudoThickness.png',
+        'kineticEnergyCell.png',
+        'temperature.png',
     ]
 
 

--- a/tests/ocean/analysis/test_global_stats_step.py
+++ b/tests/ocean/analysis/test_global_stats_step.py
@@ -1,0 +1,239 @@
+import logging
+import os
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.ocean.model.time import days_per_year
+from polaris.tasks.ocean import Ocean
+from polaris.tasks.ocean.analysis import add_analysis_tasks
+from polaris.tasks.ocean.analysis.sim_files import AnalysisStream, OmegaConfig
+
+# what the QU240 mock-up writes: snapshots of six fields, four statistics
+# each, on a time axis of daily values in a noleap calendar
+MOCKUP_FIELDS = [
+    'Temperature',
+    'Salinity',
+    'NormalVelocity',
+    'KineticEnergyCell',
+    'SshCell',
+    'PseudoThickness',
+]
+MOCKUP_STATS = ['SpatialMean', 'SpatialMin', 'SpatialMax', 'SpatialStdDev']
+
+
+def write_stats_file(path, fields=None, stats=None, days=730):
+    """Write a global statistics file shaped like the ones Omega writes."""
+    if fields is None:
+        fields = MOCKUP_FIELDS
+    if stats is None:
+        stats = MOCKUP_STATS
+
+    time = xr.date_range(
+        start='0001-01-01',
+        periods=days,
+        freq='D',
+        calendar='noleap',
+        use_cftime=True,
+    )
+    ds = xr.Dataset(coords={'time': ('time', time)})
+    values = np.linspace(0.0, 1.0, days)
+    for index, field in enumerate(fields):
+        for stat in stats:
+            ds[f'{field}_{stat}'] = (
+                ('time', 'Scalar'),
+                (values + index)[:, np.newaxis],
+            )
+            ds[f'{field}_{stat}'].attrs['units'] = 'degC'
+    ds.to_netcdf(path)
+
+
+def make_step(tmp_path, start_year=1, end_year=2, **options):
+    """A global_stats step wired up as it would be after setup()."""
+    component = Ocean()
+    component.model = 'omega'
+    component._read_var_map()
+    add_analysis_tasks(component)
+
+    config = component.tasks['analysis/global_stats'].config
+    config.set('ocean', 'model', 'omega', user=True)
+    config.set('ocean_analysis', 'simulation_name', 'test_run', user=True)
+    for option, value in options.items():
+        config.set('ocean_analysis_time_series', option, value, user=True)
+
+    step = component.tasks['analysis/global_stats'].steps['global_stats']
+    step.start_year = start_year
+    step.end_year = end_year
+    step.work_dir = str(tmp_path)
+    step.base_work_dir = str(tmp_path)
+    step.config = config
+    step.logger = logging.getLogger('test_global_stats_step')
+    step.input_filenames = ['global_stats_1DayInstants']
+    step.outputs = []
+    return step
+
+
+def run_on_a_file(tmp_path, fields=None, stats=None, fields_asked=None):
+    """Write a statistics file, run the step over it, and return the step."""
+    options = {} if fields_asked is None else {'fields': fields_asked}
+    step = make_step(tmp_path, **options)
+    write_stats_file(
+        os.path.join(str(tmp_path), 'global_stats_1DayInstants'),
+        fields=fields,
+        stats=stats,
+    )
+    step.run()
+    return step
+
+
+def test_a_netcdf_is_registered_beside_every_plot(tmp_path):
+    """The data behind a plot is a product, so it is declared like one."""
+    step = run_on_a_file(tmp_path, fields=['Temperature', 'SshCell'])
+
+    plots = sorted(o for o in step.outputs if o.endswith('.png'))
+    data = sorted(o for o in step.outputs if o.endswith('.nc'))
+    assert len(plots) == 2
+    assert [f'{os.path.splitext(o)[0]}.nc' for o in plots] == data
+    for output in step.outputs:
+        assert os.path.exists(output)
+
+
+def test_outputs_are_in_the_steps_own_work_directory(tmp_path):
+    """A step that depends on the process working directory cannot run
+    beside another one."""
+    step = run_on_a_file(tmp_path, fields=['Temperature'])
+    for output in step.outputs:
+        assert os.path.dirname(output) == str(tmp_path)
+
+
+def test_the_netcdf_holds_what_was_plotted(tmp_path):
+    step = run_on_a_file(tmp_path, fields=['Temperature'])
+    filename = next(o for o in step.outputs if o.endswith('.nc'))
+
+    with xr.open_dataset(filename) as ds:
+        # data_vars keys are Hashable, not str, so sort the names
+        assert sorted(str(name) for name in ds.data_vars) == [
+            'max',
+            'mean',
+            'min',
+            'simulationYears',
+            'std',
+        ]
+        assert ds.attrs['field'] == 'temperature'
+        assert ds.attrs['simulation_name'] == 'test_run'
+        assert ds.attrs['start_year'] == step.start_year
+        assert ds.attrs['end_year'] == step.end_year
+        assert ds['mean'].attrs['omega_name'] == 'Temperature_SpatialMean'
+        assert ds['mean'].attrs['units'] == 'degC'
+
+
+def test_the_time_axis_is_in_simulation_years(tmp_path):
+    """Two years of daily values span two years of a noleap calendar."""
+    step = run_on_a_file(tmp_path, fields=['Temperature'])
+    filename = next(o for o in step.outputs if o.endswith('.nc'))
+
+    with xr.open_dataset(filename) as ds:
+        years = ds['simulationYears'].values
+        assert ds['simulationYears'].attrs['units'] == 'years'
+    # the file starts on the first day of year 1 and runs for 730 days
+    assert years[0] == pytest.approx(1.0)
+    assert years[-1] - years[0] == pytest.approx(
+        729.0 / days_per_year('noleap')
+    )
+
+
+def test_a_field_the_simulation_did_not_write_is_skipped(tmp_path):
+    """The default list describes what we would like, not what a run wrote."""
+    step = run_on_a_file(
+        tmp_path,
+        fields=['Temperature', 'SshCell'],
+        fields_asked='temperature, salinity, ssh',
+    )
+    plotted = sorted(
+        os.path.basename(o) for o in step.outputs if o.endswith('.png')
+    )
+    assert plotted == ['global_stats_ssh.png', 'global_stats_temperature.png']
+
+
+def test_a_statistic_the_simulation_did_not_write_is_skipped(tmp_path):
+    step = run_on_a_file(
+        tmp_path,
+        fields=['Temperature'],
+        stats=['SpatialMean', 'SpatialMax'],
+    )
+    filename = next(o for o in step.outputs if o.endswith('.nc'))
+    with xr.open_dataset(filename) as ds:
+        assert sorted(ds.attrs['statistics'].split(', ')) == ['max', 'mean']
+
+
+def test_nothing_the_step_asked_for_present_raises(tmp_path):
+    """Usually the year range is wrong, which is worth interrupting for."""
+    with pytest.raises(ValueError, match='years 1 through 2'):
+        run_on_a_file(
+            tmp_path,
+            fields=['Salinity'],
+            fields_asked='temperature, ssh',
+        )
+
+
+def test_an_empty_field_list_plots_what_the_simulation_wrote(tmp_path):
+    step = run_on_a_file(
+        tmp_path,
+        fields=['Temperature', 'KineticEnergyCell', 'PseudoThickness'],
+        fields_asked='',
+    )
+    plotted = sorted(
+        os.path.basename(o) for o in step.outputs if o.endswith('.png')
+    )
+    assert plotted == [
+        'global_stats_PseudoThickness.png',
+        'global_stats_kineticEnergyCell.png',
+        'global_stats_temperature.png',
+    ]
+
+
+def test_a_time_mean_stream_is_read_with_the_time_mean_names(tmp_path):
+    """A reduction spells its variables with the period in the name."""
+    step = make_step(tmp_path)
+    step.time_mean_period = '1Month'
+    write_stats_file(
+        os.path.join(str(tmp_path), 'global_stats_1DayInstants'),
+        fields=['Temperature'],
+        stats=['SpatialMean_TimeMean1Month'],
+    )
+    step.run()
+
+    filename = next(o for o in step.outputs if o.endswith('.nc'))
+    with xr.open_dataset(filename) as ds:
+        assert (
+            ds['mean'].attrs['omega_name']
+            == 'Temperature_SpatialMean_TimeMean1Month'
+        )
+        assert ds.attrs['time_mean_period'] == '1Month'
+
+
+def test_the_stream_says_whether_it_is_a_reduction():
+    """setup() needs the stream, not just the file name it supplies."""
+    omega_config = OmegaConfig(
+        filename='omega.yml',
+        streams={},
+        options={
+            'Analysis': {
+                'GlobalStats': {
+                    'Enable': True,
+                    'Filename': 'global_stats',
+                    'ReductionPeriod': [],
+                    'SnapshotPeriod': ['1Day'],
+                }
+            }
+        },
+    )
+    streams = omega_config.analysis_streams('GlobalStats')
+    assert streams == [
+        AnalysisStream(
+            filename='global_stats_1DayInstants',
+            period='1Day',
+            is_reduction=False,
+        )
+    ]

--- a/tests/ocean/analysis/test_global_stats_step.py
+++ b/tests/ocean/analysis/test_global_stats_step.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 
@@ -83,6 +84,7 @@ def run_on_a_file(tmp_path, fields=None, stats=None, fields_asked=None):
         fields=fields,
         stats=stats,
     )
+    step.runtime_setup()
     step.run()
     return step
 
@@ -154,6 +156,26 @@ def test_a_field_the_simulation_did_not_write_is_skipped(tmp_path):
         os.path.basename(o) for o in step.outputs if o.endswith('.png')
     )
     assert plotted == ['ssh.png', 'temperature.png']
+
+
+def test_each_series_is_described_in_the_manifest(tmp_path):
+    step = run_on_a_file(
+        tmp_path,
+        fields=['Temperature', 'SshCell'],
+        fields_asked='temperature, ssh',
+    )
+    with open(os.path.join(str(tmp_path), 'manifest.json')) as manifest:
+        products = json.load(manifest)['products']
+
+    # one gallery for all of the global statistics, not one per field
+    assert {product['gallery'] for product in products} == {'global_stats'}
+    for product in products:
+        assert product['group'] == 'time_series'
+        assert product['plot'] == f'{product["field"]}.png'
+        assert product['data'] == f'{product["field"]}.nc'
+        # the range comes from the step, so a caller does not repeat it
+        assert product['start_year'] == step.start_year
+        assert product['end_year'] == step.end_year
 
 
 def test_a_statistic_the_simulation_did_not_write_is_skipped(tmp_path):

--- a/tests/ocean/test_global_stats_names.py
+++ b/tests/ocean/test_global_stats_names.py
@@ -5,6 +5,7 @@ import xarray as xr
 from polaris.ocean.global_stats_names import (
     GLOBAL_STATS,
     available_stats,
+    discover_fields,
     global_stats_var_names,
     select_global_stats,
 )
@@ -224,3 +225,67 @@ def test_default_stats_are_all_ones_omega_computes():
     """The stats in analysis.cfg are all ones Omega computes."""
     for stat in ['mean', 'min', 'max', 'std']:
         assert stat in GLOBAL_STATS['omega']
+
+
+def test_discover_omega_fields():
+    """The fields of the QU240 mock-up, found from the names alone."""
+    ds = make_dataset(
+        [
+            'KineticEnergyCell_SpatialMax',
+            'KineticEnergyCell_SpatialMean',
+            'SshCell_SpatialMean',
+            'Temperature_SpatialStdDev',
+        ]
+    )
+    assert discover_fields(ds, model='omega') == [
+        'KineticEnergyCell',
+        'SshCell',
+        'Temperature',
+    ]
+
+
+def test_discover_mpas_ocean_fields():
+    """Variables the analysis member writes that are not statistics."""
+    ds = make_dataset(
+        [
+            'daysSinceStartOfSim',
+            'CFLNumberGlobal',
+            'temperatureAvg',
+            'temperatureRms',
+            'layerThicknessMin',
+        ]
+    )
+    assert discover_fields(ds, model='mpas-ocean') == [
+        'temperature',
+        'layerThickness',
+    ]
+
+
+def test_discover_does_not_mix_snapshots_and_time_means():
+    """A run that writes both is searched for the one that was asked for."""
+    ds = make_dataset(
+        [
+            'Temperature_SpatialMean',
+            'Salinity_SpatialMean_TimeMean1Month',
+        ]
+    )
+    assert discover_fields(ds, model='omega') == ['Temperature']
+    assert discover_fields(ds, model='omega', time_mean_period='1Month') == [
+        'Salinity'
+    ]
+
+
+def test_no_stats_means_every_one_the_model_computes():
+    """An empty config option asks for whatever the simulation wrote."""
+    ds = make_dataset(['Temperature_SpatialMean', 'Temperature_SpatialStdDev'])
+    found = select_global_stats(
+        ds=ds,
+        fields=['temperature'],
+        stats=None,
+        model='omega',
+        field_map=OMEGA_FIELDS,
+    )
+    assert found['temperature'] == {
+        'mean': 'Temperature_SpatialMean',
+        'std': 'Temperature_SpatialStdDev',
+    }

--- a/tests/ocean/test_global_stats_names.py
+++ b/tests/ocean/test_global_stats_names.py
@@ -1,0 +1,226 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.ocean.global_stats_names import (
+    GLOBAL_STATS,
+    available_stats,
+    global_stats_var_names,
+    select_global_stats,
+)
+
+# what mpaso_to_omega.yaml gives for the fields in the default list
+OMEGA_FIELDS = {
+    'temperature': 'Temperature',
+    'salinity': 'Salinity',
+    'normalVelocity': 'NormalVelocity',
+    'kineticEnergyCell': 'KineticEnergyCell',
+    'ssh': 'SshCell',
+}
+
+
+def make_dataset(var_names):
+    """A dataset holding one time series per name, as the models write them"""
+    time = np.arange(5.0)
+    ds = xr.Dataset(coords={'Time': ('Time', time)})
+    for var_name in var_names:
+        ds[var_name] = ('Time', time)
+    return ds
+
+
+def test_the_two_models_compute_different_statistics():
+    """MPAS-Ocean writes a root-mean-square where Omega writes an SD."""
+    assert 'rms' in available_stats('mpas-ocean')
+    assert 'std' not in available_stats('mpas-ocean')
+    assert 'std' in available_stats('omega')
+    assert 'rms' not in available_stats('omega')
+    # what they do share, they share
+    for stat in ['min', 'max', 'mean']:
+        assert stat in available_stats('mpas-ocean')
+        assert stat in available_stats('omega')
+
+
+def test_unknown_model_raises():
+    with pytest.raises(ValueError, match='mpas-atmosphere'):
+        available_stats('mpas-atmosphere')
+
+
+def test_omega_snapshot_var_names():
+    """Snapshots carry no period, which is how the mock-up writes them."""
+    var_names = global_stats_var_names(
+        fields=['temperature', 'ssh'],
+        stats=['mean', 'min', 'max', 'std'],
+        model='omega',
+        field_map=OMEGA_FIELDS,
+    )
+    assert var_names[('temperature', 'mean')] == 'Temperature_SpatialMean'
+    assert var_names[('temperature', 'min')] == 'Temperature_SpatialMin'
+    assert var_names[('temperature', 'max')] == 'Temperature_SpatialMax'
+    assert var_names[('temperature', 'std')] == 'Temperature_SpatialStdDev'
+    assert var_names[('ssh', 'mean')] == 'SshCell_SpatialMean'
+
+
+def test_omega_time_mean_var_names():
+    """A time reduction adds the period the variables were averaged over."""
+    var_names = global_stats_var_names(
+        fields=['temperature', 'kineticEnergyCell'],
+        stats=['mean', 'std'],
+        model='omega',
+        field_map=OMEGA_FIELDS,
+        time_mean_period='1Month',
+    )
+    assert (
+        var_names[('temperature', 'mean')]
+        == 'Temperature_SpatialMean_TimeMean1Month'
+    )
+    assert (
+        var_names[('kineticEnergyCell', 'std')]
+        == 'KineticEnergyCell_SpatialStdDev_TimeMean1Month'
+    )
+
+
+def test_mpas_ocean_var_names():
+    """MPAS-Ocean appends the statistic to the field with no separator."""
+    var_names = global_stats_var_names(
+        fields=['temperature', 'layerThickness'],
+        stats=['min', 'max', 'mean', 'rms'],
+        model='mpas-ocean',
+    )
+    assert var_names[('temperature', 'min')] == 'temperatureMin'
+    assert var_names[('temperature', 'max')] == 'temperatureMax'
+    assert var_names[('temperature', 'mean')] == 'temperatureAvg'
+    assert var_names[('temperature', 'rms')] == 'temperatureRms'
+    assert var_names[('layerThickness', 'mean')] == 'layerThicknessAvg'
+
+
+def test_mpas_ocean_writes_no_time_means():
+    with pytest.raises(ValueError, match='1Month'):
+        global_stats_var_names(
+            fields=['temperature'],
+            stats=['mean'],
+            model='mpas-ocean',
+            time_mean_period='1Month',
+        )
+
+
+def test_a_statistic_the_model_does_not_compute_raises():
+    """Asking Omega for an RMS is a mistake in the caller, not a subset."""
+    with pytest.raises(ValueError, match='rms'):
+        global_stats_var_names(
+            fields=['temperature'], stats=['rms'], model='omega'
+        )
+    with pytest.raises(ValueError, match='std'):
+        global_stats_var_names(
+            fields=['temperature'], stats=['std'], model='mpas-ocean'
+        )
+
+
+def test_unmapped_field_keeps_its_name():
+    """A field only one model has has no map entry, so its name is used."""
+    var_names = global_stats_var_names(
+        fields=['PseudoThickness'],
+        stats=['mean'],
+        model='omega',
+        field_map=OMEGA_FIELDS,
+    )
+    assert (
+        var_names[('PseudoThickness', 'mean')] == 'PseudoThickness_SpatialMean'
+    )
+
+
+def test_var_names_keep_the_configured_order():
+    """The plots come out in the order the config file asked for."""
+    var_names = global_stats_var_names(
+        fields=['ssh', 'temperature'],
+        stats=['max', 'mean'],
+        model='omega',
+        field_map=OMEGA_FIELDS,
+    )
+    assert list(var_names) == [
+        ('ssh', 'max'),
+        ('ssh', 'mean'),
+        ('temperature', 'max'),
+        ('temperature', 'mean'),
+    ]
+
+
+def test_a_missing_statistic_is_skipped():
+    """A statistic the simulation did not write is dropped, not raised on."""
+    ds = make_dataset(
+        [
+            'Temperature_SpatialMean',
+            'Temperature_SpatialMin',
+            'SshCell_SpatialMean',
+        ]
+    )
+    messages: list = []
+    found = select_global_stats(
+        ds=ds,
+        fields=['temperature', 'ssh'],
+        stats=['mean', 'min'],
+        model='omega',
+        field_map=OMEGA_FIELDS,
+        log=messages.append,
+    )
+    assert found['temperature'] == {
+        'mean': 'Temperature_SpatialMean',
+        'min': 'Temperature_SpatialMin',
+    }
+    assert found['ssh'] == {'mean': 'SshCell_SpatialMean'}
+    assert any('SshCell_SpatialMin' in message for message in messages)
+
+
+def test_a_field_with_no_statistics_is_dropped():
+    """A field the simulation did not write at all does not get a plot."""
+    ds = make_dataset(['Temperature_SpatialMean'])
+    messages: list = []
+    found = select_global_stats(
+        ds=ds,
+        fields=['temperature', 'ssh'],
+        stats=['mean'],
+        model='omega',
+        field_map=OMEGA_FIELDS,
+        log=messages.append,
+    )
+    assert list(found) == ['temperature']
+    assert any('no statistics of ssh' in message for message in messages)
+
+
+def test_nothing_found_raises():
+    """None of them is a step reading the wrong thing, so it interrupts."""
+    ds = make_dataset(['Salinity_SpatialMean'])
+    with pytest.raises(ValueError, match='years 21 through 40'):
+        select_global_stats(
+            ds=ds,
+            fields=['temperature', 'ssh'],
+            stats=['mean', 'min'],
+            model='omega',
+            field_map=OMEGA_FIELDS,
+            source='stats.nc',
+            hint='Check that years 21 through 40 are years it covers.',
+        )
+
+
+def test_selection_keeps_the_configured_order():
+    ds = make_dataset(
+        [
+            'SshCell_SpatialMean',
+            'Temperature_SpatialMean',
+            'Temperature_SpatialMax',
+        ]
+    )
+    found = select_global_stats(
+        ds=ds,
+        fields=['ssh', 'temperature'],
+        stats=['max', 'mean'],
+        model='omega',
+        field_map=OMEGA_FIELDS,
+    )
+    assert list(found) == ['ssh', 'temperature']
+    assert list(found['temperature']) == ['max', 'mean']
+
+
+def test_default_stats_are_all_ones_omega_computes():
+    """The stats in analysis.cfg are all ones Omega computes."""
+    for stat in ['mean', 'min', 'max', 'std']:
+        assert stat in GLOBAL_STATS['omega']

--- a/tests/ocean/test_var_list_mapping.py
+++ b/tests/ocean/test_var_list_mapping.py
@@ -1,0 +1,48 @@
+import pytest
+
+from polaris.tasks.ocean import Ocean
+
+
+@pytest.fixture
+def component():
+    """An ocean component set up to read Omega output."""
+    component = Ocean()
+    component.model = 'omega'
+    component._read_var_map()
+    return component
+
+
+def test_mapping_from_native_names_is_the_inverse_of_mapping_to_them(
+    component,
+):
+    """The two directions have to agree, or a round trip loses variables."""
+    mpaso = ['temperature', 'salinity', 'ssh', 'kineticEnergyCell']
+    omega = component.map_var_list_to_native_model(mpaso)
+    assert omega == ['Temperature', 'Salinity', 'SshCell', 'KineticEnergyCell']
+    assert component.map_var_list_from_native_model(omega) == mpaso
+
+
+def test_an_omega_only_field_keeps_its_name(component):
+    """PseudoThickness is deliberately unmapped, so it survives unchanged."""
+    omega = ['Temperature', 'PseudoThickness', 'SurfacePressure']
+    assert component.map_var_list_from_native_model(omega) == [
+        'temperature',
+        'PseudoThickness',
+        'SurfacePressure',
+    ]
+
+
+def test_the_order_asked_for_is_the_order_returned(component):
+    omega = ['SshCell', 'Temperature', 'Salinity']
+    assert component.map_var_list_from_native_model(omega) == [
+        'ssh',
+        'temperature',
+        'salinity',
+    ]
+
+
+def test_mpas_ocean_names_are_left_alone():
+    component = Ocean()
+    component.model = 'mpas-ocean'
+    names = ['temperature', 'layerThickness']
+    assert component.map_var_list_from_native_model(names) == names


### PR DESCRIPTION
This implements the `global_stats` product of the `omega_analysis` suite: time series of the global statistics Omega's `GlobalStats` analysis group writes, over a range of simulation years the user asks for. It is item 5 of the order of work in the ocean analysis design document, and the first point at which the suite produces a plot a scientist wants rather than a step that only reports what it read.

Getting there meant settling how Polaris names the variables in a model's global statistics output, and that turned out to be worth doing properly rather than extending what was already there. Two bugs surfaced along the way and are fixed here rather than deferred, because both are entangled with the naming: `StatsAnalysis` was choosing its fields from the wrong list, and `map_var_list_from_native_model()` was silently dropping variables. Both change behavior, and the details are below.

## What the product makes

For each field, in `ocean/analysis/global_stats/<range>/`:

* `<field>.png` --- two panels sharing a time axis in simulation years: the statistics themselves, with the standard deviation as a shaded envelope around the mean, and the change in each statistic since the beginning of the series, since drift is usually what the reader is looking for and is easy to miss at the scale of the absolute values.
* `<field>.nc` --- exactly the data that were plotted, per the design's `data-products` requirement, with the field, the statistics, the simulation name and the year range as global attributes, so the numbers can be inspected or re-plotted without re-reading the simulation.

A field or statistic the simulation did not write is reported in the step's log and skipped, and a field with no surviving statistics is dropped entirely. Only a file with *none* of the requested variables stops the step, since that usually means the year range does not overlap the simulation rather than that a variable is missing. Which plots a step makes is therefore not known until it has read the simulation, so it registers each product as it writes it, through a new `OceanIOStep.add_produced_file()`, rather than declaring per-field outputs at setup. That is also what keeps a plot and the netCDF file beside it from getting out of step with each other.

The plotting itself was already right in `realistic_global`'s `StatsAnalysis`, so it is factored into `polaris/ocean/analysis_plots.py` and both steps call it, rather than there being two copies to keep in agreement.

## Naming the models' global statistics

`mpaso_to_omega.yaml` carried sixteen entries mapping composite global statistics names, one per (field, statistic). That does not scale: two of the fields in the analysis suite's own default list already had no entries, and Omega's time means would need one entry per (field, statistic, period). Four of the entries also equated `layerThickness` with `PseudoThickness`, which the Conventions section of the design deliberately refuses to do, and all four `Rms` entries equated a root-mean-square with a standard deviation.

Those entries are deleted. `polaris/ocean/global_stats_names.py` builds the names instead --- from the field, the statistic, and for one of Omega's time reductions the period --- so the map needs an entry only for the field itself, which it already has. The new module also writes down where the two models genuinely differ: MPAS-Ocean computes a root-mean-square where Omega computes a standard deviation, so neither model's list of available statistics has an entry for the other's, and a step that wants a standard deviation from MPAS-Ocean derives one from the root-mean-square and the mean. That is a conversion rather than a difference of spelling, and it now lives in the step instead of being asserted by a table of names.

## The `realistic_global` `analysis_members` task

`StatsAnalysis` took its list of fields from the model's state variables, which is the list that says what an **initial condition** must contain, not what a run wrote statistics for. The two diverge in practice: Omega's default `GlobalStats` field list has `PseudoThickness` but not `SurfacePressure`, so the step would have asked for a variable that was never written. It now takes its list from a new `fields` option in `analysis_members.cfg` that defaults to whatever the file holds, and skips a field or statistic the run did not write. This answers the `TODO` that stood over those lines.

**This changes what the task plots** --- six fields rather than three on the QU240 mock-up. The step is `run_by_default=False`, so the `omega_pr` suite sets it up but does not run it.

## A framework fix with reach beyond this branch

`map_var_list_from_native_model()` built its result by walking the map and keeping the entries whose Omega name appeared in the list. A variable with no entry therefore vanished, and the ones that survived came back in the map's order rather than the caller's. Its counterpart in the other direction leaves an unmapped variable alone, as the conventions say it should: a field only one model has is not renamed, because there is nothing to rename it to.

The visible effect is on baseline validation, which round-trips the state and vertical-coordinate variables through both directions to get a list in MPAS-Ocean names. For Omega that quietly dropped `PseudoThickness`, `SurfacePressure` and `RefPseudoThickness`, so the fields that are Omega's alone were exactly the ones never compared. **Every Omega task with a validated `init.nc` or `vert_coord.nc` now compares three more variables than it did before.** This reaches well past the analysis suite and is the change here most worth a careful look.

## One deviation from the design document

The design says the time axis comes from `get_days_since_start` divided by the length of the year in the file's calendar. That helper reads a capitalized, non-CF `Units` attribute, which works only because Omega happens to write both `Units` and `units`; xarray moves the CF spelling into `.encoding` when it decodes times, so any file that has been through xarray raises `AttributeError`. The step instead computes the decimal simulation year from the calendar date, which depends on no attribute beyond the calendar and puts a series covering years 21 through 40 at 21 through 41, rather than at wherever the model's reference date happens to sit. The design document is being updated separately to match.

The `Units` fragility in `get_days_since_start` itself is untouched here and remains for its other callers.

## Base branch

This is based on `add-omega-analysis-scaffolding`, which is not merged yet, and should be reviewed and merged after it. `add-omega-analysis-climatology-maps` is being developed from the same base and will conflict textually in the products table of `docs/users_guide/ocean/tasks/analysis.md` and the `### analysis` block of `docs/developers_guide/ocean/api.md`. Nothing else is shared: `analysis_step.py` is untouched by this branch, and `sim_files.py` gains only one additive method.

## Since this PR was opened

The step now describes each product in a manifest fragment, so the `publish` step below it can put the time series in the generated gallery. The files are named for the field alone rather than `global_stats_<field>`, because the publisher publishes a product as its group, then the name the step gave it, then the range — a step that repeats its own group gets it twice.

The products go in a `time_series` group, shared with the ocean heat content series, so both appear in one section of the landing page with a gallery per field.

## This is one of three remaining PRs, reviewed in order

The work is a chain in dependency order. GitHub cannot base a cross-fork PR on another fork branch, so every one of these is based on `main` and its diff contains everything below it. Reviewing them in order is what keeps each diff small — review only the commits this branch adds.

| order | PR | branch | what it adds |
| --- | --- | --- | --- |
| 1 | #729 | `add-omega-analysis-global-stats` | global statistics time series |
| 2 | #730 | `add-omega-analysis-climatology-maps` | the ncclimo climatology and its maps |
| 3 | #737 | `add-omega-analysis-heat-content` | ocean heat content, maps and time series |

Four are already merged: #706 the design documents, #735 the vertical reduction kernel, #726 the analysis scaffolding, and #736 the publisher and gallery.

A gallery generated by the whole chain against the QU240 mock-up is published here, which is the quickest way to see what the suite produces: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/xasaydavis/omega_analysis_qu240_mockup_20260830/

Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite
