### PR TITLE
Two fixes to the benchmark utility

### DIFF
--- a/utils/benchmark/gitrepo.py
+++ b/utils/benchmark/gitrepo.py
@@ -761,7 +761,13 @@ def _check_dirty(path, model):
     ``--ignore-submodules=dirty``, which ignores a submodule's work tree
     but still reports one checked out at a commit other than the pinned
     one.  That matters for jigsaw-python and MALI-Dev, which affect
-    results but are not among the hashes ``compare_shas`` records.
+    results but are not among the hashes ``compare_shas`` records, and
+    which nothing later puts right.
+
+    The submodule the model is built from is the exception, and uses
+    ``--ignore-submodules=all``: polaris re-initializes the nested
+    submodules it builds against before it builds, so their commits are
+    not ours to police.
 
     An untracked file outside the ``polaris`` package is not dirty
     either.  A working polaris worktree normally carries notes, plan
@@ -829,7 +835,16 @@ def _check_dirty(path, model):
         # no source here to be dirty; ``git status`` in the empty
         # directory would walk up and report on polaris again
         return False, '', untracked
-    command = 'git status --porcelain --ignore-submodules=dirty'
+    # ...but inside that submodule, use =all rather than =dirty.  Polaris
+    # runs `git submodule update --init --recursive` over the nested
+    # submodules it builds against -- for Omega, ekat, scorpio,
+    # components/omega/external and cime -- as the first step of the build,
+    # so one of them sitting at a commit other than the pinned one is a
+    # state that the very next step resets.  Reporting it stops a benchmark
+    # for something that was about to be put right, and =dirty already
+    # ignored edits to a nested submodule's files, so =all gives up nothing
+    # that was being caught.
+    command = 'git status --porcelain --ignore-submodules=all'
     kind = 'uncommitted or untracked changes'
     if model in IN_SOURCE_BUILDS:
         command = f'{command} --untracked-files=no'

--- a/utils/benchmark/shared.py
+++ b/utils/benchmark/shared.py
@@ -10,6 +10,15 @@ import os
 import subprocess
 import sys
 
+#: The shell to run commands in.
+#:
+#: ``shell=True`` runs ``/bin/sh``, and where that is a symlink to bash --
+#: as it is on the machines polaris runs on -- bash started under that name
+#: enters POSIX mode, where process substitution is a syntax error.  The
+#: load scripts source bash-completion files that use ``< <(...)``, so
+#: sourcing one under ``/bin/sh`` fails before polaris is ever reached.
+SHELL = '/bin/bash'
+
 
 def to_abs(path, base_path):
     """
@@ -91,12 +100,13 @@ def check_call(args, logger=None, **kwargs):
         If the command returns a non-zero exit code
     """
     if logger is None:
-        subprocess.check_call(args, shell=True, **kwargs)
+        subprocess.check_call(args, shell=True, executable=SHELL, **kwargs)
         return
 
     process = subprocess.Popen(
         args,
         shell=True,
+        executable=SHELL,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         **kwargs,
@@ -142,6 +152,7 @@ def check_output(args, cwd=None):
     process = subprocess.run(
         args,
         shell=True,
+        executable=SHELL,
         cwd=cwd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
This fixes two problems in `utils/benchmark` that between them stopped a benchmark of the `omega_pr` suite from starting at all. Both are about the driver's view of the world being subtly wrong rather than about what it does with the answer, and each produced an error message that pointed somewhere other than the actual cause.

## The driver ran its commands in a shell that cannot source the load script

`subprocess(..., shell=True)` runs `/bin/sh`. On the machines polaris runs on that is a symlink to bash, and bash started under the name `sh` enters POSIX mode, where process substitution is a syntax error rather than a feature.

Every command the driver runs sources a load script, which in turn sources the environment's bash-completion files, and at least one of those uses `done < <(...)`. So setting up either side died on a syntax error inside a completion script for an audio utility, before `polaris` was reached at all. The failure was reported as the whole `polaris suite` command failing, which is a long way from the truth.

The shell is now named explicitly, the way `utils/e3sm_update` already does it, at all three places the driver shells out rather than only the one that happened to fail first. A module-level constant carries the reason so the three cannot drift apart.

## The driver refused to start over a state the next step resets

The dirty check ran `git status --porcelain --ignore-submodules=dirty` inside the submodule the model is built from. That mode ignores changes to a nested submodule's files but still reports one checked out at a commit other than the pinned one, so a benchmark was refused with a message about reproducibility whenever a nested submodule had drifted.

That is a state polaris is about to correct. The first thing the Omega build script does is

```
git submodule update --init --recursive \
    externals/ekat externals/scorpio components/omega/external cime
```

so those four are put right before anything is compiled, and which of them are needed is polaris's business rather than the driver's. In the run that prompted this, the two that blocked it — `cime` and `externals/ekat` — are both on that list.

The check on the model's submodule now uses `--ignore-submodules=all`. This gives up nothing that was being caught: `=dirty` was already blind to edits inside a nested submodule, so commit drift was the only thing it reported, and that is exactly the part polaris owns. The check on the polaris worktree itself is unchanged and still uses `=dirty`, because drift in `jigsaw-python` or `MALI-Dev` really does change results and nothing later puts it right.

## Scope

Only `utils/benchmark` changes, so nothing here affects a task, a suite or the polaris package. Two further gaps in the driver are known and not addressed here: it has no way to label a run, and `component_path` still has to be given as a hand-written hash.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes