### PR TITLE
Add climatology maps to Omega analysis

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -244,6 +244,17 @@ seaice/api
    image_size
 ```
 
+#### analysis.units
+
+```{eval-rst}
+.. currentmodule:: polaris.analysis.units
+
+.. autosummary::
+   :toctree: generated/
+
+   units_to_mathtext
+```
+
 #### analysis.site
 
 ```{eval-rst}

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -51,11 +51,16 @@
    climatology.Climatology
    climatology.Climatology.setup
    climatology.Climatology.run
+   climatology.get_climatology_variables
+   climatology.find_climatology_file
 
    climatology_maps.ClimatologyMaps
    climatology_maps.ClimatologyMaps.setup
    climatology_maps.ClimatologyMaps.run
    climatology_maps.get_field_groups
+
+   config_sections.camel_to_snake
+   config_sections.map_section
 
    global_stats.GlobalStatsTimeSeries
    global_stats.GlobalStatsTimeSeries.setup
@@ -853,6 +858,11 @@
    vertical.diagnostics.pseudothickness_from_ds
    vertical.diagnostics.get_z_mid_and_interface
    vertical.diagnostics.depth_from_thickness
+   vertical.elevation.VerticalReduction
+   vertical.elevation.parse_vertical_reduction
+   vertical.elevation.apply_vertical_reduction
+   vertical.elevation.get_valid_level_range
+   vertical.elevation.elevation_label
    vertical.grid_1d.generate_1d_grid
    vertical.grid_1d.write_1d_grid
    vertical.partial_cells.alter_bottom_depth

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -1074,6 +1074,98 @@ Steps are created with
 tasks want --- the climatology, which every field group of `climatology_maps`
 reads --- is built once for a range no matter how many of them ask for it.
 
+### Reading a climatology
+
+{py:class}`polaris.tasks.ocean.analysis.climatology.Climatology` computes a
+climatology with `ncclimo`, and a step that reads one gets at it in two
+pieces.
+
+The climatology is added as a **dependency** with
+{py:meth}`polaris.Step.add_dependency()` rather than as an input file, because
+`ncclimo` names its output `<caseid>_<season>_<start>_<end>_climo.nc` and
+those names are not known until it has run.  The reading step then finds one
+season's file with
+{py:func}`polaris.tasks.ocean.analysis.climatology.find_climatology_file`,
+which globs on the season in the dependency's work directory --- and which
+also knows that `ncclimo` names the twelve monthly climatologies by month
+number rather than `JAN` through `DEC`.
+
+The variable list is the other piece.
+{py:func}`polaris.tasks.ocean.analysis.climatology.get_climatology_variables`
+assembles it from config options rather than from the steps that read the
+climatology, so that the shared step stays neutral with respect to which
+tasks pulled it in.  A step that needs a new variable in the climatology adds
+it there.
+
+Because `ncclimo` works on files rather than on an opened data set, the list
+is mapped back to the names the files use with
+{py:meth}`polaris.tasks.ocean.Ocean.map_var_list_to_native_model()`.  This is
+the one place in the analysis where model-specific names are unavoidable.
+
+### Reducing a field to a map
+
+A field with a vertical dimension has to be reduced to a horizontal map
+before it can be plotted, and `polaris.ocean.vertical.elevation` is where
+that lives.  It imports nothing from {py:class}`polaris.Step`, so it can be
+unit tested directly and reused by any vertically reduced diagnostic.
+
+{py:func}`polaris.ocean.vertical.elevation.parse_vertical_reduction` turns one
+entry of the `elevations` config option into a
+{py:class}`polaris.ocean.vertical.elevation.VerticalReduction`, and
+{py:func}`polaris.ocean.vertical.elevation.apply_vertical_reduction` applies
+one.  Every case turns `nVertLevels` into nothing, which is what will let
+ocean heat content be a field group of the climatology maps rather than a
+product of its own.
+
+So far only the reductions that pick a layer by index --- `top`, `bottom` and
+`k<index>` --- are implemented, because they need no vertical geometry.  The
+rest raise `NotImplementedError`, and a step checks
+`polaris.ocean.vertical.elevation.IMPLEMENTED_KINDS` up front so that it can
+report what it is skipping once rather than per plot.
+
+One detail catches people: both models write `minLevelCell` and
+`maxLevelCell` with the one-based indexing of MPAS-Ocean's Fortran, Omega's
+`MinLayerCell` and `MaxLayerCell` included, while the reductions index layers
+from zero.
+{py:func}`polaris.ocean.vertical.elevation.get_valid_level_range` is the one
+place that converts, and a step should get the two indices from it rather
+than reading them itself.
+
+### Plotting steps
+
+A step that plots maps writes, beside each PNG, a netCDF file with the same
+base name holding exactly what was plotted and the config options that
+produced it.  Both go in the step's own work directory.
+
+Two things are worth copying from
+{py:class}`polaris.tasks.ocean.analysis.climatology_maps.ClimatologyMaps`:
+
+- The `mosaic` descriptor that
+  {py:func}`polaris.viz.plot_global_mpas_field` returns is built once per step
+  and passed back in, since building it is the expensive part of plotting a
+  global mesh.
+- Outputs are registered during `run()` rather than `setup()`.  A field the
+  simulation did not write is reported and skipped, and a step that had
+  declared that field's plots at setup would fail Polaris's missing-output
+  check instead.
+
+The colormap options for a field live in a config section of its own, and
+{py:func}`polaris.tasks.ocean.analysis.config_sections.map_section` is what
+names it.  Field names are the models' own and are therefore camel case, while
+Polaris config sections are lower case with underscores, so `velocityZonal` is
+configured by `[ocean_analysis_map_velocity_zonal]` rather than by the field
+name pasted onto a prefix.  Call `map_section()` rather than building the name,
+so that exactly one place knows the prefix and the spelling rule.
+
+The mesh and vertical-coordinate files a simulation names are often its
+initial condition, which carries a full model state.  Opening one with
+{py:meth}`polaris.ocean.model.OceanIOStep.open_model_dataset` would solve the
+equation of state to derive a specific volume that a step wanting two index
+fields has no use for, so read the few fields you need and translate their
+names with
+{py:meth}`polaris.ocean.model.OceanIOStep.map_from_native_model_vars`
+instead.
+
 ### Publishing what the steps made
 
 Publication is three pieces, none of which knows anything about the ocean, so

--- a/docs/users_guide/ocean/tasks/analysis.md
+++ b/docs/users_guide/ocean/tasks/analysis.md
@@ -251,7 +251,7 @@ The suite is being built up product by product.  What exists so far:
 
 | task | product | status |
 | --- | --- | --- |
-| `climatology_maps` | map-view climatologies, one step per field group | not yet implemented |
+| `climatology_maps` | map-view climatologies, one step per field group | {ref}`available <ocean-analysis-climatology-maps>` |
 | `global_stats` | time series of the simulation's global statistics | {ref}`available <ocean-analysis-global-stats>` |
 | `heat_content_series` | time series of globally integrated ocean heat content | not yet implemented |
 | `moc` | latitude-elevation plot of the meridional overturning circulation | not yet implemented |
@@ -267,6 +267,120 @@ The `moc` task additionally depends on a diagnostic that Omega computes in
 situ and does not yet provide.  A simulation without it is an ordinary case:
 the step reports that no MOC output was written and produces nothing, rather
 than failing the suite.
+
+(ocean-analysis-climatology-maps)=
+
+### climatology maps
+
+The `climatology_maps` task computes a climatology of the simulation's
+monthly-mean output and plots global maps from it, on the native MPAS mesh.
+Nothing is remapped anywhere in the analysis.
+
+It has a **shared climatology step** and then **one step per field group**.
+The climatology runs once for a range of years no matter how many field
+groups read it, and the groups are `temperature`, `salinity`, `velocity`,
+`ssh`, `mixed_layer_depth` and `heat_content`.  A group is the unit of work
+so that adding a field costs that field and not the others.
+
+#### the climatology
+
+The climatology is computed with `ncclimo` from the NCO package, which is what
+the rest of the E3SM post-processing workflow uses, so that these
+climatologies are comparable with the ones zppy produces.  It writes the
+twelve monthly climatologies and one file per season in `seasons`, into
+`ocean/analysis/climatology/<range>/`.
+
+Two conventions are worth knowing:
+
+- Seasons are weighted by the length of each month in the simulation's own
+  calendar, and the annual mean is the same weighting over all twelve months.
+- `DJF` takes its December from the same calendar year as its January and
+  February, so every year in the range contributes exactly one December and
+  no data from outside the range are needed.  This is what MPAS-Analysis
+  does.
+
+Only the variables the analysis needs are averaged, so the cost scales with
+what is being plotted rather than with the size of the monthly means.  A
+variable the simulation did not write is reported in the step's log and left
+out.
+
+#### the maps
+
+Each field group's step writes, for every combination of season, field and
+vertical reduction it was asked for, a PNG and a netCDF file with the same
+base name holding exactly what was plotted:
+
+```none
+temperature_ANN_top.png     temperature_ANN_top.nc
+temperature_DJF_bottom.png  temperature_DJF_bottom.nc
+ssh_ANN.png                 ssh_ANN.nc
+```
+
+A field with no vertical dimension, such as `ssh`, is already a map, so its
+files carry no reduction label.  The netCDF files carry the simulation name,
+the field, the season, the vertical reduction and the range of years as
+global attributes, so a plot cannot be mistaken for a different one.
+
+#### the config options that govern it
+
+All of these are in `[ocean_analysis_climatology]`:
+
+`start_year`, `end_year`
+: The range of years the climatology covers.  It is also the directory the
+  results land in, so a different range recomputes rather than overwriting.
+
+`seasons`
+: The seasons to compute, beyond the twelve monthly climatologies, which are
+  always computed.
+
+`plot_seasons`
+: The seasons to plot, which may include the monthly climatologies as `JAN`
+  through `DEC`.  Every season here has to be one the climatology computed.
+
+`fields`
+: The fields to map, using MPAS-Ocean names whatever model produced the
+  output.  This is what decides which field group steps exist.
+
+`elevations`
+: How to reduce a field with a vertical dimension to a map.  `top` and
+  `bottom` are the topmost and bottommost valid layer of each column, so they
+  respect ice-shelf cavities and partial bottom cells; `k<index>` is a fixed,
+  zero-based vertical index, masked in columns where it falls outside the
+  valid range; and a number is an elevation in m, positive up, so `-100.0` is
+  100 m below the sea surface.
+
+An elevation is interpolated linearly between the midpoints of the two layers
+it falls between, using the layer elevations the simulation wrote.  Because
+the input is a climatology, a `-100.0` map is a map on the climatological-mean
+position of the -100 m surface rather than the time mean of maps on its
+instantaneous position; the two differ only where the seasonal cycle in layer
+thickness is large.
+
+Two ends of a column are worth knowing about.  Above the midpoint of its
+topmost layer the topmost value is used rather than the map being masked,
+which is what makes `0.0` and `-5.0` mean what a near-surface map is asked
+for; likewise below the midpoint of the bottommost layer, down to the
+seafloor.  Below the seafloor the map is masked, so a column with partial
+bottom cells ending at -97 m is blank at `-100.0` while `k9` still has a value
+in it.
+
+The colors come from one config section per field, so the color map and its
+range can be set for each field independently.  A section is named for its
+field with the field name in lower case with underscores, so `velocityZonal`
+is configured by `[ocean_analysis_map_velocity_zonal]`.
+
+#### what is not there yet
+
+Two fields in the config file are asked for and reported as skipped rather
+than silently dropped.  Each says so in the step's log:
+
+- **`velocityZonal` and `velocityMeridional`** are not written by Omega yet.
+  Polaris does not reconstruct them from the edge-normal velocity; the
+  reconstruction belongs in the model, where it costs nothing in accuracy.
+- **`mixedLayerDepth`** is likewise a diagnostic Omega does not compute yet.
+
+The `heat_content` field group exists but derives nothing yet, so it produces
+no maps.
 
 (ocean-analysis-global-stats)=
 
@@ -320,6 +434,13 @@ two cases.  Polaris reads the simulation's Omega configuration to find out
 which it wrote, so this needs no option of its own.
 
 ## troubleshooting
