### PR TITLE
Fit figure titles to the figure rather than cropping them

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -504,6 +504,7 @@ seaice/api
 .. autosummary::
    :toctree: generated/
 
+   add_fitted_suptitle
    determine_time_variable
    get_projection
    get_viz_defaults

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -1,4 +1,7 @@
 from polaris.viz.helper import (
+    add_fitted_suptitle as add_fitted_suptitle,
+)
+from polaris.viz.helper import (
     determine_time_variable as determine_time_variable,
 )
 from polaris.viz.helper import (

--- a/polaris/viz/helper.py
+++ b/polaris/viz/helper.py
@@ -1,4 +1,7 @@
+import textwrap
+
 import cartopy.crs as ccrs
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 
 projections = {
     'PlateCarree': ccrs.PlateCarree,
@@ -72,3 +75,64 @@ def determine_time_variable(ds):
         prefix = 'timeMonthly_avg_'
         time_variable = 'Time'
     return prefix, time_variable
+
+
+def add_fitted_suptitle(fig, title, y=None, min_fontsize=8.0):
+    """
+    Add a title to a figure, sized so that it fits across the figure
+
+    A title wider than the figure runs off both ends of the canvas, and is
+    simply cropped when the figure is saved at a fixed size.  What it loses is
+    the part that distinguishes one plot from another --- the elevation range,
+    the season, the years --- so the title is shrunk to fit, and wrapped onto a
+    second line if shrinking alone is not enough.  Nothing is dropped.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to title
+
+    title : str
+        The title, which may be longer than the figure is wide
+
+    y : float, optional
+        Where to place the title in figure coordinates.  A wrapped title is
+        placed by the layout engine instead, since a fixed position would put
+        its second line over the axes.
+
+    min_fontsize : float, optional
+        The size below which the title is wrapped rather than shrunk further
+
+    Returns
+    -------
+    text : matplotlib.text.Text
+        The title that was added
+    """
+    # measuring rendered text needs a canvas that can produce a renderer; a
+    # bare figure carries one that cannot, and savefig would attach an Agg
+    # canvas anyway, so attaching it here changes nothing that is drawn
+    if not hasattr(fig.canvas, 'get_renderer'):
+        FigureCanvasAgg(fig)
+
+    text = fig.suptitle(title, y=y) if y is not None else fig.suptitle(title)
+    fontsize = text.get_fontsize()
+    # leave a small margin so the title does not touch the figure edge
+    limit = 0.96 * fig.get_size_inches()[0] * fig.dpi
+
+    def too_wide():
+        extent = text.get_window_extent(renderer=fig.canvas.get_renderer())
+        return extent.width > limit
+
+    while too_wide() and fontsize > min_fontsize:
+        fontsize = max(min_fontsize, fontsize * 0.95)
+        text.set_fontsize(fontsize)
+
+    if too_wide():
+        # shrinking hit the floor, so wrap instead, and let the layout engine
+        # place a title that is now two lines tall
+        halves = textwrap.wrap(title, width=max(len(title) // 2, 1))
+        text.set_text('\n'.join(halves[:1] + [' '.join(halves[1:])]))
+        text.set_position((text.get_position()[0], 1.0))
+        text.set_verticalalignment('top')
+
+    return text

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -14,7 +14,7 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from pyremap.descriptor.utility import interp_extrap_corner
 from ruamel.yaml import YAML
 
-from polaris.viz.helper import get_projection
+from polaris.viz.helper import add_fitted_suptitle, get_projection
 from polaris.viz.style import mplstyle_context
 
 
@@ -163,7 +163,7 @@ def plot_global_mpas_field(
         ax = fig.add_subplot(111, projection=projection)
 
         if title is not None:
-            fig.suptitle(title, y=0.935)
+            add_fitted_suptitle(fig, title, y=0.935)
 
         colormap, norm, ticks = setup_colormap(config, colormap_section)
 
@@ -304,7 +304,7 @@ def plot_global_lat_lon_field(
         figsize = (8, 4.5)
         fig = Figure(figsize=figsize)
         if title is not None:
-            fig.suptitle(title, y=0.935)
+            add_fitted_suptitle(fig, title, y=0.935)
 
         subplots = [111]
         ref_projection = cartopy.crs.PlateCarree()

--- a/tests/viz/test_fitted_suptitle.py
+++ b/tests/viz/test_fitted_suptitle.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for the figure title that fits the figure.
+
+A title wider than the figure is cropped when the figure is saved at a fixed
+size, and what it loses is what distinguishes one plot from another.  These
+check that it is made to fit, and that nothing is dropped to do it.
+
+They run in the Polaris style, since that is what sets the title size the
+plots are actually drawn with.
+"""
+
+from matplotlib.figure import Figure
+
+from polaris.viz.helper import add_fitted_suptitle
+from polaris.viz.style import mplstyle_context
+
+SHORT = 'qu240: ssh, ANN'
+LONG = (
+    'qu240_mockup: ocean heat content, -2000m to bottom, ANN, years 0001-0001'
+)
+ABSURD = (
+    'qu240_mockup: ocean heat content over the deep ocean from -2000 m to '
+    'the seafloor, annual mean, simulation years 0001-0001, on the native '
+    'unstructured mesh with no remapping of any kind applied to it'
+)
+
+
+def _figure():
+    fig = Figure(figsize=(8, 4.5), constrained_layout=True)
+    fig.add_subplot(111)
+    return fig
+
+
+def _default_fontsize(fig, title):
+    text = fig.suptitle(title)
+    size = text.get_fontsize()
+    text.remove()
+    return size
+
+
+def _fits(fig, text):
+    renderer = fig.canvas.get_renderer()
+    width = text.get_window_extent(renderer=renderer).width
+    return width <= fig.get_size_inches()[0] * fig.dpi
+
+
+def test_a_title_that_fits_is_left_alone():
+    with mplstyle_context():
+        fig = _figure()
+        default = _default_fontsize(fig, SHORT)
+        text = add_fitted_suptitle(fig, SHORT)
+        assert text.get_fontsize() == default
+        assert _fits(fig, text)
+
+
+def test_a_long_title_is_shrunk_until_it_fits():
+    with mplstyle_context():
+        fig = _figure()
+        default = _default_fontsize(fig, LONG)
+        text = add_fitted_suptitle(fig, LONG)
+        assert text.get_fontsize() < default
+        assert '\n' not in text.get_text()
+        assert _fits(fig, text)
+
+
+def test_a_title_too_long_to_shrink_is_wrapped():
+    with mplstyle_context():
+        fig = _figure()
+        text = add_fitted_suptitle(fig, ABSURD)
+        assert '\n' in text.get_text()
+        assert _fits(fig, text)
+
+
+def test_no_title_loses_any_of_its_words():
+    """Fitting must not drop what tells two plots apart."""
+    with mplstyle_context():
+        for title in (SHORT, LONG, ABSURD):
+            fig = _figure()
+            text = add_fitted_suptitle(fig, title)
+            assert text.get_text().split() == title.split()


### PR DESCRIPTION
# Fit a figure title to the figure rather than cropping it

A title wider than the figure runs off both ends of the canvas and is cut when the figure is saved. `plot_global_mpas_field()` saves at a fixed size without a tight bounding box — deliberately, since a tight box collapses a fixed-aspect `GeoAxes` with an attached colorbar — so nothing rescues an overlong title.

It is easy to see in the published ocean analysis gallery. This title:

```
qu240_mockup: ocean heat content, -2000m to bottom, ANN, years 0001-0001
```

is rendered as `40_mockup: ocean heat content, -2000m to bottom, ANN, years 0001-0`, losing both the simulation it came from and half the year range — the two things that tell one of the four heat content maps from another.

## What this does

`add_fitted_suptitle()` measures the rendered title and shrinks it until it fits, then wraps it onto a second line if shrinking alone would take it below a readable floor. Both spherical plotting functions use it.

Nothing is dropped. An ellipsis was considered and rejected: on a scientific figure it removes exactly what distinguishes one plot from another, and it does so silently.

This is framework code used by at least eight tasks — cosine bell, sphere transport, geostrophic, topo remap, unified base mesh, realistic global, customizable viz and the ocean analysis maps — so their titles will change where they were previously too wide. Titles that already fit are untouched.

## Not fixed here

The outermost longitude labels on `plot_global_mpas_field()` are also cropped at the figure edge — visible as `30°` where the label should read `180°`. It has the same underlying cause, a fixed canvas the axes overflow, but a different remedy, and it seemed better not to widen this PR into a general layout rework.

Checklist
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
