### PR TITLE
Leave room around a spherical plot, and let one cover part of the globe

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -508,6 +508,7 @@ seaice/api
    determine_time_variable
    get_projection
    get_viz_defaults
+   make_room_for_gridline_labels
    mplstyle_context
    plot_horiz_field
    plot_global_lat_lon_field

--- a/polaris/viz/__init__.py
+++ b/polaris/viz/__init__.py
@@ -10,6 +10,9 @@ from polaris.viz.helper import (
 from polaris.viz.helper import (
     get_viz_defaults as get_viz_defaults,
 )
+from polaris.viz.helper import (
+    make_room_for_gridline_labels as make_room_for_gridline_labels,
+)
 from polaris.viz.planar import plot_horiz_field as plot_horiz_field
 from polaris.viz.spherical import (
     plot_global_lat_lon_field as plot_global_lat_lon_field,

--- a/polaris/viz/helper.py
+++ b/polaris/viz/helper.py
@@ -136,3 +136,32 @@ def add_fitted_suptitle(fig, title, y=None, min_fontsize=8.0):
         text.set_verticalalignment('top')
 
     return text
+
+
+def make_room_for_gridline_labels(ax):
+    """
+    Let the layout engine reserve room for a map's gridline labels
+
+    Cartopy draws gridline labels outside the axes, so a layout engine only
+    leaves room for them if the axes report a finite tight bounding box.  A
+    ``GeoAxes`` does not.  Whenever its gridliner draws top or "geo" labels ---
+    and geo labels are on by default --- cartopy repositions the axes titles
+    to sit above them, and lands them at an infinite position.  Matplotlib
+    folds the titles into the tight bounding box, so the box comes back as
+    ``nan``, the layout engine reserves nothing, and the labels are drawn off
+    the canvas: the outermost longitude label is cut in half and every
+    latitude label is lost entirely.
+
+    Giving the title an explicit position turns cartopy's repositioning off,
+    which is all it takes for the bounding box to be finite and the margins to
+    be reserved.  Polaris titles its spherical plots with ``fig.suptitle()``,
+    so the axes titles are empty and nothing is drawn differently.
+
+    Parameters
+    ----------
+    ax : cartopy.mpl.geoaxes.GeoAxes
+        The map axes whose gridline labels need room
+    """
+    # passing an explicit ``y`` is what tells matplotlib and cartopy that the
+    # title has been placed by hand and must not be moved
+    ax.set_title('', y=1.0)

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -5,7 +5,9 @@ import cartopy
 import cmocean  # noqa: F401
 import matplotlib.colors as cols
 import mosaic
+import mosaic.utils
 import numpy as np
+import xarray as xr
 from cartopy.geodesic import Geodesic
 from matplotlib import colormaps
 from matplotlib.figure import Figure
@@ -20,6 +22,16 @@ from polaris.viz.helper import (
     make_room_for_gridline_labels,
 )
 from polaris.viz.style import mplstyle_context
+
+# the connectivity arrays mosaic remaps when it culls a mesh, mirroring
+# ``mosaic.descriptor.connectivity_arrays``
+_CONNECTIVITY_ARRAYS = [
+    'cellsOnEdge',
+    'cellsOnVertex',
+    'verticesOnEdge',
+    'verticesOnCell',
+    'edgesOnVertex',
+]
 
 
 def plot_global_mpas_field(
@@ -155,7 +167,7 @@ def plot_global_mpas_field(
             mesh_ds.attrs['is_periodic'] = 'NO'
 
             if cell_indices is not None:
-                mesh_ds = mesh_ds.isel(nCells=cell_indices)
+                mesh_ds = _cull_mesh_to_cells(mesh_ds, cell_indices)
             descriptor = mosaic.Descriptor(
                 mesh_ds,
                 projection=projection,
@@ -441,6 +453,57 @@ def setup_colormap(config, colormap_section):
         colormap.set_over(over_color)
 
     return colormap, norm, ticks
+
+
+def _cull_mesh_to_cells(mesh_ds, cell_indices):
+    """
+    Cull an MPAS mesh down to a subset of its cells
+
+    Selecting cells with ``isel(nCells=...)`` alone leaves the edge and vertex
+    dimensions at their original size and the connectivity arrays pointing at
+    cells that are no longer there.  Mosaic then culls the mesh again for the
+    projection, and indexes those stale arrays out of bounds.
+
+    ``mosaic.utils.cull_mesh()`` does the job properly, but it expects
+    zero-based connectivity, so the arrays are shifted into that convention
+    and back again around the call.  The shift back is faithful: mosaic marks
+    a neighbor it culled with ``-2`` and a land boundary with ``-1``, which
+    become ``-1`` and ``0`` here and are read back as ``-2`` and ``-1`` when
+    the descriptor zero-bases them again.
+
+    Parameters
+    ----------
+    mesh_ds : xarray.Dataset
+        An MPAS mesh, with one-based connectivity arrays
+
+    cell_indices : integer array
+        The cells to keep.  Cells are kept in mesh order, so a field plotted
+        on the culled mesh must be selected the same way.
+
+    Returns
+    -------
+    culled_ds : xarray.Dataset
+        The mesh with only those cells, and the edges and vertices that
+        touch them
+    """
+    culled_ds = mesh_ds.copy()
+    for array_name in _CONNECTIVITY_ARRAYS:
+        dim = 'n' + array_name.split('On')[0].title()
+        zero_based = culled_ds[array_name] - 1
+        # some meshes mark "no neighbor" with the size of the dimension
+        # rather than with zero, which is out of bounds once zero-based
+        culled_ds[array_name] = xr.where(
+            zero_based == mesh_ds.sizes[dim], -1, zero_based
+        )
+
+    cells_to_cull = np.ones(mesh_ds.sizes['nCells'], dtype=bool)
+    cells_to_cull[cell_indices] = False
+    culled_ds = mosaic.utils.cull_mesh(culled_ds, cells_to_cull)
+
+    for array_name in _CONNECTIVITY_ARRAYS:
+        culled_ds[array_name] = culled_ds[array_name] + 1
+
+    return culled_ds
 
 
 def _add_land_lakes_coastline(ax, ice_shelves=True):

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -266,6 +266,7 @@ def plot_global_lat_lon_field(
     title=None,
     plot_land=True,
     colorbar_label=None,
+    figsize=(8, 4.5),
 ):
     """
     Plots a data set as a longitude-latitude map
@@ -312,6 +313,10 @@ def plot_global_lat_lon_field(
 
     colorbar_label : str, optional
         Label on the colorbar
+
+    figsize : tuple, optional
+        The size of the figure in inches.  A size that matches the aspect
+        ratio of the map leaves the least empty canvas around it
     """
 
     with mplstyle_context():
@@ -336,7 +341,6 @@ def plot_global_lat_lon_field(
                 f'be either {nlat} or {nlat + 1}'
             )
 
-        figsize = (8, 4.5)
         fig = Figure(figsize=figsize)
         if title is not None:
             add_fitted_suptitle(fig, title)

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -4,6 +4,7 @@ import importlib.resources as imp_res
 import cartopy
 import cmocean  # noqa: F401
 import matplotlib.colors as cols
+import matplotlib.path as mpath
 import mosaic
 import mosaic.utils
 import numpy as np
@@ -52,6 +53,8 @@ def plot_global_mpas_field(
     cell_indices=None,
     ds_transect=None,
     enforce_aspect_ratio=False,
+    extent=None,
+    circular_boundary=False,
 ):
     """
     Plots a data set as a longitude-latitude map
@@ -117,6 +120,16 @@ def plot_global_mpas_field(
         Whether to enforce the aspect ratio of the figure according to lat,
         lon bounds
 
+    extent : tuple of float, optional
+        The ``(lon_min, lon_max, lat_min, lat_max)`` the map covers, in
+        degrees.  The map is scaled to the data being plotted if this is not
+        given.
+
+    circular_boundary : bool, optional
+        Whether to clip the map to a circle inscribed in the axes, which is
+        how a polar stereographic map of everything poleward of some latitude
+        is drawn.  Meaningless without ``extent``
+
     Returns
     -------
     descriptor : mosaic.Descriptor
@@ -177,6 +190,11 @@ def plot_global_mpas_field(
 
         fig = Figure(figsize=figsize, constrained_layout=True)
         ax = fig.add_subplot(111, projection=projection)
+
+        if extent is not None:
+            ax.set_extent(extent, crs=cartopy.crs.PlateCarree())
+        if circular_boundary:
+            _set_circular_boundary(ax)
 
         if title is not None:
             add_fitted_suptitle(fig, title)
@@ -453,6 +471,24 @@ def setup_colormap(config, colormap_section):
         colormap.set_over(over_color)
 
     return colormap, norm, ticks
+
+
+def _set_circular_boundary(ax):
+    """
+    Clip a map to the circle inscribed in its axes
+
+    A polar stereographic map of everything poleward of some latitude is a
+    disc, but the axes are rectangular, so without this the corners are drawn
+    too and the map reads as a box with a cap in it.
+
+    Parameters
+    ----------
+    ax : cartopy.mpl.geoaxes.GeoAxes
+        The map axes to clip
+    """
+    theta = np.linspace(0.0, 2.0 * np.pi, 100)
+    vertices = np.column_stack([np.sin(theta), np.cos(theta)])
+    ax.set_boundary(mpath.Path(0.5 * vertices + 0.5), transform=ax.transAxes)
 
 
 def _cull_mesh_to_cells(mesh_ds, cell_indices):

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -179,7 +179,7 @@ def plot_global_mpas_field(
         ax = fig.add_subplot(111, projection=projection)
 
         if title is not None:
-            add_fitted_suptitle(fig, title, y=0.935)
+            add_fitted_suptitle(fig, title)
 
         colormap, norm, ticks = setup_colormap(config, colormap_section)
 
@@ -321,7 +321,7 @@ def plot_global_lat_lon_field(
         figsize = (8, 4.5)
         fig = Figure(figsize=figsize)
         if title is not None:
-            add_fitted_suptitle(fig, title, y=0.935)
+            add_fitted_suptitle(fig, title)
 
         subplots = [111]
         ref_projection = cartopy.crs.PlateCarree()

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -14,7 +14,11 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from pyremap.descriptor.utility import interp_extrap_corner
 from ruamel.yaml import YAML
 
-from polaris.viz.helper import add_fitted_suptitle, get_projection
+from polaris.viz.helper import (
+    add_fitted_suptitle,
+    get_projection,
+    make_room_for_gridline_labels,
+)
 from polaris.viz.style import mplstyle_context
 
 
@@ -179,6 +183,7 @@ def plot_global_mpas_field(
         )
         gl.right_labels = False
         gl.top_labels = False
+        make_room_for_gridline_labels(ax)
 
         if plot_land:
             _add_land_lakes_coastline(ax)
@@ -330,6 +335,7 @@ def plot_global_lat_lon_field(
         )
         gl.right_labels = False
         gl.top_labels = False
+        make_room_for_gridline_labels(ax)
 
         plotHandle = ax.pcolormesh(
             lon_corner,

--- a/tests/viz/test_cull_mesh_to_cells.py
+++ b/tests/viz/test_cull_mesh_to_cells.py
@@ -1,0 +1,185 @@
+"""
+Unit tests for culling a mesh down to the cells that are being plotted.
+
+Selecting cells with ``isel(nCells=...)`` leaves the connectivity arrays
+pointing at cells that are no longer there, and mosaic indexes them out of
+bounds when it culls the mesh again for the projection.  These check that the
+culled mesh is self-consistent and that mosaic will accept it.
+"""
+
+import cartopy.crs as ccrs
+import mosaic
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.viz.spherical import _CONNECTIVITY_ARRAYS, _cull_mesh_to_cells
+
+
+def test_the_connectivity_arrays_match_mosaic():
+    """Mosaic remaps a fixed set of arrays; ours has to be the same set."""
+    from mosaic.descriptor import connectivity_arrays
+
+    assert sorted(_CONNECTIVITY_ARRAYS) == sorted(connectivity_arrays)
+
+
+def test_culling_keeps_the_cells_asked_for():
+    mesh_ds = _quad_mesh_dataset(4, 4)
+    cell_indices = np.array([5, 6, 9, 10])
+
+    culled_ds = _cull_mesh_to_cells(mesh_ds, cell_indices)
+
+    assert culled_ds.sizes['nCells'] == cell_indices.size
+    np.testing.assert_allclose(
+        culled_ds.latCell.values, mesh_ds.latCell.values[cell_indices]
+    )
+    np.testing.assert_allclose(
+        culled_ds.lonCell.values, mesh_ds.lonCell.values[cell_indices]
+    )
+
+
+def test_culling_drops_the_edges_and_vertices_left_behind():
+    mesh_ds = _quad_mesh_dataset(4, 4)
+
+    culled_ds = _cull_mesh_to_cells(mesh_ds, np.array([5, 6, 9, 10]))
+
+    assert culled_ds.sizes['nEdges'] < mesh_ds.sizes['nEdges']
+    assert culled_ds.sizes['nVertices'] < mesh_ds.sizes['nVertices']
+
+
+def test_no_connectivity_index_points_outside_the_culled_mesh():
+    """The invariant that ``isel(nCells=...)`` on its own breaks."""
+    mesh_ds = _quad_mesh_dataset(4, 4)
+
+    culled_ds = _cull_mesh_to_cells(mesh_ds, np.array([5, 6, 9, 10]))
+
+    for array_name in _CONNECTIVITY_ARRAYS:
+        dim = 'n' + array_name.split('On')[0].title()
+        indices = culled_ds[array_name].values
+        assert indices.max() <= culled_ds.sizes[dim], array_name
+
+
+@pytest.mark.parametrize(
+    'projection_name', ['PlateCarree', 'NorthPolarStereo']
+)
+def test_mosaic_accepts_the_culled_mesh(projection_name):
+    """Handing mosaic the uncut mesh subset raises IndexError instead."""
+    mesh_ds = _quad_mesh_dataset(4, 4)
+    cell_indices = np.array([5, 6, 9, 10])
+
+    culled_ds = _cull_mesh_to_cells(mesh_ds, cell_indices)
+    descriptor = mosaic.Descriptor(
+        culled_ds,
+        projection=getattr(ccrs, projection_name)(),
+        transform=ccrs.Geodetic(),
+        use_latlon=True,
+    )
+
+    assert descriptor.sizes['nCells'] == cell_indices.size
+    assert mosaic.utils.get_invalid_patches(descriptor.cell_patches) is None
+
+
+def _quad_mesh_dataset(nx, ny):
+    """
+    An ``nx`` by ``ny`` mesh of quadrilateral cells, one degree on a side,
+    with the connectivity arrays mosaic needs.  Cells are numbered in row
+    order, and a missing neighbor is marked with zero, as MPAS does.
+    """
+    lon_vertex, lat_vertex = np.meshgrid(
+        np.arange(nx + 1, dtype=float), np.arange(ny + 1, dtype=float)
+    )
+
+    def vertex(i, j):
+        return j * (nx + 1) + i + 1
+
+    def cell(i, j):
+        inside = (0 <= i < nx) and (0 <= j < ny)
+        return j * nx + i + 1 if inside else 0
+
+    # horizontal edges first, then vertical ones
+    def horiz_edge(i, j):
+        inside = (0 <= i < nx) and (0 <= j < ny + 1)
+        return j * nx + i + 1 if inside else 0
+
+    def vert_edge(i, j):
+        inside = (0 <= i < nx + 1) and (0 <= j < ny)
+        return nx * (ny + 1) + j * (nx + 1) + i + 1 if inside else 0
+
+    lon_cell, lat_cell = [], []
+    vertices_on_cell = []
+    for j in range(ny):
+        for i in range(nx):
+            lon_cell.append(i + 0.5)
+            lat_cell.append(j + 0.5)
+            vertices_on_cell.append(
+                [
+                    vertex(i, j),
+                    vertex(i + 1, j),
+                    vertex(i + 1, j + 1),
+                    vertex(i, j + 1),
+                ]
+            )
+
+    lon_edge, lat_edge = [], []
+    cells_on_edge, vertices_on_edge = [], []
+    for j in range(ny + 1):
+        for i in range(nx):
+            lon_edge.append(i + 0.5)
+            lat_edge.append(float(j))
+            cells_on_edge.append([cell(i, j - 1), cell(i, j)])
+            vertices_on_edge.append([vertex(i, j), vertex(i + 1, j)])
+    for j in range(ny):
+        for i in range(nx + 1):
+            lon_edge.append(float(i))
+            lat_edge.append(j + 0.5)
+            cells_on_edge.append([cell(i - 1, j), cell(i, j)])
+            vertices_on_edge.append([vertex(i, j), vertex(i, j + 1)])
+
+    cells_on_vertex, edges_on_vertex = [], []
+    for j in range(ny + 1):
+        for i in range(nx + 1):
+            cells_on_vertex.append(
+                [
+                    cell(i - 1, j - 1),
+                    cell(i, j - 1),
+                    cell(i, j),
+                    cell(i - 1, j),
+                ]
+            )
+            edges_on_vertex.append(
+                [
+                    horiz_edge(i - 1, j),
+                    horiz_edge(i, j),
+                    vert_edge(i, j - 1),
+                    vert_edge(i, j),
+                ]
+            )
+
+    mesh_ds = xr.Dataset(
+        {
+            'latCell': ('nCells', np.deg2rad(lat_cell)),
+            'lonCell': ('nCells', np.deg2rad(lon_cell)),
+            'latEdge': ('nEdges', np.deg2rad(lat_edge)),
+            'lonEdge': ('nEdges', np.deg2rad(lon_edge)),
+            'latVertex': ('nVertices', np.deg2rad(lat_vertex.ravel())),
+            'lonVertex': ('nVertices', np.deg2rad(lon_vertex.ravel())),
+            'verticesOnCell': (
+                ('nCells', 'maxEdges'),
+                np.array(vertices_on_cell),
+            ),
+            'cellsOnEdge': (('nEdges', 'TWO'), np.array(cells_on_edge)),
+            'verticesOnEdge': (('nEdges', 'TWO'), np.array(vertices_on_edge)),
+            'cellsOnVertex': (
+                ('nVertices', 'vertexDegree'),
+                np.array(cells_on_vertex),
+            ),
+            'edgesOnVertex': (
+                ('nVertices', 'vertexDegree'),
+                np.array(edges_on_vertex),
+            ),
+        }
+    )
+    mesh_ds.attrs['on_a_sphere'] = 'YES'
+    mesh_ds.attrs['sphere_radius'] = 6371229.0
+    mesh_ds.attrs['is_periodic'] = 'NO'
+    return mesh_ds

--- a/tests/viz/test_cull_mesh_to_cells.py
+++ b/tests/viz/test_cull_mesh_to_cells.py
@@ -1,5 +1,5 @@
 """
-Unit tests for culling a mesh down to the cells that are being plotted.
+Unit tests for restricting a spherical plot to part of the globe.
 
 Selecting cells with ``isel(nCells=...)`` leaves the connectivity arrays
 pointing at cells that are no longer there, and mosaic indexes them out of
@@ -12,8 +12,14 @@ import mosaic
 import numpy as np
 import pytest
 import xarray as xr
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 
-from polaris.viz.spherical import _CONNECTIVITY_ARRAYS, _cull_mesh_to_cells
+from polaris.viz.spherical import (
+    _CONNECTIVITY_ARRAYS,
+    _cull_mesh_to_cells,
+    _set_circular_boundary,
+)
 
 
 def test_the_connectivity_arrays_match_mosaic():
@@ -183,3 +189,33 @@ def _quad_mesh_dataset(nx, ny):
     mesh_ds.attrs['sphere_radius'] = 6371229.0
     mesh_ds.attrs['is_periodic'] = 'NO'
     return mesh_ds
+
+
+def test_a_circular_boundary_leaves_the_corners_undrawn():
+    """A polar map of everything poleward of a latitude is a disc, not a box"""
+    corner, centre = _corner_and_centre(circular=True)
+    assert tuple(centre) == (255, 0, 0)
+    assert tuple(corner) == (255, 255, 255)
+
+
+def test_the_corners_are_drawn_without_a_circular_boundary():
+    """So the test above cannot pass vacuously"""
+    corner, centre = _corner_and_centre(circular=False)
+    assert tuple(centre) == (255, 0, 0)
+    assert tuple(corner) == (255, 0, 0)
+
+
+def _corner_and_centre(circular):
+    """Render a polar map filled with red and sample two of its pixels"""
+    fig = Figure(figsize=(2, 2), dpi=100)
+    canvas = FigureCanvasAgg(fig)
+    ax = fig.add_subplot(111, projection=ccrs.NorthPolarStereo())
+    # fill the figure, so that a corner of the axes is a corner of the image
+    ax.set_position((0.0, 0.0, 1.0, 1.0))
+    ax.set_extent((-180.0, 180.0, 60.0, 90.0), crs=ccrs.PlateCarree())
+    ax.patch.set_facecolor('red')
+    if circular:
+        _set_circular_boundary(ax)
+    canvas.draw()
+    rgba = np.asarray(canvas.buffer_rgba())
+    return rgba[3, 3, :3], rgba[100, 100, :3]

--- a/tests/viz/test_gridline_labels.py
+++ b/tests/viz/test_gridline_labels.py
@@ -1,11 +1,12 @@
 """
-Unit tests for the room a spherical plot leaves for its gridline labels.
+Unit tests for the room a spherical plot leaves around its map.
 
 Cartopy draws gridline labels outside the axes, and a ``GeoAxes`` reports a
 non-finite tight bounding box, so the layout engine reserves no room for them
 and they are drawn off the canvas: the outermost longitude label is cut in
 half and every latitude label is lost entirely.  These check that the axes
-report a finite bounding box and that every label lands inside the figure.
+report a finite bounding box, that every label lands inside the figure, and
+that the title clears the map rather than being drawn over it.
 
 They run in the Polaris style, since that is what sets the figure size and
 label size the plots are actually drawn with.
@@ -17,7 +18,11 @@ import pytest
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 
-from polaris.viz.helper import get_projection, make_room_for_gridline_labels
+from polaris.viz.helper import (
+    add_fitted_suptitle,
+    get_projection,
+    make_room_for_gridline_labels,
+)
 from polaris.viz.style import mplstyle_context
 
 # a rectangular projection, one with a curved boundary, an interrupted one and
@@ -30,15 +35,19 @@ PROJECTIONS = [
 ]
 
 
-def _figure(projection_name, make_room):
+def _figure(
+    projection_name, make_room, figsize=(8, 4.5), title=None, title_y=None
+):
     """Build the figure that ``plot_global_mpas_field()`` builds"""
     projection = get_projection(projection_name)
-    fig = Figure(figsize=(8, 4.5), constrained_layout=True)
+    fig = Figure(figsize=figsize, constrained_layout=True)
     # measuring rendered labels needs a canvas that can produce a renderer;
     # a bare figure carries one that cannot
     FigureCanvasAgg(fig)
     ax = fig.add_subplot(111, projection=projection)
     ax.set_global()
+    if title is not None:
+        add_fitted_suptitle(fig, title, y=title_y)
     gl = ax.gridlines(color='gray', linestyle=':', zorder=5, draw_labels=True)
     gl.right_labels = False
     gl.top_labels = False
@@ -81,6 +90,39 @@ def test_no_gridline_label_is_cropped(projection_name):
         bbox = ax.get_tightbbox(fig.canvas.get_renderer())
         assert np.isfinite([bbox.x0, bbox.y0, bbox.x1, bbox.y1]).all()
         assert _cropped_labels(fig, gl) == []
+
+
+# the default figure is wider than a global map is tall, so a title placed a
+# fixed distance from the top of the canvas happens to clear the map; a figure
+# sized to a taller projection is where that goes wrong
+@pytest.mark.parametrize('figsize', [(8, 4.5), (8, 6.4)])
+def test_the_title_clears_the_map(figsize):
+    with mplstyle_context():
+        fig, ax, _ = _figure(
+            'Mercator', make_room=True, figsize=figsize, title='a title'
+        )
+        renderer = fig.canvas.get_renderer()
+        title = fig._suptitle.get_window_extent(renderer=renderer)
+        assert title.ymin >= ax.get_window_extent(renderer).ymax
+        assert title.ymax <= fig.bbox.y1
+
+
+def test_a_title_at_a_fixed_height_lands_on_the_map():
+    """The bug the test above guards against: a hand-placed title is one the
+    layout engine does not reserve room for, so a figure sized to a taller
+    projection draws it over the map.  0.935 is where the title used to be
+    pinned."""
+    with mplstyle_context():
+        fig, ax, _ = _figure(
+            'Mercator',
+            make_room=True,
+            figsize=(8, 6.4),
+            title='a title',
+            title_y=0.935,
+        )
+        renderer = fig.canvas.get_renderer()
+        title = fig._suptitle.get_window_extent(renderer=renderer)
+        assert title.ymin < ax.get_window_extent(renderer).ymax
 
 
 def test_labels_are_cropped_without_the_fix():

--- a/tests/viz/test_gridline_labels.py
+++ b/tests/viz/test_gridline_labels.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for the room a spherical plot leaves for its gridline labels.
+
+Cartopy draws gridline labels outside the axes, and a ``GeoAxes`` reports a
+non-finite tight bounding box, so the layout engine reserves no room for them
+and they are drawn off the canvas: the outermost longitude label is cut in
+half and every latitude label is lost entirely.  These check that the axes
+report a finite bounding box and that every label lands inside the figure.
+
+They run in the Polaris style, since that is what sets the figure size and
+label size the plots are actually drawn with.
+"""
+
+import cartopy.crs as ccrs
+import numpy as np
+import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+
+from polaris.viz.helper import get_projection, make_room_for_gridline_labels
+from polaris.viz.style import mplstyle_context
+
+# a rectangular projection, one with a curved boundary, an interrupted one and
+# a polar one, since where cartopy puts a label depends on the boundary
+PROJECTIONS = [
+    'PlateCarree',
+    'Robinson',
+    'InterruptedGoodeHomolosine',
+    'NorthPolarStereo',
+]
+
+
+def _figure(projection_name, make_room):
+    """Build the figure that ``plot_global_mpas_field()`` builds"""
+    projection = get_projection(projection_name)
+    fig = Figure(figsize=(8, 4.5), constrained_layout=True)
+    # measuring rendered labels needs a canvas that can produce a renderer;
+    # a bare figure carries one that cannot
+    FigureCanvasAgg(fig)
+    ax = fig.add_subplot(111, projection=projection)
+    ax.set_global()
+    gl = ax.gridlines(color='gray', linestyle=':', zorder=5, draw_labels=True)
+    gl.right_labels = False
+    gl.top_labels = False
+    if make_room:
+        make_room_for_gridline_labels(ax)
+
+    lon = np.linspace(-180.0, 180.0, 13)
+    lat = np.linspace(-90.0, 90.0, 7)
+    field = np.zeros((lat.shape[0] - 1, lon.shape[0] - 1))
+    pc = ax.pcolormesh(lon, lat, field, transform=ccrs.PlateCarree(), zorder=1)
+    fig.colorbar(pc, ax=ax, label='', extend='both', shrink=0.6)
+    fig.canvas.draw()
+    return fig, ax, gl
+
+
+def _cropped_labels(fig, gl):
+    """The visible gridline labels that are not wholly inside the figure"""
+    renderer = fig.canvas.get_renderer()
+    cropped = []
+    for artist in gl.label_artists:
+        if not artist.get_visible():
+            continue
+        extent = artist.get_window_extent(renderer=renderer)
+        if not fig.bbox.containsx(extent.x0) or not fig.bbox.containsx(
+            extent.x1
+        ):
+            cropped.append(artist.get_text())
+        elif not fig.bbox.containsy(extent.y0) or not fig.bbox.containsy(
+            extent.y1
+        ):
+            cropped.append(artist.get_text())
+    return cropped
+
+
+@pytest.mark.parametrize('projection_name', PROJECTIONS)
+def test_no_gridline_label_is_cropped(projection_name):
+    with mplstyle_context():
+        fig, ax, gl = _figure(projection_name, make_room=True)
+        # a non-finite box is what makes the layout engine reserve nothing
+        bbox = ax.get_tightbbox(fig.canvas.get_renderer())
+        assert np.isfinite([bbox.x0, bbox.y0, bbox.x1, bbox.y1]).all()
+        assert _cropped_labels(fig, gl) == []
+
+
+def test_labels_are_cropped_without_the_fix():
+    """The bug this guards against, so the tests above cannot pass vacuously"""
+    with mplstyle_context():
+        fig, ax, gl = _figure('PlateCarree', make_room=False)
+        assert _cropped_labels(fig, gl)


### PR DESCRIPTION
# Leave room around a spherical plot, and let one cover part of the globe

Two groups of bugs in `polaris/viz/spherical.py`. Nothing gets drawn in the margin around a map — the gridline labels land off the canvas and the title lands on the map — and there is no way to plot part of the globe: `cell_indices` raises `IndexError` and nothing says what the map covers.

## Nothing is left room around the map

On the ocean analysis gallery's PlateCarree maps, all five latitude labels are absent — they are drawn up to 189 pixels *left* of the canvas — and the leftmost longitude label reads `30°` where it should read `180°`. On a figure sized to a taller projection the title is drawn over the top of the map as well.

Both come from a position that is set by hand where the layout engine should be doing the work.

Cartopy draws gridline labels outside the axes, so `constrained_layout` leaves room for them only if the axes report a finite tight bounding box. A `GeoAxes` does not. Whenever its gridliner draws top or "geo" labels — and `geo_labels` is on by default — `GeoAxes._update_title_position()` repositions the axes titles to sit above them, and lands them at an infinite position. Matplotlib folds those titles into the axes tight bounding box, so the box comes back as `nan`, and nothing is reserved at all. Polaris never uses the axes titles; it titles these figures with `fig.suptitle()`. So the titles doing the damage are empty ones that are never drawn. `make_room_for_gridline_labels()` gives the axes title an explicit position, which is what tells matplotlib and cartopy that it has been placed by hand and must not be moved, and that is enough for the bounding box to be finite.

The figure title was pinned at `y=0.935` in figure coordinates, which tells matplotlib the same thing about the suptitle — so the layout engine reserved no room for that either. At the default 8×4.5 a global map is short enough that the title clears it anyway; a figure sized to a global Mercator map, which is 1.17 wide for every 1 tall, draws the title across the Arctic. #740 shrinks a title that is too wide but still passed that `y`; dropping it is all this takes, since `add_fitted_suptitle()` already places a title the layout engine's way when it is not given one.

`plot_global_lat_lon_field()` gains more than labels from this. It saves with `bbox_inches='tight'`, which is computed from the same non-finite bounding box, so the map itself was being cut off on the right and the bottom; it is now drawn whole.

## No way to plot part of the globe

`plot_global_mpas_field(cell_indices=...)` selected cells with `mesh_ds.isel(nCells=cell_indices)`, which leaves the edge and vertex dimensions at their original size and the connectivity arrays pointing at cells that are no longer there. Mosaic culls the mesh again for the projection and indexes those stale arrays out of bounds, so the call raised `IndexError` for every projection, not only the polar ones. `customizable_viz` is the caller this affects: its longitude/latitude window plots cannot have worked. `_cull_mesh_to_cells()` hands the job to `mosaic.utils.cull_mesh()`, which drops the edges and vertices left behind and remaps the connectivity; mosaic works on zero-based connectivity, so the arrays are shifted into that convention and back again around the call.

Even with the right cells, the axes were always scaled to whatever was plotted, and drawn as a box. `extent` says what longitude and latitude range the map covers, and `circular_boundary` clips it to the disc that a polar stereographic map of everything poleward of some latitude is. Both default to the old behaviour.

`plot_global_lat_lon_field()` also gains the `figsize` its sibling has always had, defaulting to the size it hard-coded before. That matters more now that the layout engine places the title: a fixed-aspect map that does not fill its cell is centred in it, and the leftover space ends up between the title and the map, so matching the figure to the map is how a caller closes that gap.

## What changes for existing plots

This is framework code used by at least eight tasks — cosine bell, sphere transport, geostrophic, topo remap, unified base mesh, realistic global, customizable viz and the ocean analysis maps — so their maps change: each is drawn a little smaller to make room for what surrounds it, and the title is placed by the layout engine rather than at a fixed height. Roughly 8% narrower for a global PlateCarree map. Nothing about a map's projection, extent or figure size changes unless a caller asks for it, and no label is dropped.

One thing this does not change is that the default 8x4.5 does not match the aspect of a global map on any of these projections, so a plot at the default still has more space between its title and its map than one at a matched size. Choosing the figure size is the caller's, and every task still passes what it passed before.

## Relationship to #740

#740 fits an over-wide title to the figure on the same plots, and listed the cropped gridline labels under "Not fixed here". This is that follow-up, now rebased onto it: `add_fitted_suptitle()` is called without a `y`, so the title is both shrunk to fit and placed by the layout engine. `make_room_for_gridline_labels()` sits beside it in `polaris/viz/helper.py`.

Checklist
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