+
+**`The data set has no zMid, zInterface`.**  The simulation did not write the
+elevation of its layers, which every map at an elevation is a position in.
+Polaris cannot reconstruct it: geometric thickness is derived from
+pseudo-thickness through specific volume, and the monthly mean of that product
+is not the product of the monthly means.  A run without it is out of spec
+rather than merely configured without a field.
 
 **`invalid interpolation syntax`** while reading the config file.  Polaris
 config files use extended interpolation, so a bare `$` in a value is an error.

--- a/docs/users_guide/ocean/tasks/analysis.md
+++ b/docs/users_guide/ocean/tasks/analysis.md
@@ -186,14 +186,19 @@ its netCDF file linked beside it.  Every page carries the simulation name, the
 ranges and the Polaris provenance, so a page found later can be traced back to
 what produced it.
 
-Three config options control what a page costs to load, which matters on a
+Four config options control what a page costs to load, which matters on a
 portal that throttles:
 
 ```cfg
 [ocean_analysis]
 
-# the box, in pixels, each thumbnail is scaled to fit inside
+# the box, in displayed pixels, each thumbnail is scaled to fit inside
 thumbnail_size = 320, 240
+
+# image pixels per displayed pixel, so a thumbnail is sharp on a
+# high-resolution display; need not be whole, and 2 is about three times
+# the bytes of 1
+thumbnail_scale = 2.0
 
 # jpeg or webp; webp is a third to a half smaller at the same quality
 thumbnail_format = jpeg
@@ -202,10 +207,10 @@ thumbnail_format = jpeg
 thumbnail_quality = 75
 ```
 
-Reducing `thumbnail_size` is the first thing to try if gallery pages are slow
-to appear.  Thumbnails are the only images a page fetches, they are one to two
-hundred times smaller than the plots they stand for, and a browser fetches
-only the ones that have been scrolled to.
+Reducing `thumbnail_size`, then `thumbnail_scale`, is the first thing to try
+if gallery pages are slow to appear.  Thumbnails are the only images a page
+fetches, they are tens to a hundred times smaller than the plots they stand
+for, and a browser fetches only the ones that have been scrolled to.
 
 Publishing again is cheap and safe.  A thumbnail is regenerated only when it
 is missing or older than its plot, so adding one product to an analysis costs

--- a/polaris/analysis/publish.py
+++ b/polaris/analysis/publish.py
@@ -5,6 +5,7 @@ from polaris.analysis.manifest import range_key, read_fragment
 from polaris.analysis.thumbnail import (
     DEFAULT_FORMAT,
     DEFAULT_QUALITY,
+    DEFAULT_SCALE,
     DEFAULT_SIZE,
     THUMBNAILS_DIRNAME,
     image_size,
@@ -52,6 +53,7 @@ def publish(
     output_path,
     logger=None,
     thumbnail_size=DEFAULT_SIZE,
+    thumbnail_scale=DEFAULT_SCALE,
     thumbnail_format=DEFAULT_FORMAT,
     thumbnail_quality=DEFAULT_QUALITY,
 ):
@@ -82,7 +84,13 @@ def publish(
         nothing, and what was missing
 
     thumbnail_size : tuple of int, optional
-        The bounding box in pixels each thumbnail is scaled to fit inside
+        The bounding box, in displayed pixels, each thumbnail is scaled to
+        fit inside
+
+    thumbnail_scale : float, optional
+        The number of image pixels rendered per displayed pixel, so that a
+        thumbnail is sharp on a high-resolution display; it need not be a
+        whole number
 
     thumbnail_format : {'jpeg', 'webp'}, optional
         The format thumbnails are written in
@@ -140,6 +148,7 @@ def publish(
         published=published,
         output_path=output_path,
         size=thumbnail_size,
+        scale=thumbnail_scale,
         image_format=thumbnail_format,
         quality=thumbnail_quality,
     )
@@ -210,8 +219,13 @@ def _symlink(source, link_path):
     os.symlink(source, link_path)
 
 
-def _add_thumbnails(published, output_path, size, image_format, quality):
+def _add_thumbnails(
+    published, output_path, size, scale, image_format, quality
+):
     """Render a thumbnail for each published plot and record it"""
+    # the box is in displayed pixels, and the image has ``scale`` times as
+    # many along each side so that it is sharp on a high-resolution display
+    pixels = (round(size[0] * scale), round(size[1] * scale))
     rendered = 0
     for entry in published:
         basename = os.path.basename(entry['plot'])
@@ -220,17 +234,18 @@ def _add_thumbnails(published, output_path, size, image_format, quality):
         if make_thumbnail(
             plot_filename=os.path.join(output_path, entry['plot']),
             thumbnail_filename=filename,
-            size=size,
+            size=pixels,
             image_format=image_format,
             quality=quality,
         ):
             rendered += 1
         entry['thumbnail'] = os.path.join(THUMBNAILS_DIRNAME, name)
-        # the generated page gives every image its own width and height, so
-        # that lazy loading does not make the page reflow as they arrive
+        # the generated page gives every image its own width and height, in
+        # displayed pixels, so that lazy loading does not make the page
+        # reflow as they arrive
         width, height = image_size(filename)
-        entry['thumbnail_width'] = width
-        entry['thumbnail_height'] = height
+        entry['thumbnail_width'] = round(width / scale)
+        entry['thumbnail_height'] = round(height / scale)
     return rendered
 
 

--- a/polaris/analysis/thumbnail.py
+++ b/polaris/analysis/thumbnail.py
@@ -5,8 +5,13 @@ from PIL import Image
 #: The subdirectory of the staging tree holding the thumbnails
 THUMBNAILS_DIRNAME = 'thumbnails'
 
-#: The default bounding box, in pixels, a thumbnail is scaled to fit inside
+#: The default bounding box, in displayed pixels, a thumbnail is scaled to
+#: fit inside
 DEFAULT_SIZE = (320, 240)
+
+#: The default number of image pixels rendered per displayed pixel, so that
+#: a thumbnail is sharp on a high-resolution display
+DEFAULT_SCALE = 2
 
 #: The default image format for thumbnails
 DEFAULT_FORMAT = 'jpeg'

--- a/polaris/analysis/units.py
+++ b/polaris/analysis/units.py
@@ -1,0 +1,92 @@
+"""
+Render a CF ``units`` attribute for a plot label
+
+CF units follow udunits: factors separated by spaces, each a symbol with an
+optional integer exponent, as in ``kg m-2 s-1``.  Matplotlib renders an
+exponent only as mathtext, so this turns each exponent into a superscript and
+a few symbols into the characters a reader expects, and leaves anything it
+does not recognize as it is rather than guessing.
+
+Omega does not yet write one spelling of an exponent (E3SM-Project/Omega#544),
+so ``m-2``, ``m^-2``, ``m**-2`` and ``m^{-2}`` are all read, as is ``m/s``.
+"""
+
+import re
+
+#: Symbols rendered as something other than themselves.  A dimensionless
+#: quantity has no units worth printing, and a degree is a sign rather than
+#: a word.
+_SYMBOLS = {
+    '1': '',
+    'dimensionless': '',
+    'degC': r'$^\circ$C',
+    'degree_C': r'$^\circ$C',
+    'degrees_C': r'$^\circ$C',
+    'degree_Celsius': r'$^\circ$C',
+    'degrees_Celsius': r'$^\circ$C',
+    'degree': r'$^\circ$',
+    'degrees': r'$^\circ$',
+    'degree_north': r'$^\circ$N',
+    'degrees_north': r'$^\circ$N',
+    'degree_east': r'$^\circ$E',
+    'degrees_east': r'$^\circ$E',
+}
+
+# a factor is a symbol, or a number such as the 1e6 of a sverdrup, followed
+# by an optional integer exponent written any of the ways Omega writes one
+_FACTOR = re.compile(
+    r'^(?P<symbol>[A-Za-z_%]+|[0-9][0-9.eE+-]*)'
+    r'(?:(?:\^|\*\*)?(?P<exponent>\{[+-]?\d+\}|[+-]?\d+))?$'
+)
+
+
+def units_to_mathtext(units):
+    """
+    Render a CF units string as matplotlib text
+
+    Parameters
+    ----------
+    units : str
+        The ``units`` attribute of a field, e.g. ``kg m-2 s-1``, ``m/s`` or
+        ``degree_C``.  A string that is already mathtext, with ``$`` in it,
+        is returned as it is.
+
+    Returns
+    -------
+    text : str
+        The units with each exponent as a superscript, e.g.
+        ``kg m$^{-2}$ s$^{-1}$``, and a dimensionless quantity as an empty
+        string.  A factor that is not recognized is left as it was.
+    """
+    units = str(units).strip()
+    if not units or '$' in units:
+        return units
+
+    rendered = []
+    # what follows a slash is divided by, so its exponents change sign
+    for sign, part in zip(_signs(units), units.split('/'), strict=True):
+        for factor in part.strip('()').split():
+            rendered.append(_render_factor(factor, sign))
+    return ' '.join(text for text in rendered if text)
+
+
+def _signs(units):
+    """The sign of the exponents in each part of a units string split on
+    its slashes: the first part is multiplied, every other one divided by"""
+    return [1] + [-1] * units.count('/')
+
+
+def _render_factor(factor, sign):
+    """Render one factor, a symbol with an optional integer exponent"""
+    match = _FACTOR.match(factor)
+    if match is None:
+        return factor
+    text = _SYMBOLS.get(match.group('symbol'), match.group('symbol'))
+    exponent = match.group('exponent')
+    if exponent is None:
+        power = sign
+    else:
+        power = sign * int(exponent.strip('{}'))
+    if power == 1 or not text:
+        return text
+    return f'{text}$^{{{power}}}$'

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -61,12 +61,6 @@ class VerticalReduction(NamedTuple):
     z_bot: Optional[float] = None
 
 
-# The reductions a step can offer without reading any vertical geometry, since
-# they pick a layer by index.  Interpolating to an elevation reads ``zMid``
-# and ``zInterface``, which the map step does not pass yet.  An elevation
-# range is not a slice and is not here at all; see ``elevation_range_weights``.
-IMPLEMENTED_KINDS = ('top', 'bottom', 'index')
-
 # The dimension the layer interfaces are along, one longer than ``nVertLevels``
 INTERFACE_DIM = 'nVertLevelsP1'
 

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -382,7 +382,8 @@ def apply_vertical_reduction(
     -------
     da_map : xarray.DataArray
         The reduced field, without an ``nVertLevels`` dimension, masked where
-        the reduction falls outside the column
+        the reduction falls outside the column, and with the attributes of
+        ``da``, since a slice of a field has the field's units and name
 
     Raises
     ------
@@ -403,7 +404,7 @@ def apply_vertical_reduction(
         )
 
     if reduction.kind == 'elevation':
-        return _interpolate_to_elevation(
+        da_map = _interpolate_to_elevation(
             da=da,
             elevation=reduction.elevation,
             z_mid=z_mid,
@@ -411,7 +412,22 @@ def apply_vertical_reduction(
             min_level_cell=min_level_cell,
             max_level_cell=max_level_cell,
         )
+    else:
+        da_map = _select_layer(
+            da=da,
+            reduction=reduction,
+            min_level_cell=min_level_cell,
+            max_level_cell=max_level_cell,
+        )
+    # interpolating drops the attributes and slicing is not promised to keep
+    # them, while the units and long name of a field are those of a slice of
+    # it, so they are carried over here rather than by every caller
+    da_map.attrs = dict(da.attrs)
+    return da_map
 
+
+def _select_layer(da, reduction, min_level_cell, max_level_cell):
+    """Pick one layer of each column: its top, its bottom or a fixed index"""
     n_levels = da.sizes['nVertLevels']
     if reduction.kind == 'top':
         index = min_level_cell

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -179,6 +179,11 @@ class Ocean(Component):
         renamed_vars = var_list
         model = self.model
         if model == 'omega':
+            if self.mpaso_to_omega_var_map is None:
+                # a step that only reads model output never went through
+                # set_model(), so prime the map the way the other public
+                # methods here do
+                self._read_var_map()
             assert self.mpaso_to_omega_var_map is not None
             renamed_vars = [
                 self.mpaso_to_omega_var_map.get(v, v) for v in var_list

--- a/polaris/tasks/ocean/analysis/__init__.py
+++ b/polaris/tasks/ocean/analysis/__init__.py
@@ -192,7 +192,7 @@ class ClimatologyMapsTask(AnalysisTask):
 
         self._remove_all_steps()
 
-        self._add_shared_step(
+        climatology = self._add_shared_step(
             step_cls=Climatology,
             subdir=f'analysis/climatology/{key}',
             symlink='climatology',
@@ -209,6 +209,7 @@ class ClimatologyMapsTask(AnalysisTask):
                 fields=group_fields,
                 start_year=start_year,
                 end_year=end_year,
+                climatology=climatology,
             )
 
 

--- a/polaris/tasks/ocean/analysis/analysis.cfg
+++ b/polaris/tasks/ocean/analysis/analysis.cfg
@@ -22,13 +22,22 @@ simulation_name = omega
 # somewhere web-servable if you want to share the results.
 output_path =
 
-# The maximum width and height in pixels of the thumbnail generated for each
-# plot.  A thumbnail is scaled to fit inside this box, so that a portrait plot
-# and a landscape one cost about the same and sit in the same grid.
-# Thumbnails are what make a few hundred plots browsable, and their total size
-# is what decides whether a gallery page loads over a throttled link, so this
-# is the first thing to reduce if pages are slow to appear.
+# The maximum width and height, in displayed pixels, of the thumbnail
+# generated for each plot.  A thumbnail is scaled to fit inside this box, so
+# that a portrait plot and a landscape one cost about the same and sit in the
+# same grid.  Thumbnails are what make a few hundred plots browsable, and
+# their total size is what decides whether a gallery page loads over a
+# throttled link, so this is the first thing to reduce if pages are slow to
+# appear.
 thumbnail_size = 320, 240
+
+# The number of image pixels rendered per displayed pixel of a thumbnail.  A
+# thumbnail is shown at the size above but carries this many times as many
+# pixels along each side, so that it is sharp on a high-resolution display.
+# It need not be a whole number: 1.5 renders the box above at 480 x 360.
+# Going from 1 to 2 roughly triples the bytes of a thumbnail, so this is the
+# second thing to reduce if pages are slow to appear.
+thumbnail_scale = 2.0
 
 # The image format for thumbnails, jpeg or webp.  webp is between a third and
 # a half smaller at the same quality and every current browser reads it; jpeg

--- a/polaris/tasks/ocean/analysis/climatology.py
+++ b/polaris/tasks/ocean/analysis/climatology.py
@@ -1,9 +1,134 @@
+import glob
+import os
+
+import xarray as xr
+from mpas_tools.logging import check_call
+
 from polaris.tasks.ocean.analysis.analysis_step import AnalysisStep
 
 # ``ncclimo`` in background mode runs one process per month, so this is what
 # the step will start and therefore what it declares.  The pool is sized from
 # this number and never from the size of the machine.
 NCCLIMO_PROCESSES = 12
+
+# The vertical geometry every map that slices at an elevation needs, and that
+# the partial layers at a heat content range boundary need.  Both models write
+# these and both are translated as usual.
+GEOMETRY_VARIABLES = ('zMid', 'zInterface')
+
+# What ocean heat content is derived from, beside the layer mass below.  Heat
+# content is a field group of the maps rather than a product a user lists, so
+# its inputs are always in the climatology.
+HEAT_CONTENT_VARIABLES = ('temperature',)
+
+# The model's mass-like thickness, read under its native name.  This is the
+# one variable the analysis deliberately does not translate: Omega's
+# ``PseudoThickness`` and MPAS-Ocean's ``layerThickness`` agree on the mass
+# per unit area they imply and disagree on the geometry, so renaming one to
+# the other would hide the distinction that matters.  The analysis reads Omega
+# output only, so this is the Omega spelling.
+MASS_THICKNESS_VARIABLE = 'PseudoThickness'
+
+# ``ncclimo`` names the twelve monthly climatologies by month number, so a
+# user who asks to plot JAN is asking for the file with 01 in its name
+SEASON_KEYS = {
+    'JAN': '01',
+    'FEB': '02',
+    'MAR': '03',
+    'APR': '04',
+    'MAY': '05',
+    'JUN': '06',
+    'JUL': '07',
+    'AUG': '08',
+    'SEP': '09',
+    'OCT': '10',
+    'NOV': '11',
+    'DEC': '12',
+}
+
+
+def get_climatology_variables(config):
+    """
+    Get the variables a climatology is computed for, in MPAS-Ocean names
+
+    The list is the union of the fields requested for maps, the fields ocean
+    heat content is derived from, and the vertical geometry.  It is assembled
+    from config options rather than passed in by the steps that read the
+    climatology, so that the shared step stays neutral with respect to which
+    tasks pulled it in.
+
+    The model's mass-like thickness is not here, because it has no MPAS-Ocean
+    name to translate from; it is added under its native name once the rest of
+    the list has been mapped into the names the files use.
+
+    Parameters
+    ----------
+    config : polaris.config.PolarisConfigParser
+        The config options for the analysis
+
+    Returns
+    -------
+    variables : list of str
+        The variables, in the order they were requested, with the derived
+        ones appended
+    """
+    variables = list(config.getlist('ocean_analysis_climatology', 'fields'))
+    for variable in HEAT_CONTENT_VARIABLES + GEOMETRY_VARIABLES:
+        if variable not in variables:
+            variables.append(variable)
+    return variables
+
+
+def find_climatology_file(work_dir, season):
+    """
+    Find the ``ncclimo`` output file for one season
+
+    ``ncclimo`` names its output ``<caseid>_<season>_<start>_<end>_climo.nc``.
+    Steps that read a climatology glob on the season rather than
+    reconstructing that pattern, which is robust to what ``ncclimo`` makes of
+    the case name and to its naming changing.  The one substitution that has
+    to be made is that the twelve monthly climatologies are named by month
+    number rather than by ``JAN`` through ``DEC``.
+
+    Parameters
+    ----------
+    work_dir : str
+        The work directory of the climatology step
+
+    season : str
+        The season to find, e.g. ``'ANN'`` or ``'JAN'``
+
+    Returns
+    -------
+    filename : str
+        The absolute path to the climatology file
+
+    Raises
+    ------
+    FileNotFoundError
+        If no file for that season is there
+
+    ValueError
+        If more than one file matches, which would make the choice arbitrary
+    """
+    key = SEASON_KEYS.get(season.upper(), season)
+    pattern = os.path.join(work_dir, f'*_{key}_*_climo.nc')
+    matches = sorted(glob.glob(pattern))
+    if not matches:
+        raise FileNotFoundError(
+            f'No climatology for season {season} in {work_dir}.  The '
+            f'climatology step writes the twelve monthly climatologies and '
+            f'one file per season in [ocean_analysis_climatology] seasons, '
+            f'so check that option against plot_seasons.'
+        )
+    if len(matches) > 1:
+        names = ', '.join(os.path.basename(match) for match in matches)
+        raise ValueError(
+            f'{len(matches)} climatology files for season {season} in '
+            f'{work_dir}: {names}.  Only one is expected, so the choice '
+            f'would be arbitrary.'
+        )
+    return matches[0]
 
 
 class Climatology(AnalysisStep):
@@ -58,6 +183,114 @@ class Climatology(AnalysisStep):
 
     def run(self):
         """
-        Report the monthly means; the climatology itself is not computed yet
+        Compute the climatology with ``ncclimo``
         """
         self.log_inputs()
+        seasons = self.config.getlist('ocean_analysis_climatology', 'seasons')
+        variables = self._native_variables()
+        check_call(
+            self._ncclimo_args(variables, seasons),
+            self.logger,
+            env=self._ncclimo_env(),
+        )
+
+    def _native_variables(self):
+        """
+        Get the variables to compute the climatology for, under the names
+        they have in the files, dropping the ones the simulation did not write
+        """
+        variables = get_climatology_variables(self.config)
+        native = self.component.map_var_list_to_native_model(variables)
+        # the mass-like thickness has no MPAS-Ocean name to be mapped from,
+        # so it joins the list already spelled the way the files spell it
+        pairs = list(zip(variables, native, strict=True))
+        pairs.append((MASS_THICKNESS_VARIABLE, MASS_THICKNESS_VARIABLE))
+
+        written = self._variables_written()
+        present = [native for _, native in pairs if native in written]
+        missing = [
+            f'{polaris} ({native})' if native != polaris else polaris
+            for polaris, native in pairs
+            if native not in written
+        ]
+        if missing:
+            self.logger.info(
+                f'The simulation did not write {", ".join(missing)}, so '
+                f'these are left out of the climatology and the products '
+                f'that need them are skipped.'
+            )
+        if not present:
+            raise ValueError(
+                'The simulation wrote none of the variables the analysis '
+                'asked for, so there is nothing to compute a climatology '
+                'of.  Check the [ocean_analysis_climatology] fields option '
+                'against the contents of the History stream.'
+            )
+        self.logger.info(f'climatology variables: {", ".join(present)}')
+        return present
+
+    def _variables_written(self):
+        """Get the names of the variables in the monthly means"""
+        filename = self.work_path(self.input_filenames[0])
+        with xr.open_dataset(filename, decode_times=False) as ds:
+            return set(ds.variables)
+
+    def _ncclimo_args(self, variables, seasons):
+        """Build the ``ncclimo`` command line"""
+        # ncclimo's background mode runs one process per month.  The count
+        # comes from what the step declared it would start, never from the
+        # size of the machine, so that a step running beside this one does
+        # not find the node oversubscribed.
+        threads = self.cpus_per_task
+        parallel_mode = 'bck' if threads > 1 else 'nil'
+        # The seasonally discontinuous December convention -- every year in
+        # the range contributes its own December, so no data outside the
+        # range are needed -- used to be selected with "-a sdd".  NCO 5.3.7
+        # dropped that option and made the convention its behavior, so asking
+        # for it now only produces a deprecation warning.  The test of this
+        # invocation compares DJF against a day-weighted mean of the monthly
+        # climatologies, which is what would catch the convention changing
+        # back underneath us.
+        return [
+            'ncclimo',
+            '--no_stdin',
+            '-4',
+            '--clm_md=mth',
+            # ncclimo needs a case name to build its output file names from
+            # when, as here, the input files are given rather than generated
+            '-c',
+            self.config.get('ocean_analysis', 'simulation_name'),
+            '-p',
+            parallel_mode,
+            '-j',
+            f'{threads}',
+            '-v',
+            ','.join(variables),
+            f'--seasons={",".join(seasons)}',
+            '-s',
+            f'{self.start_year}',
+            '-e',
+            f'{self.end_year}',
+            # ncclimo resolves the input files it is given against its input
+            # directory, so the directory is named once and the files are
+            # named relative to it.  Both are the step's own work directory,
+            # which is where the monthly means are symlinked.
+            '-i',
+            self.work_path(),
+            '-o',
+            self.work_path(),
+        ] + list(self.input_filenames)
+
+    def _ncclimo_env(self):
+        """
+        Get the environment to run ``ncclimo`` in, with its scratch space
+        pointed at the step's own work directory
+
+        Two climatologies can run at once, so leaving the scratch path to
+        ``TMPDIR`` would let them collide on it.
+        """
+        scratch_dir = self.work_path('ncclimo_scratch')
+        os.makedirs(scratch_dir, exist_ok=True)
+        env = dict(os.environ)
+        env['TMPDIR'] = scratch_dir
+        return env

--- a/polaris/tasks/ocean/analysis/climatology_maps.py
+++ b/polaris/tasks/ocean/analysis/climatology_maps.py
@@ -349,6 +349,18 @@ class ClimatologyMaps(AnalysisStep):
         # instead.
         for filename in (f'{basename}.nc', f'{basename}.png'):
             self.add_produced_file(filename)
+        # a gallery per field, so the landing page shows one thumbnail for
+        # each field rather than one for the whole group of maps
+        self.add_product(
+            plot=f'{basename}.png',
+            data=f'{basename}.nc',
+            group='climatology_maps',
+            gallery=field,
+            title=title,
+            field=field,
+            season=season,
+            reduction=reduction,
+        )
         self.logger.info(f'  {os.path.basename(png_filename)}')
         return descriptor
 

--- a/polaris/tasks/ocean/analysis/climatology_maps.py
+++ b/polaris/tasks/ocean/analysis/climatology_maps.py
@@ -1,11 +1,10 @@
 import os
-from typing import Optional
 
 import xarray as xr
 from mpas_tools.io import write_netcdf
 
+from polaris.ocean.vertical.diagnostics import get_z_mid_and_interface
 from polaris.ocean.vertical.elevation import (
-    IMPLEMENTED_KINDS,
     apply_vertical_reduction,
     get_valid_level_range,
     parse_vertical_reduction,
@@ -145,7 +144,6 @@ class ClimatologyMaps(AnalysisStep):
         )
         self.field_group = field_group
         self.fields = list(fields)
-        self._reductions: Optional[list] = None
         self._coords: dict = {}
         self.add_dependency(climatology, name='climatology')
 
@@ -178,7 +176,8 @@ class ClimatologyMaps(AnalysisStep):
 
         config = self.config
         seasons = config.getlist('ocean_analysis_climatology', 'plot_seasons')
-        self._reductions = None
+        specs = config.getlist('ocean_analysis_climatology', 'elevations')
+        reductions = [parse_vertical_reduction(spec) for spec in specs]
         self._coords = self._mesh_coords()
         min_level_cell, max_level_cell = self._valid_level_range()
         climatology_dir = self.dependencies['climatology'].work_dir
@@ -190,6 +189,11 @@ class ClimatologyMaps(AnalysisStep):
             filename = find_climatology_file(climatology_dir, season)
             self.logger.info(f'{season}: {filename}')
             with self.open_model_dataset(filename, config) as ds:
+                # the climatological-mean layer geometry, which is what a map
+                # at an elevation is a map on
+                z_mid, z_interface = get_z_mid_and_interface(ds)
+                z_mid = _drop_time(z_mid)
+                z_interface = _drop_time(z_interface)
                 for field in self.fields:
                     if field not in ds:
                         self.logger.info(
@@ -201,37 +205,13 @@ class ClimatologyMaps(AnalysisStep):
                         da=ds[field],
                         field=field,
                         season=season,
+                        reductions=reductions,
+                        z_mid=z_mid,
+                        z_interface=z_interface,
                         min_level_cell=min_level_cell,
                         max_level_cell=max_level_cell,
                         descriptor=descriptor,
                     )
-
-    def _get_reductions(self):
-        """
-        Get the vertical reductions to plot fields with a vertical dimension
-        at, reporting the ones that are not implemented yet
-
-        This is worked out on first use rather than up front so that a group
-        with no field that has a vertical dimension does not report anything
-        about elevations, which do not apply to it.
-        """
-        if self._reductions is not None:
-            return self._reductions
-
-        reductions = []
-        specs = self.config.getlist('ocean_analysis_climatology', 'elevations')
-        for spec in specs:
-            reduction = parse_vertical_reduction(spec)
-            if reduction.kind in IMPLEMENTED_KINDS:
-                reductions.append(reduction)
-            else:
-                self.logger.info(
-                    f'  reducing to {reduction.label} needs the vertical '
-                    f'geometry, which is not implemented yet, so no maps '
-                    f'are plotted there'
-                )
-        self._reductions = reductions
-        return reductions
 
     def _mesh_coords(self):
         """
@@ -284,13 +264,15 @@ class ClimatologyMaps(AnalysisStep):
         da,
         field,
         season,
+        reductions,
+        z_mid,
+        z_interface,
         min_level_cell,
         max_level_cell,
         descriptor,
     ):
         """Plot one field for one season, at every reduction that applies"""
-        if 'Time' in da.dims:
-            da = da.isel(Time=0)
+        da = _drop_time(da)
 
         if 'nVertLevels' not in da.dims:
             # a field with no vertical dimension is already a map, so there
@@ -304,10 +286,12 @@ class ClimatologyMaps(AnalysisStep):
                 descriptor=descriptor,
             )
 
-        for reduction in self._get_reductions():
+        for reduction in reductions:
             da_map = apply_vertical_reduction(
                 da,
                 reduction,
+                z_mid=z_mid,
+                z_interface=z_interface,
                 min_level_cell=min_level_cell,
                 max_level_cell=max_level_cell,
             )
@@ -402,3 +386,10 @@ def _group_for_field(field):
         f'to no field group.  The fields that can be mapped are: '
         f'{", ".join(known)}.'
     )
+
+
+def _drop_time(da):
+    """Drop the singleton time dimension a climatology carries"""
+    if 'Time' in da.dims:
+        return da.isel(Time=0)
+    return da

--- a/polaris/tasks/ocean/analysis/climatology_maps.py
+++ b/polaris/tasks/ocean/analysis/climatology_maps.py
@@ -347,8 +347,8 @@ class ClimatologyMaps(AnalysisStep):
         # field the simulation did not write is skipped, and a step that had
         # declared its plots at setup would fail on the missing files
         # instead.
-        for filename in (nc_filename, png_filename):
-            self.add_output_file(filename)
+        for filename in (f'{basename}.nc', f'{basename}.png'):
+            self.add_produced_file(filename)
         self.logger.info(f'  {os.path.basename(png_filename)}')
         return descriptor
 

--- a/polaris/tasks/ocean/analysis/climatology_maps.py
+++ b/polaris/tasks/ocean/analysis/climatology_maps.py
@@ -1,4 +1,20 @@
+import os
+from typing import Optional
+
+import xarray as xr
+from mpas_tools.io import write_netcdf
+
+from polaris.ocean.vertical.elevation import (
+    IMPLEMENTED_KINDS,
+    apply_vertical_reduction,
+    get_valid_level_range,
+    parse_vertical_reduction,
+)
 from polaris.tasks.ocean.analysis.analysis_step import AnalysisStep
+from polaris.tasks.ocean.analysis.climatology import find_climatology_file
+from polaris.tasks.ocean.analysis.config_sections import map_section
+from polaris.tasks.ocean.analysis.sim_files import year_range_key
+from polaris.viz import plot_global_mpas_field
 
 # The field groups maps are chunked into.
 #
@@ -80,7 +96,14 @@ class ClimatologyMaps(AnalysisStep):
     """
 
     def __init__(
-        self, component, subdir, field_group, fields, start_year, end_year
+        self,
+        component,
+        subdir,
+        field_group,
+        fields,
+        start_year,
+        end_year,
+        climatology,
     ):
         """
         Create a climatology map step for one field group
@@ -104,6 +127,12 @@ class ClimatologyMaps(AnalysisStep):
 
         end_year : int
             The last year of the climatology, inclusive
+
+        climatology : polaris.tasks.ocean.analysis.Climatology
+            The climatology this step plots maps of.  It is a dependency
+            rather than an input file because ``ncclimo`` names its output
+            for the case and the dates, so the file names are not known
+            until it has run.
         """
         super().__init__(
             component=component,
@@ -116,23 +145,247 @@ class ClimatologyMaps(AnalysisStep):
         )
         self.field_group = field_group
         self.fields = list(fields)
+        self._reductions: Optional[list] = None
+        self._coords: dict = {}
+        self.add_dependency(climatology, name='climatology')
 
     def setup(self):
         """
-        Link the mesh the maps are plotted on
+        Link the mesh the maps are plotted on and the vertical coordinate
+
+        The vertical coordinate supplies the topmost and bottommost valid
+        layer of each column, which the climatology does not carry.
         """
         sim_files = self.get_sim_files()
         self.add_sim_input_file(sim_files.mesh_filename(), 'mesh.nc')
+        self.add_sim_input_file(
+            sim_files.vert_coord_filename(), 'vert_coord.nc'
+        )
 
     def run(self):
         """
-        Report the fields and inputs; no maps are plotted yet
+        Plot a map of each field of this group, for each season and each
+        vertical reduction that was asked for
         """
-        self.logger.info(
-            f'field group {self.field_group}: '
-            f'{", ".join(self.fields) if self.fields else "derived"}'
-        )
         self.log_inputs()
+        if not self.fields:
+            self.logger.info(
+                f'The {self.field_group} field group is derived rather than '
+                f'read, and deriving it is not implemented yet, so no maps '
+                f'are plotted.'
+            )
+            return
+
+        config = self.config
+        seasons = config.getlist('ocean_analysis_climatology', 'plot_seasons')
+        self._reductions = None
+        self._coords = self._mesh_coords()
+        min_level_cell, max_level_cell = self._valid_level_range()
+        climatology_dir = self.dependencies['climatology'].work_dir
+
+        # building the mosaic descriptor is the expensive part of plotting a
+        # global mesh, so it is built once and shared by every plot
+        descriptor = None
+        for season in seasons:
+            filename = find_climatology_file(climatology_dir, season)
+            self.logger.info(f'{season}: {filename}')
+            with self.open_model_dataset(filename, config) as ds:
+                for field in self.fields:
+                    if field not in ds:
+                        self.logger.info(
+                            f'  the simulation did not write {field}, so its '
+                            f'maps are skipped'
+                        )
+                        continue
+                    descriptor = self._plot_field(
+                        da=ds[field],
+                        field=field,
+                        season=season,
+                        min_level_cell=min_level_cell,
+                        max_level_cell=max_level_cell,
+                        descriptor=descriptor,
+                    )
+
+    def _get_reductions(self):
+        """
+        Get the vertical reductions to plot fields with a vertical dimension
+        at, reporting the ones that are not implemented yet
+
+        This is worked out on first use rather than up front so that a group
+        with no field that has a vertical dimension does not report anything
+        about elevations, which do not apply to it.
+        """
+        if self._reductions is not None:
+            return self._reductions
+
+        reductions = []
+        specs = self.config.getlist('ocean_analysis_climatology', 'elevations')
+        for spec in specs:
+            reduction = parse_vertical_reduction(spec)
+            if reduction.kind in IMPLEMENTED_KINDS:
+                reductions.append(reduction)
+            else:
+                self.logger.info(
+                    f'  reducing to {reduction.label} needs the vertical '
+                    f'geometry, which is not implemented yet, so no maps '
+                    f'are plotted there'
+                )
+        self._reductions = reductions
+        return reductions
+
+    def _mesh_coords(self):
+        """
+        Get the cell latitudes and longitudes, so that the netCDF beside each
+        plot carries the coordinates of what was plotted
+        """
+        ds = self._read_fields('mesh.nc', ['latCell', 'lonCell'])
+        return {name: ds[name] for name in ds.data_vars}
+
+    def _valid_level_range(self):
+        """Get the topmost and bottommost valid layer of each column"""
+        ds = self._read_fields(
+            'vert_coord.nc', ['minLevelCell', 'maxLevelCell']
+        )
+        return get_valid_level_range(ds)
+
+    def _read_fields(self, filename, fields):
+        """
+        Read a few named fields from a file of the simulation, translating
+        their names but nothing else
+
+        The mesh and the vertical coordinate are both the simulation's
+        initial condition, which carries a full model state.  Opening either
+        as a model data set would derive specific volume from that state ---
+        an equation-of-state solve --- to get a handful of fields that are
+        already there, so the names are translated and nothing else is done.
+
+        Parameters
+        ----------
+        filename : str
+            The local name of the file in the step's work directory
+
+        fields : list of str
+            The MPAS-Ocean names of the fields to read; a field the file does
+            not have is left out
+
+        Returns
+        -------
+        ds : xarray.Dataset
+            The fields that were there, with MPAS-Ocean names, in memory
+        """
+        wanted = self.component.map_var_list_to_native_model(fields)
+        with xr.open_dataset(self.work_path(filename)) as ds_native:
+            present = [name for name in wanted if name in ds_native]
+            return self.map_from_native_model_vars(ds_native[present]).load()
+
+    def _plot_field(
+        self,
+        da,
+        field,
+        season,
+        min_level_cell,
+        max_level_cell,
+        descriptor,
+    ):
+        """Plot one field for one season, at every reduction that applies"""
+        if 'Time' in da.dims:
+            da = da.isel(Time=0)
+
+        if 'nVertLevels' not in da.dims:
+            # a field with no vertical dimension is already a map, so there
+            # is nothing to reduce and nothing to label it with
+            return self._plot_map(
+                da_map=da,
+                field=field,
+                season=season,
+                basename=f'{field}_{season}',
+                title=f'{field}, {season}',
+                descriptor=descriptor,
+            )
+
+        for reduction in self._get_reductions():
+            da_map = apply_vertical_reduction(
+                da,
+                reduction,
+                min_level_cell=min_level_cell,
+                max_level_cell=max_level_cell,
+            )
+            da_map.attrs = dict(da.attrs)
+            descriptor = self._plot_map(
+                da_map=da_map,
+                field=field,
+                season=season,
+                basename=f'{field}_{season}_{reduction.label}',
+                title=f'{field} at {reduction.label}, {season}',
+                descriptor=descriptor,
+                reduction=reduction.label,
+            )
+        return descriptor
+
+    def _plot_map(
+        self,
+        da_map,
+        field,
+        season,
+        basename,
+        title,
+        descriptor,
+        reduction=None,
+    ):
+        """Write one map to netCDF and plot it, and register both"""
+        config = self.config
+        section = map_section(field)
+        if not config.has_section(section):
+            raise ValueError(
+                f'There is no [{section}] section giving the colormap for '
+                f'maps of {field}.  Every field that can be mapped needs '
+                f'one; see analysis.cfg.'
+            )
+
+        nc_filename = self.work_path(f'{basename}.nc')
+        png_filename = self.work_path(f'{basename}.png')
+        self._write_netcdf(da_map, field, season, nc_filename, reduction)
+
+        simulation_name = config.get('ocean_analysis', 'simulation_name')
+        descriptor = plot_global_mpas_field(
+            da=da_map,
+            out_filename=png_filename,
+            config=config,
+            colormap_section=section,
+            mesh_filename=self.work_path('mesh.nc'),
+            descriptor=descriptor,
+            title=f'{simulation_name}: {title}, years {self._range_key()}',
+            colorbar_label=da_map.attrs.get('units', ''),
+        )
+
+        # The outputs are registered here rather than in setup() because a
+        # field the simulation did not write is skipped, and a step that had
+        # declared its plots at setup would fail on the missing files
+        # instead.
+        for filename in (nc_filename, png_filename):
+            self.add_output_file(filename)
+        self.logger.info(f'  {os.path.basename(png_filename)}')
+        return descriptor
+
+    def _write_netcdf(self, da_map, field, season, filename, reduction):
+        """Write exactly what was plotted, with what produced it"""
+        config = self.config
+        ds = xr.Dataset({field: da_map}, coords=self._coords)
+        ds = ds.drop_vars('Time', errors='ignore')
+        ds.attrs = dict(
+            simulation_name=config.get('ocean_analysis', 'simulation_name'),
+            field=field,
+            season=season,
+            vertical_reduction='none' if reduction is None else reduction,
+            start_year=self.start_year,
+            end_year=self.end_year,
+            year_range=self._range_key(),
+        )
+        write_netcdf(ds=ds, fileName=filename)
+
+    def _range_key(self):
+        """The zero-padded range of years, as the work tree spells it"""
+        return year_range_key(self.start_year, self.end_year)
 
 
 def _group_for_field(field):

--- a/polaris/tasks/ocean/analysis/climatology_maps.py
+++ b/polaris/tasks/ocean/analysis/climatology_maps.py
@@ -253,11 +253,12 @@ class ClimatologyMaps(AnalysisStep):
         Read a few named fields from a file of the simulation, translating
         their names but nothing else
 
-        The mesh and the vertical coordinate are both the simulation's
-        initial condition, which carries a full model state.  Opening either
-        as a model data set would derive specific volume from that state ---
-        an equation-of-state solve --- to get a handful of fields that are
-        already there, so the names are translated and nothing else is done.
+        The mesh and the vertical coordinate a simulation names are often
+        its initial condition, which carries a full model state.  Opening one
+        as a model data set would then derive specific volume from that
+        state --- an equation-of-state solve --- to get a handful of fields
+        that are already there, so the names are translated and nothing else
+        is done.
 
         Parameters
         ----------

--- a/polaris/tasks/ocean/analysis/climatology_maps.py
+++ b/polaris/tasks/ocean/analysis/climatology_maps.py
@@ -295,7 +295,6 @@ class ClimatologyMaps(AnalysisStep):
                 min_level_cell=min_level_cell,
                 max_level_cell=max_level_cell,
             )
-            da_map.attrs = dict(da.attrs)
             descriptor = self._plot_map(
                 da_map=da_map,
                 field=field,

--- a/polaris/tasks/ocean/analysis/climatology_maps.py
+++ b/polaris/tasks/ocean/analysis/climatology_maps.py
@@ -3,6 +3,7 @@ import os
 import xarray as xr
 from mpas_tools.io import write_netcdf
 
+from polaris.analysis.units import units_to_mathtext
 from polaris.ocean.vertical.diagnostics import get_z_mid_and_interface
 from polaris.ocean.vertical.elevation import (
     apply_vertical_reduction,
@@ -339,7 +340,7 @@ class ClimatologyMaps(AnalysisStep):
             mesh_filename=self.work_path('mesh.nc'),
             descriptor=descriptor,
             title=f'{simulation_name}: {title}, years {self._range_key()}',
-            colorbar_label=da_map.attrs.get('units', ''),
+            colorbar_label=units_to_mathtext(da_map.attrs.get('units', '')),
         )
 
         # The outputs are registered here rather than in setup() because a

--- a/polaris/tasks/ocean/analysis/config_sections.py
+++ b/polaris/tasks/ocean/analysis/config_sections.py
@@ -1,0 +1,58 @@
+import re
+
+# camel case broken before an upper-case letter that begins a word, and
+# between a lower-case letter or digit and the upper-case letter after it, so
+# that an acronym stays whole: "velocityZonal" gives "velocity_zonal" and
+# "sshMaxSSH" gives "ssh_max_ssh"
+_WORD_START = re.compile(r'(.)([A-Z][a-z]+)')
+_AFTER_LOWER = re.compile(r'([a-z0-9])([A-Z])')
+
+# The prefix of the config section holding the plotting options for maps of
+# one field
+_MAP_PREFIX = 'ocean_analysis_map'
+
+
+def camel_to_snake(name):
+    """
+    Convert a model's camel-case variable name to the lower case with
+    underscores that Polaris config sections and options are spelled with
+
+    Parameters
+    ----------
+    name : str
+        A variable name in the spelling a model writes it with, such as
+        ``velocityZonal``
+
+    Returns
+    -------
+    snake_name : str
+        The same name in lower case with underscores, such as
+        ``velocity_zonal``
+    """
+    snake_name = _WORD_START.sub(r'\1_\2', name)
+    snake_name = _AFTER_LOWER.sub(r'\1_\2', snake_name)
+    return snake_name.lower()
+
+
+def map_section(field):
+    """
+    Get the config section with the plotting options for maps of a field
+
+    Field names are the models' own and are therefore camel case, while
+    Polaris config sections are lower case with underscores, so the section
+    name is not the field name pasted onto a prefix.  This is the one place
+    that knows both the prefix and the spelling rule.
+
+    Parameters
+    ----------
+    field : str
+        The field being mapped, using the name the model writes it with,
+        such as ``velocityZonal``
+
+    Returns
+    -------
+    section : str
+        The name of the config section, such as
+        ``ocean_analysis_map_velocity_zonal``
+    """
+    return f'{_MAP_PREFIX}_{camel_to_snake(field)}'

--- a/polaris/tasks/ocean/analysis/global_stats.py
+++ b/polaris/tasks/ocean/analysis/global_stats.py
@@ -1,5 +1,6 @@
 import xarray as xr
 
+from polaris.analysis.units import units_to_mathtext
 from polaris.ocean.analysis_plots import plot_global_stats
 from polaris.ocean.global_stats_names import (
     STAT_DESCRIPTIONS,
@@ -229,7 +230,7 @@ class GlobalStatsTimeSeries(AnalysisStep):
 
 def _axis_label(ds, field, field_stats):
     """Label the vertical axes with the field and its units, if it has any"""
-    units = _units(ds, field_stats)
+    units = units_to_mathtext(_units(ds, field_stats))
     if units:
         return f'{field} ({units})'
     return field

--- a/polaris/tasks/ocean/analysis/publish.py
+++ b/polaris/tasks/ocean/analysis/publish.py
@@ -84,6 +84,9 @@ class Publish(Step):
             thumbnail_size=tuple(
                 config.getlist('ocean_analysis', 'thumbnail_size', dtype=int)
             ),
+            thumbnail_scale=config.getfloat(
+                'ocean_analysis', 'thumbnail_scale'
+            ),
             thumbnail_format=config.get('ocean_analysis', 'thumbnail_format'),
             thumbnail_quality=config.getint(
                 'ocean_analysis', 'thumbnail_quality'

--- a/tests/analysis/test_publish.py
+++ b/tests/analysis/test_publish.py
@@ -39,7 +39,14 @@ def write_plot(filename, size=(160, 90)):
     return filename
 
 
-def _make_step(work_dir, step_name, subdir, seasons=None, years=(21, 40)):
+def _make_step(
+    work_dir,
+    step_name,
+    subdir,
+    seasons=None,
+    years=(21, 40),
+    plot_size=(160, 90),
+):
     """A step directory holding maps of temperature and its fragment."""
     if seasons is None:
         seasons = SEASONS
@@ -49,7 +56,7 @@ def _make_step(work_dir, step_name, subdir, seasons=None, years=(21, 40)):
     for season in seasons:
         plot = f'temperature_{season}_-100m.png'
         data = f'temperature_{season}_-100m.nc'
-        write_plot(os.path.join(step_path, plot))
+        write_plot(os.path.join(step_path, plot), size=plot_size)
         with open(os.path.join(step_path, data), 'w') as out:
             out.write(f'{subdir}/{data}')
         manifest.add(

--- a/tests/analysis/test_site.py
+++ b/tests/analysis/test_site.py
@@ -167,9 +167,11 @@ def test_images_are_lazy_and_carry_their_size(tmp_path):
         assert images
         for image in images:
             assert 'loading="lazy"' in image
-            # the thumbnails are made from a 160x90 stand-in plot
-            assert 'width="160"' in image
-            assert 'height="90"' in image
+            # the thumbnails are made from a 160x90 stand-in plot, which is
+            # smaller than the box so is not scaled, and are laid out at
+            # half that under the default thumbnail_scale of 2
+            assert 'width="80"' in image
+            assert 'height="45"' in image
 
 
 def test_a_page_asks_for_nothing_but_its_images(tmp_path):

--- a/tests/analysis/test_thumbnail.py
+++ b/tests/analysis/test_thumbnail.py
@@ -123,6 +123,59 @@ def test_publishing_renders_a_thumbnail_for_every_plot(tmp_path):
         assert os.path.exists(os.path.join(output_path, entry['thumbnail']))
 
 
+def test_a_thumbnail_carries_more_pixels_than_it_is_shown_at(tmp_path):
+    """The box is in displayed pixels and the image has ``scale`` times as
+    many along each side, so it is sharp on a high-resolution display while
+    the page lays it out at the same size."""
+    work_dir = str(tmp_path / 'work')
+    output_path = str(tmp_path / 'output')
+    step_path = _make_step(
+        work_dir,
+        'maps',
+        'climatology_maps/0021-0040/temperature',
+        seasons=['ANN'],
+        plot_size=(1600, 900),
+    )
+
+    published, _ = publish(
+        _fragments(step_path),
+        output_path,
+        thumbnail_size=(320, 240),
+        thumbnail_scale=2,
+    )
+
+    entry = published[0]
+    with Image.open(os.path.join(output_path, entry['thumbnail'])) as image:
+        assert image.size == (640, 360)
+    assert entry['thumbnail_width'] == 320
+    assert entry['thumbnail_height'] == 180
+
+
+def test_the_scale_need_not_be_a_whole_number(tmp_path):
+    work_dir = str(tmp_path / 'work')
+    output_path = str(tmp_path / 'output')
+    step_path = _make_step(
+        work_dir,
+        'maps',
+        'climatology_maps/0021-0040/temperature',
+        seasons=['ANN'],
+        plot_size=(1600, 900),
+    )
+
+    published, _ = publish(
+        _fragments(step_path),
+        output_path,
+        thumbnail_size=(320, 240),
+        thumbnail_scale=1.5,
+    )
+
+    entry = published[0]
+    with Image.open(os.path.join(output_path, entry['thumbnail'])) as image:
+        assert image.size == (480, 270)
+    assert entry['thumbnail_width'] == 320
+    assert entry['thumbnail_height'] == 180
+
+
 def test_thumbnails_are_files_not_symlinks(tmp_path):
     """They are generated here, so nothing upstream owns them."""
     work_dir = str(tmp_path / 'work')

--- a/tests/analysis/test_units.py
+++ b/tests/analysis/test_units.py
@@ -1,0 +1,75 @@
+"""
+Unit tests for rendering a CF ``units`` attribute as matplotlib text.
+
+The spellings are the ones Omega writes today (E3SM-Project/Omega#544), so
+that a label made from any of them renders with a superscript rather than a
+bare ``-2``, and what is not a units string at all is left alone.
+"""
+
+import pytest
+from matplotlib.mathtext import MathTextParser
+
+from polaris.analysis.units import units_to_mathtext
+
+# every spelling of an exponent that Omega writes, and the CF one
+EXPONENTS = [
+    ('kg m-2 s-1', 'kg m$^{-2}$ s$^{-1}$'),
+    ('m^-1 s^-1', 'm$^{-1}$ s$^{-1}$'),
+    ('N m^{-2}', 'N m$^{-2}$'),
+    ('m**-2', 'm$^{-2}$'),
+    ('m2', 'm$^{2}$'),
+    ('m3 kg-1', 'm$^{3}$ kg$^{-1}$'),
+    ('g kg-1', 'g kg$^{-1}$'),
+]
+
+
+@pytest.mark.parametrize('units, expected', EXPONENTS)
+def test_an_exponent_becomes_a_superscript(units, expected):
+    assert units_to_mathtext(units) == expected
+
+
+def test_a_slash_divides_by_what_follows_it():
+    assert units_to_mathtext('m/s') == 'm s$^{-1}$'
+    assert units_to_mathtext('m/s^2') == 'm s$^{-2}$'
+    assert units_to_mathtext('J/(m2 s)') == 'J m$^{-2}$ s$^{-1}$'
+
+
+def test_degrees_are_a_sign():
+    assert units_to_mathtext('degree_C') == r'$^\circ$C'
+    assert units_to_mathtext('degC') == r'$^\circ$C'
+    assert units_to_mathtext('degrees_north') == r'$^\circ$N'
+
+
+def test_a_dimensionless_quantity_has_nothing_to_print():
+    for units in ('', '1', 'dimensionless'):
+        assert units_to_mathtext(units) == ''
+
+
+def test_a_symbol_without_an_exponent_is_itself():
+    for units in ('m', 'Pa', 'Sv', 'radians', 'years', '%'):
+        assert units_to_mathtext(units) == units
+    assert units_to_mathtext('1e6 m3 s-1') == '1e6 m$^{3}$ s$^{-1}$'
+
+
+def test_what_is_not_recognized_is_left_alone():
+    """Guessing would put a wrong label on a plot; the raw string is at
+    least honest."""
+    assert units_to_mathtext('tracer units') == 'tracer units'
+    assert units_to_mathtext('seconds since 0001-01-01') == (
+        'seconds since 0001-01-01'
+    )
+
+
+def test_mathtext_is_already_rendered():
+    assert units_to_mathtext(r'kg/m$^3$') == r'kg/m$^3$'
+
+
+@pytest.mark.parametrize(
+    'units',
+    [units for units, _ in EXPONENTS]
+    + ['m/s', 'J/(m2 s)', 'degree_C', 'degrees_north', '1e6 m3 s-1'],
+)
+def test_the_result_is_valid_mathtext(units):
+    """What matplotlib would raise on when the plot is drawn is raised
+    here instead."""
+    MathTextParser('agg').parse(units_to_mathtext(units))

--- a/tests/ocean/analysis/test_climatology_maps.py
+++ b/tests/ocean/analysis/test_climatology_maps.py
@@ -3,9 +3,18 @@ Unit tests for the climatology map step.
 
 What is checked here is the bookkeeping around the plots rather than the
 plots themselves: that every PNG has a netCDF beside it, that a field the
-simulation did not write is skipped rather than failing the step, and that a
-vertical reduction the machinery cannot reach yet is skipped too.  Plotting
-is stubbed out, since drawing a global mesh needs a mesh.
+simulation did not write is skipped rather than failing the step, and that
+the vertical geometry, which nothing can stand in for, stops it instead.
+Plotting is stubbed out, since drawing a global mesh needs a mesh.
+
+The two reductions that read that geometry are checked on their values as
+well, since the synthetic grid is uniform and shallow enough for both to be
+written down: an elevation halfway between two layer midpoints, and a heat
+content range ending halfway through a layer.
+
+Heat content is the one field group that derives its field instead of
+reading it, so what it adds is that the value written is the one the kernel
+gives, in the unit the file claims, while what is plotted is in another.
 """
 
 import logging
@@ -28,6 +37,14 @@ from polaris.tasks.ocean.analysis.climatology_maps import (
 
 N_CELLS = 5
 N_LEVELS = 4
+
+# a uniform layer thickness, so that the heat content of a column is a number
+# that can be written down
+THICKNESS = 100.0
+
+# the geometry that thickness implies, the same in every column
+Z_INTERFACE = -THICKNESS * np.arange(N_LEVELS + 1)[None, None, :]
+Z_MID = 0.5 * (Z_INTERFACE[:, :, :-1] + Z_INTERFACE[:, :, 1:])
 
 SEASONS = ['ANN', 'JJA']
 
@@ -72,30 +89,50 @@ def test_a_field_the_simulation_did_not_write_is_skipped(step, caplog):
     assert any(name.startswith('temperature') for name in _images(step))
 
 
-def test_an_elevation_that_is_not_implemented_yet_is_skipped(step, caplog):
+def test_a_map_is_plotted_at_an_elevation(step):
     step.config.set(
         'ocean_analysis_climatology',
         'elevations',
         'top, -100.0, bottom',
         user=True,
     )
-    with caplog.at_level(logging.INFO):
-        step.run()
-    assert 'reducing to -100m' in caplog.text
+    step.run()
     assert _images(step) == {
         f'temperature_{season}_{label}.png'
         for season in SEASONS
-        for label in ('top', 'bottom')
+        for label in ('top', '-100m', 'bottom')
     }
 
 
-def test_a_derived_field_group_plots_nothing_yet(step, caplog):
-    step.field_group = 'heat_content'
-    step.fields = []
-    with caplog.at_level(logging.INFO):
+def test_the_map_at_an_elevation_is_the_interpolated_field(step):
+    """-100 m is midway between the midpoints of the top two layers of this
+    uniform 100 m grid, so the value there is the average of the two."""
+    step.config.set(
+        'ocean_analysis_climatology', 'elevations', '-100.0', user=True
+    )
+    step.run()
+    with xr.open_dataset(
+        os.path.join(step.work_dir, 'temperature_ANN_-100m.nc')
+    ) as ds:
+        values = ds.temperature.values
+    for cell in range(N_CELLS):
+        # the climatology holds cell + 10 * level for season ANN
+        assert values[cell] == pytest.approx(cell + 5.0)
+
+
+def test_a_map_at_an_elevation_needs_the_geometry_the_model_wrote(
+    step, tmp_path
+):
+    """A simulation that did not write it is out of spec rather than merely
+    configured without a field, and there is nothing to reconstruct it
+    from, so this stops the step instead of skipping a plot."""
+    for filename in os.listdir(str(tmp_path / 'climatology')):
+        path = str(tmp_path / 'climatology' / filename)
+        with xr.open_dataset(path) as ds:
+            trimmed = ds.drop_vars(['GeomZMid', 'GeomZInterface']).load()
+        trimmed.to_netcdf(path)
+    with pytest.raises(ValueError, match='no zMid, zInterface'):
         step.run()
-    assert 'derived rather than' in caplog.text
-    assert not _images(step)
 
 
 def test_the_field_groups_cover_the_fields_that_are_asked_for():
@@ -135,7 +172,9 @@ def _make_step(tmp_path, monkeypatch, field_group, fields):
     _write_mesh_and_vert_coord(str(work_dir))
 
     config = PolarisConfigParser()
+    config.add_from_package('polaris.ocean', 'ocean.cfg')
     config.add_from_package('polaris.tasks.ocean.analysis', 'analysis.cfg')
+    config.set('ocean', 'model', 'omega')
     config.set(
         'ocean_analysis_climatology',
         'plot_seasons',
@@ -198,6 +237,18 @@ def _write_climatology(climatology_dir):
                     (index + cells + 10.0 * levels)[None, :, :],
                 ),
                 SshCell=(('time', 'NCells'), (index + cells.T)),
+                PseudoThickness=(
+                    ('time', 'NCells', 'NVertLayers'),
+                    np.full((1, N_CELLS, N_LEVELS), THICKNESS),
+                ),
+                GeomZInterface=(
+                    ('time', 'NCells', 'NVertLayersP1'),
+                    np.tile(Z_INTERFACE, (1, N_CELLS, 1)),
+                ),
+                GeomZMid=(
+                    ('time', 'NCells', 'NVertLayers'),
+                    np.tile(Z_MID, (1, N_CELLS, 1)),
+                ),
             )
         )
         ds.to_netcdf(f'{climatology_dir}/case_{season}_000101_000312_climo.nc')

--- a/tests/ocean/analysis/test_climatology_maps.py
+++ b/tests/ocean/analysis/test_climatology_maps.py
@@ -17,6 +17,7 @@ reading it, so what it adds is that the value written is the one the kernel
 gives, in the unit the file claims, while what is plotted is in another.
 """
 
+import json
 import logging
 import os
 
@@ -56,6 +57,30 @@ def test_a_netcdf_is_registered_beside_every_plot(step):
     assert images
     for image in images:
         assert image.replace('.png', '.nc') in outputs
+
+
+def test_each_map_is_described_in_the_manifest(step):
+    step.runtime_setup()
+    step.run()
+    with open(os.path.join(step.work_dir, 'manifest.json')) as manifest:
+        products = json.load(manifest)['products']
+
+    # every plot the step made is described, and nothing else is
+    assert {product['plot'] for product in products} == _images(step)
+
+    for product in products:
+        assert product['group'] == 'climatology_maps'
+        assert product['gallery'] == 'temperature'
+        assert product['field'] == 'temperature'
+        assert product['season'] in SEASONS
+        assert product['data'] == product['plot'].replace('.png', '.nc')
+        assert product['reduction'] in product['plot']
+
+    # order is meaning: the seasons appear in the order they were plotted,
+    # which is what lets the gallery read ANN, DJF, MAM, JJA, SON with no
+    # sort key anywhere
+    seasons = list(dict.fromkeys(product['season'] for product in products))
+    assert seasons == SEASONS
 
 
 def test_a_map_is_plotted_for_each_season_and_reduction(step):

--- a/tests/ocean/analysis/test_climatology_maps.py
+++ b/tests/ocean/analysis/test_climatology_maps.py
@@ -1,0 +1,231 @@
+"""
+Unit tests for the climatology map step.
+
+What is checked here is the bookkeeping around the plots rather than the
+plots themselves: that every PNG has a netCDF beside it, that a field the
+simulation did not write is skipped rather than failing the step, and that a
+vertical reduction the machinery cannot reach yet is skipped too.  Plotting
+is stubbed out, since drawing a global mesh needs a mesh.
+"""
+
+import logging
+import os
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.config import PolarisConfigParser
+from polaris.tasks.ocean import Ocean
+from polaris.tasks.ocean.analysis import (
+    climatology_maps as climatology_maps_module,
+)
+from polaris.tasks.ocean.analysis.climatology import Climatology
+from polaris.tasks.ocean.analysis.climatology_maps import (
+    ClimatologyMaps,
+    get_field_groups,
+)
+
+N_CELLS = 5
+N_LEVELS = 4
+
+SEASONS = ['ANN', 'JJA']
+
+
+def test_a_netcdf_is_registered_beside_every_plot(step):
+    step.run()
+    outputs = [os.path.basename(output) for output in step.outputs]
+    images = [name for name in outputs if name.endswith('.png')]
+    assert images
+    for image in images:
+        assert image.replace('.png', '.nc') in outputs
+
+
+def test_a_map_is_plotted_for_each_season_and_reduction(step):
+    step.run()
+    images = _images(step)
+    assert images == {
+        f'temperature_{season}_{label}.png'
+        for season in SEASONS
+        for label in ('top', 'bottom', 'k1')
+    }
+
+
+def test_the_registered_outputs_are_the_files_that_were_written(step):
+    step.run()
+    for output in step.outputs:
+        assert os.path.exists(output), output
+
+
+def test_a_field_with_no_vertical_dimension_has_no_reduction_label(ssh_step):
+    ssh_step.run()
+    assert _images(ssh_step) == {f'ssh_{season}.png' for season in SEASONS}
+
+
+def test_a_field_the_simulation_did_not_write_is_skipped(step, caplog):
+    """The climatology has temperature but not salinity."""
+    step.fields = ['temperature', 'salinity']
+    with caplog.at_level(logging.INFO):
+        step.run()
+    assert 'did not write salinity' in caplog.text
+    assert not any(name.startswith('salinity') for name in _images(step))
+    assert any(name.startswith('temperature') for name in _images(step))
+
+
+def test_an_elevation_that_is_not_implemented_yet_is_skipped(step, caplog):
+    step.config.set(
+        'ocean_analysis_climatology',
+        'elevations',
+        'top, -100.0, bottom',
+        user=True,
+    )
+    with caplog.at_level(logging.INFO):
+        step.run()
+    assert 'reducing to -100m' in caplog.text
+    assert _images(step) == {
+        f'temperature_{season}_{label}.png'
+        for season in SEASONS
+        for label in ('top', 'bottom')
+    }
+
+
+def test_a_derived_field_group_plots_nothing_yet(step, caplog):
+    step.field_group = 'heat_content'
+    step.fields = []
+    with caplog.at_level(logging.INFO):
+        step.run()
+    assert 'derived rather than' in caplog.text
+    assert not _images(step)
+
+
+def test_the_field_groups_cover_the_fields_that_are_asked_for():
+    groups = get_field_groups(['ssh', 'temperature'])
+    assert groups['temperature'] == ['temperature']
+    assert groups['ssh'] == ['ssh']
+    # heat content is derived, so it is always there
+    assert groups['heat_content'] == []
+
+
+def test_a_field_in_no_group_is_reported():
+    with pytest.raises(ValueError, match='belongs to no field group'):
+        get_field_groups(['notAField'])
+
+
+@pytest.fixture
+def step(tmp_path, monkeypatch):
+    return _make_step(tmp_path, monkeypatch, 'temperature', ['temperature'])
+
+
+@pytest.fixture
+def ssh_step(tmp_path, monkeypatch):
+    return _make_step(tmp_path, monkeypatch, 'ssh', ['ssh'])
+
+
+def _make_step(tmp_path, monkeypatch, field_group, fields):
+    """A map step with a synthetic climatology to read and plotting stubbed"""
+    monkeypatch.setattr(
+        climatology_maps_module, 'plot_global_mpas_field', _fake_plot
+    )
+
+    work_dir = tmp_path / field_group
+    climatology_dir = tmp_path / 'climatology'
+    work_dir.mkdir(parents=True)
+    climatology_dir.mkdir(parents=True)
+    _write_climatology(str(climatology_dir))
+    _write_mesh_and_vert_coord(str(work_dir))
+
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.tasks.ocean.analysis', 'analysis.cfg')
+    config.set(
+        'ocean_analysis_climatology',
+        'plot_seasons',
+        ', '.join(SEASONS),
+        user=True,
+    )
+    config.set(
+        'ocean_analysis_climatology',
+        'elevations',
+        'top, bottom, k1',
+        user=True,
+    )
+
+    component = Ocean()
+    component.model = 'omega'
+
+    climatology = Climatology(
+        component=component,
+        subdir='analysis/climatology/0001-0003',
+        start_year=1,
+        end_year=3,
+    )
+    climatology.work_dir = str(climatology_dir)
+    step = ClimatologyMaps(
+        component=component,
+        subdir=f'analysis/climatology_maps/0001-0003/{field_group}',
+        field_group=field_group,
+        fields=fields,
+        start_year=1,
+        end_year=3,
+        climatology=climatology,
+    )
+    step.work_dir = str(work_dir)
+    step.config = config
+    step.logger = logging.getLogger('climatology_maps')
+    step.input_filenames = ['mesh.nc', 'vert_coord.nc']
+    step.outputs = []
+    step.dependencies['climatology'] = climatology
+    return step
+
+
+def _fake_plot(da, out_filename, config, colormap_section, **kwargs):
+    """Write a placeholder in place of the plot, and hand back a descriptor
+    so that the step's reuse of one can be seen to work."""
+    assert colormap_section.startswith('ocean_analysis_map_')
+    with open(out_filename, 'w') as image:
+        image.write('not really a plot\n')
+    return kwargs.get('descriptor') or 'descriptor'
+
+
+def _write_climatology(climatology_dir):
+    """One ncclimo-style file per season, with Omega names"""
+    cells = np.arange(N_CELLS)[:, None]
+    levels = np.arange(N_LEVELS)[None, :]
+    for index, season in enumerate(SEASONS):
+        ds = xr.Dataset(
+            dict(
+                Temperature=(
+                    ('time', 'NCells', 'NVertLayers'),
+                    (index + cells + 10.0 * levels)[None, :, :],
+                ),
+                SshCell=(('time', 'NCells'), (index + cells.T)),
+            )
+        )
+        ds.to_netcdf(f'{climatology_dir}/case_{season}_000101_000312_climo.nc')
+
+
+def _write_mesh_and_vert_coord(work_dir):
+    """The mesh and vertical coordinate the step reads, with Omega names"""
+    ds_mesh = xr.Dataset(
+        dict(
+            LatCell=('NCells', np.linspace(-1.0, 1.0, N_CELLS)),
+            LonCell=('NCells', np.linspace(0.0, 6.0, N_CELLS)),
+        )
+    )
+    ds_mesh.to_netcdf(f'{work_dir}/mesh.nc')
+    ds_vert = xr.Dataset(
+        dict(
+            MinLayerCell=('NCells', np.ones(N_CELLS, dtype=int)),
+            MaxLayerCell=(
+                'NCells',
+                np.full(N_CELLS, N_LEVELS, dtype=int),
+            ),
+        )
+    )
+    ds_vert.to_netcdf(f'{work_dir}/vert_coord.nc')
+
+
+def _images(step):
+    """The base names of the images the step wrote"""
+    return {
+        name for name in os.listdir(step.work_dir) if name.endswith('.png')
+    }

--- a/tests/ocean/analysis/test_climatology_ncclimo.py
+++ b/tests/ocean/analysis/test_climatology_ncclimo.py
@@ -1,0 +1,221 @@
+"""
+Validate the ``ncclimo`` invocation of the climatology step.
+
+A synthetic monthly-mean data set with Omega names and CF time metadata is
+run through the step, and the resulting climatologies are compared against
+day-weighted means computed here.  What this tests is our invocation --- the
+seasonally discontinuous December convention, the day weighting, and the
+claim that ``ncclimo`` reads Omega-style files without ``-P mpaso`` --- and
+not ``ncclimo`` itself.
+"""
+
+import logging
+import shutil
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.config import PolarisConfigParser
+from polaris.tasks.ocean import Ocean
+from polaris.tasks.ocean.analysis.climatology import (
+    Climatology,
+    find_climatology_file,
+)
+
+# the noleap calendar the simulation is run on
+DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+START_YEAR = 1
+END_YEAR = 3
+
+N_CELLS = 4
+N_LEVELS = 3
+
+SEASON_MONTHS = {
+    'ANN': list(range(1, 13)),
+    'DJF': [12, 1, 2],
+    'MAM': [3, 4, 5],
+    'JJA': [6, 7, 8],
+    'SON': [9, 10, 11],
+}
+
+pytestmark = pytest.mark.skipif(
+    shutil.which('ncclimo') is None,
+    reason='ncclimo is not on the path',
+)
+
+
+def monthly_mean(year, month):
+    """The value of the synthetic field in a given month, before offsets"""
+    return 10.0 * year + month
+
+
+def test_the_monthly_climatologies_are_means_over_the_years(climatology):
+    """Each month's climatology is the unweighted mean over the years."""
+    for month in range(1, 13):
+        expected = np.mean(
+            [
+                monthly_mean(year, month)
+                for year in range(START_YEAR, END_YEAR + 1)
+            ]
+        )
+        _assert_field(climatology, f'{month:02d}', expected)
+
+
+def test_the_seasons_are_day_weighted(climatology):
+    """Every season, including the annual mean, weights each month by its
+    length in the simulation's calendar."""
+    for season, months in SEASON_MONTHS.items():
+        _assert_field(climatology, season, _day_weighted(months))
+
+
+def test_december_comes_from_the_same_year_as_january(climatology):
+    """The seasonally discontinuous December convention: every year in the
+    range contributes exactly one December and no data outside the range are
+    needed.  This used to be ``-a sdd`` and is now ncclimo's behavior, so it
+    is worth pinning."""
+    # under the other convention DJF would draw on a December from the year
+    # before the range, which does not exist here, so the two differ
+    discontinuous = _day_weighted([12, 1, 2])
+    continuous = (
+        31.0 * np.mean([monthly_mean(year, 12) for year in (0, 1, 2)])
+        + 31.0 * np.mean([monthly_mean(year, 1) for year in (1, 2, 3)])
+        + 28.0 * np.mean([monthly_mean(year, 2) for year in (1, 2, 3)])
+    ) / 90.0
+    assert not np.isclose(discontinuous, continuous)
+    _assert_field(climatology, 'DJF', discontinuous)
+
+
+def test_a_month_can_be_found_by_its_name(climatology):
+    """``plot_seasons`` names months JAN through DEC; ncclimo names its files
+    by month number."""
+    assert find_climatology_file(climatology, 'JAN') == find_climatology_file(
+        climatology, '01'
+    )
+
+
+def test_a_season_that_was_not_computed_is_reported(climatology):
+    with pytest.raises(FileNotFoundError, match='No climatology for season'):
+        find_climatology_file(climatology, 'XYZ')
+
+
+def test_a_variable_the_simulation_did_not_write_is_left_out(climatology):
+    """The default field list asks for velocity components and mixed-layer
+    depth, which the synthetic simulation does not write, and the step
+    computes a climatology of the rest rather than failing."""
+    filename = find_climatology_file(climatology, 'ANN')
+    with xr.open_dataset(filename) as ds:
+        assert 'Temperature' in ds
+        assert 'PseudoThickness' in ds
+        assert 'velocityZonal' not in ds
+        assert 'mixedLayerDepth' not in ds
+
+
+@pytest.fixture(scope='module')
+def climatology(tmp_path_factory):
+    """Run the climatology step on a synthetic data set, once."""
+    work_dir = tmp_path_factory.mktemp('climatology')
+    filenames = _write_monthly_means(str(work_dir))
+
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.tasks.ocean.analysis', 'analysis.cfg')
+
+    component = Ocean()
+    # the analysis reads Omega output only; a step that never runs a model
+    # does not go through set_model()
+    component.model = 'omega'
+
+    step = Climatology(
+        component=component,
+        subdir='analysis/climatology/0001-0003',
+        start_year=START_YEAR,
+        end_year=END_YEAR,
+    )
+    step.work_dir = str(work_dir)
+    step.config = config
+    step.logger = logging.getLogger(__name__)
+    step.input_filenames = filenames
+    step.run()
+
+    return str(work_dir)
+
+
+def _write_monthly_means(work_dir):
+    """Write one file per month with Omega names and CF time metadata"""
+    filenames = []
+    day = 0.0
+    for year in range(START_YEAR, END_YEAR + 1):
+        for month in range(1, 13):
+            first, last = day, day + DAYS_IN_MONTH[month - 1]
+            day = last
+            filename = f'ocn.hist.{year:04d}-{month:02d}.nc'
+            _write_month(
+                f'{work_dir}/{filename}',
+                monthly_mean(year, month),
+                first,
+                last,
+            )
+            filenames.append(filename)
+    return filenames
+
+
+def _write_month(filename, value, first_day, last_day):
+    """Write one month of synthetic monthly means"""
+    cells = np.arange(N_CELLS)[:, None]
+    levels = np.arange(N_LEVELS)[None, :]
+    field = value + cells + 100.0 * levels
+    ds = xr.Dataset(
+        data_vars=dict(
+            Temperature=(
+                ('time', 'NCells', 'NVertLayers'),
+                field[None, :, :],
+            ),
+            Salinity=(('time', 'NCells', 'NVertLayers'), field[None, :, :]),
+            SshCell=(('time', 'NCells'), value + cells.T),
+            PseudoThickness=(
+                ('time', 'NCells', 'NVertLayers'),
+                np.full((1, N_CELLS, N_LEVELS), 10.0),
+            ),
+            GeomZMid=(('time', 'NCells', 'NVertLayers'), field[None, :, :]),
+            GeomZInterface=(
+                ('time', 'NCells', 'NVertLayersP1'),
+                np.zeros((1, N_CELLS, N_LEVELS + 1)),
+            ),
+            time_bnds=(('time', 'd2'), [[first_day, last_day]]),
+        ),
+        coords=dict(time=('time', [0.5 * (first_day + last_day)])),
+    )
+    ds.time.attrs = dict(
+        units='days since 0001-01-01',
+        calendar='noleap',
+        bounds='time_bnds',
+    )
+    ds.to_netcdf(filename, unlimited_dims=['time'])
+
+
+def _day_weighted(months):
+    """The day-weighted mean of the monthly climatologies of some months"""
+    weights = [float(DAYS_IN_MONTH[month - 1]) for month in months]
+    values = [
+        np.mean(
+            [
+                monthly_mean(year, month)
+                for year in range(START_YEAR, END_YEAR + 1)
+            ]
+        )
+        for month in months
+    ]
+    return float(np.average(values, weights=weights))
+
+
+def _assert_field(work_dir, season, expected):
+    """The synthetic field is ``expected`` plus a known per-cell, per-level
+    offset, so one comparison covers the whole array"""
+    filename = find_climatology_file(work_dir, season)
+    with xr.open_dataset(filename) as ds:
+        cells = np.arange(N_CELLS)[:, None]
+        levels = np.arange(N_LEVELS)[None, :]
+        offsets = cells + 100.0 * levels
+        field = ds.Temperature.isel(time=0).values
+        np.testing.assert_allclose(field, expected + offsets)

--- a/tests/ocean/analysis/test_config_sections.py
+++ b/tests/ocean/analysis/test_config_sections.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for the mapping from a field name to its config section.
+
+The mapping exists because field names are the models' own, and therefore
+camel case, while Polaris config sections are lower case with underscores.
+What matters is that the conversion is right and that the sections it names
+are the ones ``analysis.cfg`` actually ships, so a field whose section was
+spelled by hand does not go unnoticed until someone plots it.
+"""
+
+import pytest
+
+from polaris.config import PolarisConfigParser
+from polaris.tasks.ocean.analysis.climatology_maps import FIELD_GROUPS
+from polaris.tasks.ocean.analysis.config_sections import (
+    camel_to_snake,
+    map_section,
+)
+
+
+@pytest.mark.parametrize(
+    'name, expected',
+    [
+        ('ssh', 'ssh'),
+        ('temperature', 'temperature'),
+        ('velocityZonal', 'velocity_zonal'),
+        ('velocityMeridional', 'velocity_meridional'),
+        ('mixedLayerDepth', 'mixed_layer_depth'),
+        ('heatContent', 'heat_content'),
+        ('PseudoThickness', 'pseudo_thickness'),
+        ('zMid', 'z_mid'),
+        ('maxLevelCell', 'max_level_cell'),
+    ],
+)
+def test_camel_case_becomes_lower_case_with_underscores(name, expected):
+    assert camel_to_snake(name) == expected
+
+
+def test_a_name_that_is_already_snake_case_is_unchanged():
+    for name in ('mixed_layer_depth', 'heat_content', 'ssh'):
+        assert camel_to_snake(name) == name
+
+
+def test_the_section_is_the_prefix_and_the_converted_field():
+    assert map_section('velocityZonal') == 'ocean_analysis_map_velocity_zonal'
+    assert map_section('ssh') == 'ocean_analysis_map_ssh'
+
+
+def test_every_mappable_field_has_a_section_in_analysis_cfg():
+    config = PolarisConfigParser()
+    config.add_from_package('polaris.tasks.ocean.analysis', 'analysis.cfg')
+    fields = [field for fields in FIELD_GROUPS.values() for field in fields]
+    assert fields
+    for field in fields:
+        section = map_section(field)
+        assert config.has_section(section), (
+            f'analysis.cfg has no [{section}] for the field {field}'
+        )

--- a/tests/ocean/analysis/test_publish_step.py
+++ b/tests/ocean/analysis/test_publish_step.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 import pytest
+from PIL import Image
 
 from polaris.analysis.manifest import FRAGMENT_FILENAME
 from polaris.analysis.publish import MERGED_FILENAME, PLOTS_DIRNAME
@@ -213,6 +214,7 @@ def test_the_step_reads_the_thumbnail_options_from_the_config(tmp_path):
     )
     config = step.config
     config.set('ocean_analysis', 'thumbnail_size', '40, 40', user=True)
+    config.set('ocean_analysis', 'thumbnail_scale', '1', user=True)
     config.set('ocean_analysis', 'thumbnail_format', 'webp', user=True)
     config.set('ocean_analysis', 'thumbnail_quality', '50', user=True)
 
@@ -220,6 +222,12 @@ def test_the_step_reads_the_thumbnail_options_from_the_config(tmp_path):
 
     thumbnails = os.listdir(os.path.join(output_path, THUMBNAILS_DIRNAME))
     assert thumbnails == ['climatology_maps_moc_ANN_0001-0010.webp']
+    with Image.open(
+        os.path.join(output_path, THUMBNAILS_DIRNAME, thumbnails[0])
+    ) as image:
+        # the stand-in plot is larger than the box, so this is the box at
+        # the scale asked for rather than the default
+        assert max(image.size) == 40
 
 
 def test_a_suite_that_made_nothing_publishes_an_empty_gallery(tmp_path):

--- a/tests/ocean/vertical/test_elevation.py
+++ b/tests/ocean/vertical/test_elevation.py
@@ -140,6 +140,23 @@ def test_the_vertical_dimension_is_gone(columns):
     assert da_map.dims == ('nCells',)
 
 
+def test_the_attributes_survive_every_reduction(columns):
+    """A slice of a field has the field's units and name, whether it is a
+    layer or an interpolation, which drops them in its arithmetic."""
+    ds = columns.copy()
+    ds['field'] = ds.field.assign_attrs(units='degC', long_name='temperature')
+    for spec in ('top', 'bottom', 'k1', '-100.0'):
+        da_map = apply_vertical_reduction(
+            ds.field,
+            parse_vertical_reduction(spec),
+            z_mid=ds.zMid,
+            z_interface=ds.zInterface,
+            min_level_cell=ds.minLevelCell,
+            max_level_cell=ds.maxLevelCell,
+        )
+        assert da_map.attrs == ds.field.attrs, spec
+
+
 def test_a_time_dimension_survives(columns):
     """Maps are made from a climatology, which has a length-one time axis."""
     ds = columns.copy()


### PR DESCRIPTION
# The ncclimo climatology and the first climatology maps

This is items 6 and 7 of the order of work in `ocean_analysis_initial.md`, and it is the point at which the `omega_analysis` suite stops reporting what it would read and starts producing plots. A shared `Climatology` step computes monthly, seasonal and annual climatologies of a simulation's monthly means with `ncclimo`, and one `ClimatologyMaps` step per field group plots global maps from them on the native MPAS mesh, writing a netCDF beside each PNG holding exactly what was plotted. Every elevation a user asks for is produced, since the vertical reduction is in place below this branch.

## Three corrections to the design's `ncclimo` command line

The design was written against an older NCO, and its command line does not run under the 5.3.9 in the current environment. None of the three changes what is computed, but the first is worth a careful look because it is the one that could go wrong silently later.

`-a sdd` was removed in NCO 5.3.7 and is now a no-op that prints a deprecation warning. The seasonally discontinuous December convention it used to select — every year in the range contributing its own December, so that no data from outside the range are needed — is `ncclimo`'s own behavior now, and it says so in its log as `jfd-mode`. Dropping the flag is therefore correct rather than a concession, but it means nothing on the command line records which convention is in force, so the convention is pinned by a unit test comparing `DJF` against a day-weighted mean instead.

`-c <caseid>` is required when the input files are given positionally rather than generated from a case name; without it `ncclimo` refuses because it does not know what to name its output. The case name comes from `simulation_name`.

`-i <dir>` is required, because `ncclimo` resolves the input file names it is given against its input directory. Absolute paths are concatenated onto it and are not found, which is not obvious from the error.

The design's one genuinely risky claim held: `ncclimo` reads Omega output with no `-P mpaso`, given `time_bnds`. These corrections belong on the design branch as well; they are not made here, since design changes do not go on this branch.

## One design change

The design assumes every name in the `fields` config option is a field the model wrote, which is what makes mapping the variable list back to Omega names well defined. It is not true of the default list: it asks for `velocityZonal`, `velocityMeridional` and `mixedLayerDepth`, none of which Omega writes yet. `ncclimo` would fail on `-v` before the map steps ever got their chance to skip them.

So the climatology reads the variable names out of the first monthly-mean file and leaves out the ones that are not there, reporting them. This is the rule the design already states for the map steps — "a field the simulation did not write is reported clearly and its maps are skipped, rather than failing the whole step" — applied at the point where it first bites rather than one step later.

## What is reported and skipped rather than failing

Three things the default config asks for cannot be produced yet, and each says so in the step's log rather than quietly producing fewer plots than were requested:

- elevations given as a number, such as the default `-100.0`, which need linear interpolation in the vertical;
- `velocityZonal` and `velocityMeridional`, which Omega does not write and which this design deliberately does not reconstruct offline;
- `mixedLayerDepth`, likewise a diagnostic Omega does not compute yet.

The `heat_content` field group exists and derives nothing yet, and reports that too. The default `elevations` is left alone rather than temporarily changed to something fully supported, so that the config keeps saying what the product is ultimately for and there is nothing to remember to revert.

## Reading the vertical geometry

The map step takes `zMid` and `zInterface` from the climatology and hands them to the reductions in `polaris/ocean/vertical/elevation.py`, which lands below this branch. The geometry comes from the climatology rather than from the vertical coordinate file because it is a geometry that moves: what a map at -100 m is a map *on* is the climatological-mean position of that surface. The vertical coordinate file supplies only the topmost and bottommost valid layer of each column, which do not move.

A simulation that did not write the geometry stops the step with a message saying so, rather than being skipped the way a missing plotted field is. Polaris cannot reconstruct it — geometric thickness is derived from pseudo-thickness through specific volume, and the monthly mean of that product is not the product of the monthly means — so a run without it is out of spec rather than merely configured without a field.

`get_valid_level_range` is in the same module and is the one place that converts `minLevelCell` and `maxLevelCell` from the one-based indexing of MPAS-Ocean's Fortran — which Omega's `MinLayerCell` and `MaxLayerCell` use too — to the zero-based indices the reductions use. It is a named function rather than an inline `- 1` because an off-by-one here is a plausible bug in every step that reads them, and this way it is a bug in one function. A simulation with no ice-shelf cavities need not write `minLevelCell` at all, so its absence means the topmost valid layer is the topmost layer of the grid.

`Ocean.map_var_list_to_native_model` now primes its own name map, the way the other public methods on `Ocean` already do. It previously asserted the map had been read, which only happens in `set_model` or as a side effect of one of the writing methods, so a step that merely reads model output tripped the assertion.

## Notes for review

The map step registers its PNG and netCDF outputs during `run()` rather than `setup()`. This is the one place where "report and skip" and Polaris's missing-output check pull against each other: a step cannot know at setup which fields the simulation wrote, and a step that had declared a plot for a field that turns out to be absent would fail the missing-output check instead of skipping it.

The climatology is a dependency of the map steps rather than an input file, because `ncclimo` names its output for the case and the dates and those names are not known until it has run. The map steps then glob on the season in the dependency's work directory, which is what the design asks for. `find_climatology_file` also knows that `ncclimo` names the twelve monthly climatologies by month number rather than `JAN` through `DEC`, which matters because `plot_seasons` accepts the latter.

The mesh and vertical-coordinate files a simulation names are often its initial condition, carrying a full model state. Opening one with `open_model_dataset` solves the equation of state to derive a specific volume, which is a lot of work to obtain two integer fields, so the map step reads the few fields it wants and translates their names with `map_from_native_model_vars` instead.

A field with no vertical dimension gets `<field>_<season>.png` with no reduction label, since there is nothing to reduce and nothing to name it after. The design only names the reduced case, so this is a choice rather than a reading of it.

## Since this PR was opened

Each map is now described in a manifest fragment, so the `publish` step below can put it in the generated gallery, with a gallery per field and the field, season and vertical reduction as its facets. The heat content maps go through the same call, so they are described here too.

## This is one of two remaining PRs, reviewed in order

The work is a chain in dependency order. GitHub cannot base a cross-fork PR on another fork branch, so both are based on `main` and this diff contains everything below it. Review only the commits this branch adds.

| order | PR | branch | what it adds |
| --- | --- | --- | --- |
| 1 | #730 | `add-omega-analysis-climatology-maps` | the ncclimo climatology and its maps |
| 2 | #737 | `add-omega-analysis-heat-content` | ocean heat content, maps and time series |

Five are already merged: #706 the design documents, #735 the vertical reduction kernel, #726 the analysis scaffolding, #736 the publisher and gallery, and #729 the global statistics time series.

A gallery generated by the whole chain against the QU240 mock-up is published here, which is the quickest way to see what the suite produces: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/xasaydavis/omega_analysis_qu240_mockup_20260830/

Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite
