### PR TITLE
Add the vertical reduction to Omega analysis

### DIFF
--- a/docs/design_docs/ocean_analysis.md
+++ b/docs/design_docs/ocean_analysis.md
@@ -973,6 +973,16 @@ is explained in context in {ref}`design-ocean-analysis-initial`.
   follow-up is a stamp derived from the code and configuration themselves,
   covering the full dependency graph of a product, so that correctness does not
   rest on discipline.
+- **Separate slicing from weighting an elevation range.**  Both are parsed by
+  `parse_vertical_reduction()` into one `VerticalReduction` whose `kind` spans
+  both, but they are different operations with different workflows: a slice is
+  completed by `apply_vertical_reduction()`, while a range yields only weights
+  and the diagnostic applies them, because what a weighted sum means belongs to
+  the diagnostic rather than to the vertical coordinate.  The two are already
+  separate at the config level, so the shared type buys little.  Splitting them
+  would make the asymmetry explicit rather than something a caller has to know.
+  Raised by @cbegeman in review; deferred as a follow-up rather than reworked
+  under the September 15 deadline.
 - **Measure Polaris's per-step overhead** --- setup and run of a step that does
   nothing --- and record it under the organizing principles, so that the step
   sizing targets in principle 9 rest on a number rather than on judgment.

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -740,6 +740,7 @@
    vertical.compute_zint_zmid_from_layer_thickness
    vertical.diagnostics.geom_thickness_from_ds
    vertical.diagnostics.pseudothickness_from_ds
+   vertical.diagnostics.get_z_mid_and_interface
    vertical.diagnostics.depth_from_thickness
    vertical.grid_1d.generate_1d_grid
    vertical.grid_1d.write_1d_grid

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -132,7 +132,77 @@ def pseudothickness_from_ds(
     return pseudothickness, spec_vol
 
 
+def get_z_mid_and_interface(ds, allow_reconstruct=False):
+    """
+    Get the elevation of layer midpoints and of layer interfaces
+
+    What the model wrote is preferred.  Reconstructing them from
+    ``layerThickness`` is available but off by default, because it is not
+    always valid: the monthly mean of geometric thickness cannot be derived
+    from the monthly means of pseudo-thickness and specific volume, so
+    analysis of monthly means has to read what the model wrote or refuse.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A data set holding the vertical geometry, with MPAS-Ocean names
+
+    allow_reconstruct : bool, optional
+        Whether to reconstruct the geometry from ``layerThickness`` when the
+        data set does not carry it
+
+    Returns
+    -------
+    z_mid : xarray.DataArray
+        The elevation of layer midpoints, in m, positive up
+
+    z_interface : xarray.DataArray
+        The elevation of layer interfaces, in m, positive up
+
+    Raises
+    ------
+    ValueError
+        If the data set lacks the geometry and it may not be reconstructed
+    """
+    missing = [name for name in ('zMid', 'zInterface') if name not in ds]
+    if not missing:
+        return ds.zMid, ds.zInterface
+    if not allow_reconstruct:
+        raise ValueError(
+            f'The data set has no {", ".join(missing)}, which is the '
+            f'vertical geometry an elevation is a position in.  Polaris '
+            f'cannot reconstruct it from the monthly means of the other '
+            f'fields, so a simulation has to write it for its output to be '
+            f'analysed at an elevation.'
+        )
+    return _z_from_thickness(ds)
+
+
 def depth_from_thickness(ds):
+    """
+    Get the elevation of the midpoint of each layer
+
+    A thin face on :py:func:`get_z_mid_and_interface` for callers that want
+    only the midpoints.  What the model wrote is preferred; the geometry is
+    reconstructed from ``layerThickness`` when it is absent.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        An ocean dataset carrying the geometry or ``layerThickness``, and
+        optionally ``ssh`` and ``bottomDepth``
+
+    Returns
+    -------
+    z_mid : xarray.DataArray
+        The location in meters from the sea surface of the midpoint of each
+        layer, positive upward
+    """
+    z_mid, _ = get_z_mid_and_interface(ds, allow_reconstruct=True)
+    return z_mid
+
+
+def _z_from_thickness(ds):
     """
     Compute the depth of the midpoint of each layer from `layerThickness`.
 
@@ -221,4 +291,4 @@ def depth_from_thickness(ds):
                 'The maximum discrepancy between bottom_depth and the lower'
                 f'boundary of z_interface is {np.max(np.abs(cell_diff))}'
             )
-    return z_mid
+    return z_mid, z_interface

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -191,6 +191,30 @@ def elevation_label(elevation):
     return f'{elevation:g}m'
 
 
+def range_bound_label(elevation, keyword):
+    """
+    Get the label one end of an elevation range is identified by
+
+    Parameters
+    ----------
+    elevation : float
+        The elevation of the bound in m, positive up, or an infinity where
+        the bound resolves per column
+
+    keyword : str
+        ``'top'`` for the upper bound and ``'bottom'`` for the lower one,
+        which is what an infinite bound is labeled with
+
+    Returns
+    -------
+    label : str
+        The label, e.g. ``'top'`` or ``'-700m'``
+    """
+    if np.isinf(elevation):
+        return keyword
+    return elevation_label(elevation)
+
+
 def is_whole_column(reduction):
     """
     Whether an elevation range covers every valid layer of every column
@@ -408,8 +432,8 @@ def _parse_elevation_range(spec):
             f'given as <top>:<bottom> in m, positive up, so the first '
             f'elevation is the higher one.'
         )
-    top_label = _range_bound_label(z_top, 'top')
-    bot_label = _range_bound_label(z_bot, 'bottom')
+    top_label = range_bound_label(z_top, 'top')
+    bot_label = range_bound_label(z_bot, 'bottom')
     return VerticalReduction(
         kind='range',
         label=f'{top_label}_to_{bot_label}',
@@ -431,10 +455,3 @@ def _parse_range_bound(spec, text, keyword):
             f'  It is either "{keyword}" or an elevation in m, positive up, '
             f'so negative within the ocean.'
         ) from None
-
-
-def _range_bound_label(elevation, keyword):
-    """The label one end of an elevation range is identified by"""
-    if np.isinf(elevation):
-        return keyword
-    return elevation_label(elevation)

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -309,16 +309,15 @@ def elevation_range_weights(
     mass, and the geometric coordinate enters only through the partial layers
     at the boundaries.
 
-    Only the whole column, ``top:bottom``, is implemented so far.  It is the
-    range in which every valid layer is whole, so no ``z_interface`` is read
-    and none need be passed.  A range with a boundary in the interior of a
-    layer needs the vertical geometry and is not implemented yet.
+    The whole column, ``top:bottom``, is the one range in which every valid
+    layer is whole, so its overlap fraction is one, no ``z_interface`` is read
+    and none need be passed.
 
     Parameters
     ----------
     z_interface : xarray.DataArray or None
-        The elevation of layer interfaces, needed only for a range with a
-        finite boundary
+        The elevation of layer interfaces, needed for any range but the whole
+        column
 
     layer_mass : xarray.DataArray
         The mass per unit area of each layer, from
@@ -347,20 +346,37 @@ def elevation_range_weights(
 
     Raises
     ------
-    NotImplementedError
-        If either bound is a finite elevation
+    ValueError
+        If a range with a finite bound is asked for without ``z_interface``
     """
-    if not (z_top == np.inf and z_bot == -np.inf):
-        raise NotImplementedError(
-            'Weighting an elevation range with a boundary in the interior of '
-            'a layer needs the vertical geometry, which is not implemented '
-            'yet.  The range that works is the whole column, top:bottom.'
-        )
-
     n_levels = layer_mass.sizes['nVertLevels']
     levels = xr.DataArray(np.arange(n_levels), dims='nVertLevels')
     in_column = (levels >= min_level_cell) & (levels <= max_level_cell)
-    weights = layer_mass.where(in_column, 0.0)
+
+    if z_interface is None:
+        if not (z_top == np.inf and z_bot == -np.inf):
+            raise ValueError(
+                'z_interface is needed to weigh an elevation range with a '
+                'bound in the interior of a layer.  The one range that needs '
+                'no vertical geometry is the whole column, top:bottom, in '
+                'which every valid layer is whole.'
+            )
+        fraction = 1.0
+    else:
+        z_upper = _layer_bound(z_interface, slice(0, -1))
+        z_lower = _layer_bound(z_interface, slice(1, None))
+        thickness = z_upper - z_lower
+        overlap = np.minimum(z_upper, z_top) - np.maximum(z_lower, z_bot)
+        # a layer the range misses entirely has a negative overlap, and one
+        # with no thickness has no fraction to speak of; both weigh nothing
+        fraction = xr.where(
+            thickness > 0.0, np.maximum(overlap, 0.0) / thickness, 0.0
+        )
+
+    # a layer outside the range or outside the column weighs nothing rather
+    # than NaN, since a model may write anything below the seafloor and a NaN
+    # here would poison the sum the weights are for
+    weights = (layer_mass * fraction).where(in_column, 0.0)
     weights.attrs = dict(
         units='kg m-2',
         long_name='mass per unit area within the elevation range',
@@ -457,6 +473,14 @@ def apply_vertical_reduction(
 
     da_map = da.isel(nVertLevels=safe).where(in_column)
     return da_map.drop_vars('nVertLevels', errors='ignore')
+
+
+def _layer_bound(z_interface, levels):
+    """One of the two interfaces bounding each layer, along ``nVertLevels``"""
+    z_bound = z_interface.isel({INTERFACE_DIM: levels})
+    return z_bound.drop_vars(INTERFACE_DIM, errors='ignore').rename(
+        {INTERFACE_DIM: 'nVertLevels'}
+    )
 
 
 def _interpolate_to_elevation(

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -1,0 +1,206 @@
+"""
+Reduce a field with a vertical dimension to a horizontal map.
+
+Slicing at the sea surface, the seafloor, a layer index or an elevation, and
+integrating over an elevation range, are cases of one operation: every one of
+them turns ``nVertLevels`` into nothing.  Keeping them behind a single entry
+point is what lets ocean heat content be a field of the climatology maps
+rather than a product of its own.
+
+This module is deliberately dependency-light --- it imports nothing from
+:py:class:`polaris.Step` --- so that it can be unit tested directly and reused
+by any vertically reduced diagnostic.
+"""
+
+from typing import NamedTuple, Optional
+
+import numpy as np
+import xarray as xr
+
+
+class VerticalReduction(NamedTuple):
+    """
+    One way of reducing a field with a vertical dimension to a horizontal map
+
+    Attributes
+    ----------
+    kind : str
+        ``'top'``, ``'bottom'``, ``'index'`` or ``'elevation'``
+
+    label : str
+        The label that identifies the reduction in a file name and a plot
+        title, e.g. ``'top'``, ``'k10'`` or ``'-100m'``
+
+    level : int or None
+        The zero-based vertical index, for ``'index'``
+
+    elevation : float or None
+        The elevation in m, positive up, for ``'elevation'``
+    """
+
+    kind: str
+    label: str
+    level: Optional[int] = None
+    elevation: Optional[float] = None
+
+
+# The reductions that pick a layer by index need no vertical geometry at all,
+# so they work before there is any.  Interpolating to an elevation and
+# integrating over an elevation range both read ``zMid`` and ``zInterface``
+# and are not implemented yet.
+IMPLEMENTED_KINDS = ('top', 'bottom', 'index')
+
+
+def parse_vertical_reduction(spec):
+    """
+    Parse one entry of the ``elevations`` config option
+
+    Parameters
+    ----------
+    spec : str
+        ``'top'``, ``'bottom'``, ``'k<index>'`` with a zero-based index, or an
+        elevation in m, positive up, so negative within the ocean
+
+    Returns
+    -------
+    reduction : VerticalReduction
+        The parsed reduction
+
+    Raises
+    ------
+    ValueError
+        If ``spec`` is none of those
+    """
+    spec = spec.strip()
+    lowered = spec.lower()
+
+    if lowered in ('top', 'bottom'):
+        return VerticalReduction(kind=lowered, label=lowered)
+
+    if lowered.startswith('k'):
+        try:
+            index = int(spec[1:])
+        except ValueError:
+            index = -1
+        if index < 0:
+            raise ValueError(
+                f'"{spec}" is not a vertical index.  A fixed layer is given '
+                f'as k<index> with a zero-based index, e.g. k0 for the '
+                f'topmost layer of the grid.'
+            )
+        return VerticalReduction(kind='index', label=f'k{index}', level=index)
+
+    try:
+        elevation = float(spec)
+    except ValueError:
+        raise ValueError(
+            f'"{spec}" is not a vertical reduction.  Use "top", "bottom", '
+            f'"k<index>" for a fixed layer, or an elevation in m, positive '
+            f'up, so negative within the ocean.'
+        ) from None
+    return VerticalReduction(
+        kind='elevation',
+        label=elevation_label(elevation),
+        elevation=elevation,
+    )
+
+
+def elevation_label(elevation):
+    """
+    Get the label an elevation is identified by in file names and plot titles
+
+    Parameters
+    ----------
+    elevation : float
+        The elevation in m, positive up
+
+    Returns
+    -------
+    label : str
+        The label, e.g. ``'-100m'``
+    """
+    return f'{elevation:g}m'
+
+
+def apply_vertical_reduction(
+    da,
+    reduction,
+    z_mid=None,
+    z_interface=None,
+    layer_mass=None,
+    min_level_cell=None,
+    max_level_cell=None,
+):
+    """
+    Reduce a field with a vertical dimension to a horizontal map
+
+    Only the reductions in :py:data:`IMPLEMENTED_KINDS` are available so far;
+    interpolating to an elevation and integrating over an elevation range
+    raise :py:exc:`NotImplementedError`, since they need vertical geometry
+    that nothing writes yet.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        The field to reduce, with an ``nVertLevels`` dimension
+
+    reduction : VerticalReduction
+        How to reduce it, from :py:func:`parse_vertical_reduction`
+
+    z_mid : xarray.DataArray, optional
+        The elevation of layer midpoints, needed only for the reductions that
+        are not implemented yet
+
+    z_interface : xarray.DataArray, optional
+        The elevation of layer interfaces, as for ``z_mid``
+
+    layer_mass : xarray.DataArray, optional
+        The mass per unit area of each layer, as for ``z_mid``
+
+    min_level_cell : xarray.DataArray
+        The zero-based index of the topmost valid layer of each column
+
+    max_level_cell : xarray.DataArray
+        The zero-based index of the bottommost valid layer of each column
+
+    Returns
+    -------
+    da_map : xarray.DataArray
+        The reduced field, without an ``nVertLevels`` dimension, masked where
+        the reduction falls outside the column
+
+    Raises
+    ------
+    NotImplementedError
+        If the reduction needs vertical geometry
+    """
+    if reduction.kind not in IMPLEMENTED_KINDS:
+        raise NotImplementedError(
+            f'Reducing a field to {reduction.label} needs the vertical '
+            f'geometry, which is not implemented yet.  The reductions that '
+            f'work are "top", "bottom" and "k<index>".'
+        )
+    if min_level_cell is None or max_level_cell is None:
+        raise ValueError(
+            'min_level_cell and max_level_cell are needed to tell the valid '
+            'layers of each column from the rest.'
+        )
+
+    n_levels = da.sizes['nVertLevels']
+    if reduction.kind == 'top':
+        index = min_level_cell
+    elif reduction.kind == 'bottom':
+        index = max_level_cell
+    else:
+        index = xr.full_like(min_level_cell, reduction.level)
+
+    # a column is land where maxLevelCell is above minLevelCell, and an index
+    # outside the valid range has no value to take, so both are masked rather
+    # than extrapolated
+    in_column = (index >= min_level_cell) & (index <= max_level_cell)
+    # index into the array only where there is something to index, so that a
+    # masked column cannot raise
+    safe = np.minimum(np.maximum(index, 0), n_levels - 1)
+
+    da_map = da.isel(nVertLevels=safe).where(in_column)
+    return da_map.drop_vars('nVertLevels', errors='ignore')

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -2,10 +2,17 @@
 Reduce a field with a vertical dimension to a horizontal map.
 
 Slicing at the sea surface, the seafloor, a layer index or an elevation, and
-integrating over an elevation range, are cases of one operation: every one of
-them turns ``nVertLevels`` into nothing.  Keeping them behind a single entry
-point is what lets ocean heat content be a field of the climatology maps
-rather than a product of its own.
+integrating over an elevation range, both turn ``nVertLevels`` into nothing,
+and both are described by the same parsed reduction.  That is what lets ocean
+heat content be a field group of the climatology maps rather than a product of
+its own.
+
+They differ in how they get there.  A slice picks one layer, and
+``apply_vertical_reduction`` does that for any field.  A range is a weighted
+integral, so this module supplies the weights --- ``elevation_range_weights``
+--- and the diagnostic that consumes them supplies the rest, because what the
+weighted sum of a field means is a property of the diagnostic rather than of
+the vertical coordinate.
 
 This module is deliberately dependency-light --- it imports nothing from
 :py:class:`polaris.Step` --- so that it can be unit tested directly and reused
@@ -25,29 +32,39 @@ class VerticalReduction(NamedTuple):
     Attributes
     ----------
     kind : str
-        ``'top'``, ``'bottom'``, ``'index'`` or ``'elevation'``
+        ``'top'``, ``'bottom'``, ``'index'``, ``'elevation'`` or ``'range'``
 
     label : str
         The label that identifies the reduction in a file name and a plot
-        title, e.g. ``'top'``, ``'k10'`` or ``'-100m'``
+        title, e.g. ``'top'``, ``'k10'``, ``'-100m'`` or ``'top_to_-700m'``
 
     level : int or None
         The zero-based vertical index, for ``'index'``
 
     elevation : float or None
         The elevation in m, positive up, for ``'elevation'``
+
+    z_top : float or None
+        The upper bound of the range in m, positive up, for ``'range'``.  It
+        is ``inf`` where the bound is the free surface of each column.
+
+    z_bot : float or None
+        The lower bound of the range in m, positive up, for ``'range'``.  It
+        is ``-inf`` where the bound is the seafloor of each column.
     """
 
     kind: str
     label: str
     level: Optional[int] = None
     elevation: Optional[float] = None
+    z_top: Optional[float] = None
+    z_bot: Optional[float] = None
 
 
 # The reductions that pick a layer by index need no vertical geometry at all,
-# so they work before there is any.  Interpolating to an elevation and
-# integrating over an elevation range both read ``zMid`` and ``zInterface``
-# and are not implemented yet.
+# so they work before there is any.  Interpolating to an elevation reads
+# ``zMid`` and ``zInterface`` and is not implemented yet.  An elevation range
+# is not a slice and is not here at all; see ``elevation_range_weights``.
 IMPLEMENTED_KINDS = ('top', 'bottom', 'index')
 
 
@@ -97,13 +114,18 @@ def get_valid_level_range(ds):
 
 def parse_vertical_reduction(spec):
     """
-    Parse one entry of the ``elevations`` config option
+    Parse one entry of the ``elevations`` or the ``elevation_ranges`` config
+    option
+
+    Both options describe a way of turning ``nVertLevels`` into nothing, so
+    both are parsed here and the result says which way it is.
 
     Parameters
     ----------
     spec : str
-        ``'top'``, ``'bottom'``, ``'k<index>'`` with a zero-based index, or an
-        elevation in m, positive up, so negative within the ocean
+        ``'top'``, ``'bottom'``, ``'k<index>'`` with a zero-based index, an
+        elevation in m, positive up, so negative within the ocean, or an
+        elevation range written ``<top>:<bottom>``
 
     Returns
     -------
@@ -117,6 +139,9 @@ def parse_vertical_reduction(spec):
     """
     spec = spec.strip()
     lowered = spec.lower()
+
+    if ':' in spec:
+        return _parse_elevation_range(spec)
 
     if lowered in ('top', 'bottom'):
         return VerticalReduction(kind=lowered, label=lowered)
@@ -164,6 +189,116 @@ def elevation_label(elevation):
         The label, e.g. ``'-100m'``
     """
     return f'{elevation:g}m'
+
+
+def is_whole_column(reduction):
+    """
+    Whether an elevation range covers every valid layer of every column
+
+    The whole column is the one range whose weights need no geometry at all.
+    Every valid layer lies entirely within it, so the overlap fraction is one
+    and the geometric coordinate drops out of the answer, which is why it is
+    the range that works before there is any vertical geometry to read.
+
+    Parameters
+    ----------
+    reduction : VerticalReduction
+        The reduction to ask about
+
+    Returns
+    -------
+    whole_column : bool
+        Whether it is the whole column
+    """
+    return (
+        reduction.kind == 'range'
+        and reduction.z_top == np.inf
+        and reduction.z_bot == -np.inf
+    )
+
+
+def elevation_range_weights(
+    z_interface,
+    layer_mass,
+    min_level_cell,
+    max_level_cell,
+    z_top,
+    z_bot,
+):
+    r"""
+    Get the mass per unit area of the part of each layer within an elevation
+    range
+
+    The range is given in geometric elevation while the integral it weights is
+    in mass, so the geometric overlap thickness
+
+    .. math::
+        w_k = \max\left(0, \min(z^{int}_k, z_{top}) -
+              \max(z^{int}_{k+1}, z_{bot})\right)
+
+    is computed from ``z_interface`` and used only as the fraction
+    :math:`w_k / h_k` of the layer, which is then applied to ``layer_mass``.
+    A layer lying entirely within the range therefore contributes its whole
+    mass, and the geometric coordinate enters only through the partial layers
+    at the boundaries.
+
+    Only the whole column, ``top:bottom``, is implemented so far.  It is the
+    range in which every valid layer is whole, so no ``z_interface`` is read
+    and none need be passed.  A range with a boundary in the interior of a
+    layer needs the vertical geometry and is not implemented yet.
+
+    Parameters
+    ----------
+    z_interface : xarray.DataArray or None
+        The elevation of layer interfaces, needed only for a range with a
+        finite boundary
+
+    layer_mass : xarray.DataArray
+        The mass per unit area of each layer, from
+        :py:func:`polaris.ocean.model.get_layer_mass`.  Passing differences of
+        ``z_interface`` instead recovers the purely geometric weights.
+
+    min_level_cell : xarray.DataArray
+        The zero-based index of the topmost valid layer of each column
+
+    max_level_cell : xarray.DataArray
+        The zero-based index of the bottommost valid layer of each column
+
+    z_top : float
+        The upper bound of the range in m, positive up, or ``inf`` for the
+        free surface of each column
+
+    z_bot : float
+        The lower bound of the range in m, positive up, or ``-inf`` for the
+        seafloor of each column
+
+    Returns
+    -------
+    weights : xarray.DataArray
+        The mass per unit area of the overlap of each layer with the range,
+        zero outside the valid layers of a column
+
+    Raises
+    ------
+    NotImplementedError
+        If either bound is a finite elevation
+    """
+    if not (z_top == np.inf and z_bot == -np.inf):
+        raise NotImplementedError(
+            'Weighting an elevation range with a boundary in the interior of '
+            'a layer needs the vertical geometry, which is not implemented '
+            'yet.  The range that works is the whole column, top:bottom.'
+        )
+
+    n_levels = layer_mass.sizes['nVertLevels']
+    levels = xr.DataArray(np.arange(n_levels), dims='nVertLevels')
+    in_column = (levels >= min_level_cell) & (levels <= max_level_cell)
+    weights = layer_mass.where(in_column, 0.0)
+    weights.attrs = dict(
+        units='kg m-2',
+        long_name='mass per unit area within the elevation range',
+    )
+    return weights
 
 
 def apply_vertical_reduction(
@@ -218,6 +353,13 @@ def apply_vertical_reduction(
     NotImplementedError
         If the reduction needs vertical geometry
     """
+    if reduction.kind == 'range':
+        raise ValueError(
+            'An elevation range is not a slice of a field but a weighted '
+            'integral of it, so it goes through elevation_range_weights and '
+            'the diagnostic that consumes the weights, rather than through '
+            'apply_vertical_reduction.'
+        )
     if reduction.kind not in IMPLEMENTED_KINDS:
         raise NotImplementedError(
             f'Reducing a field to {reduction.label} needs the vertical '
@@ -248,3 +390,51 @@ def apply_vertical_reduction(
 
     da_map = da.isel(nVertLevels=safe).where(in_column)
     return da_map.drop_vars('nVertLevels', errors='ignore')
+
+
+def _parse_elevation_range(spec):
+    """Parse an elevation range written ``<top>:<bottom>``"""
+    parts = spec.split(':')
+    if len(parts) != 2:
+        raise ValueError(
+            f'"{spec}" is not an elevation range.  A range is given as '
+            f'<top>:<bottom> in m, positive up, e.g. top:-700.0.'
+        )
+    z_top = _parse_range_bound(spec, parts[0], 'top')
+    z_bot = _parse_range_bound(spec, parts[1], 'bottom')
+    if z_top <= z_bot:
+        raise ValueError(
+            f'The elevation range "{spec}" does not descend.  A range is '
+            f'given as <top>:<bottom> in m, positive up, so the first '
+            f'elevation is the higher one.'
+        )
+    top_label = _range_bound_label(z_top, 'top')
+    bot_label = _range_bound_label(z_bot, 'bottom')
+    return VerticalReduction(
+        kind='range',
+        label=f'{top_label}_to_{bot_label}',
+        z_top=z_top,
+        z_bot=z_bot,
+    )
+
+
+def _parse_range_bound(spec, text, keyword):
+    """Parse one end of an elevation range, which may be a keyword"""
+    text = text.strip()
+    if text.lower() == keyword:
+        return np.inf if keyword == 'top' else -np.inf
+    try:
+        return float(text)
+    except ValueError:
+        raise ValueError(
+            f'"{text}" is not the {keyword} of the elevation range "{spec}".'
+            f'  It is either "{keyword}" or an elevation in m, positive up, '
+            f'so negative within the ocean.'
+        ) from None
+
+
+def _range_bound_label(elevation, keyword):
+    """The label one end of an elevation range is identified by"""
+    if np.isinf(elevation):
+        return keyword
+    return elevation_label(elevation)

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -51,6 +51,50 @@ class VerticalReduction(NamedTuple):
 IMPLEMENTED_KINDS = ('top', 'bottom', 'index')
 
 
+def get_valid_level_range(ds):
+    """
+    Get the zero-based indices of the topmost and bottommost valid layer of
+    each column
+
+    Both models write ``minLevelCell`` and ``maxLevelCell`` with the one-based
+    indexing of MPAS-Ocean's Fortran, so this is the one place that converts
+    them to the zero-based indices the reductions use.
+
+    A data set with no ``minLevelCell`` has no ice-shelf cavities, so the
+    topmost valid layer is the topmost layer of the grid.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The vertical coordinate, with MPAS-Ocean names
+
+    Returns
+    -------
+    min_level_cell : xarray.DataArray
+        The zero-based index of the topmost valid layer of each column
+
+    max_level_cell : xarray.DataArray
+        The zero-based index of the bottommost valid layer of each column
+
+    Raises
+    ------
+    ValueError
+        If the data set has no ``maxLevelCell``, without which a column has
+        no seafloor
+    """
+    if 'maxLevelCell' not in ds:
+        raise ValueError(
+            'The vertical coordinate has no maxLevelCell, so there is no '
+            'way to tell the valid layers of a column from the rest.'
+        )
+    max_level_cell = ds.maxLevelCell - 1
+    if 'minLevelCell' in ds:
+        min_level_cell = ds.minLevelCell - 1
+    else:
+        min_level_cell = xr.zeros_like(max_level_cell)
+    return min_level_cell, max_level_cell
+
+
 def parse_vertical_reduction(spec):
     """
     Parse one entry of the ``elevations`` config option

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -120,15 +120,17 @@ def parse_vertical_reduction(spec):
     Parse one entry of the ``elevations`` or the ``elevation_ranges`` config
     option
 
-    Both options describe a way of turning ``nVertLevels`` into nothing, so
+    Both options describe a way of reducing the ``nVertLevels`` dimension,
+    so
     both are parsed here and the result says which way it is.
 
     Parameters
     ----------
     spec : str
-        ``'top'``, ``'bottom'``, ``'k<index>'`` with a zero-based index, an
-        elevation in m, positive up, so negative within the ocean, or an
-        elevation range written ``<top>:<bottom>``
+        One of ``'top'``, ``'bottom'``, ``'k<index>'`` with a zero-based
+        index, an elevation in m (positive up, so negative within the
+        ocean), or an elevation range written
+        ``<top_elevation>:<bottom_elevation>``
 
     Returns
     -------
@@ -194,27 +196,28 @@ def elevation_label(elevation):
     return f'{elevation:g}m'
 
 
-def range_bound_label(elevation, keyword):
+def range_bound_label(elevation):
     """
     Get the label one end of an elevation range is identified by
+
+    Which end it is follows from the bound itself, since a bound that
+    resolves per column is an infinity with the sign of the end it is.
 
     Parameters
     ----------
     elevation : float
-        The elevation of the bound in m, positive up, or an infinity where
-        the bound resolves per column
-
-    keyword : str
-        ``'top'`` for the upper bound and ``'bottom'`` for the lower one,
-        which is what an infinite bound is labeled with
+        The elevation of the bound in m, positive up, ``np.inf`` for the sea
+        surface or ``-np.inf`` for the seafloor
 
     Returns
     -------
     label : str
-        The label, e.g. ``'top'`` or ``'-700m'``
+        The label, e.g. ``'top'``, ``'bottom'`` or ``'-700m'``
     """
-    if np.isinf(elevation):
-        return keyword
+    if elevation == np.inf:
+        return 'top'
+    if elevation == -np.inf:
+        return 'bottom'
     return elevation_label(elevation)
 
 
@@ -357,7 +360,7 @@ def apply_vertical_reduction(
 
     Slicing at the sea surface, the seafloor, a layer index or an elevation
     are cases of one operation: each picks one layer of each column, or the
-    two layers an elevation falls between, whatever the field means.  Only
+    two layers an elevation falls between, for any DataArray.  Only
     the last of them reads the vertical geometry.
 
     Parameters
@@ -533,8 +536,8 @@ def _parse_elevation_range(spec):
             f'given as <top>:<bottom> in m, positive up, so the first '
             f'elevation is the higher one.'
         )
-    top_label = range_bound_label(z_top, 'top')
-    bot_label = range_bound_label(z_bot, 'bottom')
+    top_label = range_bound_label(z_top)
+    bot_label = range_bound_label(z_bot)
     return VerticalReduction(
         kind='range',
         label=f'{top_label}_to_{bot_label}',

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -115,46 +115,6 @@ def get_valid_level_range(ds):
     return min_level_cell, max_level_cell
 
 
-def get_z_mid_and_interface(ds):
-    """
-    Get the elevation of layer midpoints and of layer interfaces
-
-    These are the vertical geometry, read directly from what the model wrote
-    rather than reconstructed.  Polaris cannot rebuild them from the monthly
-    means of the other fields, because geometric thickness is derived from
-    pseudo-thickness through specific volume, so a simulation that does not
-    write them cannot be analysed at an elevation at all.  That is why this
-    reports what is missing rather than falling back on something.
-
-    Parameters
-    ----------
-    ds : xarray.Dataset
-        A data set holding the vertical geometry, with MPAS-Ocean names
-
-    Returns
-    -------
-    z_mid : xarray.DataArray
-        The elevation of layer midpoints, in m, positive up
-
-    z_interface : xarray.DataArray
-        The elevation of layer interfaces, in m, positive up
-
-    Raises
-    ------
-    ValueError
-        If the data set has neither or only one of them
-    """
-    missing = [name for name in ('zMid', 'zInterface') if name not in ds]
-    if missing:
-        raise ValueError(
-            f'The data set has no {", ".join(missing)}, which is the '
-            f'vertical geometry an elevation is a position in.  Polaris '
-            f'cannot reconstruct it from the other fields, so a simulation '
-            f'has to write it for its output to be analysed at an elevation.'
-        )
-    return ds.zMid, ds.zInterface
-
-
 def parse_vertical_reduction(spec):
     """
     Parse one entry of the ``elevations`` or the ``elevation_ranges`` config

--- a/polaris/ocean/vertical/elevation.py
+++ b/polaris/ocean/vertical/elevation.py
@@ -61,11 +61,14 @@ class VerticalReduction(NamedTuple):
     z_bot: Optional[float] = None
 
 
-# The reductions that pick a layer by index need no vertical geometry at all,
-# so they work before there is any.  Interpolating to an elevation reads
-# ``zMid`` and ``zInterface`` and is not implemented yet.  An elevation range
-# is not a slice and is not here at all; see ``elevation_range_weights``.
+# The reductions a step can offer without reading any vertical geometry, since
+# they pick a layer by index.  Interpolating to an elevation reads ``zMid``
+# and ``zInterface``, which the map step does not pass yet.  An elevation
+# range is not a slice and is not here at all; see ``elevation_range_weights``.
 IMPLEMENTED_KINDS = ('top', 'bottom', 'index')
+
+# The dimension the layer interfaces are along, one longer than ``nVertLevels``
+INTERFACE_DIM = 'nVertLevelsP1'
 
 
 def get_valid_level_range(ds):
@@ -110,6 +113,46 @@ def get_valid_level_range(ds):
     else:
         min_level_cell = xr.zeros_like(max_level_cell)
     return min_level_cell, max_level_cell
+
+
+def get_z_mid_and_interface(ds):
+    """
+    Get the elevation of layer midpoints and of layer interfaces
+
+    These are the vertical geometry, read directly from what the model wrote
+    rather than reconstructed.  Polaris cannot rebuild them from the monthly
+    means of the other fields, because geometric thickness is derived from
+    pseudo-thickness through specific volume, so a simulation that does not
+    write them cannot be analysed at an elevation at all.  That is why this
+    reports what is missing rather than falling back on something.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A data set holding the vertical geometry, with MPAS-Ocean names
+
+    Returns
+    -------
+    z_mid : xarray.DataArray
+        The elevation of layer midpoints, in m, positive up
+
+    z_interface : xarray.DataArray
+        The elevation of layer interfaces, in m, positive up
+
+    Raises
+    ------
+    ValueError
+        If the data set has neither or only one of them
+    """
+    missing = [name for name in ('zMid', 'zInterface') if name not in ds]
+    if missing:
+        raise ValueError(
+            f'The data set has no {", ".join(missing)}, which is the '
+            f'vertical geometry an elevation is a position in.  Polaris '
+            f'cannot reconstruct it from the other fields, so a simulation '
+            f'has to write it for its output to be analysed at an elevation.'
+        )
+    return ds.zMid, ds.zInterface
 
 
 def parse_vertical_reduction(spec):
@@ -330,17 +373,16 @@ def apply_vertical_reduction(
     reduction,
     z_mid=None,
     z_interface=None,
-    layer_mass=None,
     min_level_cell=None,
     max_level_cell=None,
 ):
     """
     Reduce a field with a vertical dimension to a horizontal map
 
-    Only the reductions in :py:data:`IMPLEMENTED_KINDS` are available so far;
-    interpolating to an elevation and integrating over an elevation range
-    raise :py:exc:`NotImplementedError`, since they need vertical geometry
-    that nothing writes yet.
+    Slicing at the sea surface, the seafloor, a layer index or an elevation
+    are cases of one operation: each picks one layer of each column, or the
+    two layers an elevation falls between, whatever the field means.  Only
+    the last of them reads the vertical geometry.
 
     Parameters
     ----------
@@ -351,14 +393,11 @@ def apply_vertical_reduction(
         How to reduce it, from :py:func:`parse_vertical_reduction`
 
     z_mid : xarray.DataArray, optional
-        The elevation of layer midpoints, needed only for the reductions that
-        are not implemented yet
+        The elevation of layer midpoints, needed only to interpolate to an
+        elevation
 
     z_interface : xarray.DataArray, optional
         The elevation of layer interfaces, as for ``z_mid``
-
-    layer_mass : xarray.DataArray, optional
-        The mass per unit area of each layer, as for ``z_mid``
 
     min_level_cell : xarray.DataArray
         The zero-based index of the topmost valid layer of each column
@@ -374,8 +413,8 @@ def apply_vertical_reduction(
 
     Raises
     ------
-    NotImplementedError
-        If the reduction needs vertical geometry
+    ValueError
+        If the reduction is a range, or if what it needs was not passed
     """
     if reduction.kind == 'range':
         raise ValueError(
@@ -384,16 +423,20 @@ def apply_vertical_reduction(
             'the diagnostic that consumes the weights, rather than through '
             'apply_vertical_reduction.'
         )
-    if reduction.kind not in IMPLEMENTED_KINDS:
-        raise NotImplementedError(
-            f'Reducing a field to {reduction.label} needs the vertical '
-            f'geometry, which is not implemented yet.  The reductions that '
-            f'work are "top", "bottom" and "k<index>".'
-        )
     if min_level_cell is None or max_level_cell is None:
         raise ValueError(
             'min_level_cell and max_level_cell are needed to tell the valid '
             'layers of each column from the rest.'
+        )
+
+    if reduction.kind == 'elevation':
+        return _interpolate_to_elevation(
+            da=da,
+            elevation=reduction.elevation,
+            z_mid=z_mid,
+            z_interface=z_interface,
+            min_level_cell=min_level_cell,
+            max_level_cell=max_level_cell,
         )
 
     n_levels = da.sizes['nVertLevels']
@@ -414,6 +457,80 @@ def apply_vertical_reduction(
 
     da_map = da.isel(nVertLevels=safe).where(in_column)
     return da_map.drop_vars('nVertLevels', errors='ignore')
+
+
+def _interpolate_to_elevation(
+    da, elevation, z_mid, z_interface, min_level_cell, max_level_cell
+):
+    """
+    Interpolate a field linearly in elevation between the two layer midpoints
+    an elevation falls between
+
+    The search for the upper of the two layers is a count rather than a loop
+    over columns: with the midpoints outside the valid range set to ``NaN``,
+    the number of valid midpoints at or above the elevation says how far
+    below the topmost valid layer it lies.
+
+    Above the topmost midpoint the topmost value is returned, and below the
+    bottommost midpoint the bottommost one, rather than either being masked
+    or extrapolated.  Both fall out of clamping the interpolation weight into
+    ``[0, 1]``, and the clamping at the top is deliberate: a request for 0 m
+    or -5 m lies above every midpoint, and masking it would leave a
+    near-surface map empty everywhere.
+    """
+    if z_mid is None or z_interface is None:
+        raise ValueError(
+            'z_mid and z_interface are needed to interpolate to an '
+            'elevation, which is a position in the vertical geometry rather '
+            'than a layer of the grid.'
+        )
+
+    n_levels = da.sizes['nVertLevels']
+    levels = xr.DataArray(np.arange(n_levels), dims='nVertLevels')
+    in_column = (levels >= min_level_cell) & (levels <= max_level_cell)
+    # a layer outside the valid range has no position in the column, so it
+    # takes no part in the search and cannot supply a value
+    z_valid = z_mid.where(in_column)
+
+    # the count is of valid midpoints, so it is measured from the topmost
+    # valid layer of the column rather than from layer zero, which is not the
+    # same thing under an ice-shelf cavity
+    above = (z_valid >= elevation).sum(dim='nVertLevels')
+    k_upper = min_level_cell + above - 1
+    # the pair is (k_upper, k_upper + 1), so the lowest pair of a column
+    # starts one layer above its seafloor.  A column with a single valid
+    # layer has no pair at all and is handled below; land has none either and
+    # is masked, so both only need an index that can be taken safely.
+    lowest_pair = np.maximum(max_level_cell - 1, min_level_cell)
+    k_upper = np.minimum(np.maximum(k_upper, min_level_cell), lowest_pair)
+    k_upper = np.minimum(np.maximum(k_upper, 0), n_levels - 1)
+    k_lower = np.minimum(k_upper + 1, n_levels - 1)
+
+    z_upper = z_valid.isel(nVertLevels=k_upper)
+    z_lower = z_valid.isel(nVertLevels=k_lower)
+    thickness = z_upper - z_lower
+    weight = xr.where(thickness > 0.0, (elevation - z_lower) / thickness, 1.0)
+    weight = np.minimum(np.maximum(weight, 0.0), 1.0)
+
+    da_upper = da.isel(nVertLevels=k_upper)
+    da_lower = da.isel(nVertLevels=k_lower)
+    # a column with one valid layer is that layer everywhere within it; the
+    # layer below is outside the column, so it is selected away rather than
+    # weighted by zero, which would let a fill value poison the sum
+    single_layer = min_level_cell >= max_level_cell
+    da_map = xr.where(
+        single_layer, da_upper, weight * da_upper + (1.0 - weight) * da_lower
+    )
+
+    # land has no layer to take a value from, and an elevation below the
+    # seafloor has no water at it
+    n_interfaces = z_interface.sizes[INTERFACE_DIM]
+    k_floor = np.minimum(np.maximum(max_level_cell + 1, 0), n_interfaces - 1)
+    z_floor = z_interface.isel({INTERFACE_DIM: k_floor})
+    in_water = (max_level_cell >= min_level_cell) & (elevation >= z_floor)
+
+    da_map = da_map.where(in_water)
+    return da_map.drop_vars(['nVertLevels', INTERFACE_DIM], errors='ignore')
 
 
 def _parse_elevation_range(spec):

--- a/tests/ocean/vertical/test_elevation.py
+++ b/tests/ocean/vertical/test_elevation.py
@@ -1,5 +1,6 @@
 """
-Unit tests for the vertical reductions that pick a layer by index.
+Unit tests for the vertical reductions that need no vertical geometry: the
+ones that pick a layer by index, and the weights of the whole column.
 
 The columns are synthetic and their geometry is known, so what is checked is
 that ``minLevelCell`` and ``maxLevelCell`` are respected: an ice-shelf cavity
@@ -13,7 +14,9 @@ import xarray as xr
 
 from polaris.ocean.vertical.elevation import (
     apply_vertical_reduction,
+    elevation_range_weights,
     get_valid_level_range,
+    is_whole_column,
     parse_vertical_reduction,
 )
 
@@ -35,6 +38,12 @@ def columns():
     return xr.Dataset(
         dict(
             field=(('nCells', 'nVertLevels'), 100.0 * cells + levels),
+            # a distinct mass per layer and per column, so that a weight can
+            # only be right by coming from the layer it belongs to
+            layer_mass=(
+                ('nCells', 'nVertLevels'),
+                1000.0 + 10.0 * levels + 1.0 * cells,
+            ),
             minLevelCell=('nCells', np.array(MIN_LEVEL_CELL)),
             maxLevelCell=('nCells', np.array(MAX_LEVEL_CELL)),
         )
@@ -160,3 +169,138 @@ def test_a_column_with_no_cavities_starts_at_the_top_of_the_grid():
 def test_a_column_with_no_seafloor_is_reported():
     with pytest.raises(ValueError, match='no maxLevelCell'):
         get_valid_level_range(xr.Dataset())
+
+
+def test_an_elevation_range_parses_into_its_bounds():
+    """A bound is either a keyword, which resolves per column, or a fixed
+    elevation."""
+    whole = parse_vertical_reduction('top:bottom')
+    assert whole.kind == 'range'
+    assert (whole.z_top, whole.z_bot) == (np.inf, -np.inf)
+
+    upper = parse_vertical_reduction('top:-700.0')
+    assert (upper.z_top, upper.z_bot) == (np.inf, -700.0)
+
+    middle = parse_vertical_reduction(' -700.0 : -2000.0 ')
+    assert (middle.z_top, middle.z_bot) == (-700.0, -2000.0)
+
+    abyss = parse_vertical_reduction('-2000.0:BOTTOM')
+    assert (abyss.z_top, abyss.z_bot) == (-2000.0, -np.inf)
+
+
+def test_a_range_is_labeled_by_both_of_its_bounds():
+    """The label names a file, so the elevations are spelled the way a
+    single elevation is, and joined by _to_ rather than by a hyphen, which
+    the negative elevations already use."""
+    assert parse_vertical_reduction('top:bottom').label == 'top_to_bottom'
+    assert parse_vertical_reduction('top:-700.0').label == 'top_to_-700m'
+    assert (
+        parse_vertical_reduction('-2000.0:bottom').label == '-2000m_to_bottom'
+    )
+
+
+def test_a_range_that_does_not_descend_is_reported():
+    with pytest.raises(ValueError, match='does not descend'):
+        parse_vertical_reduction('-700.0:-100.0')
+    with pytest.raises(ValueError, match='does not descend'):
+        parse_vertical_reduction('-700.0:-700.0')
+
+
+def test_a_bound_on_the_wrong_end_is_reported():
+    """ "top" is the free surface and "bottom" the seafloor, so neither can
+    stand in for the other end of the range."""
+    with pytest.raises(ValueError, match='is not the top'):
+        parse_vertical_reduction('bottom:top')
+    with pytest.raises(ValueError, match='is not the bottom'):
+        parse_vertical_reduction('top:seafloor')
+
+
+def test_something_that_is_not_a_range_is_reported():
+    with pytest.raises(ValueError, match='not an elevation range'):
+        parse_vertical_reduction('top:-700.0:-2000.0')
+
+
+def test_only_the_whole_column_is_the_whole_column():
+    assert is_whole_column(parse_vertical_reduction('top:bottom'))
+    assert not is_whole_column(parse_vertical_reduction('top:-700.0'))
+    assert not is_whole_column(parse_vertical_reduction('top'))
+
+
+def test_the_whole_column_weighs_every_valid_layer_and_nothing_else(columns):
+    """No geometry is read: every valid layer is whole, so its weight is its
+    whole mass, and every other layer weighs nothing."""
+    weights = _whole_column_weights(columns)
+    layer_mass = columns.layer_mass.values
+    np.testing.assert_allclose(weights[0], layer_mass[0])
+    np.testing.assert_allclose(
+        weights[1], [0.0, 0.0, 0.0] + list(layer_mass[1, 3:])
+    )
+    np.testing.assert_allclose(
+        weights[2], list(layer_mass[2, :3]) + [0.0, 0.0, 0.0]
+    )
+    np.testing.assert_allclose(weights[LAND], np.zeros(N_LEVELS))
+
+
+def test_the_whole_column_weights_are_a_mass_per_unit_area(columns):
+    weights = elevation_range_weights(
+        None,
+        columns.layer_mass,
+        columns.minLevelCell,
+        columns.maxLevelCell,
+        np.inf,
+        -np.inf,
+    )
+    assert weights.attrs['units'] == 'kg m-2'
+
+
+def test_a_layer_with_no_mass_written_still_weighs_nothing(columns):
+    """A model may write anything below the seafloor, including a fill value
+    that arrives as NaN, and it must not reach the sum."""
+    levels = xr.DataArray(np.arange(N_LEVELS), dims='nVertLevels')
+    layer_mass = columns.layer_mass.where(levels <= columns.maxLevelCell)
+    weights = elevation_range_weights(
+        None,
+        layer_mass,
+        columns.minLevelCell,
+        columns.maxLevelCell,
+        np.inf,
+        -np.inf,
+    )
+    assert np.all(np.isfinite(weights.values))
+    np.testing.assert_allclose(weights.values[LAND], np.zeros(N_LEVELS))
+
+
+def test_a_range_with_a_finite_bound_is_not_implemented_yet(columns):
+    with pytest.raises(NotImplementedError, match='vertical geometry'):
+        elevation_range_weights(
+            None,
+            columns.layer_mass,
+            columns.minLevelCell,
+            columns.maxLevelCell,
+            np.inf,
+            -700.0,
+        )
+
+
+def test_a_range_is_not_a_slice(columns):
+    """A range is a weighted integral, so it does not go through the entry
+    point that picks a layer."""
+    with pytest.raises(ValueError, match='not a slice'):
+        apply_vertical_reduction(
+            columns.field,
+            parse_vertical_reduction('top:bottom'),
+            min_level_cell=columns.minLevelCell,
+            max_level_cell=columns.maxLevelCell,
+        )
+
+
+def _whole_column_weights(ds):
+    """The weights of the whole column, as an array"""
+    return elevation_range_weights(
+        None,
+        ds.layer_mass,
+        ds.minLevelCell,
+        ds.maxLevelCell,
+        np.inf,
+        -np.inf,
+    ).values

--- a/tests/ocean/vertical/test_elevation.py
+++ b/tests/ocean/vertical/test_elevation.py
@@ -459,8 +459,10 @@ def test_a_layer_with_no_mass_written_still_weighs_nothing(columns):
     np.testing.assert_allclose(weights.values[LAND], np.zeros(N_LEVELS))
 
 
-def test_a_range_with_a_finite_bound_is_not_implemented_yet(columns):
-    with pytest.raises(NotImplementedError, match='vertical geometry'):
+def test_a_range_with_a_finite_bound_needs_the_geometry(columns):
+    """The whole column is the one range whose weights can be worked out
+    without it."""
+    with pytest.raises(ValueError, match='z_interface is needed'):
         elevation_range_weights(
             None,
             columns.layer_mass,

--- a/tests/ocean/vertical/test_elevation.py
+++ b/tests/ocean/vertical/test_elevation.py
@@ -1,0 +1,133 @@
+"""
+Unit tests for the vertical reductions that pick a layer by index.
+
+The columns are synthetic and their geometry is known, so what is checked is
+that ``minLevelCell`` and ``maxLevelCell`` are respected: an ice-shelf cavity
+whose topmost valid layer is not the topmost layer of the grid, a column
+whose seafloor is above the bottom of the grid, and land.
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.ocean.vertical.elevation import (
+    apply_vertical_reduction,
+    parse_vertical_reduction,
+)
+
+N_LEVELS = 6
+
+# one column per case: a full-depth column, an ice-shelf cavity whose top
+# three layers are in the ice, a shallow column, and a land column
+MIN_LEVEL_CELL = [0, 3, 0, 0]
+MAX_LEVEL_CELL = [5, 5, 2, -1]
+LAND = 3
+
+
+@pytest.fixture
+def columns():
+    """A field whose value is the layer index plus 100 times the cell, so
+    that a value says which layer of which column it came from."""
+    cells = np.arange(len(MIN_LEVEL_CELL))[:, None]
+    levels = np.arange(N_LEVELS)[None, :]
+    return xr.Dataset(
+        dict(
+            field=(('nCells', 'nVertLevels'), 100.0 * cells + levels),
+            minLevelCell=('nCells', np.array(MIN_LEVEL_CELL)),
+            maxLevelCell=('nCells', np.array(MAX_LEVEL_CELL)),
+        )
+    )
+
+
+def test_top_is_the_topmost_valid_layer(columns):
+    """Including under an ice-shelf cavity, where it is not layer zero."""
+    values = _reduce(columns, 'top')
+    assert values[0] == 0.0
+    assert values[1] == 100.0 + 3
+    assert values[2] == 200.0
+    assert np.isnan(values[LAND])
+
+
+def test_bottom_is_the_bottommost_valid_layer(columns):
+    """Including where the seafloor is above the bottom of the grid."""
+    values = _reduce(columns, 'bottom')
+    assert values[0] == 5.0
+    assert values[1] == 100.0 + 5
+    assert values[2] == 200.0 + 2
+    assert np.isnan(values[LAND])
+
+
+def test_a_fixed_index_returns_that_index(columns):
+    values = _reduce(columns, 'k1')
+    assert values[0] == 1.0
+    assert values[2] == 200.0 + 1
+
+
+def test_a_fixed_index_is_masked_above_the_topmost_valid_layer(columns):
+    """In the cavity column, layer 1 is in the ice."""
+    values = _reduce(columns, 'k1')
+    assert np.isnan(values[1])
+
+
+def test_a_fixed_index_is_masked_below_the_seafloor(columns):
+    """In the shallow column, layer 4 is below the seafloor."""
+    values = _reduce(columns, 'k4')
+    assert np.isnan(values[2])
+    assert values[0] == 4.0
+
+
+def test_land_is_masked_for_every_reduction(columns):
+    for spec in ('top', 'bottom', 'k0', 'k5'):
+        assert np.isnan(_reduce(columns, spec)[LAND])
+
+
+def test_the_vertical_dimension_is_gone(columns):
+    da_map = _reduce(columns, 'top', raw=True)
+    assert 'nVertLevels' not in da_map.dims
+    assert da_map.dims == ('nCells',)
+
+
+def test_a_time_dimension_survives(columns):
+    """Maps are made from a climatology, which has a length-one time axis."""
+    ds = columns.copy()
+    ds['field'] = ds.field.expand_dims(dim='time', axis=0)
+    da_map = apply_vertical_reduction(
+        ds.field,
+        parse_vertical_reduction('top'),
+        min_level_cell=ds.minLevelCell,
+        max_level_cell=ds.maxLevelCell,
+    )
+    assert da_map.dims == ('time', 'nCells')
+
+
+def test_the_reductions_parse():
+    assert parse_vertical_reduction('top').kind == 'top'
+    assert parse_vertical_reduction('BOTTOM').kind == 'bottom'
+    assert parse_vertical_reduction(' k10 ').level == 10
+    assert parse_vertical_reduction('k10').label == 'k10'
+    assert parse_vertical_reduction('-100.0').elevation == -100.0
+    assert parse_vertical_reduction('-100.0').label == '-100m'
+
+
+def test_something_that_is_neither_is_reported():
+    with pytest.raises(ValueError, match='not a vertical reduction'):
+        parse_vertical_reduction('surface')
+    with pytest.raises(ValueError, match='not a vertical index'):
+        parse_vertical_reduction('k-1')
+
+
+def test_interpolating_to_an_elevation_is_not_implemented_yet(columns):
+    with pytest.raises(NotImplementedError, match='vertical geometry'):
+        _reduce(columns, '-100.0')
+
+
+def _reduce(ds, spec, raw=False):
+    """Apply a reduction given by its config spelling"""
+    da_map = apply_vertical_reduction(
+        ds.field,
+        parse_vertical_reduction(spec),
+        min_level_cell=ds.minLevelCell,
+        max_level_cell=ds.maxLevelCell,
+    )
+    return da_map if raw else da_map.values

--- a/tests/ocean/vertical/test_elevation.py
+++ b/tests/ocean/vertical/test_elevation.py
@@ -1,11 +1,15 @@
 """
-Unit tests for the vertical reductions that need no vertical geometry: the
-ones that pick a layer by index, and the weights of the whole column.
+Unit tests for the vertical reductions that turn a field with an
+``nVertLevels`` dimension into a horizontal map.
 
 The columns are synthetic and their geometry is known, so what is checked is
 that ``minLevelCell`` and ``maxLevelCell`` are respected: an ice-shelf cavity
 whose topmost valid layer is not the topmost layer of the grid, a column
-whose seafloor is above the bottom of the grid, and land.
+whose seafloor is above the bottom of the grid, a column with a single valid
+layer, and land.  The layers are of different thicknesses in every column, so
+a reduction cannot be right by assuming a uniform grid, and everything
+outside the valid range of a column is ``NaN``, so it cannot be right by
+reading what a model wrote below its seafloor either.
 """
 
 import numpy as np
@@ -16,6 +20,7 @@ from polaris.ocean.vertical.elevation import (
     apply_vertical_reduction,
     elevation_range_weights,
     get_valid_level_range,
+    get_z_mid_and_interface,
     is_whole_column,
     parse_vertical_reduction,
 )
@@ -23,26 +28,63 @@ from polaris.ocean.vertical.elevation import (
 N_LEVELS = 6
 
 # one column per case: a full-depth column, an ice-shelf cavity whose top
-# three layers are in the ice, a shallow column, and a land column
-MIN_LEVEL_CELL = [0, 3, 0, 0]
-MAX_LEVEL_CELL = [5, 5, 2, -1]
+# three layers are in the ice, a shallow column, a land column, and a column
+# with a single valid layer
+MIN_LEVEL_CELL = [0, 3, 0, 0, 2]
+MAX_LEVEL_CELL = [5, 5, 2, -1, 2]
 LAND = 3
+ONE_LAYER = 4
+
+_CELLS = np.arange(len(MIN_LEVEL_CELL))[:, None]
+_LEVELS = np.arange(N_LEVELS)[None, :]
+_INTERFACES = np.arange(N_LEVELS + 1)[None, :]
+
+# a thickness that varies both down a column and from column to column
+LAYER_THICKNESS = 100.0 + 20.0 * _LEVELS + 10.0 * _CELLS
+
+# the elevation of the interfaces and of the midpoints of every layer of the
+# grid, valid or not; the fixture is what masks them
+Z_INTERFACE = np.concatenate(
+    (
+        np.zeros((len(MIN_LEVEL_CELL), 1)),
+        -np.cumsum(LAYER_THICKNESS, axis=1),
+    ),
+    axis=1,
+)
+Z_MID = 0.5 * (Z_INTERFACE[:, :-1] + Z_INTERFACE[:, 1:])
+
+_WATER = (_LEVELS >= np.array(MIN_LEVEL_CELL)[:, None]) & (
+    _LEVELS <= np.array(MAX_LEVEL_CELL)[:, None]
+)
+# the interfaces of a column are the ones bounding its valid layers, so there
+# is one more of them, and a land column has none at all
+_WATER_INTERFACE = (
+    (_INTERFACES >= np.array(MIN_LEVEL_CELL)[:, None])
+    & (_INTERFACES <= np.array(MAX_LEVEL_CELL)[:, None] + 1)
+    & (np.array(MAX_LEVEL_CELL) >= np.array(MIN_LEVEL_CELL))[:, None]
+)
 
 
 @pytest.fixture
 def columns():
     """A field whose value is the layer index plus 100 times the cell, so
     that a value says which layer of which column it came from."""
-    cells = np.arange(len(MIN_LEVEL_CELL))[:, None]
-    levels = np.arange(N_LEVELS)[None, :]
     return xr.Dataset(
         dict(
-            field=(('nCells', 'nVertLevels'), 100.0 * cells + levels),
+            field=(('nCells', 'nVertLevels'), 100.0 * _CELLS + _LEVELS),
             # a distinct mass per layer and per column, so that a weight can
             # only be right by coming from the layer it belongs to
             layer_mass=(
                 ('nCells', 'nVertLevels'),
-                1000.0 + 10.0 * levels + 1.0 * cells,
+                1000.0 + 10.0 * _LEVELS + 1.0 * _CELLS,
+            ),
+            zMid=(
+                ('nCells', 'nVertLevels'),
+                np.where(_WATER, Z_MID, np.nan),
+            ),
+            zInterface=(
+                ('nCells', 'nVertLevelsP1'),
+                np.where(_WATER_INTERFACE, Z_INTERFACE, np.nan),
             ),
             minLevelCell=('nCells', np.array(MIN_LEVEL_CELL)),
             maxLevelCell=('nCells', np.array(MAX_LEVEL_CELL)),
@@ -127,9 +169,156 @@ def test_something_that_is_neither_is_reported():
         parse_vertical_reduction('k-1')
 
 
-def test_interpolating_to_an_elevation_is_not_implemented_yet(columns):
-    with pytest.raises(NotImplementedError, match='vertical geometry'):
-        _reduce(columns, '-100.0')
+def test_interpolating_at_a_midpoint_returns_that_layer(columns):
+    """Exactly: the elevation is where the layer's own value sits, so the
+    other layer of the pair is weighed by nothing."""
+    for cell, level in ((0, 2), (1, 4), (2, 0)):
+        values = _interpolate(columns, Z_MID[cell, level])
+        assert values[cell] == 100.0 * cell + level
+
+
+def test_interpolating_midway_returns_the_average(columns):
+    """Midway between two midpoints, not midway down a layer, which is not
+    the same place unless the layers are of equal thickness."""
+    elevation = 0.5 * (Z_MID[0, 1] + Z_MID[0, 2])
+    values = _interpolate(columns, elevation)
+    assert values[0] == pytest.approx(1.5)
+
+
+def test_the_bounding_layers_are_counted_from_the_topmost_valid_layer(
+    columns,
+):
+    """Under an ice-shelf cavity the count of valid midpoints at or above an
+    elevation says how far below minLevelCell it lies, not how far below
+    layer zero.  Counting from layer zero puts every elevation of this
+    column in its topmost pair, which happens to be right near the top of it
+    and is wrong near the bottom."""
+    elevation = 0.5 * (Z_MID[1, 4] + Z_MID[1, 5])
+    values = _interpolate(columns, elevation)
+    assert values[1] == pytest.approx(104.5)
+
+
+def test_an_elevation_above_the_topmost_midpoint_is_the_topmost_value(
+    columns,
+):
+    """Clamped rather than masked, since a request for 0 m or -5 m lies
+    above every midpoint and would otherwise give an empty map."""
+    for elevation in (0.0, -5.0):
+        values = _interpolate(columns, elevation)
+        assert values[0] == 0.0
+        # in the cavity column the topmost value is not layer zero, and the
+        # elevation is above the ice draft rather than merely above a
+        # midpoint
+        assert values[1] == 103.0
+
+
+def test_an_elevation_below_the_bottommost_midpoint_is_the_seafloor_value(
+    columns,
+):
+    """Above the seafloor but below the last midpoint, which is the other
+    half of the same clamp."""
+    elevation = 0.5 * (Z_MID[0, 5] + Z_INTERFACE[0, 6])
+    values = _interpolate(columns, elevation)
+    assert values[0] == 5.0
+
+
+def test_an_elevation_below_the_seafloor_is_masked(columns):
+    """The shallow column ends where the others go on."""
+    elevation = Z_INTERFACE[2, 3] - 1.0
+    values = _interpolate(columns, elevation)
+    assert np.isnan(values[2])
+    assert not np.isnan(values[0])
+
+
+def test_land_is_masked_at_every_elevation(columns):
+    for elevation in (0.0, -137.0, -1000.0):
+        assert np.isnan(_interpolate(columns, elevation)[LAND])
+
+
+def test_a_column_with_one_valid_layer_is_that_layer_throughout(columns):
+    """It has no pair of midpoints to interpolate between, and the layer
+    below it is outside the column, so its value cannot reach the answer."""
+    elevations = (
+        Z_INTERFACE[ONE_LAYER, 2],
+        Z_MID[ONE_LAYER, 2],
+        Z_INTERFACE[ONE_LAYER, 3],
+    )
+    for elevation in elevations:
+        values = _interpolate(columns, elevation)
+        assert values[ONE_LAYER] == 100.0 * ONE_LAYER + 2
+
+
+def test_a_linear_field_is_recovered_exactly(columns):
+    """The strongest of these.  A field that is linear in elevation is what
+    linear interpolation reproduces, so an index off by one or an inverted
+    weight changes the answer, while a constant field or a check only at the
+    midpoints would not notice either."""
+    slope, intercept = -0.017, 3.5
+    da = xr.DataArray(
+        slope * np.where(_WATER, Z_MID, np.nan) + intercept,
+        dims=('nCells', 'nVertLevels'),
+    )
+    checked = 0
+    for elevation in (-137.0, -390.0, -455.5, -700.0, -855.0):
+        values = _interpolate(columns, elevation, field=da)
+        for cell in range(len(MIN_LEVEL_CELL)):
+            if not _between_the_midpoints(cell, elevation):
+                continue
+            assert values[cell] == pytest.approx(slope * elevation + intercept)
+            checked += 1
+    # every case above is clamped or masked in some column, so count what was
+    # actually interpolated rather than trusting the elevations to land well
+    assert checked >= 6
+
+
+def test_interpolating_without_the_geometry_is_reported(columns):
+    """An elevation is a position in the geometry, so there is nothing to
+    fall back on."""
+    with pytest.raises(ValueError, match='z_mid and z_interface are needed'):
+        apply_vertical_reduction(
+            columns.field,
+            parse_vertical_reduction('-100.0'),
+            min_level_cell=columns.minLevelCell,
+            max_level_cell=columns.maxLevelCell,
+        )
+
+
+def test_the_vertical_geometry_is_read_under_its_polaris_names(columns):
+    z_mid, z_interface = get_z_mid_and_interface(columns)
+    assert z_mid.dims == ('nCells', 'nVertLevels')
+    assert z_interface.dims == ('nCells', 'nVertLevelsP1')
+
+
+def test_a_data_set_with_no_vertical_geometry_is_reported():
+    """A simulation that did not write it cannot be analysed at an
+    elevation at all, so this says so rather than reconstructing
+    something."""
+    with pytest.raises(ValueError, match='no zMid, zInterface'):
+        get_z_mid_and_interface(xr.Dataset())
+
+
+def _interpolate(ds, elevation, field=None):
+    """Interpolate a field to an elevation, as an array"""
+    da = ds.field if field is None else field
+    da_map = apply_vertical_reduction(
+        da,
+        parse_vertical_reduction(f'{elevation}'),
+        z_mid=ds.zMid,
+        z_interface=ds.zInterface,
+        min_level_cell=ds.minLevelCell,
+        max_level_cell=ds.maxLevelCell,
+    )
+    return da_map.values
+
+
+def _between_the_midpoints(cell, elevation):
+    """Whether an elevation is one the column interpolates at rather than
+    clamps to an end of or masks"""
+    k_min = MIN_LEVEL_CELL[cell]
+    k_max = MAX_LEVEL_CELL[cell]
+    if k_max < k_min:
+        return False
+    return Z_MID[cell, k_max] <= elevation <= Z_MID[cell, k_min]
 
 
 def _reduce(ds, spec, raw=False):

--- a/tests/ocean/vertical/test_elevation.py
+++ b/tests/ocean/vertical/test_elevation.py
@@ -13,6 +13,7 @@ import xarray as xr
 
 from polaris.ocean.vertical.elevation import (
     apply_vertical_reduction,
+    get_valid_level_range,
     parse_vertical_reduction,
 )
 
@@ -131,3 +132,31 @@ def _reduce(ds, spec, raw=False):
         max_level_cell=ds.maxLevelCell,
     )
     return da_map if raw else da_map.values
+
+
+def test_the_valid_level_range_is_converted_from_one_based_indices():
+    """Both models write minLevelCell and maxLevelCell the way MPAS-Ocean's
+    Fortran indexes them."""
+    ds = xr.Dataset(
+        dict(
+            minLevelCell=('nCells', np.array([1, 4])),
+            maxLevelCell=('nCells', np.array([6, 6])),
+        )
+    )
+    min_level_cell, max_level_cell = get_valid_level_range(ds)
+    np.testing.assert_array_equal(min_level_cell.values, [0, 3])
+    np.testing.assert_array_equal(max_level_cell.values, [5, 5])
+
+
+def test_a_column_with_no_cavities_starts_at_the_top_of_the_grid():
+    """A simulation without ice-shelf cavities need not write
+    minLevelCell."""
+    ds = xr.Dataset(dict(maxLevelCell=('nCells', np.array([6, 3]))))
+    min_level_cell, max_level_cell = get_valid_level_range(ds)
+    np.testing.assert_array_equal(min_level_cell.values, [0, 0])
+    np.testing.assert_array_equal(max_level_cell.values, [5, 2])
+
+
+def test_a_column_with_no_seafloor_is_reported():
+    with pytest.raises(ValueError, match='no maxLevelCell'):
+        get_valid_level_range(xr.Dataset())

--- a/tests/ocean/vertical/test_elevation.py
+++ b/tests/ocean/vertical/test_elevation.py
@@ -485,6 +485,101 @@ def test_a_range_is_not_a_slice(columns):
         )
 
 
+def test_a_range_aligned_with_the_interfaces_weighs_whole_layers(columns):
+    """And weighs them by their mass: the layer masses of these columns are
+    not proportional to their geometric thicknesses, so a weight that came
+    from the geometry would be a different number."""
+    weights = _range_weights(columns, Z_INTERFACE[0, 1], Z_INTERFACE[0, 3])
+    layer_mass = columns.layer_mass.values
+    np.testing.assert_allclose(
+        weights[0], [0.0, layer_mass[0, 1], layer_mass[0, 2], 0.0, 0.0, 0.0]
+    )
+
+
+def test_a_bound_inside_a_layer_weighs_the_geometric_fraction(columns):
+    """The one place the geometry legitimately enters: the partial layer at
+    a boundary contributes the fraction of its mass that the range covers of
+    its thickness."""
+    thickness = Z_INTERFACE[0, 2] - Z_INTERFACE[0, 3]
+    z_bot = Z_INTERFACE[0, 2] - 0.25 * thickness
+    weights = _range_weights(columns, Z_INTERFACE[0, 1], z_bot)
+    layer_mass = columns.layer_mass.values
+    np.testing.assert_allclose(
+        weights[0],
+        [0.0, layer_mass[0, 1], 0.25 * layer_mass[0, 2], 0.0, 0.0, 0.0],
+    )
+
+
+def test_a_bound_swept_across_a_layer_varies_linearly(columns):
+    """From the answer with that layer left out to the answer with it whole,
+    which is what says the fraction is the overlap and not something that
+    merely happens to be right at the two ends."""
+    z_upper = Z_INTERFACE[0, 2]
+    z_lower = Z_INTERFACE[0, 3]
+    fractions = np.linspace(0.0, 1.0, 5)
+    totals = [
+        _range_weights(
+            columns,
+            Z_INTERFACE[0, 1],
+            z_upper - fraction * (z_upper - z_lower),
+        )[0].sum()
+        for fraction in fractions
+    ]
+    layer_mass = columns.layer_mass.values
+    expected = layer_mass[0, 1] + fractions * layer_mass[0, 2]
+    np.testing.assert_allclose(totals, expected)
+
+
+def test_a_range_reaching_below_the_seafloor_is_truncated_there(columns):
+    """There is no mass below it to add, so the answer is the whole
+    column's."""
+    weights = _range_weights(columns, np.inf, -10000.0)
+    np.testing.assert_allclose(weights, _whole_column_weights(columns))
+
+
+def test_the_whole_column_is_the_sum_of_ranges_that_partition_it(columns):
+    """Which also exercises an infinite bound at each end, since the free
+    surface and the seafloor of a column are its outermost interfaces."""
+    partition = ((np.inf, -290.0), (-290.0, -700.0), (-700.0, -np.inf))
+    total = sum(
+        _range_weights(columns, z_top, z_bot) for z_top, z_bot in partition
+    )
+    np.testing.assert_allclose(total, _whole_column_weights(columns))
+
+
+def test_a_column_that_the_range_misses_weighs_nothing_rather_than_nan(
+    columns,
+):
+    """The shallow column ends above this range, and a NaN here would poison
+    the sum the weights are for."""
+    weights = _range_weights(columns, -500.0, -600.0)
+    assert np.all(np.isfinite(weights))
+    np.testing.assert_allclose(weights[2], np.zeros(N_LEVELS))
+    np.testing.assert_allclose(weights[LAND], np.zeros(N_LEVELS))
+    assert weights[0].sum() > 0.0
+
+
+def test_the_whole_column_is_the_same_with_the_geometry_and_without(columns):
+    """Every valid layer is whole in it, so reading the interfaces cannot
+    change the answer."""
+    np.testing.assert_allclose(
+        _range_weights(columns, np.inf, -np.inf),
+        _whole_column_weights(columns),
+    )
+
+
+def _range_weights(ds, z_top, z_bot):
+    """The weights of an elevation range, as an array"""
+    return elevation_range_weights(
+        ds.zInterface,
+        ds.layer_mass,
+        ds.minLevelCell,
+        ds.maxLevelCell,
+        z_top,
+        z_bot,
+    ).values
+
+
 def _whole_column_weights(ds):
     """The weights of the whole column, as an array"""
     return elevation_range_weights(

--- a/tests/ocean/vertical/test_elevation.py
+++ b/tests/ocean/vertical/test_elevation.py
@@ -16,11 +16,11 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from polaris.ocean.vertical.diagnostics import get_z_mid_and_interface
 from polaris.ocean.vertical.elevation import (
     apply_vertical_reduction,
     elevation_range_weights,
     get_valid_level_range,
-    get_z_mid_and_interface,
     is_whole_column,
     parse_vertical_reduction,
 )


### PR DESCRIPTION
# The full vertical reduction for ocean analysis

This is the vertical kernel every vertically reduced product depends on: slicing a field at the sea surface, the seafloor, a layer index or an elevation, and the mass weights for an elevation range. It is one module, `polaris/ocean/vertical/elevation.py`, and its unit tests. Nothing consumes it in this diff; the branches above it do.

It imports nothing from `polaris.Step` and is tested against synthetic columns with known geometry, which is why it can sit at the bottom of the chain.

## What it does

An elevation is interpolated linearly between the midpoints of the two layers it falls between. Above the topmost midpoint the topmost value is used rather than the map being masked, and likewise below the bottommost midpoint down to the seafloor, so that a request for `0.0` or `-5.0` means what someone asking for a near-surface map intends. Below the seafloor, and in land columns, the result is masked. `minLevelCell` and `maxLevelCell` are respected throughout, so ice-shelf cavities and partial bottom cells behave.

An elevation range weights each layer by the fraction of its thickness the range covers, so a range boundary inside a layer is exact, a layer wholly inside the range contributes its whole mass, and a range reaching below the seafloor is truncated there.

## One design bug found and fixed before writing the code

The design's vectorized search for the bounding layer was `k1 = (z_mid >= z).sum(...) - 1`. Because `z_mid` is `NaN` above the valid range as well as below it, that count is `k1 - k_min + 1`, so the index lands `k_min` layers too high. Every column with `k_min = 0` passes either way, which is why it survived review; in an ice-shelf cavity it inverts a clamp, returning the top of the column where the rule says the bottom. The design is corrected on the branch below, and two tests that would have caught it are now in the design's testing section and in this branch.

## This is one of seven PRs, reviewed in order

The work is a chain in dependency order. GitHub cannot base a cross-fork PR on another fork branch, so every one of these is based on `main` and its diff contains everything below it. Reviewing them in order is what keeps each diff small — review only the commits this branch adds.

| order | PR | branch | what it adds |
| --- | --- | --- | --- |
| 1 | #706 | `add-analysis-designs` | the two design documents |
| 2 | #735 | `add-omega-analysis-elevation` | the vertical reduction kernel |
| 3 | #726 | `add-omega-analysis-scaffolding` | the suite, tasks and step structure |
| 4 | #736 | `add-omega-analysis-publisher` | manifests, the staging tree, the gallery |
| 5 | #729 | `add-omega-analysis-global-stats` | global statistics time series |
| 6 | #730 | `add-omega-analysis-climatology-maps` | the ncclimo climatology and its maps |
| 7 | #737 | `add-omega-analysis-heat-content` | ocean heat content, maps and time series |

A gallery generated by the whole chain against the QU240 mock-up is published here, which is the quickest way to see what the suite produces: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/xasaydavis/omega_analysis_qu240_mockup_20260830/

Checklist
* [ ] User's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] New tests have been added to a test suite
