### PR TITLE
Add realistic global restart test and fix Omega options

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -444,6 +444,24 @@
    stats_analysis.StatsAnalysis.run
 ```
 
+### realistic_global.restart
+
+```{eval-rst}
+.. currentmodule:: polaris.tasks.ocean.realistic_global.restart
+
+.. autosummary::
+   :toctree: generated/
+
+   Restart
+
+   restart_step.RestartStep
+   restart_step.RestartStep.setup
+   restart_step.RestartStep.runtime_setup
+
+   validate.Validate
+   validate.Validate.run
+```
+
 ### realistic_global.hydrography.woa23
 
 ```{eval-rst}

--- a/docs/developers_guide/ocean/tasks/realistic_global.md
+++ b/docs/developers_guide/ocean/tasks/realistic_global.md
@@ -134,9 +134,14 @@ one; because model config data is processed in the order it was added, the
 task's overrides win.  It also rejects any model other than Omega, since the
 failure being tested cannot arise in MPAS-Ocean.
 
-`runtime_setup()` creates the `restarts` directory shared by both segments,
+`runtime_setup()` creates the restart directory this segment writes into,
 which Omega does not create itself, and, for a continuing segment, copies the
-previous segment's `output.nc` into place.  The copy is what makes the test
+previous segment's `output.nc` into place.  Each segment gets a directory of
+its own under the task's `restarts`, named for the step, and a continuing
+segment reads its predecessor's.  A single shared directory would mean a
+segment's own end-of-run restart replaced the pointer file it had just read
+from, so re-running that step alone would silently continue from the wrong
+time.  The copy is what makes the test
 meaningful: it reproduces what a continuation run finds on disk, a history
 file that already holds the earlier frames.  It is a copy rather than a
 symlink so that appending to it cannot reach back into the previous segment's

--- a/docs/developers_guide/ocean/tasks/realistic_global.md
+++ b/docs/developers_guide/ocean/tasks/realistic_global.md
@@ -3,7 +3,7 @@
 # realistic_global
 
 The `realistic_global` tasks in `polaris.tasks.ocean.realistic_global` use
-realistic global ocean meshes, bathymetry and forcing.  They fall into two
+realistic global ocean meshes, bathymetry and forcing.  They fall into three
 groups:
 
 - `hydrography/woa23`, a mesh-independent preprocessing task that builds a
@@ -11,11 +11,13 @@ groups:
   0.25-degree latitude-longitude grid.
 - `analysis_members`, short forward runs on realistic global meshes that
   exercise the global-statistics analysis member in both MPAS-Ocean and Omega.
+- `restart`, a short Omega run split across a restart, checking that the
+  history output survives the restart intact.
 
 Tasks are added to the ocean component by
 {py:func}`polaris.tasks.ocean.realistic_global.add_realistic_global_tasks`,
-which registers the `woa23` task and one `analysis_members` task per mesh in
-its `mesh_dict`.  Adding a new mesh requires only a new entry in that
+which registers the `woa23` task, one `analysis_members` task per mesh in its
+`mesh_dict`, and a single `restart` task on `QU.240km`.  Adding a new mesh requires only a new entry in that
 dictionary giving the MPAS-Ocean and Omega initial-condition IDs and the cell
 count, plus a matching entry in the `mesh_info` dictionary in
 {py:class}`polaris.tasks.ocean.realistic_global.analysis_members.AnalysisMembers`
@@ -106,6 +108,67 @@ This step normalizes two differences between the models:
   `Rms` field, while MPAS-Ocean writes a true root-mean-square, so the
   standard deviation is recovered as
   $\sigma = \sqrt{\mathrm{rms}^2 - \mathrm{mean}^2}$.
+
+(dev-ocean-realistic-global-restart)=
+
+## restart
+
+The {py:class}`polaris.tasks.ocean.realistic_global.restart.Restart` task is a
+regression test for
+[Omega #482](https://github.com/E3SM-Project/Omega/issues/482).  It runs the
+same period twice, once in one go and once split across a restart, and checks
+that the two histories agree.
+
+The run lengths live as module-level constants in the task rather than in the
+config file, since they are chosen to make the failure visible -- two history
+frames per segment, so that a segment that clobbered rather than appended
+would be obvious -- rather than to be tuned by a user.
+
+### restart_step
+
+The class
+{py:class}`polaris.tasks.ocean.realistic_global.restart.restart_step.RestartStep`
+extends the shared `Forward` step with what a segment of a restart chain
+needs.  `setup()` layers the task's own `forward.yaml` on top of the shared
+one; because model config data is processed in the order it was added, the
+task's overrides win.  It also rejects any model other than Omega, since the
+failure being tested cannot arise in MPAS-Ocean.
+
+`runtime_setup()` creates the `restarts` directory shared by both segments,
+which Omega does not create itself, and, for a continuing segment, copies the
+previous segment's `output.nc` into place.  The copy is what makes the test
+meaningful: it reproduces what a continuation run finds on disk, a history
+file that already holds the earlier frames.  It is a copy rather than a
+symlink so that appending to it cannot reach back into the previous segment's
+work directory.
+
+The previous segment's output is also added as an input file under the name
+`previous_output.nc`, which both establishes the dependency between the two
+steps and keeps the symlink out of the way of the copy.
+
+### the start time
+
+The one subtlety in `forward.yaml` is that every step is given the same
+`StartTime`, the start of the simulation, rather than the start of its own
+segment.  Omega measures the history time axis from the clock's start time, so
+a segment that moves the start time restarts that axis at zero, and its first
+frame then collides with the first frame already in the file.  That collision
+is what silently overwrote the earlier frames in #482.  On a `Continue` the
+clock's current time comes from the restart file instead, so the start time
+does not need to move.
+
+### validate
+
+The class
+{py:class}`polaris.tasks.ocean.realistic_global.restart.validate.Validate`
+compares the history of the restart chain with that of the full run in two
+ways.  It reads the elapsed-time coordinate with `xarray` directly, rather
+than through the Omega-to-MPAS-Ocean renaming in `open_model_dataset()`,
+because that coordinate is the variable under test; it then compares the state
+variables with {py:func}`polaris.validate.compare_variables` as any other
+exact-restart test would.  A chain that wrote fewer frames than the full run
+is reported as the #482 failure specifically, since that is the shape the bug
+takes.
 
 (dev-ocean-realistic-global-woa23)=
 

--- a/docs/users_guide/ocean/tasks/realistic_global.md
+++ b/docs/users_guide/ocean/tasks/realistic_global.md
@@ -257,11 +257,11 @@ The task contains four steps:
 4. `validate` compares the history of the restart chain with the history of
    the full run.
 
-The two segments read and write restarts through a `restarts` directory
-shared by the whole task.  `second_segment` starts from a copy of
-`first_segment`'s `output.nc`, so that it finds on disk what a continuation
-run would find: a history file that already holds the earlier frames and has
-to be appended to.
+Each segment writes its restart into a directory of its own under the task's
+`restarts` directory, and a continuing segment reads its predecessor's.
+`second_segment` starts from a copy of `first_segment`'s `output.nc`, so that
+it finds on disk what a continuation run would find: a history file that
+already holds the earlier frames and has to be appended to.
 
 `validate` checks two things, because a restart can go wrong in two ways.  The
 time axis has to hold every frame of the whole period, in increasing order,

--- a/docs/users_guide/ocean/tasks/realistic_global.md
+++ b/docs/users_guide/ocean/tasks/realistic_global.md
@@ -3,7 +3,7 @@
 # realistic_global
 
 The `realistic_global` task group contains tasks that use realistic global
-ocean meshes, bathymetry and forcing. It currently contains two kinds of
+ocean meshes, bathymetry and forcing. It currently contains three kinds of
 tasks:
 
 - {ref}`ocean-realistic-global-woa23`, a mesh-independent preprocessing task
@@ -12,6 +12,8 @@ tasks:
 - {ref}`ocean-realistic-global-analysis-members`, short forward runs on
   realistic global meshes that exercise the global-statistics analysis member
   and compare its output between MPAS-Ocean and Omega.
+- {ref}`ocean-realistic-global-restart`, a short run split across a restart,
+  checking that the history output survives the restart intact.
 
 ## supported models
 
@@ -19,6 +21,11 @@ The `woa23` task is model-independent and does not require either MPAS-Ocean
 or Omega to be built.
 
 The `analysis_members` tasks support both MPAS-Ocean and Omega.
+
+The `restart` task supports Omega only.  It is a regression test for the way
+Omega writes its history time axis across a restart, and MPAS-Ocean stamps its
+output with `xtime` rather than an elapsed time measured from the start of the
+clock, so the failure it looks for cannot arise there.
 
 (ocean-realistic-global-woa23)=
 
@@ -221,3 +228,89 @@ supports the standard Polaris colormap options described in
 The number of cores used by the `forward` step is determined
 algorithmically from the number of cells in the mesh. The `global_stats` and
 `viz` steps run serially.
+
+(ocean-realistic-global-restart)=
+
+## restart
+
+This task checks that splitting a run across a restart leaves the history
+output alone.  It is a regression test for
+[Omega #482](https://github.com/E3SM-Project/Omega/issues/482), where a run
+continued from a restart silently overwrote the history frames written before
+the restart instead of appending to them, leaving a file that was well formed
+and simply missing the earlier half of the run.
+
+It can be set up with:
+
+```bash
+polaris setup -t ocean/spherical/realistic_global/QU.240km/restart ...
+```
+
+### description
+
+The task contains four steps:
+
+1. `full_run` covers the whole two-hour period in one go.
+2. `first_segment` covers the first hour and writes a restart.
+3. `second_segment` continues from that restart and covers the second hour,
+   appending its history frames to the ones `first_segment` left behind.
+4. `validate` compares the history of the restart chain with the history of
+   the full run.
+
+The two segments read and write restarts through a `restarts` directory
+shared by the whole task.  `second_segment` starts from a copy of
+`first_segment`'s `output.nc`, so that it finds on disk what a continuation
+run would find: a history file that already holds the earlier frames and has
+to be appended to.
+
+`validate` checks two things, because a restart can go wrong in two ways.  The
+time axis has to hold every frame of the whole period, in increasing order,
+which is what #482 broke.  The state then has to match the uninterrupted run,
+which is the usual exact-restart check.
+
+### mesh
+
+The `QU.240km` quasi-uniform 240-km mesh, downloaded from the Polaris input
+database, as for the `analysis_members` tasks.
+
+### vertical grid
+
+The vertical grid is the one supplied with the cached initial condition.
+
+### initial conditions
+
+A cached TEOS-10 Omega initial condition from the `realistic_global` section
+of the Polaris input database, which supplies the mesh, vertical coordinate
+and initial state.
+
+### forcing
+
+As for the `analysis_members` tasks: zonal and meridional wind stress from the
+initial-condition file, applied through bulk wind stress.
+
+### time step and run duration
+
+The time step is 10 minutes.  Each segment runs for one hour and the full run
+for two, with a history frame every 30 minutes, so each segment writes two
+frames and the whole period has four.  The period is short on purpose: the
+task is about how the model writes its history across a restart, not about the
+circulation, and it is meant to be cheap enough for the pull-request suite.
+
+### config options
+
+```cfg
+[ocean]
+
+# Equation of state type
+eos_type = teos-10
+
+[realistic_global]
+
+# Time step duration per kilometer [s]
+dt_per_km = 3.0
+```
+
+### cores
+
+The number of cores used by each forward step is determined algorithmically
+from the number of cells in the mesh.  The `validate` step runs serially.

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -121,13 +121,11 @@ config:
     time_management: TimeIntegration
   options:
     config_start_time: StartTime
-    # Omega has no StopTime or RunDuration.  It names the kind of stop
-    # criterion in StopType and holds the value in StopCriterion, so one
-    # option becomes two and cannot be written here.  These two carry the
-    # values across under their MPAS-Ocean names, and
-    # OceanModelStep._map_stop_options turns them into the pair Omega reads.
-    config_stop_time: StopTime
-    config_run_duration: RunDuration
+    # config_stop_time and config_run_duration are deliberately absent.  Omega
+    # has no counterpart to rename them to: it names the kind of stop
+    # criterion in StopType and holds its value in StopCriterion, so one
+    # option becomes two, which cannot be written here.  They are handled by
+    # _add_stop_options in ocean_model_step.py instead.
     config_calendar_type: CalendarType
 
 - section:

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -121,6 +121,11 @@ config:
     time_management: TimeIntegration
   options:
     config_start_time: StartTime
+    # Omega has no StopTime or RunDuration.  It names the kind of stop
+    # criterion in StopType and holds the value in StopCriterion, so one
+    # option becomes two and cannot be written here.  These two carry the
+    # values across under their MPAS-Ocean names, and
+    # OceanModelStep._map_stop_options turns them into the pair Omega reads.
     config_stop_time: StopTime
     config_run_duration: RunDuration
     config_calendar_type: CalendarType

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -46,10 +46,85 @@ ConfigsType = Dict[
 #: unset, which a task uses to say "stop on the other criterion, not this one"
 UNSET_TIME_VALUES = frozenset({'', 'none', 'None'})
 
+#: The MPAS-Ocean options that say when a run ends.  These have no Omega
+#: counterpart to rename to -- Omega names the kind of criterion in
+#: ``StopType`` and holds its value in ``StopCriterion`` -- so they are kept
+#: out of the option map in ``mpaso_to_omega.yaml`` and are handled by
+#: :py:func:`_add_stop_options` instead.
+STOP_OPTIONS = frozenset({'config_run_duration', 'config_stop_time'})
+
 
 def _is_set(value: OptionValue) -> bool:
     """Whether a time option holds a value, as opposed to being left unset"""
     return str(value).strip() not in UNSET_TIME_VALUES
+
+
+def _add_stop_options(
+    configs: ConfigsType,
+    stop_options: Dict[str, OptionValue],
+) -> None:
+    """
+    Add Omega's ``StopType`` and ``StopCriterion`` to ``configs``, given the
+    MPAS-Ocean stop options a set of yaml configs asked for.
+
+    MPAS-Ocean says when a run ends with two options, either of which may be
+    left unset: ``config_run_duration`` and ``config_stop_time``.  Omega says
+    the same thing with a ``StopType`` naming which kind of criterion is in
+    use and a single ``StopCriterion`` holding its value.  One option becoming
+    two cannot be written in an option-name map, so these are kept out of
+    ``mpaso_to_omega.yaml`` and translated here.
+
+    Setting both to real values is an error.  Omega cannot express it: there
+    is one criterion field, so there is nothing for a precedence rule to
+    choose between.  MPAS-Ocean has such a rule, and Omega used to have a
+    matching one, but it went with the options it applied to, and quietly
+    honouring the old order here would mean the two models were being told
+    different things by the same yaml.
+
+    A stop option that is absent or unset is left out entirely rather than
+    written as ``none``, so that Omega falls back to its own default instead
+    of being handed a criterion it cannot parse.
+
+    Parameters
+    ----------
+    configs : dict
+        The mapped Omega configs, updated in place.
+
+    stop_options : dict
+        The MPAS-Ocean stop options found in this set of yaml configs, keyed
+        by their MPAS-Ocean names.
+
+    Raises
+    ------
+    ValueError
+        If both stop options are set to real values.
+    """
+    duration = stop_options.get('config_run_duration')
+    stop_time = stop_options.get('config_stop_time')
+
+    has_duration = duration is not None and _is_set(duration)
+    has_stop_time = stop_time is not None and _is_set(stop_time)
+
+    if has_duration and has_stop_time:
+        raise ValueError(
+            f'config_run_duration and config_stop_time are both set, to '
+            f'{duration!r} and {stop_time!r}.  Omega holds one stop '
+            f'criterion, so there is no way to say which of these it should '
+            f'use.  Set one and leave the other unset (as "none").'
+        )
+
+    if not (has_duration or has_stop_time):
+        return
+
+    section = cast(
+        Dict[str, OptionValue], configs.setdefault('TimeIntegration', {})
+    )
+    if has_duration:
+        section['StopType'] = 'AfterDuration'
+        section['StopCriterion'] = cast(OptionValue, duration)
+    else:
+        section['StopType'] = 'AtTime'
+        section['StopCriterion'] = cast(OptionValue, stop_time)
 
 
 class OceanModelStep(OceanModelFilesMixin, ModelStep):
@@ -712,6 +787,7 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
         """
         out_configs: ConfigsType = {}
         not_found = []
+        stop_options: Dict[str, OptionValue] = {}
         for section, options in configs.items():
             for option, mpaso_value in options.items():
                 if isinstance(mpaso_value, dict):
@@ -719,6 +795,11 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
                         f'Nested sections are not supported in '
                         f'MPAS-Ocean configs: {section}/{option}'
                     )
+                if option in STOP_OPTIONS:
+                    # these have no Omega counterpart to rename to; they are
+                    # turned into a StopType/StopCriterion pair below
+                    stop_options[option] = mpaso_value
+                    continue
                 try:
                     omega_sections, omega_option, omega_value = (
                         self._map_mpaso_to_omega_section_option(
@@ -742,7 +823,7 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
 
         self._warn_not_found(not_found)
 
-        self._map_stop_options(out_configs)
+        _add_stop_options(out_configs, stop_options)
 
         return out_configs
 
@@ -814,42 +895,6 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
         final_val = func(ds_mesh, ds.isel(Time=time_index_end), **kwargs)
         val_change = final_val - init_val
         return abs(val_change) / (final_val + 1.0)
-
-    @staticmethod
-    def _map_stop_options(configs: ConfigsType) -> None:
-        """
-        Translate MPAS-Ocean's stop time and run duration into Omega's stop
-        type and criterion, in place.
-
-        MPAS-Ocean says when a run ends with two options, either of which may
-        be unset: ``config_run_duration``, which wins when both are given, and
-        ``config_stop_time``.  Omega says the same thing with a ``StopType``
-        naming which kind of criterion is in use and a single
-        ``StopCriterion`` holding the value.  That is one option becoming two,
-        which the option-name map in ``mpaso_to_omega.yaml`` cannot express,
-        so the map carries the values across under their MPAS-Ocean names and
-        this turns them into the pair Omega reads.
-
-        A stop option that is absent or unset is left out entirely rather than
-        written as ``none``, so that Omega falls back to its own default
-        instead of being handed a criterion it cannot parse.
-        """
-        raw = configs.get('TimeIntegration')
-        if not isinstance(raw, dict):
-            return
-        # TimeIntegration holds options, not nested sections
-        section = cast(Dict[str, OptionValue], raw)
-
-        # these are the MPAS-Ocean names, carried across by the option map
-        duration = section.pop('RunDuration', None)
-        stop_time = section.pop('StopTime', None)
-
-        if duration is not None and _is_set(duration):
-            section['StopType'] = 'AfterDuration'
-            section['StopCriterion'] = duration
-        elif stop_time is not None and _is_set(stop_time):
-            section['StopType'] = 'AtTime'
-            section['StopCriterion'] = stop_time
 
     @staticmethod
     def _warn_not_found(not_found: List[str]) -> None:

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -1,7 +1,16 @@
 import importlib.resources as imp_res
 import os
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from ruamel.yaml import YAML
 
@@ -32,6 +41,15 @@ ConfigsType = Dict[
         Dict[str, Dict[str, Dict[str, Dict[str, OptionValue]]]],
     ],
 ]
+
+#: MPAS-Ocean spellings for a time option that has deliberately been left
+#: unset, which a task uses to say "stop on the other criterion, not this one"
+UNSET_TIME_VALUES = frozenset({'', 'none', 'None'})
+
+
+def _is_set(value: OptionValue) -> bool:
+    """Whether a time option holds a value, as opposed to being left unset"""
+    return str(value).strip() not in UNSET_TIME_VALUES
 
 
 class OceanModelStep(OceanModelFilesMixin, ModelStep):
@@ -724,6 +742,8 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
 
         self._warn_not_found(not_found)
 
+        self._map_stop_options(out_configs)
+
         return out_configs
 
     def _map_mpaso_to_omega_section_option(
@@ -794,6 +814,42 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
         final_val = func(ds_mesh, ds.isel(Time=time_index_end), **kwargs)
         val_change = final_val - init_val
         return abs(val_change) / (final_val + 1.0)
+
+    @staticmethod
+    def _map_stop_options(configs: ConfigsType) -> None:
+        """
+        Translate MPAS-Ocean's stop time and run duration into Omega's stop
+        type and criterion, in place.
+
+        MPAS-Ocean says when a run ends with two options, either of which may
+        be unset: ``config_run_duration``, which wins when both are given, and
+        ``config_stop_time``.  Omega says the same thing with a ``StopType``
+        naming which kind of criterion is in use and a single
+        ``StopCriterion`` holding the value.  That is one option becoming two,
+        which the option-name map in ``mpaso_to_omega.yaml`` cannot express,
+        so the map carries the values across under their MPAS-Ocean names and
+        this turns them into the pair Omega reads.
+
+        A stop option that is absent or unset is left out entirely rather than
+        written as ``none``, so that Omega falls back to its own default
+        instead of being handed a criterion it cannot parse.
+        """
+        raw = configs.get('TimeIntegration')
+        if not isinstance(raw, dict):
+            return
+        # TimeIntegration holds options, not nested sections
+        section = cast(Dict[str, OptionValue], raw)
+
+        # these are the MPAS-Ocean names, carried across by the option map
+        duration = section.pop('RunDuration', None)
+        stop_time = section.pop('StopTime', None)
+
+        if duration is not None and _is_set(duration):
+            section['StopType'] = 'AfterDuration'
+            section['StopCriterion'] = duration
+        elif stop_time is not None and _is_set(stop_time):
+            section['StopType'] = 'AtTime'
+            section['StopCriterion'] = stop_time
 
     @staticmethod
     def _warn_not_found(not_found: List[str]) -> None:

--- a/polaris/suites/ocean/omega_nightly.txt
+++ b/polaris/suites/ocean/omega_nightly.txt
@@ -23,6 +23,7 @@ ocean/spherical/icos/divergent_2d
 ocean/spherical/icos/nondivergent_2d
 ocean/spherical/icos/rotation_2d
 ocean/spherical/qu/rotation_2d
+ocean/spherical/realistic_global/QU.240km/restart
 
 # Supported but fails
 #ocean/planar/barotropic_channel/default

--- a/polaris/suites/ocean/omega_pr.txt
+++ b/polaris/suites/ocean/omega_pr.txt
@@ -18,6 +18,7 @@ ocean/planar/seamount/nonlinear/sigma/short
 ocean/spherical/icos/cosine_bell/decomp
 ocean/spherical/icos/cosine_bell/restart
 ocean/spherical/realistic_global/QU.240km/analysis_members_test
+ocean/spherical/realistic_global/QU.240km/restart
 
 # Supported but fails
 #ocean/planar/barotropic_channel/default

--- a/polaris/tasks/ocean/baroclinic_channel/forward.py
+++ b/polaris/tasks/ocean/baroclinic_channel/forward.py
@@ -287,12 +287,11 @@ class Forward(OceanModelStep):
 
         if self.do_restart:
             init_freq = 'never'
-            restart_start_time = start_str
+            start_type = 'Continue'
             mpaso_options['config_do_restart'] = True
         else:
             init_freq = 'OnStartup'
-            # The restart start time must be >= simulation start time
-            restart_start_time = '0001-01-01_00:00:01'
+            start_type = 'StartUp'
 
         if self.nu is not None:
             # update the viscosity to the requested value *after* loading
@@ -313,8 +312,7 @@ class Forward(OceanModelStep):
         replacements = dict(
             init_freq=init_freq,
             restart_filename=restart_filename,
-            restart_start_time=restart_start_time,
-            not_restart=not self.do_restart,
+            start_type=start_type,
             output_freq=f'{output_freq}',
             output_freq_units=output_freq_units,
             time_integrator=time_integrator,

--- a/polaris/tasks/ocean/baroclinic_channel/forward.yaml
+++ b/polaris/tasks/ocean/baroclinic_channel/forward.yaml
@@ -51,6 +51,11 @@ mpas-ocean:
       - layerThickness
 
 Omega:
+  TimeIntegration:
+    # Whether a restart is read is decided here rather than by keeping
+    # RestartRead out of the way with a start time it never reaches, which is
+    # what Omega's UseStartEnd sentinel used to be for.
+    StartType: {{ start_type }}
   IO:
     IOStride: 1
   Advection:
@@ -70,9 +75,9 @@ Omega:
       UseStartEnd: false
       Contents:
       - InitVertCoord
-    # InitialState should only be used when starting from scratch.
-    # For restart runs, the frequency units should be changed from
-    # "OnStartup" to "never" so that the initial state file is not read.
+    # InitialState is read only when TimeIntegration StartType is StartUp,
+    # so a restart run switches the frequency units from "OnStartup" to
+    # "never" as well, to keep the stream out of the way.
     InitialState:
       UsePointerFile: false
       Filename: init.nc
@@ -91,9 +96,7 @@ Omega:
       Precision: double
       Freq: 1
       FreqUnits: OnStartup
-      UseStartEnd: {{ not_restart }}
-      StartTime: {{ restart_start_time }}
-      EndTime: 99999-12-31_00:00:00
+      UseStartEnd: false
       Contents:
       - Restart
     RestartWrite:

--- a/polaris/tasks/ocean/cosine_bell/restart/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/restart/forward.yaml
@@ -18,14 +18,18 @@ mpas-ocean:
       output_interval: {{ output_interval }}
 
 Omega:
+  TimeIntegration:
+    # Whether a restart is read is decided here rather than by keeping
+    # RestartRead out of the way with a start time it never reaches, which is
+    # what Omega's UseStartEnd sentinel used to be for.
+    StartType: {{ start_type }}
   IOStreams:
     InitialState:
       FreqUnits: {{ init_freq_units }}
     RestartRead:
       UsePointerFile: false
-      UseStartEnd: {{ not_restart }}
+      UseStartEnd: false
       Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s
-      StartTime: {{ restart_time }}
     RestartWrite:
       UsePointerFile: false
       Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s

--- a/polaris/tasks/ocean/cosine_bell/restart/restart_step.py
+++ b/polaris/tasks/ocean/cosine_bell/restart/restart_step.py
@@ -59,21 +59,19 @@ class RestartStep(Forward):
         output_freq = int(output_interval)
 
         if do_restart:
-            restart_time_str = start_time_str
+            start_type = 'Continue'
             init_freq_units = 'never'
         else:
-            # Effectively never
-            restart_time_str = '99999-12-31_00:00:00'
+            start_type = 'StartUp'
             init_freq_units = 'OnStartup'
 
         package = 'polaris.tasks.ocean.cosine_bell.restart'
         replacements = dict(
             do_restart=do_restart,
-            not_restart=not do_restart,
             start_time=start_time_str,
             run_duration=run_duration_str,
             output_interval=output_interval_str,
-            restart_time=restart_time_str,
+            start_type=start_type,
             init_freq_units=init_freq_units,
             output_freq=f'{output_freq}',
         )

--- a/polaris/tasks/ocean/horiz_press_grad/forward.yaml
+++ b/polaris/tasks/ocean/horiz_press_grad/forward.yaml
@@ -2,7 +2,8 @@ Omega:
   TimeIntegration:
     TimeStep: 0000_00:00:01
     StartTime: 0001-01-01_00:00:00
-    StopTime: 0001-01-01_00:00:01
+    StopType: AtTime
+    StopCriterion: 0001-01-01_00:00:01
   Tendencies:
     ThicknessFluxTendencyEnable: false
     PVTendencyEnable: false

--- a/polaris/tasks/ocean/realistic_global/__init__.py
+++ b/polaris/tasks/ocean/realistic_global/__init__.py
@@ -4,6 +4,7 @@ from polaris.tasks.ocean.realistic_global.analysis_members import (
 from polaris.tasks.ocean.realistic_global.hydrography.woa23 import (
     Woa23 as Woa23,
 )
+from polaris.tasks.ocean.realistic_global.restart import Restart as Restart
 
 
 def add_realistic_global_tasks(component):
@@ -33,3 +34,18 @@ def add_realistic_global_tasks(component):
                 ncells=mesh_info['ncells'],
             )
         )
+
+    # the restart task is only defined for the mesh it is cheap enough to run
+    # on in the pull-request suite
+    mesh_name = 'QU.240km'
+    mesh_info = mesh_dict[mesh_name]
+    component.add_task(
+        Restart(
+            component=component,
+            subdir=f'spherical/realistic_global/{mesh_name}',
+            mesh_name=mesh_name,
+            mpaso_id=mesh_info['mpaso_id'],
+            omega_id=mesh_info['omega_id'],
+            ncells=mesh_info['ncells'],
+        )
+    )

--- a/polaris/tasks/ocean/realistic_global/restart/__init__.py
+++ b/polaris/tasks/ocean/realistic_global/restart/__init__.py
@@ -1,0 +1,155 @@
+from polaris import Task as Task
+from polaris.config import PolarisConfigParser as PolarisConfigParser
+from polaris.tasks.ocean.realistic_global.forward import Forward as Forward
+from polaris.tasks.ocean.realistic_global.restart.restart_step import (
+    RestartStep as RestartStep,
+)
+from polaris.tasks.ocean.realistic_global.restart.validate import (
+    Validate as Validate,
+)
+
+#: The start of the simulation, shared by every step so that the history time
+#: axis of the restart chain lines up with that of the full run
+SIM_START_TIME = '0001-01-01_00:00:00'
+
+#: How long each segment of the restart chain runs.  The full run covers two
+#: of these.  The period is short on purpose: this task is about how the model
+#: writes its history across a restart, not about the circulation, and it is
+#: meant to be cheap enough for the pull-request suite.
+SEGMENT_DURATION = '0000_01:00:00'
+
+#: The full run, which the restart chain is compared against
+FULL_DURATION = '0000_02:00:00'
+
+#: How often a history frame is written.  Two frames per segment, so that a
+#: segment that clobbered rather than appended would be obvious.
+OUTPUT_INTERVAL = '0000_00:30:00'
+OUTPUT_FREQ = '30'
+OUTPUT_FREQ_UNITS = 'minutes'
+
+#: Per-mesh time step
+DT = {'QU.240km': '00:10:00'}
+
+
+class Restart(Task):
+    """
+    A task that checks that splitting a run across a restart leaves the
+    history output alone.
+
+    A ``full_run`` covers the whole period in one go.  Two further steps cover
+    the same period in two segments, the second continuing from the restart
+    the first wrote and appending its frames to the history the first left
+    behind.  A ``validate`` step then checks that the two histories hold the
+    same frames at the same times and the same state.
+
+    This is a regression test for Omega #482, where the continuing segment
+    measured its history time axis from its own start rather than the
+    simulation's, so its first frame collided with the first frame already in
+    the file and silently replaced the earlier half of the run.
+    """
+
+    def __init__(
+        self, component, subdir, mesh_name, mpaso_id, omega_id, ncells
+    ):
+        """
+        Create the task
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component that this task belongs to
+
+        subdir : str
+            The subdirectory for the task, to which ``restart`` will be
+            appended
+
+        mesh_name : str
+            The name of the mesh (e.g. ``QU.240km``)
+
+        mpaso_id : int
+            The ID of the MPAS-Ocean initial condition in the Polaris input
+            database
+
+        omega_id : int
+            The ID of the Omega initial condition in the Polaris input
+            database
+
+        ncells : int
+            The approximate number of cells in the mesh, used to constrain
+            resources
+        """
+        subdir = f'{subdir}/restart'
+        super().__init__(component=component, name='restart', subdir=subdir)
+
+        config_filename = 'restart.cfg'
+        config_path = f'{component.name}/{subdir}/{config_filename}'
+        config = PolarisConfigParser(filepath=config_path)
+        config.add_from_package(
+            'polaris.tasks.ocean.realistic_global',
+            'realistic_global.cfg',
+        )
+        config.add_from_package(
+            'polaris.tasks.ocean.realistic_global.restart',
+            config_filename,
+        )
+        self.set_shared_config(config, link=config_filename)
+
+        shared = dict(
+            time_integrator='RungeKutta4',
+            dt=DT[mesh_name],
+            output_interval=OUTPUT_INTERVAL,
+            output_freq=OUTPUT_FREQ,
+            output_freq_units=OUTPUT_FREQ_UNITS,
+            sim_start_time=SIM_START_TIME,
+        )
+
+        mesh_args = dict(
+            mesh_name=mesh_name,
+            mpaso_id=mpaso_id,
+            omega_id=omega_id,
+            ncells=ncells,
+        )
+
+        # the uninterrupted run the restart chain is measured against; it
+        # keeps its own restart directory rather than the one the chain
+        # shares, so that its restart cannot be mistaken for the chain's
+        full_run = Forward(
+            component=component,
+            package='polaris.tasks.ocean.realistic_global',
+            name='full_run',
+            subdir=f'{subdir}/full_run',
+            replacements=dict(shared, run_duration=FULL_DURATION),
+            **mesh_args,
+        )
+        full_run.set_shared_config(config, link=config_filename)
+        self.add_step(full_run)
+
+        previous_step = None
+        for name, start_type in [
+            ('first_segment', 'StartUp'),
+            ('second_segment', 'Continue'),
+        ]:
+            step = RestartStep(
+                component=component,
+                name=name,
+                subdir=f'{subdir}/{name}',
+                replacements=dict(
+                    shared,
+                    run_duration=SEGMENT_DURATION,
+                    start_type=start_type,
+                ),
+                previous_step=previous_step,
+                **mesh_args,
+            )
+            step.set_shared_config(config, link=config_filename)
+            self.add_step(step)
+            previous_step = step
+
+        validate = Validate(
+            component=component,
+            full_run_subdir='full_run',
+            restart_subdir='second_segment',
+            indir=subdir,
+        )
+        validate.set_shared_config(config, link=config_filename)
+        self.add_step(validate)

--- a/polaris/tasks/ocean/realistic_global/restart/forward.yaml
+++ b/polaris/tasks/ocean/realistic_global/restart/forward.yaml
@@ -1,0 +1,41 @@
+# Overrides applied on top of realistic_global/forward.yaml by the steps of
+# the restart task.  The base file already writes history as a single
+# appended, multi-frame output.nc (IfExists: append with a FileFreq far longer
+# than any run), which is the arrangement Omega #482 was reported against, so
+# only the run length, the restart streams and the start type are set here.
+
+ocean:
+  time_management:
+    config_stop_time: none
+    config_run_duration: {{ run_duration }}
+
+Omega:
+  TimeIntegration:
+    StartType: {{ start_type }}
+    # The simulation start, deliberately *not* the start of this segment.
+    # Omega measures the history time axis from the clock's start time, so a
+    # segment that moves the start time restarts that axis at zero and its
+    # first frame collides with the first frame already in the file, which is
+    # what silently overwrote earlier frames in Omega #482.  On a Continue the
+    # clock's current time comes from the restart file instead.
+    StartTime: {{ sim_start_time }}
+    StopType: AfterDuration
+    StopCriterion: {{ run_duration }}
+  IOStreams:
+    History:
+      Freq: {{ output_freq }}
+      FreqUnits: {{ output_freq_units }}
+    # Both segments read and write through one shared directory, so that the
+    # second picks up what the first wrote.  The pointer file names the
+    # restart to read, so the reading segment needs no start time of its own;
+    # whether a restart is read at all is decided by StartType above.
+    RestartRead:
+      UsePointerFile: true
+      PointerFilename: ../restarts/ocn.pointer
+      UseStartEnd: false
+    RestartWrite:
+      UsePointerFile: true
+      PointerFilename: ../restarts/ocn.pointer
+      Filename: ../restarts/ocn.restart.$Y-$M-$D_$h.$m.$s
+      Freq: 1
+      FreqUnits: OnShutdown

--- a/polaris/tasks/ocean/realistic_global/restart/forward.yaml
+++ b/polaris/tasks/ocean/realistic_global/restart/forward.yaml
@@ -25,17 +25,21 @@ Omega:
     History:
       Freq: {{ output_freq }}
       FreqUnits: {{ output_freq_units }}
-    # Both segments read and write through one shared directory, so that the
-    # second picks up what the first wrote.  The pointer file names the
-    # restart to read, so the reading segment needs no start time of its own;
-    # whether a restart is read at all is decided by StartType above.
+    # Each segment writes its restart into a directory of its own under the
+    # task's shared ``restarts``, and a continuing segment reads the previous
+    # segment's directory.  Sharing one directory instead would mean the
+    # second segment's own restart replaced the pointer it had just read, so
+    # re-running that step alone would silently continue from the wrong time.
+    # The pointer file names the restart to read, so the reading segment
+    # needs no start time of its own; whether a restart is read at all is
+    # decided by StartType above.
     RestartRead:
       UsePointerFile: true
-      PointerFilename: ../restarts/ocn.pointer
+      PointerFilename: {{ restart_read_dir }}/ocn.pointer
       UseStartEnd: false
     RestartWrite:
       UsePointerFile: true
-      PointerFilename: ../restarts/ocn.pointer
-      Filename: ../restarts/ocn.restart.$Y-$M-$D_$h.$m.$s
+      PointerFilename: {{ restart_write_dir }}/ocn.pointer
+      Filename: {{ restart_write_dir }}/ocn.restart.$Y-$M-$D_$h.$m.$s
       Freq: 1
       FreqUnits: OnShutdown

--- a/polaris/tasks/ocean/realistic_global/restart/restart.cfg
+++ b/polaris/tasks/ocean/realistic_global/restart/restart.cfg
@@ -1,0 +1,9 @@
+[ocean]
+
+# Equation of state type
+eos_type = teos-10
+
+[realistic_global]
+
+# Time step duration per kilometer [s]
+dt_per_km = 3.0

--- a/polaris/tasks/ocean/realistic_global/restart/restart_step.py
+++ b/polaris/tasks/ocean/realistic_global/restart/restart_step.py
@@ -1,0 +1,146 @@
+import os
+import shutil
+
+from polaris.tasks.ocean.realistic_global.forward import Forward
+
+#: The package holding this task's yaml overrides
+PACKAGE = 'polaris.tasks.ocean.realistic_global.restart'
+
+
+class RestartStep(Forward):
+    """
+    One segment of the realistic global restart chain.
+
+    The chain is two segments that between them cover the same period as the
+    task's ``full_run``.  Both segments read and write restarts through a
+    ``restarts`` directory shared by the whole task, following the restart
+    chain in ``realistic_global/dynamic_adjustment``, and the continuing
+    segment appends its history to the frames the first segment already
+    wrote.
+
+    Attributes
+    ----------
+    previous_step : polaris.Step or None
+        The segment this one continues from, or ``None`` for the first
+        segment of the chain.
+    """
+
+    def __init__(
+        self,
+        component,
+        name,
+        subdir,
+        mesh_name,
+        mpaso_id,
+        omega_id,
+        ncells,
+        replacements,
+        previous_step=None,
+    ):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        component : polaris.tasks.ocean.Ocean
+            The ocean component that this step belongs to
+
+        name : str
+            The name of the step
+
+        subdir : str
+            The subdirectory for the step
+
+        mesh_name : str
+            The name of the mesh (e.g. ``QU.240km``)
+
+        mpaso_id : int
+            The ID of the MPAS-Ocean initial condition in the Polaris input
+            database
+
+        omega_id : int
+            The ID of the Omega initial condition in the Polaris input
+            database
+
+        ncells : int
+            The approximate number of cells in the mesh, used to constrain
+            resources
+
+        replacements : dict
+            Template replacements for the forward yaml files
+
+        previous_step : polaris.Step, optional
+            The segment this one continues from.  When given, this step reads
+            that segment's restart and appends to its history file.
+        """
+        super().__init__(
+            component=component,
+            package='polaris.tasks.ocean.realistic_global',
+            name=name,
+            subdir=subdir,
+            mesh_name=mesh_name,
+            mpaso_id=mpaso_id,
+            omega_id=omega_id,
+            ncells=ncells,
+            replacements=replacements,
+        )
+
+        self.previous_step = previous_step
+
+        if previous_step is not None:
+            # under a name of its own, so that the copy made in
+            # runtime_setup() writes to output.nc rather than through a
+            # symlink into the previous segment's work directory
+            self.add_input_file(
+                filename='previous_output.nc',
+                work_dir_target=f'{previous_step.path}/output.nc',
+            )
+
+    def setup(self):
+        """
+        Add this task's overrides on top of the shared realistic_global
+        forward yaml, which ``Forward.setup()`` adds first
+        """
+        model = self.config.get('ocean', 'model')
+        if model != 'omega':
+            raise ValueError(
+                f'The realistic_global restart task supports only Omega, not '
+                f'{model!r}.  It is a regression test for the way Omega '
+                f'writes its history time axis across a restart (Omega '
+                f'#482), and MPAS-Ocean stamps its output with xtime rather '
+                f'than an elapsed time measured from the clock start, so the '
+                f'failure it looks for cannot arise there.'
+            )
+
+        super().setup()
+
+        self.add_yaml_file(
+            package=PACKAGE,
+            yaml='forward.yaml',
+            template_replacements=self.replacements,
+        )
+
+    def runtime_setup(self):
+        """
+        Make the shared restart directory, and seed the history file with the
+        previous segment's frames when this segment continues from one
+        """
+        super().runtime_setup()
+
+        os.makedirs(self._restart_dir(), exist_ok=True)
+
+        if self.previous_step is None:
+            return
+
+        # Reproduce what a continuation run finds on disk: a history file
+        # that already holds the earlier frames and has to be appended to.
+        # This is copied rather than symlinked so that appending to it cannot
+        # reach back into the previous segment's work directory.
+        shutil.copy(
+            os.path.join(self.work_dir, 'previous_output.nc'),
+            os.path.join(self.work_dir, 'output.nc'),
+        )
+
+    def _restart_dir(self):
+        """The restart directory shared by both segments of the chain"""
+        return os.path.normpath(os.path.join(self.work_dir, '..', 'restarts'))

--- a/polaris/tasks/ocean/realistic_global/restart/restart_step.py
+++ b/polaris/tasks/ocean/realistic_global/restart/restart_step.py
@@ -114,10 +114,16 @@ class RestartStep(Forward):
 
         super().setup()
 
+        replacements = dict(
+            self.replacements,
+            restart_read_dir=self.restart_read_target(),
+            restart_write_dir=self.restart_write_target(),
+        )
+
         self.add_yaml_file(
             package=PACKAGE,
             yaml='forward.yaml',
-            template_replacements=self.replacements,
+            template_replacements=replacements,
         )
 
     def runtime_setup(self):
@@ -127,7 +133,7 @@ class RestartStep(Forward):
         """
         super().runtime_setup()
 
-        os.makedirs(self._restart_dir(), exist_ok=True)
+        os.makedirs(self.restart_write_dir(), exist_ok=True)
 
         if self.previous_step is None:
             return
@@ -141,6 +147,29 @@ class RestartStep(Forward):
             os.path.join(self.work_dir, 'output.nc'),
         )
 
-    def _restart_dir(self):
-        """The restart directory shared by both segments of the chain"""
-        return os.path.normpath(os.path.join(self.work_dir, '..', 'restarts'))
+    def restart_write_dir(self):
+        """
+        The absolute path of the directory this segment writes its restart
+        into
+        """
+        return os.path.normpath(
+            os.path.join(self.work_dir, self.restart_write_target())
+        )
+
+    def restart_write_target(self):
+        """
+        The path, relative to the step's work directory, that this segment
+        writes its restart into.  Each segment gets one of its own, so that
+        a segment's own restart cannot replace the pointer it read from.
+        """
+        return f'../restarts/{self.name}'
+
+    def restart_read_target(self):
+        """
+        The path, relative to the step's work directory, that this segment
+        reads a restart from.  A segment that starts from an initial state
+        never opens it, so it is pointed at its own directory.
+        """
+        if self.previous_step is None:
+            return self.restart_write_target()
+        return f'../restarts/{self.previous_step.name}'

--- a/polaris/tasks/ocean/realistic_global/restart/validate.py
+++ b/polaris/tasks/ocean/realistic_global/restart/validate.py
@@ -1,0 +1,159 @@
+import os
+
+import numpy as np
+import xarray as xr
+
+from polaris.ocean.model import OceanIOStep
+from polaris.validate import compare_variables
+
+#: The state variables compared between the full run and the restart chain
+VARIABLES = ['temperature', 'salinity', 'layerThickness', 'normalVelocity']
+
+
+class Validate(OceanIOStep):
+    """
+    Check that a run split across a restart writes the same history as the
+    same run done in one go.
+
+    Two things are checked, because a restart can go wrong in two ways.  The
+    time axis has to hold every frame of the whole period, in increasing
+    order: Omega #482 was a case where the continuing segment silently
+    overwrote the earlier frames instead of appending to them, leaving a file
+    that was well formed and simply missing its first half.  The state then
+    has to match the uninterrupted run, which is the usual exact-restart
+    check.
+
+    Attributes
+    ----------
+    full_run_subdir : str
+        Subdirectory of the step that ran the whole period in one go
+
+    restart_subdir : str
+        Subdirectory of the final segment of the restart chain
+    """
+
+    def __init__(self, component, full_run_subdir, restart_subdir, indir):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        component : polaris.Component
+            The component the step belongs to
+
+        full_run_subdir : str
+            Subdirectory of the step that ran the whole period in one go
+
+        restart_subdir : str
+            Subdirectory of the final segment of the restart chain
+
+        indir : str
+            the directory the step is in, to which ``name`` will be appended
+        """
+        super().__init__(component=component, name='validate', indir=indir)
+
+        self.full_run_subdir = full_run_subdir
+        self.restart_subdir = restart_subdir
+
+        for subdir in [full_run_subdir, restart_subdir]:
+            self.add_input_file(
+                filename=f'output_{subdir}.nc',
+                target=f'../{subdir}/output.nc',
+            )
+
+    def run(self):
+        """
+        Compare the history of the restart chain with the history of the
+        uninterrupted run
+        """
+        super().run()
+        logger = self.logger
+
+        full_run = self.inputs[0]
+        restart = self.inputs[1]
+
+        for filename in [full_run, restart]:
+            if not os.path.exists(filename):
+                raise OSError(f'File {filename} does not exist.')
+
+        frames_pass = self._compare_time_axes(full_run, restart)
+
+        ds1 = self.open_model_dataset(full_run, self.config)
+        ds2 = self.open_model_dataset(restart, self.config)
+
+        state_pass = compare_variables(
+            component=self.component,
+            variables=VARIABLES,
+            filename1=full_run,
+            filename2=restart,
+            logger=logger,
+            config=self.config,
+            ds1=ds1,
+            ds2=ds2,
+        )
+
+        if not (frames_pass and state_pass):
+            raise ValueError(
+                f'Validation failed comparing the history of '
+                f'{self.restart_subdir} with {self.full_run_subdir}.'
+            )
+
+    def _compare_time_axes(self, full_run, restart):
+        """
+        Check that the restart chain wrote every frame the full run did, and
+        that its own frames increase in time
+
+        Returns
+        -------
+        bool
+            Whether the time axes agree
+        """
+        logger = self.logger
+
+        # read the elapsed-time coordinate as the model wrote it, rather than
+        # through the Omega-to-MPAS-Ocean renaming, since it is the variable
+        # under test
+        with xr.open_dataset(full_run, decode_times=False) as ds:
+            expected = ds.time.values
+        with xr.open_dataset(restart, decode_times=False) as ds:
+            actual = ds.time.values
+
+        all_pass = True
+
+        if actual.size < expected.size:
+            logger.error(
+                f'The restart chain wrote {actual.size} history frames but '
+                f'the full run wrote {expected.size}.  Frames written before '
+                f'the restart appear to have been overwritten rather than '
+                f'appended to (see Omega #482).'
+            )
+            all_pass = False
+        elif actual.size != expected.size:
+            logger.error(
+                f'The restart chain wrote {actual.size} history frames but '
+                f'the full run wrote {expected.size}.'
+            )
+            all_pass = False
+        elif not np.allclose(actual, expected):
+            logger.error(
+                f'The restart chain wrote its history frames at different '
+                f'times than the full run.\n'
+                f'  full run:      {expected}\n'
+                f'  restart chain: {actual}'
+            )
+            all_pass = False
+
+        if actual.size > 1 and not np.all(np.diff(actual) > 0):
+            logger.error(
+                f'The history times of the restart chain do not increase: '
+                f'{actual}'
+            )
+            all_pass = False
+
+        if all_pass:
+            logger.info(
+                f'  history time axis PASS ({actual.size} frames, '
+                f'{actual[0]} to {actual[-1]} s)'
+            )
+
+        return all_pass

--- a/tests/ocean/test_map_stop_options.py
+++ b/tests/ocean/test_map_stop_options.py
@@ -1,0 +1,101 @@
+from configparser import ConfigParser
+
+import pytest
+
+from polaris.ocean.model import OceanModelStep
+from polaris.tasks.ocean import Ocean
+
+
+def _make_config():
+    config = ConfigParser()
+    config.add_section('ocean')
+    config.set('ocean', 'model', 'omega')
+    return config
+
+
+def _make_step():
+    """An Omega forward step with the MPAS-Ocean-to-Omega option map loaded"""
+    component = Ocean()
+    component.model = 'omega'
+    step = OceanModelStep(
+        component=component,
+        name='forward',
+        ntasks=1,
+        min_tasks=1,
+    )
+    step.config = _make_config()
+    step._read_config_map()
+    return step
+
+
+def _map(**time_management):
+    """Map an ``ocean`` ``time_management`` section to Omega options"""
+    step = _make_step()
+    configs = step.map_yaml_configs(
+        configs={'time_management': time_management},
+        config_model='ocean',
+    )
+    return configs['TimeIntegration']
+
+
+def test_run_duration_becomes_a_duration_criterion():
+    options = _map(
+        config_start_time='0001-01-01_00:00:00',
+        config_stop_time='none',
+        config_run_duration='0000_00:20:00',
+    )
+
+    assert options['StopType'] == 'AfterDuration'
+    assert options['StopCriterion'] == '0000_00:20:00'
+    assert options['StartTime'] == '0001-01-01_00:00:00'
+
+
+def test_stop_time_becomes_a_time_criterion():
+    options = _map(
+        config_stop_time='0001-01-02_00:00:00',
+        config_run_duration='none',
+    )
+
+    assert options['StopType'] == 'AtTime'
+    assert options['StopCriterion'] == '0001-01-02_00:00:00'
+
+
+def test_run_duration_wins_when_both_are_given():
+    """MPAS-Ocean prefers the duration, and Omega used to do the same"""
+    options = _map(
+        config_stop_time='0001-01-02_00:00:00',
+        config_run_duration='0000_00:20:00',
+    )
+
+    assert options['StopType'] == 'AfterDuration'
+    assert options['StopCriterion'] == '0000_00:20:00'
+
+
+@pytest.mark.parametrize('unset', ['none', 'None', ''])
+def test_options_omega_cannot_read_are_never_written(unset):
+    """
+    Omega has no StopTime or RunDuration, so they must not survive the
+    mapping, and an unset criterion must not be passed on as ``none``.
+    """
+    options = _map(
+        config_start_time='0001-01-01_00:00:00',
+        config_stop_time=unset,
+        config_run_duration=unset,
+    )
+
+    assert 'StopTime' not in options
+    assert 'RunDuration' not in options
+    assert 'StopCriterion' not in options
+    # with neither criterion set, Omega falls back to its own default
+    assert 'StopType' not in options
+
+
+def test_unmapped_time_options_are_left_alone():
+    """A section without stop options passes through untouched"""
+    step = _make_step()
+    configs = step.map_yaml_configs(
+        configs={'time_integration': {'config_dt': '0000_00:05:00'}},
+        config_model='ocean',
+    )
+
+    assert configs['TimeIntegration'] == {'TimeStep': '0000_00:05:00'}

--- a/tests/ocean/test_map_stop_options.py
+++ b/tests/ocean/test_map_stop_options.py
@@ -60,10 +60,24 @@ def test_stop_time_becomes_a_time_criterion():
     assert options['StopCriterion'] == '0001-01-02_00:00:00'
 
 
-def test_run_duration_wins_when_both_are_given():
-    """MPAS-Ocean prefers the duration, and Omega used to do the same"""
+def test_setting_both_criteria_is_an_error():
+    """
+    Omega holds one stop criterion, so asking for both says nothing it can
+    act on.  MPAS-Ocean would prefer the duration and Omega used to do the
+    same, but that rule went with the options it applied to, so rather than
+    quietly honouring an order the models no longer share, refuse it.
+    """
+    with pytest.raises(ValueError, match='both set'):
+        _map(
+            config_stop_time='0001-01-02_00:00:00',
+            config_run_duration='0000_00:20:00',
+        )
+
+
+def test_an_unset_criterion_is_not_both():
+    """The usual case: a duration alongside an explicitly unset stop time"""
     options = _map(
-        config_stop_time='0001-01-02_00:00:00',
+        config_stop_time='none',
         config_run_duration='0000_00:20:00',
     )
 

--- a/tests/ocean/test_omega_stop_options.py
+++ b/tests/ocean/test_omega_stop_options.py
@@ -1,0 +1,67 @@
+"""
+Guard against the options Omega removed creeping back into task yaml files.
+
+Omega replaced ``StopTime`` and ``RunDuration`` with a ``StopType`` naming the
+kind of stop criterion in use and a ``StopCriterion`` holding its value.  A
+task that writes the old names into an ``Omega:`` block bypasses the
+MPAS-Ocean-to-Omega option map entirely, so
+:py:meth:`polaris.ocean.model.OceanModelStep._map_stop_options` cannot
+translate them, and setup fails only once that particular task is set up
+against a current Omega.  This test finds them without running anything.
+"""
+
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+#: Options Omega no longer has
+REMOVED_OPTIONS = ['StopTime', 'RunDuration']
+
+#: The repository's task and framework yaml files
+POLARIS_ROOT = Path(__file__).resolve().parents[2] / 'polaris'
+
+
+def _yaml_files():
+    """Every yaml file shipped with polaris, excluding caches"""
+    return sorted(
+        p for p in POLARIS_ROOT.rglob('*.yaml') if '__pycache__' not in p.parts
+    )
+
+
+def _omega_time_integration(path):
+    """
+    The ``Omega: TimeIntegration:`` mapping in ``path``, or ``None``.
+
+    Files that are Jinja templates rather than plain yaml are skipped: they
+    cannot be parsed before rendering, and the ones that exist are covered by
+    the rendered-config checks in the tasks themselves.
+    """
+    try:
+        parsed = YAML(typ='safe').load(path.read_text())
+    except Exception:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    omega = parsed.get('Omega')
+    if not isinstance(omega, dict):
+        return None
+    section = omega.get('TimeIntegration')
+    return section if isinstance(section, dict) else None
+
+
+@pytest.mark.parametrize('path', _yaml_files(), ids=lambda p: p.name)
+def test_no_removed_omega_stop_options(path):
+    section = _omega_time_integration(path)
+    if section is None:
+        return
+
+    found = [option for option in REMOVED_OPTIONS if option in section]
+
+    assert not found, (
+        f'{path.relative_to(POLARIS_ROOT.parent)} sets {", ".join(found)} '
+        f'under Omega: TimeIntegration:, which Omega no longer has.  Use '
+        f'StopType with StopCriterion instead, or set config_run_duration / '
+        f'config_stop_time in the shared ocean section and let the option '
+        f'map translate them.'
+    )


### PR DESCRIPTION
Follow the start and stop options introduced in Omega [#524](https://github.com/E3SM-Project/Omega/pull/524), and add a `realistic_global` restart task that checks history output survives a restart, as a regression test for Omega [#482](https://github.com/E3SM-Project/Omega/issues/482).

This must merge together with Omega #524. Without it, every ocean forward task's `config_run_duration` is silently ignored once #524 lands; with it, the options this branch writes do not exist in the current submodule.

One decision worth a reviewer's eye: setting both `config_run_duration` and `config_stop_time` to real values in one yaml file is now an error for Omega, rather than following MPAS-Ocean's precedence. No existing task does this.

Changes:
* `config_run_duration` and `config_stop_time` become Omega's `StopType`/`StopCriterion` pair in `ocean_model_step.py`, since the one-to-one option map cannot express them.
* The `cosine_bell` and `baroclinic_channel` restart tasks set `StartType` instead of suppressing the restart read with `UseStartEnd`, which no longer works.
* `ocean/spherical/realistic_global/QU.240km/restart` runs two hours straight through and again split across a restart, and compares the history frame count and time axis as well as the state. It is Omega-only and is added to `omega_pr` and `omega_nightly`. The developer's guide explains why every segment keeps the simulation start as its `StartTime`.
* A unit test scans task yaml for the options Omega removed.

Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite
