### PR TITLE
Update to tranche 0.6.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         verbose: true
         additional_dependencies:
           - 'types-requests'
-          - 'tranche>=0.6.0'
+          - 'tranche>=0.6.1'
           - 'numpy>=2.0,<3.0'
           - 'xarray'
           - 'matplotlib>=3.9.0'

--- a/deploy/pixi.toml.j2
+++ b/deploy/pixi.toml.j2
@@ -50,7 +50,7 @@ requests = "*"
 scipy = ">=1.8.0"
 shapely = ">=2.0.4,<3.0"
 termcolor = "*"
-tranche = ">=0.6.0"
+tranche = ">=0.6.1"
 xarray = "*"
 
 # Static typing

--- a/polaris/version.py
+++ b/polaris/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.1.0-alpha.4'
+__version__ = '1.1.0-alpha.5'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "scipy>=1.8.0",
     "shapely>=2.0.4,<3.0",
     "termcolor",
-    "tranche>=0.6.0",
+    "tranche>=0.6.1",
     "xarray",
 ]
 


### PR DESCRIPTION
This pull request updates polaris to `tranche` 0.6.1 and bumps the polaris version to `1.1.0-alpha.5`.

tranche 0.6.0 introduced a typing regression: `getlist()` called without a `dtype` no longer infers `list[str]`. It infers an unsolved type variable instead, so mypy demands an annotation at the call site for any bare call, for example `fields = config.getlist('section', 'fields')`. `main` only passes today because its existing bare `getlist` results happen to be consumed rather than bound to a new variable; any new call would fail. tranche 0.6.1 fixes this by giving the no-`dtype` case its own overload.

Three files declare the tranche pin and a test requires all three to agree, so all three are updated: `pyproject.toml`, `deploy/pixi.toml.j2`, and the mypy hook's `additional_dependencies` in `.pre-commit-config.yaml`.

Because this is a dependency change, every deployed environment is stale until it is redeployed. The load scripts detect that only by comparing the polaris version, so the alpha version is bumped in a separate, final commit.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes
