### PR TITLE
Let mypy assume the Python it is running under

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,28 @@ repos:
     -   id: ruff-format
 
   # Can run individually with `pre-commit run mypy --all-files`
+  # Can run individually with `pre-commit run mypy --all-files`
+  #
+  # additional_dependencies is what gives this hook teeth.  The hook runs in
+  # an isolated environment, so any package missing from it is Any under
+  # `ignore_missing_imports`, and a hook holding only types-requests checks
+  # each file against the standard library alone -- it reported no issues on
+  # a tree where mypy finds 141.  These four are the ones polaris types
+  # against most: with them the hook finds 48 errors on the tree before this
+  # branch, and none after.
+  #
+  # cartopy is deliberately absent: it needs system GEOS and would make this
+  # hook fragile for what it would add.  Anything not listed stays Any, so
+  # the deployed environment still checks more than CI does.
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.0
     hooks:
     -   id: mypy
         args: ["--config=pyproject.toml", "--show-error-codes"]
         verbose: true
-        additional_dependencies: ['types-requests']
+        additional_dependencies:
+          - 'types-requests'
+          - 'tranche>=0.6.0'
+          - 'numpy>=2.0,<3.0'
+          - 'xarray'
+          - 'matplotlib>=3.9.0'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,10 @@ repos:
   # cartopy is deliberately absent: it needs system GEOS and would make this
   # hook fragile for what it would add.  Anything not listed stays Any, so
   # the deployed environment still checks more than CI does.
+  #
+  # pre-commit cannot read a version from pyproject.toml, so the constraints
+  # below repeat the ones there.  tests/test_dependency_pins.py fails if the
+  # two drift apart.
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.0
     hooks:

--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "polaris",
-    "mache_version": "3.11.0",
+    "mache_version": "3.12.0",
     "description": "Deploy polaris environment"
   },
   "arguments": [

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -3,7 +3,7 @@
 bootstrap_python = 3.14
 python = 3.14
 geometric_features = 1.6.3
-mache = 3.11.0
+mache = 3.12.0
 mpas_tools = 2.1.0
 otps = 2021.10
 parallelio = 2.6.9

--- a/deploy/pixi.toml.j2
+++ b/deploy/pixi.toml.j2
@@ -50,7 +50,7 @@ requests = "*"
 scipy = ">=1.8.0"
 shapely = ">=2.0.4,<3.0"
 termcolor = "*"
-tranche = ">=0.3.0"
+tranche = ">=0.6.0"
 xarray = "*"
 
 # Static typing

--- a/docs/developers_guide/framework/config.md
+++ b/docs/developers_guide/framework/config.md
@@ -64,13 +64,13 @@ def _get_basic_config(config_file, machine, component_path, component):
 ```
 If there isn't a config file for this machine, nothing will happen.
 
-The `MpasConfigParser` class also includes methods for adding a user
-config file and other config files by file name, but these are largely intended
-for use by the framework rather than individual tasks.
+The {py:class}`polaris.config.PolarisConfigParser` class also includes methods
+for adding a user config file and other config files by file name, but these
+are largely intended for use by the framework rather than individual tasks.
 
-Other methods for the `MpasConfigParser` are similar to those for
-{py:class}`configparser.ConfigParser`.  In addition to `get()`,
-`getinteger()`, `getfloat()` and `getboolean()` methods, this class
+Its other methods are similar to those for
+{py:class}`configparser.ConfigParser`.  In addition to `get()`, `getint()`,
+`getfloat()` and `getboolean()` methods, this class
 implements {py:meth}`tranche.Tranche.getlist()`, which
 can be used to parse a config value separated by spaces and/or commas into
 a list of strings, floats, integers, booleans, etc. Other useful methods

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -312,7 +312,7 @@ namelists, streams or YAML files to be read later if the task in question gets
 set up, so each takes a negligible amount of time.
 
 If this is a shared step with its own config options, it is also okay to call
-{py:meth}`mpas_tools.config.MpasConfigParser.add_from_package()` from the
+{py:meth}`tranche.Tranche.add_from_package()` from the
 constructor.
 
 The following is from

--- a/docs/developers_guide/organization/tasks.md
+++ b/docs/developers_guide/organization/tasks.md
@@ -190,7 +190,7 @@ these methods only keep track of a "recipe" for downloading files or
 constructing namelist and streams files, they don't actually do the work
 associated with these steps until the point where the step is being set up in
 
-- {py:meth}`mpas_tools.config.MpasConfigParser.add_from_package()`
+- {py:meth}`tranche.Tranche.add_from_package()`
 - {py:meth}`polaris.Step.add_input_file()`
 - {py:meth}`polaris.Step.add_output_file()`
 - {py:meth}`polaris.ModelStep.add_model_config_options()`

--- a/polaris/config.py
+++ b/polaris/config.py
@@ -65,6 +65,7 @@ class PolarisConfigParser(Tranche):
         sections are absolute paths
         """
         config = self.combined
+        assert config is not None  # combine() has just set it
         for section in ['paths', 'namelists', 'streams', 'executables']:
             if not config.has_section(section):
                 continue

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -150,7 +150,8 @@ def fix_out_of_bounds_indices(ds: xr.Dataset) -> xr.Dataset:
 
     def _is_connectivity_array(da: xr.DataArray) -> bool:
         # uncapitalize the name
-        name = da.name[0].lower() + da.name[1:]
+        name = str(da.name)
+        name = name[0].lower() + name[1:]
         is_int = da.dtype.kind in ('i', 'u')
 
         return 'On' in name and is_int and name.startswith(('c', 'e', 'v'))
@@ -158,9 +159,10 @@ def fix_out_of_bounds_indices(ds: xr.Dataset) -> xr.Dataset:
     for var in ds:
         if _is_connectivity_array(ds[var]):
             # supports both MPASO and Omega naming conventions
-            prefix = 'N' if var[0].isupper() else 'n'
+            var_name = str(var)
+            prefix = 'N' if var_name[0].isupper() else 'n'
             # get the dimension name for the connectivity array
-            dim = prefix + var.split('On')[0].title()
+            dim = prefix + var_name.split('On')[0].title()
             # get the maximum valid size for the array to be indexed too
             max_size = ds.sizes[dim]
             # get mask of where index is out bounds

--- a/polaris/mesh/spherical/__init__.py
+++ b/polaris/mesh/spherical/__init__.py
@@ -265,7 +265,7 @@ class SphericalBaseStep(Step):
             config.get('spherical_mesh', 'cell_width_image_filename')
         )
         register_sci_viz_colormaps()
-        fig = Figure(figsize=[16.0, 8.0])
+        fig = Figure(figsize=(16.0, 8.0))
         ax = fig.add_subplot(111, projection=ccrs.PlateCarree())
         ax.set_global()
         im = ax.imshow(

--- a/polaris/mesh/spherical/coastline.py
+++ b/polaris/mesh/spherical/coastline.py
@@ -439,7 +439,9 @@ def _write_netcdf_with_fill_values(ds, filename, format='NETCDF4'):
     """
     ds = ds.copy()
     fill_values = netCDF4.default_fillvals
-    encoding = {}
+    # a value of None means "write no _FillValue attribute for this
+    # variable", which xarray accepts alongside the numeric fill values
+    encoding: dict[str, dict[str, Any]] = {}
     vars_and_coords = list(ds.data_vars.keys()) + list(ds.coords.keys())
     for var_name in vars_and_coords:
         ds[var_name].attrs.pop('_FillValue', None)

--- a/polaris/mesh/spherical/unified/base_mesh.py
+++ b/polaris/mesh/spherical/unified/base_mesh.py
@@ -322,32 +322,32 @@ def _read_geojson_line_mesh(
         edge_tags.append(np.full(int(keep.sum()), line_index, dtype=np.int32))
         raw_point_start += n
 
-    edge_starts = np.concatenate(edge_starts)
-    edge_ends = np.concatenate(edge_ends)
-    edge_tags = np.concatenate(edge_tags)
+    all_edge_starts = np.concatenate(edge_starts)
+    all_edge_ends = np.concatenate(edge_ends)
+    all_edge_tags = np.concatenate(edge_tags)
 
     # Remove duplicate edges (same cluster pair regardless of direction).
     edge_pairs = np.column_stack(
         [
-            np.minimum(edge_starts, edge_ends),
-            np.maximum(edge_starts, edge_ends),
+            np.minimum(all_edge_starts, all_edge_ends),
+            np.maximum(all_edge_starts, all_edge_ends),
         ]
     )
     _, unique_edge_indices = np.unique(edge_pairs, axis=0, return_index=True)
-    edge_starts = edge_starts[unique_edge_indices]
-    edge_ends = edge_ends[unique_edge_indices]
-    edge_tags = edge_tags[unique_edge_indices]
+    all_edge_starts = all_edge_starts[unique_edge_indices]
+    all_edge_ends = all_edge_ends[unique_edge_indices]
+    all_edge_tags = all_edge_tags[unique_edge_indices]
 
-    if edge_starts.size == 0:
+    if all_edge_starts.size == 0:
         return None, None
 
     vert2: Any = np.zeros(len(unique_rad), dtype=temp.VERT2_t)
-    edge2: Any = np.zeros(edge_starts.size, dtype=temp.EDGE2_t)
+    edge2: Any = np.zeros(all_edge_starts.size, dtype=temp.EDGE2_t)
 
     vert2['coord'] = unique_rad
-    edge2['index'][:, 0] = edge_starts
-    edge2['index'][:, 1] = edge_ends
-    edge2['IDtag'] = edge_tags
+    edge2['index'][:, 0] = all_edge_starts
+    edge2['index'][:, 1] = all_edge_ends
+    edge2['IDtag'] = all_edge_tags
 
     return vert2, edge2
 

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -52,11 +52,17 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
     graph_target : str
         The name of the graph partition file to link to (relative to the base
         working directory)
+
+    write_coeffs_reconstruct : bool
+        Whether to write the coefficients for reconstructing vector
+        quantities during the forward run
     """
 
     # make sure component is of type Ocean, using a string to avoid circular
     # imports
     component: 'Ocean'
+
+    write_coeffs_reconstruct: bool
 
     def __init__(
         self,
@@ -241,12 +247,9 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
 
         if self.update_eos:
             self.update_namelist_eos()
-        if self.config.has_option('ocean', 'write_coeffs_reconstruct'):
-            self.write_coeffs_reconstruct = self.config.get(
-                'ocean', 'write_coeffs_reconstruct'
-            )
-        else:
-            self.write_coeffs_reconstruct = False
+        self.write_coeffs_reconstruct = self.config.getboolean(
+            'ocean', 'write_coeffs_reconstruct', fallback=False
+        )
         if self.write_coeffs_reconstruct:
             model = self.config.get('ocean', 'model')
             if model != 'mpas-ocean':

--- a/polaris/ocean/vertical/pstar_init.py
+++ b/polaris/ocean/vertical/pstar_init.py
@@ -235,13 +235,16 @@ class PStarInitStep(Step, ABC):
 
             logger.debug(f'Iteration {iteration}: p_mid = {p_mid}')
 
-            spec_vol = compute_specvol(
+            # compute_specvol() returns a scalar for scalar inputs; this
+            # workflow only ever hands it DataArrays
+            new_spec_vol = compute_specvol(
                 config=config,
                 temperature=ct,
                 salinity=sa,
                 pressure=p_mid,
             )
-            assert isinstance(spec_vol, xr.DataArray)
+            assert isinstance(new_spec_vol, xr.DataArray)
+            spec_vol = new_spec_vol
 
             min_level_cell = ds.minLevelCell - 1
             max_level_cell = ds.maxLevelCell - 1

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -58,8 +58,9 @@ def pseudothickness_from_pressure(
 
     p_top = p.isel(nVertLevelsP1=slice(0, -1))
     p_bot = p.isel(nVertLevelsP1=slice(1, None))
-    dims = list(p.dims)
-    dims = [item.replace('nVertLevelsP1', 'nVertLevels') for item in dims]
+    dims = [
+        str(item).replace('nVertLevelsP1', 'nVertLevels') for item in p.dims
+    ]
     h = xr.DataArray(
         (p_bot - p_top) / (RhoSw * Gravity),
         dims=tuple(dims),

--- a/polaris/ocean/vertical/ztilde.py
+++ b/polaris/ocean/vertical/ztilde.py
@@ -251,12 +251,17 @@ def pressure_and_spec_vol_from_state_at_geom_height(
     prev_spec_vol = spec_vol
 
     for iter in range(iter_count):
-        spec_vol = compute_specvol(
+        # compute_specvol() returns a scalar for scalar inputs; this
+        # workflow only ever hands it DataArrays, so check that rather than
+        # widening spec_vol for the rest of the function
+        new_spec_vol = compute_specvol(
             config=config,
             temperature=temperature,
             salinity=salinity,
             pressure=p_mid,
         )
+        assert isinstance(new_spec_vol, xr.DataArray)
+        spec_vol = new_spec_vol
 
         if logger is not None:
             delta_spec_vol = spec_vol - prev_spec_vol

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 from glob import glob
+from typing import Any
 
 import netCDF4
 import numpy as np
@@ -957,7 +958,9 @@ def _write_netcdf_with_fill_values(ds, filename, format='NETCDF4'):
     """Write an xarray Dataset with NetCDF4 fill values where needed"""
     ds = ds.copy()
     fill_values = netCDF4.default_fillvals
-    encoding = {}
+    # a value of None means "write no _FillValue attribute for this
+    # variable", which xarray accepts alongside the numeric fill values
+    encoding: dict[str, dict[str, Any]] = {}
     vars = list(ds.data_vars.keys()) + list(ds.coords.keys())
     for var_name in vars:
         # If there's already a fill value attribute, drop it

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -510,17 +510,17 @@ class CombineStep(Step):
             lon_indices[1] = max([lon_indices[1], nlon])
         else:
             lon_indices[1] += 1
-        lat_indices = np.arange(*lat_indices)
-        lon_indices = np.arange(*lon_indices)
+        lat_index_array = np.arange(*lat_indices)
+        lon_index_array = np.arange(*lon_indices)
 
         # Duplicate top and bottom rows to account for poles
         if lat_tile == 0:
-            lat_indices = np.insert(lat_indices, 0, 0)
+            lat_index_array = np.insert(lat_index_array, 0, 0)
         if lat_tile == lat_tiles - 1:
-            lat_indices = np.append(lat_indices, lat_indices[-1])
+            lat_index_array = np.append(lat_index_array, lat_index_array[-1])
 
         # Select tile from dataset
-        tile = ds.isel(lat=lat_indices, lon=lon_indices)
+        tile = ds.isel(lat=lat_index_array, lon=lon_index_array)
         lat = tile.lat.values.copy()
         lat_attrs = tile.lat.attrs.copy()
         # xarray may expose coordinate views from ``isel()`` as read-only.

--- a/polaris/tasks/mesh/spherical/unified/river/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/river/viz.py
@@ -1,10 +1,12 @@
 import os
+from typing import cast
 
 import cartopy.crs as ccrs
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
+from cartopy.mpl.geoaxes import GeoAxes
 from matplotlib.lines import Line2D
 from shapely.geometry import LineString, MultiLineString, box, shape
 
@@ -213,7 +215,7 @@ class VizRiverStep(Step):
         Plot the rasterized river-channel mask.
         """
         fig = plt.figure(figsize=(11.0, 5.0), dpi=dpi)
-        ax = plt.axes(projection=ccrs.PlateCarree())
+        ax = cast(GeoAxes, plt.axes(projection=ccrs.PlateCarree()))
         ax.set_global()
         plot_mask, stride = _aggregate_mask_for_plot(river_channel_mask)
         channel = np.where(plot_mask, 1.0, np.nan)
@@ -239,12 +241,16 @@ def _setup_axes_with_inset(dpi):
     Create a global Robinson plot with a CONUS inset.
     """
     fig = plt.figure(figsize=(16.0, 9.0), dpi=dpi)
-    ax = fig.add_axes([0.03, 0.12, 0.68, 0.78], projection=ccrs.Robinson())
+    ax = cast(
+        GeoAxes,
+        fig.add_axes((0.03, 0.12, 0.68, 0.78), projection=ccrs.Robinson()),
+    )
     ax.set_global()
     ax.coastlines(linewidth=0.45, color=COAST_COLOR)
 
-    inset_ax = fig.add_axes(
-        [0.63, 0.17, 0.34, 0.38], projection=ccrs.PlateCarree()
+    inset_ax = cast(
+        GeoAxes,
+        fig.add_axes((0.63, 0.17, 0.34, 0.38), projection=ccrs.PlateCarree()),
     )
     inset_ax.set_extent(CONUS_EXTENT, crs=ccrs.PlateCarree())
     inset_ax.coastlines(linewidth=0.45, color=COAST_COLOR)

--- a/polaris/tasks/ocean/cosine_bell/__init__.py
+++ b/polaris/tasks/ocean/cosine_bell/__init__.py
@@ -181,7 +181,7 @@ class CosineBell(Task):
 
         component = self.component
 
-        analysis_dependencies: Dict[str, Dict[str, Step]] = dict(
+        analysis_dependencies: Dict[str, Dict[float, Step]] = dict(
             mesh=dict(), init=dict(), forward=dict()
         )
 
@@ -278,11 +278,10 @@ class CosineBell(Task):
 def _set_convergence_configs(config, prefix):
     for refinement in ['space', 'time']:
         option = f'refinement_factors_{refinement}'
-        refinement_factors = config.getlist(
+        factor_strings = config.getlist(
             'spherical_convergence', f'{prefix}_{option}', dtype=str
         )
-        refinement_factors = ', '.join(refinement_factors)
-        config.set('convergence', option, value=refinement_factors)
+        config.set('convergence', option, value=', '.join(factor_strings))
 
         base_resolution = config.getfloat(
             'spherical_convergence', f'{prefix}_base_resolution'

--- a/polaris/tasks/ocean/customizable_viz/viz_horiz_field.py
+++ b/polaris/tasks/ocean/customizable_viz/viz_horiz_field.py
@@ -130,7 +130,7 @@ class VizHorizField(OceanIOStep):
                 h_rest = ds_mesh.restingThickness
                 z_bottom = h_rest.cumsum(dim='nVertLevels')
                 dz = z_bottom.mean(dim='nCells') - z_target
-                z_index = np.argmin(np.abs(dz.values))
+                z_index = int(np.argmin(np.abs(dz.values)))
                 if dz[z_index] > 0 and z_index > 0:
                     z_index -= 1
                 z_mean = z_bottom.mean(dim='nCells')[z_index].values

--- a/polaris/tasks/ocean/external_gravity_wave/__init__.py
+++ b/polaris/tasks/ocean/external_gravity_wave/__init__.py
@@ -173,7 +173,7 @@ class ExternalGravityWave(Task):
 
         component = self.component
 
-        analysis_dependencies: Dict[str, Dict[str, Step]] = dict(
+        analysis_dependencies: Dict[str, Dict[float, Step]] = dict(
             mesh=dict(), init=dict(), forward=dict()
         )
 
@@ -312,11 +312,10 @@ class ExternalGravityWave(Task):
 def _set_convergence_configs(config, prefix):
     for refinement in ['space', 'time']:
         option = f'refinement_factors_{refinement}'
-        refinement_factors = config.getlist(
+        factor_strings = config.getlist(
             'spherical_convergence', f'{prefix}_{option}', dtype=str
         )
-        refinement_factors = ', '.join(refinement_factors)
-        config.set('convergence', option, value=refinement_factors)
+        config.set('convergence', option, value=', '.join(factor_strings))
 
         base_resolution = config.getfloat(
             'spherical_convergence', f'{prefix}_base_resolution'

--- a/polaris/tasks/ocean/external_gravity_wave/lts_regions.py
+++ b/polaris/tasks/ocean/external_gravity_wave/lts_regions.py
@@ -154,7 +154,7 @@ def label_mesh(
     ds_ltsmsh = ds_msh.copy(deep=True)
     ltsmsh_name = 'init.nc'
     write_netcdf(ds_ltsmsh, ltsmsh_name)
-    mshnc = nc.Dataset(ltsmsh_name, 'a', format='NETCDF4_64BIT_OFFSET')
+    mshnc = nc.Dataset(ltsmsh_name, 'a', format='NETCDF3_64BIT_OFFSET')
 
     try:
         # try to get LTSRegion and assign new value

--- a/polaris/tasks/ocean/geostrophic/__init__.py
+++ b/polaris/tasks/ocean/geostrophic/__init__.py
@@ -159,11 +159,10 @@ class Geostrophic(Task):
             option = 'refinement_factors_time'
         else:
             option = 'refinement_factors_space'
-        refinement_factors = config.getlist(
+        factor_strings = config.getlist(
             'spherical_convergence', f'{prefix}_{option}', dtype=str
         )
-        refinement_factors = ', '.join(refinement_factors)
-        config.set('convergence', option, value=refinement_factors)
+        config.set('convergence', option, value=', '.join(factor_strings))
         refinement_factors = config.getlist('convergence', option, dtype=float)
 
         base_resolution = config.getfloat(

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -230,9 +230,9 @@ class Viz(OceanIOStep):
                     )
                     plt.close()
                     continue
-                plt.ylim([-100, 0])
+                plt.ylim(-100, 0)
                 if field_name == 'temperature':
-                    plt.xlim([15, 25])
+                    plt.xlim(15, 25)
                 else:
                     plt.xlim(auto=True)
                 plt.xlabel(f'{field_name} ({field_units})')

--- a/polaris/tasks/ocean/sphere_transport/__init__.py
+++ b/polaris/tasks/ocean/sphere_transport/__init__.py
@@ -191,11 +191,10 @@ class SphereTransport(Task):
             option = 'refinement_factors_time'
         else:
             option = 'refinement_factors_space'
-        refinement_factors = config.getlist(
+        factor_strings = config.getlist(
             'spherical_convergence', f'{prefix}_{option}', dtype=str
         )
-        refinement_factors = ', '.join(refinement_factors)
-        config.set('convergence', option, value=refinement_factors)
+        config.set('convergence', option, value=', '.join(factor_strings))
         refinement_factors = config.getlist('convergence', option, dtype=float)
 
         base_resolution = config.getfloat(
@@ -215,7 +214,7 @@ class SphereTransport(Task):
 
         sph_trans_dir = f'spherical/{prefix}/{case_name}'
 
-        analysis_dependencies: Dict[str, Dict[str, Step]] = dict(
+        analysis_dependencies: Dict[str, Dict[float, Step]] = dict(
             mesh=dict(), init=dict(), forward=dict()
         )
         timesteps = list()

--- a/polaris/tasks/ocean/sphere_transport/filament_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/filament_analysis.py
@@ -133,7 +133,7 @@ class FilamentAnalysis(OceanIOStep):
                     filament_tau, filament_norm[i, :], '.-', label=mesh_name
                 )
             plt.plot([filament_tau[0], filament_tau[-1]], [1.0, 1.0], 'k--')
-            ax.set_xlim([filament_tau[0], filament_tau[-1]])
+            ax.set_xlim(filament_tau[0], filament_tau[-1])
             ax.set_xlabel(r'$\tau$')
             ax.set_ylabel(r'$l_f$')
             plt.title(f'Filament preservation diagnostic for {variable_name}')

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.1.0-alpha.3'
+__version__ = '1.1.0-alpha.4'

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -410,6 +410,7 @@ def setup_colormap(config, colormap_section):
 
     kwargs = section.getnumpy('norm_args')
 
+    norm: cols.Normalize
     if norm_type == 'symlog':
         norm = cols.SymLogNorm(**kwargs)
     elif norm_type == 'log':

--- a/polaris/viz/style.py
+++ b/polaris/viz/style.py
@@ -1,6 +1,7 @@
 import importlib.resources as imp_res
 import threading
 from contextlib import contextmanager
+from typing import Any, cast
 
 import matplotlib.pyplot as plt
 import matplotlib.style
@@ -30,8 +31,13 @@ def mplstyle_context(dpi=None):
     _register_colormaps()
 
     style_filename = str(imp_res.files('polaris.viz') / 'polaris.mplstyle')
-    overrides = {} if dpi is None else {'savefig.dpi': dpi}
-    with matplotlib.style.context(style_filename), plt.rc_context(overrides):
+    overrides: dict[str, Any] = {} if dpi is None else {'savefig.dpi': dpi}
+    # rc_context is typed with a Literal of every rcParam name; 'savefig.dpi'
+    # is one of them, but the key is built here rather than written inline
+    with (
+        matplotlib.style.context(style_filename),
+        plt.rc_context(cast(Any, overrides)),
+    ):
         yield
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,11 @@ dev = [
 ]
 
 [tool.mypy]
-python_version = "3.11"
+# Deliberately no python_version: mypy applies it when parsing installed type
+# stubs as well as our own code, so pinning it below the version those stubs
+# are written for stops mypy before it checks anything.  Leaving it out makes
+# mypy assume the interpreter it runs under, which is the one `deploy.py`
+# installs.
 check_untyped_defs = true
 ignore_missing_imports = true
 warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "cartopy",
+    "cartopy>=0.23.0",
     "cmocean",
     "gsw",
     "importlib_resources",
@@ -45,7 +45,7 @@ dependencies = [
     "ruamel.yaml",
     "requests",
     "scipy>=1.8.0",
-    "shapely>=2.0,<3.0",
+    "shapely>=2.0.4,<3.0",
     "termcolor",
     "tranche>=0.6.0",
     "xarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "scipy>=1.8.0",
     "shapely>=2.0,<3.0",
     "termcolor",
-    "tranche>=0.3.0",
+    "tranche>=0.6.0",
     "xarray",
 ]
 

--- a/tests/ocean/eos/test_ct_from_potential_density.py
+++ b/tests/ocean/eos/test_ct_from_potential_density.py
@@ -17,10 +17,13 @@ def test_round_trip_scalar():
 
 def test_round_trip_data_array():
     # a Beckmann and Haidvogel exponential profile over a 5000 m column
-    z_mid = xr.DataArray(
-        -np.linspace(78.125, 4921.875, 32), dims=('nVertLevels',)
+    z_mid = -np.linspace(78.125, 4921.875, 32)
+    # built explicitly rather than by arithmetic on a DataArray: numpy's
+    # signatures say a ufunc returns an ndarray, so the DataArray that
+    # xarray really hands back is invisible to a type checker
+    sigma_0 = xr.DataArray(
+        1028.0 - 3.0 * np.exp(z_mid / 500.0), dims=('nVertLevels',)
     )
-    sigma_0 = 1028.0 - 3.0 * np.exp(z_mid / 500.0)
 
     ct = ct_from_potential_density(sigma_0, 35.0)
 

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -1,0 +1,191 @@
+import configparser
+import os
+import re
+import tomllib
+
+import pytest
+from ruamel.yaml import YAML
+
+#: Packages whose conda name in ``deploy/pixi.toml.j2`` differs from the
+#: name pip knows them by in ``pyproject.toml``
+CONDA_NAMES = {
+    'matplotlib': 'matplotlib-base',
+}
+
+#: Packages the mypy hook installs that are not polaris dependencies.  Type
+#: stubs exist only for the checker, so ``pyproject.toml`` has nothing to
+#: agree with, but the deployed environment does install them.
+STUBS_ONLY = {'types-requests'}
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _split(requirement):
+    """Split a requirement into its name and its version constraint."""
+    for index, char in enumerate(requirement):
+        if char in '=<>!~[ ':
+            return requirement[:index], requirement[index:].strip()
+    return requirement, ''
+
+
+def _normalize(constraint):
+    """Put a conda and a pip constraint into the same form."""
+    constraint = constraint.strip().strip('"')
+    # conda spells "any version" as *, pip by saying nothing
+    return '' if constraint == '*' else constraint
+
+
+def _polaris_dependencies():
+    """The constraints in ``pyproject.toml``, by pip name."""
+    with open(os.path.join(_ROOT, 'pyproject.toml'), 'rb') as data:
+        pyproject = tomllib.load(data)
+    return dict(
+        _split(entry) for entry in pyproject['project']['dependencies']
+    )
+
+
+def _deploy_dependencies():
+    """
+    The constraints the deployed environment is built from, by conda name
+
+    ``deploy/pixi.toml.j2`` is a template whose versions come from
+    ``deploy/pins.cfg``, and mache combines the two when it deploys.  The
+    pins are substituted here rather than rendering the template, so that
+    the jinja conditionals -- which depend on the platform and on how the
+    environment was asked for -- do not have to be answered.
+    """
+    pins = configparser.ConfigParser()
+    pins.read(os.path.join(_ROOT, 'deploy', 'pins.cfg'))
+    values = {}
+    for section in pins.sections():
+        values.update(dict(pins.items(section)))
+
+    with open(os.path.join(_ROOT, 'deploy', 'pixi.toml.j2')) as data:
+        template = data.read()
+
+    dependencies = {}
+    in_dependencies = False
+    for line in template.split('\n'):
+        stripped = line.strip()
+        if stripped.startswith('['):
+            in_dependencies = stripped == '[dependencies]'
+            continue
+        if not in_dependencies or not stripped or stripped.startswith('#'):
+            continue
+        if stripped.startswith('{%') or stripped.startswith('{#'):
+            continue
+        match = re.match(r'^"?([A-Za-z0-9_.\-]+)"?\s*=\s*(.+)$', stripped)
+        if match is None:
+            continue
+        name, value = match.groups()
+        # a table entry pins the version alongside a build string
+        table = re.search(r'version\s*=\s*"([^"]*)"', value)
+        constraint = table.group(1) if table else value.strip().strip('"')
+        # {{ pin }} placeholders come from pins.cfg
+        constraint = re.sub(
+            r'\{\{\s*(\w+)\s*\}\}',
+            lambda m: values.get(m.group(1), m.group(0)),
+            constraint,
+        )
+        dependencies[name] = constraint
+    return dependencies
+
+
+def _mypy_hook_dependencies():
+    """The packages the mypy pre-commit hook installs."""
+    with open(os.path.join(_ROOT, '.pre-commit-config.yaml')) as data:
+        config = YAML(typ='safe').load(data)
+    for repo in config['repos']:
+        for hook in repo['hooks']:
+            if hook['id'] == 'mypy':
+                return dict(
+                    _split(entry)
+                    for entry in hook.get('additional_dependencies', [])
+                )
+    raise AssertionError('There is no mypy hook in .pre-commit-config.yaml')
+
+
+def test_the_deploy_template_lists_the_polaris_dependencies():
+    """
+    ``deploy/`` is what most users get, so every polaris dependency has to
+    be in the environment it builds.
+    """
+    deploy = _deploy_dependencies()
+    missing = [
+        name
+        for name in _polaris_dependencies()
+        if CONDA_NAMES.get(name, name) not in deploy
+    ]
+    assert not missing, (
+        f'These are polaris dependencies but are not in '
+        f'deploy/pixi.toml.j2, so a deployed environment would not have '
+        f'them: {", ".join(sorted(missing))}.'
+    )
+
+
+@pytest.mark.parametrize('package', sorted(_polaris_dependencies()))
+def test_pyproject_agrees_with_the_deployed_environment(package):
+    """
+    deploy/ is what most polaris users get, so it is the source of truth
+    and pyproject.toml follows it.  Where the two name a version they have
+    to name the same one, or a pip install and a deployed environment are
+    two different environments wearing one set of version numbers.
+    """
+    deploy = _deploy_dependencies()
+    conda_name = CONDA_NAMES.get(package, package)
+    if conda_name not in deploy:
+        pytest.skip(f'{package} is not in the deployed environment')
+    assert _normalize(_polaris_dependencies()[package]) == _normalize(
+        deploy[conda_name]
+    ), (
+        f'pyproject.toml asks for {package}'
+        f'{_normalize(_polaris_dependencies()[package]) or " (any version)"} '
+        f'but deploy/pixi.toml.j2 asks for {conda_name} '
+        f'{_normalize(deploy[conda_name]) or "(any version)"}.  deploy/ is '
+        f'the source of truth; change pyproject.toml to match it, or change '
+        f'both.'
+    )
+
+
+@pytest.mark.parametrize('package', sorted(_mypy_hook_dependencies()))
+def test_the_mypy_hook_pins_match_the_environment(package):
+    """
+    pre-commit installs the hook's dependencies into an environment of its
+    own and cannot read a version from anywhere else, so the constraints in
+    .pre-commit-config.yaml repeat what deploy/ and pyproject.toml say.  A
+    hook pinned to a version polaris does not use checks against the wrong
+    library, which is worse than not checking, because it still looks like
+    it is working.
+    """
+    hook = _normalize(_mypy_hook_dependencies()[package])
+
+    deploy = _deploy_dependencies()
+    conda_name = CONDA_NAMES.get(package, package)
+    assert conda_name in deploy, (
+        f'The mypy hook installs "{package}" but deploy/pixi.toml.j2 has '
+        f'no "{conda_name}", so the hook would check against a library the '
+        f'deployed environment does not have.'
+    )
+    assert hook == _normalize(deploy[conda_name]), (
+        f'The mypy hook pins {package}{hook} but deploy/pixi.toml.j2 asks '
+        f'for {conda_name} {deploy[conda_name]}.'
+    )
+
+    if package in STUBS_ONLY:
+        return
+    polaris = _polaris_dependencies()
+    assert package in polaris, (
+        f'The mypy hook installs "{package}", which is not a polaris '
+        f'dependency.  Add it to pyproject.toml, or to STUBS_ONLY if it is '
+        f'only for the type checker.'
+    )
+    assert hook == _normalize(polaris[package]), (
+        f'The mypy hook pins {package}{hook} but pyproject.toml asks for '
+        f'{package}{polaris[package]}.'
+    )
+
+
+@pytest.mark.parametrize('package', sorted(STUBS_ONLY))
+def test_stub_packages_are_not_polaris_dependencies(package):
+    """A stub package is for the checker; shipping it would be a mistake."""
+    assert package not in _polaris_dependencies()

--- a/utils/omega/convert_mpaso_ic_to_omega.py
+++ b/utils/omega/convert_mpaso_ic_to_omega.py
@@ -2,6 +2,7 @@
 
 import argparse
 from pathlib import Path
+from typing import cast
 
 import gsw
 import numpy as np
@@ -688,6 +689,7 @@ def _save_percent_difference_visualizations(
         import matplotlib.colors as mcolors
         import matplotlib.pyplot as plt
         import mosaic
+        from cartopy.mpl.geoaxes import GeoAxes
     except ImportError as exc:
         raise ImportError(
             'Visualization requires cartopy, cmocean, matplotlib, and mosaic.'
@@ -856,13 +858,17 @@ def _save_percent_difference_visualizations(
         if not np.any(valid):
             return
 
-        fig, ax = plt.subplots(
+        fig, axis = plt.subplots(
             1,
             1,
             figsize=(14, 8),
             subplot_kw=dict(projection=salinity_projection),
             constrained_layout=True,
         )
+        # a projection makes this a GeoAxes, which is where add_feature(),
+        # gridlines() and set_global() come from; matplotlib's signature
+        # cannot know that
+        ax = cast(GeoAxes, axis)
 
         da = xr.DataArray(field, dims=['nCells'])
         norm = mcolors.TwoSlopeNorm(vmin=-0.2, vcenter=0.0, vmax=0.2)


### PR DESCRIPTION
This makes mypy actually check polaris, and fixes the 141 errors that turned out to be waiting once it could. It started as a one-line fix to a stale `python_version` pin and grew to cover the reason that pin had gone unnoticed: nothing was type-checking anything.

## mypy could not run, and the hook that could was checking almost nothing

`[tool.mypy] python_version` was pinned to `3.11` while `deploy.py` installs 3.14. mypy applies that setting when parsing installed type stubs as well as our own code, so with numpy 2.5's stubs using a PEP 695 `type` statement, mypy stopped at a syntax error in `numpy/__init__.pyi` before checking anything at all. The pin is now gone rather than raised, since raising it only defers the same breakage to the next dependency whose stubs adopt newer syntax.

That had gone unnoticed because the pre-commit hook never hit it. `mirrors-mypy` runs in an isolated environment holding only `types-requests`, so numpy, xarray and polaris itself are all absent, and with `ignore_missing_imports` set they resolve to `Any`. Every changed file was being checked against the standard library alone. The hook reported no issues on a tree where mypy finds 141.

The hook keeps its isolated environment, since that is all the lint job on CI has, but is now given the four packages polaris types against most: tranche, numpy, xarray and matplotlib. With them the hook finds 48 errors on the tree before this branch and none after, where before it found none either way. cartopy is deliberately left out because it needs system GEOS, and making the lint job depend on that is a poor trade for what it would add. Anything not listed is still `Any`, so mypy run from a deployed environment checks more than CI does; the two are not expected to agree exactly.

## Two of the errors were real bugs

Most of the 141 were annotations disagreeing with correct code, but two were not.

`write_coeffs_reconstruct` is a boolean config option — `mpas_ocean.cfg` sets it to `True` and its comment reads "whether to" — but it was read with `get()`, so it held the string `'True'`. Setting it to `False` in a config file gave the string `'False'`, which is truthy, so **the option could not be turned off**. It is now read with `getboolean()` and a fallback of `False`, which also retires the `has_option()` guard, since a fallback covers a missing option and a missing section alike. This is the one behaviour change in the branch and the place most worth a reviewer's attention.

`lts_regions.py` asked for `format='NETCDF4_64BIT_OFFSET'`, which is not a netCDF4 format at all and raises in write mode. The call opens in append mode, where `format` is ignored, so this changed nothing at runtime; it is corrected to `NETCDF3_64BIT_OFFSET` so it means what it says.

## The rest, by shape

Roughly two thirds of the errors came from one upstream cause: tranche's typed getters were annotated as always returning `X | None`, when they raise for a missing option and return `None` only with an explicit `fallback`. Every caller therefore had to guard against a `None` that could not occur, and arithmetic on a config value was a type error. That is fixed in tranche 0.6.0, which this branch requires.

What remained fell into a few patterns, none of which changes behaviour: a name reused for three different types in the spherical convergence tasks, and lists reassigned to arrays elsewhere, both now given separate names; matplotlib limits and figure sizes passed as lists where the documented call takes two floats or a tuple; cartopy axes typed as plain `Axes` when a projection makes them `GeoAxes`; and xarray dimension and variable names, which are `Hashable` rather than `str`, converted explicitly where they are indexed or split.

The developer's guide also still called the config parser `MpasConfigParser`, from before it moved out of MPAS-Tools. Two of those four mentions were cross-references that resolved through intersphinx to MPAS-Tools' class rather than the one polaris calls, which is worse than a broken link. The same sentence advertised `getinteger()`, which exists on neither `Tranche` nor `ConfigParser`.

## Dependencies and version

Two dependency updates land together so that one alpha bump covers both: tranche 0.6.0, which the typing above requires, and mache 3.12.0, absorbed from `update-to-mache-3.12.0` with its original authorship. That branch is superseded by this one.

An existing environment is out of date on both counts and needs `./deploy.py` re-run, though the lint hook itself does not depend on that.

Checklist
* [x] Developer's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

Closes #723 