### PR TITLE
Task parallelism Phase A: placement

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -419,6 +419,19 @@ seaice/api
    time_index_from_xtime
 ```
 
+### parallel
+
+```{eval-rst}
+.. currentmodule:: polaris.parallel
+
+.. autosummary::
+   :toctree: generated/
+
+   set_parallel_systems
+   check_mache_supports_placement
+```
+
+
 ### namelist
 
 ```{eval-rst}

--- a/docs/developers_guide/framework/model.md
+++ b/docs/developers_guide/framework/model.md
@@ -414,9 +414,9 @@ The number of MPI tasks that land on each node (and therefore the stride
 between IO tasks) comes from the machine's resources in
 [mache](https://github.com/E3SM-Project/mache) -- `cores_per_node`,
 `gpus_per_node` and `max_mpi_tasks_per_node` -- combined with the
-`cpus_per_task` and `gpus_per_task` the step requests.  On GPU builds, where
-there is typically one MPI task per GPU, the stride is the number of GPUs per
-node rather than the number of CPU cores per node.
+`cpus_per_task` the step requests and the `gpus` it requests in total.  On
+GPU builds, where there is typically one MPI task per GPU, the stride is the
+number of GPUs per node rather than the number of CPU cores per node.
 
 For Omega runs, these same MPAS options are mapped to `Omega/IO/IOTasks` and
 `Omega/IO/IOStride` in yaml config files.

--- a/docs/developers_guide/framework/parallel.md
+++ b/docs/developers_guide/framework/parallel.md
@@ -30,6 +30,46 @@ The key APIs are now:
 `ParallelSystem.get_parallel_command()` supports both CPU and GPU resources
 through `cpus_per_task` and `gpus_per_task`.
 
+## Placement
+
+A step can be confined to a **named part** of the allocation -- these nodes,
+these cores on each, this many GPUs -- rather than being launched across all
+of it.  That is what makes it possible to run two steps at once without them
+colliding or queueing behind one another.
+
+The description is machine independent.  Polaris says *where*, and `mache`
+decides which flags express it, because those differ between machines and
+even between Slurm versions on the same machine:
+
+```python
+from mache.parallel import ResourcePlacement
+
+step.placement = ResourcePlacement(
+    nodes=('nid001234',), cores=tuple(range(8)), gpus=0
+)
+```
+
+`Step.placement` is `None` by default, and a step with no placement produces
+exactly the command Polaris has always produced.  **Nothing assigns a
+placement yet.**  Deciding which subset a step should get needs a scheduler,
+which is a later phase; the only caller today is the serial path, which
+assigns none.
+
+Two consequences are worth knowing about:
+
+- A placement always states GPUs, including when the answer is zero.  A
+  launch that says nothing about GPUs is read by the batch system as a claim
+  on every GPU on the node, which stops any other step from starting.
+- {py:meth}`polaris.Component.get_available_resources` takes an optional
+  placement and, when given one, describes that subset rather than the whole
+  allocation.  A step confined to one node has to be told about one node:
+  resources withheld from a step have to be genuinely withheld, not merely
+  subtracted from a number.
+
+Not every machine can confine a launch.  `mache` reports which mechanism a
+machine has through `ParallelSystem.placement_support`, decided at run time
+from the launcher that is actually installed rather than from configuration.
+
 ## Compiler-specific parallel configs
 
 `mache.parallel` combines options in `[parallel]` with

--- a/docs/developers_guide/framework/parallel.md
+++ b/docs/developers_guide/framework/parallel.md
@@ -42,9 +42,19 @@ parallel configuration.
 
 ## GPU resources
 
-Polaris step resources now include GPU requirements (`gpus_per_task` and
-`min_gpus_per_task`) in addition to CPU requirements. Resource constraints use
-both CPU and GPU availability when determining whether a step can run.
+Polaris step resources include GPU requirements in addition to CPU
+requirements. Resource constraints use both CPU and GPU availability when
+determining whether a step can run.
+
+A step states its GPU need as `gpus` and `min_gpus`, which are totals for
+the **step**, not counts per MPI task. A step that needs no GPUs leaves them
+at zero, which is the common case. The distinction matters once steps run at
+the same time: measurements on both GPU machines showed that asking for a
+number of GPUs per task does not confine a step to those GPUs, while asking
+for a total does.
+
+`gpus_per_task` and `min_gpus_per_task` still work and are translated into a
+total, but they are deprecated and raise a `DeprecationWarning`.
 
 For ocean model steps with dynamic sizing, Omega runs on GPU-capable compiler
 configs use:

--- a/docs/developers_guide/framework/parallel.md
+++ b/docs/developers_guide/framework/parallel.md
@@ -70,6 +70,22 @@ Not every machine can confine a launch.  `mache` reports which mechanism a
 machine has through `ParallelSystem.placement_support`, decided at run time
 from the launcher that is actually installed rather than from configuration.
 
+## Memory
+
+A step can say how much memory it needs, as `max_memory` (the target) and
+`min_memory` (the least it can run in), both in MB and in the same style as
+its CPU requirements.
+
+This is a **declaration only**.  Nothing in Polaris acts on it, and no
+launcher on a supported machine has a way to reserve memory for a job step:
+`--mem-per-cpu` was measured to make no difference to whether concurrent
+steps could coexist.  Using memory to decide how many steps may run at once
+belongs to the scheduler in a later phase, and matters most for analysis
+work, where a single step may need a large fraction of a node.
+
+The only thing checked today is that a step does not declare a minimum above
+its target.
+
 ## Compiler-specific parallel configs
 
 `mache.parallel` combines options in `[parallel]` with

--- a/docs/developers_guide/framework/parallel.md
+++ b/docs/developers_guide/framework/parallel.md
@@ -131,6 +131,13 @@ said which reductions it will accept, and shrinking below it is not one.
 A step says how much memory it needs as `memory` and `min_memory`, both in
 MB.
 
+**A declared figure is a ceiling as well as a claim.** Asking a launch for a
+share of the node's memory was measured to be enforced on Perlmutter and
+Frontier -- a step allowed 1 GB and told to take 4 GB is killed -- and not
+enforced on Chrysalis. So a step that declares memory should declare a
+**peak with margin**, not a typical value: on a machine that enforces, the
+number it gives is the number it dies at.
+
 Memory does not go to the launcher, and that is not an omission.  Nothing
 below Polaris acts on it -- asking a launch for a share of the node's memory
 was measured to change nothing -- so a memory figure rendered into a launch
@@ -139,8 +146,17 @@ budget Polaris keeps: the only thing protecting one step's memory from
 another's is Polaris declining to start the second, which is admission
 control in a later phase.
 
-A step that declares nothing is given **its proportional share of a node**:
-its cores times the node's memory per core, rounded down.  The default is
+A step that declares nothing is given **its proportional share of a node**
+as its `memory_budget`, leaving `memory` as `None`: its cores times the
+node's memory per core, rounded down.
+
+The two are kept apart on purpose. `memory` is what the step declared and is
+the only figure that may be enforced as a cap; `memory_budget` is what to
+account for, declared or defaulted. Capping a step at the framework's own
+rough guess would make every step carry a measured number before it could
+run, which is the burden the default exists to avoid -- while leaving a
+declared figure unenforced makes it invisible when wrong, which is worse
+than a failure.  The default is
 chosen for a property rather than for accuracy.  A set of steps that fits on
 cores always fits in memory, so a run in which every step defaults packs
 exactly as it would have with no memory accounting at all, and introducing

--- a/docs/developers_guide/framework/parallel.md
+++ b/docs/developers_guide/framework/parallel.md
@@ -138,13 +138,18 @@ enforced on Chrysalis. So a step that declares memory should declare a
 **peak with margin**, not a typical value: on a machine that enforces, the
 number it gives is the number it dies at.
 
-Memory does not go to the launcher, and that is not an omission.  Nothing
-below Polaris acts on it -- asking a launch for a share of the node's memory
-was measured to change nothing -- so a memory figure rendered into a launch
-command would suggest an enforcement that does not happen.  Memory is a
-budget Polaris keeps: the only thing protecting one step's memory from
-another's is Polaris declining to start the second, which is admission
-control in a later phase.
+Polaris does not yet pass a memory figure to the launcher, and that is a
+consequence of where the work has got to rather than a decision that it
+never should.  `mache` accepts an optional cap alongside a placement, and
+Polaris will pass it for a step that *declared* a figure once there is a
+scheduler to admit steps -- which is a later phase.  Today nothing is
+admitted and nothing is capped.
+
+What the launcher does not do, on any machine, is *reserve* memory or say
+whether a step fits.  That stays Polaris's own accounting: the only thing
+protecting one step's memory from another's is Polaris declining to start
+the second.  Enforcement and scheduling are separate, and only enforcement
+is something a launcher offers.
 
 A step that declares nothing is given **its proportional share of a node**
 as its `memory_budget`, leaving `memory` as `None`: its cores times the

--- a/docs/developers_guide/framework/parallel.md
+++ b/docs/developers_guide/framework/parallel.md
@@ -70,6 +70,13 @@ Not every machine can confine a launch.  `mache` reports which mechanism a
 machine has through `ParallelSystem.placement_support`, decided at run time
 from the launcher that is actually installed rather than from configuration.
 
+Placement needs `mache` 3.12.0 or later, which the deployment pins.
+
+Setup refuses to go any further against a `mache` that cannot place, rather
+than letting a run fail partway through with a `TypeError` from inside the
+launcher.  This will become an ordinary version requirement once the change
+is released.
+
 ## Memory
 
 A step can say how much memory it needs, as `max_memory` (the target) and

--- a/docs/developers_guide/framework/parallel.md
+++ b/docs/developers_guide/framework/parallel.md
@@ -62,9 +62,12 @@ Two consequences are worth knowing about:
   on every GPU on the node, which stops any other step from starting.
 - {py:meth}`polaris.Component.get_available_resources` takes an optional
   placement and, when given one, describes that subset rather than the whole
-  allocation.  A step confined to one node has to be told about one node:
-  resources withheld from a step have to be genuinely withheld, not merely
-  subtracted from a number.
+  allocation.  A step confined to part of an allocation has to be told about
+  that part: resources withheld from a step have to be genuinely withheld,
+  not merely subtracted from a number.  The view carries memory beside cores,
+  nodes and GPUs, because a step sizing a worker pool or a chunk size has to
+  size it against memory, and the natural mistake is to derive memory from
+  cores.
 
 Not every machine can confine a launch.  `mache` reports which mechanism a
 machine has through `ParallelSystem.placement_support`, decided at run time
@@ -77,21 +80,82 @@ than letting a run fail partway through with a `TypeError` from inside the
 launcher.  This will become an ordinary version requirement once the change
 is released.
 
+## How a step says what it needs
+
+A step describes its resources in one of two shapes, depending on whether it
+has MPI ranks.
+
+An **MPI step** says `ntasks` ranks of `cpus_per_task` cores each, with
+`min_tasks` and `min_cpus_per_task` saying how far it can be reduced.  That
+is unchanged.
+
+A **non-MPI step** says `cores` and `min_cores` directly.  A step with no
+ranks has no meaningful `cpus_per_task`, and "one task of two hundred CPUs"
+is a sentence no launcher can act on.  For a step that does speak in ranks,
+`cores` is simply the product, so anything wanting a step's core count can
+ask for it directly either way.
+
+GPUs need no second spelling: `gpus` and `min_gpus` are already per-step
+totals, which is the shape a step with no ranks needs.  `gpus_per_task` is
+deprecated and is the only GPU field a non-MPI step cannot use.
+
+## Whether a step may span nodes
+
+`may_span_nodes` says whether a step's cores **and GPUs** may be drawn from
+more than one node.
+
+This is deliberately not the same question as whether a step uses MPI.  A
+single process that hands its work to a distributed pool spans nodes
+perfectly well; one that does its work in its own threads cannot; both are
+"not MPI".  Polaris cannot tell them apart, so the step says.
+
+It defaults to whether the step has more than one task, which is the only
+mechanism Polaris has today for reaching another node.  Nothing sets it
+otherwise yet -- it exists so that the worker pool in a later phase has
+something to turn on rather than a rule to remove.
+
+`cpus_per_task` is held to one node whatever the step says, because one
+process cannot be given cores on a node it is not running on.  The span
+property bounds the step's *total*.
+
+Where a step cannot be given what it asked for, the usual target-and-minimum
+rule decides, with the node boundary as one more thing that can make a
+request unsatisfiable.  A step held to a node may be reduced towards its
+target silently, exactly as it may be today.  A step whose **minimum** cannot
+be met within a node is an error, naming what it needs, what a node holds,
+and the property that would let it span -- a step that names a minimum has
+said which reductions it will accept, and shrinking below it is not one.
+
 ## Memory
 
-A step can say how much memory it needs, as `max_memory` (the target) and
-`min_memory` (the least it can run in), both in MB and in the same style as
-its CPU requirements.
+A step says how much memory it needs as `memory` and `min_memory`, both in
+MB.
 
-This is a **declaration only**.  Nothing in Polaris acts on it, and no
-launcher on a supported machine has a way to reserve memory for a job step:
-`--mem-per-cpu` was measured to make no difference to whether concurrent
-steps could coexist.  Using memory to decide how many steps may run at once
-belongs to the scheduler in a later phase, and matters most for analysis
-work, where a single step may need a large fraction of a node.
+Memory does not go to the launcher, and that is not an omission.  Nothing
+below Polaris acts on it -- asking a launch for a share of the node's memory
+was measured to change nothing -- so a memory figure rendered into a launch
+command would suggest an enforcement that does not happen.  Memory is a
+budget Polaris keeps: the only thing protecting one step's memory from
+another's is Polaris declining to start the second, which is admission
+control in a later phase.
 
-The only thing checked today is that a step does not declare a minimum above
-its target.
+A step that declares nothing is given **its proportional share of a node**:
+its cores times the node's memory per core, rounded down.  The default is
+chosen for a property rather than for accuracy.  A set of steps that fits on
+cores always fits in memory, so a run in which every step defaults packs
+exactly as it would have with no memory accounting at all, and introducing
+memory can never schedule an existing suite worse than before.  A step that
+has been measured says what it needs and is scheduled on that instead.
+
+That default is weakest on a GPU machine, where a step wanting every GPU on a
+node and four cores to drive them gets four cores' share of the memory.  The
+answer is for such a step to declare, not to make the default depend on GPUs
+-- it is exactly the default's being core-proportional that makes it safe.
+
+The per-node figure comes from `memory_per_node` in `mache`'s `[parallel]`
+config, beside `cores_per_node` and `gpus_per_node`.  A machine that does not
+set it leaves memory undeclared rather than guessed at, since a wrong figure
+there would propagate into every step's default.
 
 ## Compiler-specific parallel configs
 

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -236,15 +236,19 @@ the planar mesh.  By default, the number of MPI tasks tries to apportion 200
 cells to each core, but it will allow as many as 2000.
 
 For Omega on GPU-capable parallel configs (`gpus_per_node > 0`), dynamic
-sizing switches to GPU-based targets and sets one GPU per MPI task:
+sizing switches to GPU-based targets and asks for one GPU per MPI task.  That
+is stated as a total for the step rather than as a count per task, because a
+per-task count does not confine a step to those GPUs when steps run at the
+same time:
 
 ```python
-self.gpus_per_task = 1
-self.min_gpus_per_task = 1
 # ideally, about 8000 cells per GPU
 self.ntasks = max(1, 4 * round(cell_count / (4 * goal_cells_per_gpu)))
 # In a pinch, about 80000 cells per GPU
 self.min_tasks = max(1, 4 * round(cell_count / (4 * max_cells_per_gpu)))
+# one GPU per task, as a total for the step
+self.gpus = self.ntasks
+self.min_gpus = self.min_tasks
 ```
 
 The corresponding `[ocean]` config options are `goal_cells_per_gpu` and

--- a/docs/developers_guide/organization/steps.md
+++ b/docs/developers_guide/organization/steps.md
@@ -105,10 +105,23 @@ Some attributes are available after calling the base class' constructor
 
 : the number of OpenMP threads the step will use
 
-`self.max_memory`
+`self.memory`
 
-: An aspirational attribute that will be used in the future to indicate the
-  amount of memory that the step is allowed to use in MB
+: the memory the step says it needs, in MB, or `None` if it has not said.
+  A declared figure is a ceiling as well as a claim on machines that enforce
+  one, so declare a peak with margin rather than a typical value.  This
+  replaces the former `max_memory` placeholder
+
+`self.min_memory`
+
+: the least memory the step can run in, in MB
+
+`self.memory_budget`
+
+: the memory to account for, whether declared or defaulted.  A step that
+  declares nothing is given its proportional share of a node -- its cores
+  times the node's memory per core.  See {ref}`dev-parallel` for why the
+  declared and defaulted figures are kept apart
 
 `self.cached`
 

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -1,6 +1,7 @@
 import importlib.resources as imp_res
 import json
 import os
+import warnings
 
 from mache.parallel import ParallelSystem, get_parallel_system
 from mpas_tools.io import open_dataset, write_netcdf
@@ -99,7 +100,8 @@ class Component:
         ntasks,
         openmp_threads,
         logger,
-        gpus_per_task=0,
+        gpus=0,
+        gpus_per_task=None,
     ):
         """
         Run a command using the active parallel system
@@ -121,13 +123,29 @@ class Component:
         logger : logging.Logger
             Logger to output command-line execution info
 
+        gpus : int, optional
+            Number of GPUs this launch needs, as a total rather than a count
+            per task
+
         gpus_per_task : int, optional
             Number of GPUs per task
+
+            .. deprecated:: 1.1.0
+                Use ``gpus`` instead
         """
         if self.parallel_system is None:
             raise ValueError(
                 f'Parallel system has not been set for component {self.name}'
             )
+
+        if gpus_per_task is not None:
+            warnings.warn(
+                'gpus_per_task is deprecated. Use gpus, which says how many '
+                'GPUs the launch needs in total.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            gpus = max(gpus, gpus_per_task * ntasks)
 
         env = dict(os.environ)
         env['OMP_NUM_THREADS'] = f'{openmp_threads}'
@@ -138,7 +156,7 @@ class Component:
             args=args,
             ntasks=ntasks,
             cpus_per_task=cpus_per_task,
-            gpus_per_task=gpus_per_task,
+            gpus_per_task=_gpus_per_task(gpus, ntasks),
         )
         check_call(command_line_args, logger, env=env)
 
@@ -322,3 +340,16 @@ class Component:
         except FileNotFoundError:
             # no cached files for this core
             pass
+
+
+def _gpus_per_task(gpus, ntasks):
+    """
+    Convert a launch's total GPUs into the per-task count mache asks for.
+
+    Without a placement to carry a total, mache expresses GPUs per task, so
+    a step's total has to be divided back out.  Rounding up rather than down
+    keeps a launch from being handed fewer GPUs than it asked for.
+    """
+    if gpus <= 0 or ntasks <= 0:
+        return 0
+    return -(-gpus // ntasks)

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -70,9 +70,18 @@ class Component:
         assert config.combined is not None
         self.parallel_system = get_parallel_system(config.combined)
 
-    def get_available_resources(self):
+    def get_available_resources(self, placement=None):
         """
         Get available resources from the active parallel system
+
+        Parameters
+        ----------
+        placement : mache.parallel.ResourcePlacement, optional
+            The part of the allocation a step is confined to.  When it is
+            given, the resources described are that subset's rather than the
+            whole allocation's, so that a confined step is told about what it
+            can actually use.  Resources withheld from a step have to be
+            genuinely withheld, not merely subtracted from a number.
 
         Returns
         -------
@@ -83,6 +92,9 @@ class Component:
             raise ValueError(
                 f'Parallel system has not been set for component {self.name}'
             )
+
+        if placement is not None:
+            return _placement_resources(placement, self.parallel_system)
 
         return dict(
             cores=self.parallel_system.cores,
@@ -101,6 +113,7 @@ class Component:
         openmp_threads,
         logger,
         gpus=0,
+        placement=None,
         gpus_per_task=None,
     ):
         """
@@ -127,6 +140,10 @@ class Component:
             Number of GPUs this launch needs, as a total rather than a count
             per task
 
+        placement : mache.parallel.ResourcePlacement, optional
+            The part of the allocation to confine this launch to.  Passing
+            none gives exactly the command Polaris has always built.
+
         gpus_per_task : int, optional
             Number of GPUs per task
 
@@ -138,7 +155,7 @@ class Component:
                 f'Parallel system has not been set for component {self.name}'
             )
 
-        if gpus_per_task is not None:
+        if gpus_per_task:
             warnings.warn(
                 'gpus_per_task is deprecated. Use gpus, which says how many '
                 'GPUs the launch needs in total.',
@@ -146,6 +163,16 @@ class Component:
                 stacklevel=2,
             )
             gpus = max(gpus, gpus_per_task * ntasks)
+
+        if placement is not None and placement.gpus != gpus:
+            # a placement carries the GPUs itself, so the two saying
+            # different things means whatever built the placement and the
+            # step have drifted apart.  Much cheaper to catch here than as
+            # silent oversubscription once the work is running.
+            raise ValueError(
+                f'This launch asks for {gpus} GPUs but its placement asks '
+                f'for {placement.gpus}. They must agree.'
+            )
 
         env = dict(os.environ)
         env['OMP_NUM_THREADS'] = f'{openmp_threads}'
@@ -157,6 +184,7 @@ class Component:
             ntasks=ntasks,
             cpus_per_task=cpus_per_task,
             gpus_per_task=_gpus_per_task(gpus, ntasks),
+            placement=placement,
         )
         check_call(command_line_args, logger, env=env)
 
@@ -353,3 +381,17 @@ def _gpus_per_task(gpus, ntasks):
     if gpus <= 0 or ntasks <= 0:
         return 0
     return -(-gpus // ntasks)
+
+
+def _placement_resources(placement, parallel_system):
+    """Describe what a placement gives a step, in the usual resource terms."""
+    nodes = max(len(placement.nodes), 1)
+    cores_per_node = len(placement.cores)
+    return dict(
+        cores=cores_per_node * nodes,
+        nodes=nodes,
+        cores_per_node=cores_per_node,
+        gpus=placement.gpus,
+        gpus_per_node=placement.gpus // nodes,
+        mpi_allowed=parallel_system.mpi_allowed,
+    )

--- a/polaris/component.py
+++ b/polaris/component.py
@@ -96,12 +96,20 @@ class Component:
         if placement is not None:
             return _placement_resources(placement, self.parallel_system)
 
+        memory_per_node = _get_memory_per_node(self.parallel_system)
+        nodes = self.parallel_system.nodes
+        memory = None
+        if memory_per_node is not None and nodes is not None:
+            memory = memory_per_node * nodes
+
         return dict(
             cores=self.parallel_system.cores,
-            nodes=self.parallel_system.nodes,
+            nodes=nodes,
             cores_per_node=self.parallel_system.cores_per_node,
             gpus=self.parallel_system.gpus,
             gpus_per_node=self.parallel_system.gpus_per_node,
+            memory=memory,
+            memory_per_node=memory_per_node,
             mpi_allowed=self.parallel_system.mpi_allowed,
         )
 
@@ -387,11 +395,45 @@ def _placement_resources(placement, parallel_system):
     """Describe what a placement gives a step, in the usual resource terms."""
     nodes = max(len(placement.nodes), 1)
     cores_per_node = len(placement.cores)
+
+    # a placement carries no memory, because no launcher acts on one.  What
+    # a placement does imply is a share of the nodes it names, in the same
+    # proportion as the cores it took from them.
+    memory_per_node = _get_memory_per_node(parallel_system)
+    memory = None
+    machine_cores_per_node = parallel_system.cores_per_node
+    if memory_per_node is not None and machine_cores_per_node:
+        memory = (
+            cores_per_node * nodes * memory_per_node // machine_cores_per_node
+        )
+
     return dict(
         cores=cores_per_node * nodes,
         nodes=nodes,
         cores_per_node=cores_per_node,
         gpus=placement.gpus,
         gpus_per_node=placement.gpus // nodes,
+        memory=memory,
+        memory_per_node=memory_per_node,
         mpi_allowed=parallel_system.mpi_allowed,
     )
+
+
+def _get_memory_per_node(parallel_system):
+    """
+    Get the memory a node has, in MB, or ``None`` if this machine has not
+    said.
+
+    Read from the attribute where a newer mache offers one and from the
+    config option otherwise, because the option is arriving in mache while
+    this is being written and Polaris should work either side of it.  A
+    machine that says nothing leaves memory undeclared rather than guessed
+    at: a wrong figure here would propagate into every step's default.
+    """
+    memory_per_node = getattr(parallel_system, 'memory_per_node', None)
+    if memory_per_node:
+        return int(memory_per_node)
+    memory_per_node = parallel_system.get_config_int('memory_per_node')
+    if memory_per_node:
+        return int(memory_per_node)
+    return None

--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -86,7 +86,7 @@ class ModelStep(Step):
         min_gpus=None,
         gpus_per_task=0,
         min_gpus_per_task=0,
-        max_memory=None,
+        memory=None,
         min_memory=None,
         cached=False,
         namelist=None,
@@ -151,7 +151,7 @@ class ModelStep(Step):
             .. deprecated:: 1.1.0
                 Use ``min_gpus`` instead
 
-        max_memory : int, optional
+        memory : int, optional
             the amount of memory in MB the step would ideally be given
 
         min_memory : int, optional
@@ -209,7 +209,7 @@ class ModelStep(Step):
             min_gpus=min_gpus,
             gpus_per_task=gpus_per_task,
             min_gpus_per_task=min_gpus_per_task,
-            max_memory=max_memory,
+            memory=memory,
             min_memory=min_memory,
             cached=cached,
         )
@@ -276,7 +276,7 @@ class ModelStep(Step):
         min_gpus=None,
         gpus_per_task=None,
         min_gpus_per_task=None,
-        max_memory=None,
+        memory=None,
         min_memory=None,
     ):
         """
@@ -320,7 +320,7 @@ class ModelStep(Step):
             .. deprecated:: 1.1.0
                 Use ``min_gpus`` instead
 
-        max_memory : int, optional
+        memory : int, optional
             the amount of memory in MB the step would ideally be given
 
         min_memory : int, optional
@@ -337,7 +337,7 @@ class ModelStep(Step):
             min_gpus=min_gpus,
             gpus_per_task=gpus_per_task,
             min_gpus_per_task=min_gpus_per_task,
-            max_memory=max_memory,
+            memory=memory,
             min_memory=min_memory,
         )
 

--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -87,6 +87,7 @@ class ModelStep(Step):
         gpus_per_task=0,
         min_gpus_per_task=0,
         max_memory=None,
+        min_memory=None,
         cached=False,
         namelist=None,
         streams=None,
@@ -151,9 +152,11 @@ class ModelStep(Step):
                 Use ``min_gpus`` instead
 
         max_memory : int, optional
-            the amount of memory that the step is allowed to use in MB.
-            This is currently just a placeholder for later use with task
-            parallelism
+            the amount of memory in MB the step would ideally be given
+
+        min_memory : int, optional
+            the amount of memory in MB the step needs in order to run at
+            all
 
         cached : bool, optional
             Whether to get all of the outputs for the step from the database of
@@ -207,6 +210,7 @@ class ModelStep(Step):
             gpus_per_task=gpus_per_task,
             min_gpus_per_task=min_gpus_per_task,
             max_memory=max_memory,
+            min_memory=min_memory,
             cached=cached,
         )
 
@@ -273,6 +277,7 @@ class ModelStep(Step):
         gpus_per_task=None,
         min_gpus_per_task=None,
         max_memory=None,
+        min_memory=None,
     ):
         """
         Update the resources for the step.  This can be done within init,
@@ -316,9 +321,11 @@ class ModelStep(Step):
                 Use ``min_gpus`` instead
 
         max_memory : int, optional
-            the amount of memory that the step is allowed to use in MB.
-            This is currently just a placeholder for later use with task
-            parallelism
+            the amount of memory in MB the step would ideally be given
+
+        min_memory : int, optional
+            the amount of memory in MB the step needs in order to run at
+            all
         """
         self.set_resources(
             cpus_per_task=openmp_threads,
@@ -331,6 +338,7 @@ class ModelStep(Step):
             gpus_per_task=gpus_per_task,
             min_gpus_per_task=min_gpus_per_task,
             max_memory=max_memory,
+            min_memory=min_memory,
         )
 
     def add_model_config_options(self, options, config_model=None):

--- a/polaris/model_step.py
+++ b/polaris/model_step.py
@@ -82,6 +82,8 @@ class ModelStep(Step):
         ntasks=None,
         min_tasks=None,
         openmp_threads=None,
+        gpus=None,
+        min_gpus=None,
         gpus_per_task=0,
         min_gpus_per_task=0,
         max_memory=None,
@@ -129,11 +131,24 @@ class ModelStep(Step):
         openmp_threads : int, optional
             the number of OpenMP threads to use
 
+        gpus : int, optional
+            the number of GPUs to use, as a total for the step rather than
+            a count per task
+
+        min_gpus : int, optional
+            the minimum number of GPUs required, again as a total
+
         gpus_per_task : int, optional
             the number of GPUs per task to use
 
+            .. deprecated:: 1.1.0
+                Use ``gpus`` instead
+
         min_gpus_per_task : int, optional
             the minimum number of GPUs per task required
+
+            .. deprecated:: 1.1.0
+                Use ``min_gpus`` instead
 
         max_memory : int, optional
             the amount of memory that the step is allowed to use in MB.
@@ -187,6 +202,8 @@ class ModelStep(Step):
             ntasks=ntasks,
             min_tasks=min_tasks,
             openmp_threads=openmp_threads,
+            gpus=gpus,
+            min_gpus=min_gpus,
             gpus_per_task=gpus_per_task,
             min_gpus_per_task=min_gpus_per_task,
             max_memory=max_memory,
@@ -251,6 +268,8 @@ class ModelStep(Step):
         ntasks=None,
         min_tasks=None,
         openmp_threads=None,
+        gpus=None,
+        min_gpus=None,
         gpus_per_task=None,
         min_gpus_per_task=None,
         max_memory=None,
@@ -277,11 +296,24 @@ class ModelStep(Step):
         openmp_threads : int, optional
             the number of OpenMP threads to use
 
+        gpus : int, optional
+            the number of GPUs to use, as a total for the step rather than
+            a count per task
+
+        min_gpus : int, optional
+            the minimum number of GPUs required, again as a total
+
         gpus_per_task : int, optional
             the number of GPUs per task to use
 
+            .. deprecated:: 1.1.0
+                Use ``gpus`` instead
+
         min_gpus_per_task : int, optional
             the minimum number of GPUs per task required
+
+            .. deprecated:: 1.1.0
+                Use ``min_gpus`` instead
 
         max_memory : int, optional
             the amount of memory that the step is allowed to use in MB.
@@ -294,6 +326,8 @@ class ModelStep(Step):
             ntasks=ntasks,
             min_tasks=min_tasks,
             openmp_threads=openmp_threads,
+            gpus=gpus,
+            min_gpus=min_gpus,
             gpus_per_task=gpus_per_task,
             min_gpus_per_task=min_gpus_per_task,
             max_memory=max_memory,
@@ -677,17 +711,18 @@ class ModelStep(Step):
             tasks_per_node = min(tasks_per_node, max_tasks_per_node)
 
         # if this step requires GPUs, tasks are placed according to the GPUs
-        # available on each node, not the CPU cores
-        if self.gpus_per_task > 0:
+        # available on each node, not the CPU cores.  The step's GPUs are a
+        # total spread over its tasks, so a node holds as many tasks as its
+        # own GPUs cover.
+        if self.gpus > 0:
             gpus_per_node = parallel_system.gpus_per_node
             if not gpus_per_node:
                 raise ValueError(
-                    f'Step {self.name} requests {self.gpus_per_task} GPUs per '
-                    f'task but gpus_per_node is not set in the parallel '
-                    f'config'
+                    f'Step {self.name} requests {self.gpus} GPUs but '
+                    f'gpus_per_node is not set in the parallel config'
                 )
             tasks_per_node = min(
-                tasks_per_node, gpus_per_node // self.gpus_per_task
+                tasks_per_node, gpus_per_node * self.ntasks // self.gpus
             )
 
         # never more tasks per node than the step has in total, and always at

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -73,7 +73,7 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
         ntasks: Optional[int] = None,
         min_tasks: Optional[int] = None,
         openmp_threads: Optional[int] = None,
-        max_memory: Optional[int] = None,
+        memory: Optional[int] = None,
         min_memory: Optional[int] = None,
         cached: bool = False,
         yaml: Optional[str] = None,
@@ -118,7 +118,7 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
         openmp_threads : int, optional
             the number of OpenMP threads to use
 
-        max_memory : int, optional
+        memory : int, optional
             the amount of memory in MB the step would ideally be given
 
         min_memory : int, optional
@@ -168,7 +168,7 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
             ntasks=ntasks,
             min_tasks=min_tasks,
             openmp_threads=openmp_threads,
-            max_memory=max_memory,
+            memory=memory,
             min_memory=min_memory,
             cached=cached,
             yaml=yaml,

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -74,6 +74,7 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
         min_tasks: Optional[int] = None,
         openmp_threads: Optional[int] = None,
         max_memory: Optional[int] = None,
+        min_memory: Optional[int] = None,
         cached: bool = False,
         yaml: Optional[str] = None,
         update_io_tasks: bool = True,
@@ -118,9 +119,11 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
             the number of OpenMP threads to use
 
         max_memory : int, optional
-            the amount of memory that the step is allowed to use in MB.
-            This is currently just a placeholder for later use with task
-            parallelism
+            the amount of memory in MB the step would ideally be given
+
+        min_memory : int, optional
+            the amount of memory in MB the step needs in order to run at
+            all
 
         cached : bool, optional
             Whether to get all of the outputs for the step from the database of
@@ -166,6 +169,7 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
             min_tasks=min_tasks,
             openmp_threads=openmp_threads,
             max_memory=max_memory,
+            min_memory=min_memory,
             cached=cached,
             yaml=yaml,
             update_io_tasks=update_io_tasks,

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -220,7 +220,7 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
 
         if self.dynamic_ntasks:
             self._update_ntasks()
-        self._set_gpus_per_task()
+        self._set_gpus()
 
         super().setup()
 
@@ -267,7 +267,7 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
         """
         if self.dynamic_ntasks:
             self._update_ntasks()
-        self._set_gpus_per_task()
+        self._set_gpus()
         super().constrain_resources(available_cores)
 
     def process_inputs_and_outputs(self) -> None:
@@ -646,17 +646,21 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
             'init_filename': self.get_init_filename(),
         }
 
-    def _set_gpus_per_task(self) -> None:
+    def _set_gpus(self) -> None:
         """
-        Set ``gpus_per_task`` and ``min_gpus_per_task`` for the step based
-        on whether gpus are available and the model is Omega
+        Set ``gpus`` and ``min_gpus`` for the step based on whether gpus are
+        available and the model is Omega.
+
+        One GPU per task, stated as a total for the step: a per-task count
+        does not confine a step to those GPUs when steps run at the same
+        time.
         """
         if self._use_gpu_resources():
-            self.gpus_per_task = 1
-            self.min_gpus_per_task = 1
+            self.gpus = self.ntasks
+            self.min_gpus = self.min_tasks
         else:
-            self.gpus_per_task = 0
-            self.min_gpus_per_task = 0
+            self.gpus = 0
+            self.min_gpus = 0
 
     def _use_gpu_resources(self) -> bool:
         """

--- a/polaris/parallel.py
+++ b/polaris/parallel.py
@@ -1,4 +1,40 @@
+import inspect
+
+import mache
+from mache.parallel import ParallelSystem
+
 from polaris.config import PolarisConfigParser
+
+
+def check_mache_supports_placement():
+    """
+    Check that the installed mache can confine a launch to part of an
+    allocation.
+
+    A mache without placement takes none of the arguments Polaris now passes
+    it, so a run against one fails partway through with a ``TypeError`` from
+    deep inside the launcher rather than saying what is wrong.  Worse, a
+    future mache that accepted the argument and ignored it would let a run
+    appear to work while oversubscribing the machine -- no error, wrong
+    results, and slower than running one step at a time.  Both are much
+    better caught here.
+
+    Raises
+    ------
+    RuntimeError
+        If the installed mache has no placement support
+    """
+    parameters = inspect.signature(
+        ParallelSystem.get_parallel_command
+    ).parameters
+    if 'placement' in parameters:
+        return
+
+    raise RuntimeError(
+        f'The installed mache ({mache.__version__}) cannot confine a launch '
+        f'to part of an allocation, which Polaris now requires.\n'
+        f'Install mache 3.12.0 or later.'
+    )
 
 
 def set_parallel_systems(tasks, config: PolarisConfigParser):
@@ -14,6 +50,8 @@ def set_parallel_systems(tasks, config: PolarisConfigParser):
     config : polaris.config.PolarisConfigParser
         The config to use in constructing the parallel systems
     """
+    check_mache_supports_placement()
+
     seen_components: set[int] = set()
     seen_steps: set[int] = set()
 

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -653,7 +653,16 @@ def _run_step(
         step_logger.info('')
         log_method_call(method=step.constrain_resources, logger=step_logger)
         step_logger.info('')
-        step.constrain_resources(available_resources)
+        # a step confined to part of the allocation has to be told about
+        # that part, not about the whole job.  Nothing assigns a placement
+        # yet, so this is the whole job in every case today.
+        if step.placement is not None:
+            step_resources = step.component.get_available_resources(
+                step.placement
+            )
+        else:
+            step_resources = available_resources
+        step.constrain_resources(step_resources)
 
         # runtime_setup() will perform small tasks that require knowing the
         # resources of the task before the step runs (such as creating
@@ -681,6 +690,7 @@ def _run_step(
                     step.openmp_threads,
                     step.logger,
                     gpus=step.gpus,
+                    placement=step.placement,
                 )
         else:
             step_logger.info('')

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -680,7 +680,7 @@ def _run_step(
                     step.ntasks,
                     step.openmp_threads,
                     step.logger,
-                    gpus_per_task=step.gpus_per_task,
+                    gpus=step.gpus,
                 )
         else:
             step_logger.info('')

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -364,8 +364,8 @@ def setup_task(path, task, machine, work_dir, baseline_dir, cached_steps):
         _symlink_load_script(step.work_dir)
 
         if machine is not None:
-            cores = step.cpus_per_task * step.ntasks
-            min_cores = step.min_cpus_per_task * step.min_tasks
+            cores = step.cores
+            min_cores = step.min_cores
             gpus = step.gpus
             min_gpus = step.min_gpus
             write_job_script(
@@ -855,8 +855,8 @@ def _get_required_resources(tasks):
                     f'The number of CPUs per task (cpus_per_task) was never '
                     f'set for {task.path} step {step_name}'
                 )
-            cores = step.cpus_per_task * step.ntasks
-            min_cores = step.min_cpus_per_task * step.min_tasks
+            cores = step.cores
+            min_cores = step.min_cores
             gpus = step.gpus
             min_gpus = step.min_gpus
             max_cores = max(max_cores, cores)

--- a/polaris/setup.py
+++ b/polaris/setup.py
@@ -366,8 +366,8 @@ def setup_task(path, task, machine, work_dir, baseline_dir, cached_steps):
         if machine is not None:
             cores = step.cpus_per_task * step.ntasks
             min_cores = step.min_cpus_per_task * step.min_tasks
-            gpus = step.gpus_per_task * step.ntasks
-            min_gpus = step.min_gpus_per_task * step.min_tasks
+            gpus = step.gpus
+            min_gpus = step.min_gpus
             write_job_script(
                 config=step.config,
                 machine=machine,
@@ -857,8 +857,8 @@ def _get_required_resources(tasks):
                 )
             cores = step.cpus_per_task * step.ntasks
             min_cores = step.min_cpus_per_task * step.min_tasks
-            gpus = step.gpus_per_task * step.ntasks
-            min_gpus = step.min_gpus_per_task * step.min_tasks
+            gpus = step.gpus
+            min_gpus = step.min_gpus
             max_cores = max(max_cores, cores)
             max_of_min_cores = max(max_of_min_cores, min_cores)
             max_gpus = max(max_gpus, gpus)

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -88,6 +88,15 @@ class Step:
         This is currently just a placeholder for later use with task
         parallelism
 
+    placement : mache.parallel.ResourcePlacement or None
+        the part of the allocation this step is confined to -- which nodes,
+        which cores on each and how many GPUs -- or ``None`` to run on the
+        whole allocation, as steps have always done.
+
+        Nothing assigns this yet.  Deciding which subset a step should get
+        needs a scheduler, and there is not one: the only caller is the
+        serial path, which assigns no placement.
+
     input_data : list of dict
         a list of dict used to define input files typically to be
         downloaded to a database and/or symlinked in the work directory
@@ -301,6 +310,7 @@ class Step:
         self._min_gpus = min_gpus
         _warn_if_gpus_per_task(gpus_per_task, min_gpus_per_task)
         self.max_memory = max_memory
+        self.placement = None
 
         self.path = os.path.join(self.component.name, self.subdir)
 
@@ -484,6 +494,13 @@ class Step:
 
         available_cores = available_resources['cores']
         cores_per_node = available_resources['cores_per_node']
+        if self.ntasks == 1:
+            # a single-process step cannot reach cores on another node
+            # without a distributed launcher, so the cores in the rest of
+            # what it was given are not its to count.  `cpus_per_task` is
+            # capped at one node below in any case; saying it here is what
+            # keeps the task count honest too.
+            available_cores = min(available_cores, cores_per_node)
         self.cpus_per_task = min(
             self.cpus_per_task, min(available_cores, cores_per_node)
         )

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -84,9 +84,14 @@ class Step:
             Use ``min_gpus`` instead
 
     max_memory : int
-        the amount of memory that the step is allowed to use in MB.
-        This is currently just a placeholder for later use with task
-        parallelism
+        the amount of memory in MB the step would ideally be given.  This
+        is a declaration only: nothing in Polaris acts on it yet, and no
+        supported launcher has a way to reserve memory for a job step
+
+    min_memory : int
+        the amount of memory in MB the step needs in order to run at all,
+        the minimum to ``max_memory``'s target, in the same style as
+        ``min_tasks`` and ``min_cpus_per_task``
 
     placement : mache.parallel.ResourcePlacement or None
         the part of the allocation this step is confined to -- which nodes,
@@ -205,6 +210,7 @@ class Step:
         min_tasks=1,
         openmp_threads=1,
         max_memory=None,
+        min_memory=None,
         cached=False,
         run_as_subprocess=False,
         gpus=None,
@@ -255,9 +261,11 @@ class Step:
             the number of OpenMP threads to use
 
         max_memory : int, optional
-            the amount of memory that the step is allowed to use in MB.
-            This is currently just a placeholder for later use with task
-            parallelism
+            the amount of memory in MB the step would ideally be given
+
+        min_memory : int, optional
+            the amount of memory in MB the step needs in order to run at
+            all
 
         gpus : int, optional
             the number of GPUs the step would ideally use, as a total for
@@ -310,6 +318,7 @@ class Step:
         self._min_gpus = min_gpus
         _warn_if_gpus_per_task(gpus_per_task, min_gpus_per_task)
         self.max_memory = max_memory
+        self.min_memory = min_memory
         self.placement = None
 
         self.path = os.path.join(self.component.name, self.subdir)
@@ -391,6 +400,7 @@ class Step:
         min_tasks=None,
         openmp_threads=None,
         max_memory=None,
+        min_memory=None,
         gpus=None,
         min_gpus=None,
         gpus_per_task=None,
@@ -429,9 +439,11 @@ class Step:
             the number of OpenMP threads to use
 
         max_memory : int, optional
-            the amount of memory that the step is allowed to use in MB.
-            This is currently just a placeholder for later use with task
-            parallelism
+            the amount of memory in MB the step would ideally be given
+
+        min_memory : int, optional
+            the amount of memory in MB the step needs in order to run at
+            all
 
         gpus : int, optional
             the number of GPUs the step would ideally use, as a total for
@@ -473,6 +485,8 @@ class Step:
             self.min_gpus_per_task = min_gpus_per_task
         if max_memory is not None:
             self.max_memory = max_memory
+        if min_memory is not None:
+            self.min_memory = min_memory
 
     def constrain_resources(self, available_resources):
         """
@@ -517,6 +531,16 @@ class Step:
             raise ValueError(
                 f'Available number of MPI tasks ({self.ntasks}) is below the '
                 f'minimum of {self.min_tasks} for step {self.name}'
+            )
+
+        if (
+            self.max_memory is not None
+            and self.min_memory is not None
+            and self.min_memory > self.max_memory
+        ):
+            raise ValueError(
+                f'Step {self.name} needs at least {self.min_memory} MB of '
+                f'memory but asks for only {self.max_memory} MB.'
             )
 
         self._constrain_gpus(available_resources)

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -91,11 +91,28 @@ class Step:
     min_cores : int
         the number of cores the step needs in order to run at all
 
-    memory : int
-        the amount of memory in MB the step needs.  A step that says
-        nothing is given its proportional share of a node -- its cores
-        times the node's memory per core -- which is chosen so that packing
-        steps on memory comes out the same as packing them on cores alone
+    memory : int or None
+        the amount of memory in MB the step declares it needs, or ``None``
+        if it has not said.  This stays ``None`` for a step that declares
+        nothing: it is never filled in with the default, because the two
+        are treated differently.
+
+        A declared figure is a **ceiling as well as a claim**.  The
+        launcher will hold a step to a memory figure on machines that
+        enforce, so a step author should declare a peak with margin rather
+        than a typical value.
+
+    memory_budget : int or None
+        the memory in MB to account for this step: what it declared, or its
+        proportional share of a node if it declared nothing.  Resolved when
+        resources are constrained, and ``None`` where the machine has not
+        said how much memory a node has.
+
+        Use this for accounting and ``memory`` for capping.  Only a
+        declared figure may be enforced as a cap -- capping a step at the
+        framework's own rough estimate of it would make every step carry a
+        measured number before it could run, which is the burden the
+        default exists to avoid.
 
     min_memory : int
         the amount of memory in MB the step needs in order to run at all,
@@ -298,7 +315,9 @@ class Step:
             the number of OpenMP threads to use
 
         memory : int, optional
-            the amount of memory in MB the step would ideally be given
+            the amount of memory in MB the step needs.  Declaring one makes
+            it a ceiling on machines that enforce, so declare a peak with
+            margin rather than a typical value
 
         min_memory : int, optional
             the amount of memory in MB the step needs in order to run at
@@ -359,6 +378,7 @@ class Step:
         _warn_if_gpus_per_task(gpus_per_task, min_gpus_per_task)
         self.memory = memory
         self.min_memory = min_memory
+        self.memory_budget = None
         self.placement = None
 
         self.path = os.path.join(self.component.name, self.subdir)
@@ -695,21 +715,31 @@ class Step:
 
         A step that has been measured says what it needs and is scheduled on
         that instead.
+
+        The default lands in ``memory_budget`` and never in ``memory``,
+        which stays as the step declared it.  Downstream has to be able to
+        tell the two apart: a declared figure may be enforced as a cap,
+        because getting it wrong is then immediate and attributable, while
+        a defaulted one may not, since capping every step at the
+        framework's own guess would make them all carry a measured number
+        before they could run.
         """
         cores_per_node = available_resources['cores_per_node']
         memory_per_node = available_resources.get('memory_per_node')
 
-        if self.memory is None and memory_per_node and cores_per_node:
-            self.memory = self.cores * memory_per_node // cores_per_node
+        if self.memory is not None:
+            self.memory_budget = self.memory
+        elif memory_per_node and cores_per_node:
+            self.memory_budget = self.cores * memory_per_node // cores_per_node
 
         if (
-            self.memory is not None
+            self.memory_budget is not None
             and self.min_memory is not None
-            and self.min_memory > self.memory
+            and self.min_memory > self.memory_budget
         ):
             raise ValueError(
                 f'Step {self.name} needs at least {self.min_memory} MB of '
-                f'memory but asks for only {self.memory} MB.'
+                f'memory but has {self.memory_budget} MB.'
             )
 
     def _constrain_gpus(

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -83,15 +83,36 @@ class Step:
         .. deprecated:: 1.1.0
             Use ``min_gpus`` instead
 
-    max_memory : int
-        the amount of memory in MB the step would ideally be given.  This
-        is a declaration only: nothing in Polaris acts on it yet, and no
-        supported launcher has a way to reserve memory for a job step
+    cores : int
+        the number of cores the step needs in total.  A non-MPI step says
+        this directly; an MPI step says ``ntasks`` and ``cpus_per_task``
+        instead and this is their product
+
+    min_cores : int
+        the number of cores the step needs in order to run at all
+
+    memory : int
+        the amount of memory in MB the step needs.  A step that says
+        nothing is given its proportional share of a node -- its cores
+        times the node's memory per core -- which is chosen so that packing
+        steps on memory comes out the same as packing them on cores alone
 
     min_memory : int
         the amount of memory in MB the step needs in order to run at all,
-        the minimum to ``max_memory``'s target, in the same style as
+        the minimum to ``memory``'s target, in the same style as
         ``min_tasks`` and ``min_cpus_per_task``
+
+    may_span_nodes : bool
+        whether this step's resources -- its cores and its GPUs alike -- may
+        be drawn from more than one node.  True for an MPI step, whose
+        launcher spreads its ranks; false for a step that runs in one
+        process, which has no way to reach another node.
+
+        This is not the same question as whether a step uses MPI.  A single
+        process that hands its work to a distributed pool spans nodes
+        perfectly well, and one that does its work in its own threads
+        cannot; both are "not MPI".  Nothing in Polaris sets this true today
+        beyond the MPI default.
 
     placement : mache.parallel.ResourcePlacement or None
         the part of the allocation this step is confined to -- which nodes,
@@ -208,8 +229,11 @@ class Step:
         min_cpus_per_task=1,
         ntasks=1,
         min_tasks=1,
+        cores=None,
+        min_cores=None,
+        may_span_nodes=None,
         openmp_threads=1,
-        max_memory=None,
+        memory=None,
         min_memory=None,
         cached=False,
         run_as_subprocess=False,
@@ -257,10 +281,23 @@ class Step:
             few cores to accommodate the number of tasks and cores per task,
             the step will fail
 
+        cores : int, optional
+            the number of cores the step needs in total.  For a non-MPI
+            step this is the direct way to say it; an MPI step says
+            ``ntasks`` and ``cpus_per_task`` instead
+
+        min_cores : int, optional
+            the number of cores the step needs in order to run at all
+
+        may_span_nodes : bool, optional
+            whether the step's cores and GPUs may be drawn from more than
+            one node.  Defaults to whether the step has more than one MPI
+            task
+
         openmp_threads : int
             the number of OpenMP threads to use
 
-        max_memory : int, optional
+        memory : int, optional
             the amount of memory in MB the step would ideally be given
 
         min_memory : int, optional
@@ -311,13 +348,16 @@ class Step:
         self.min_cpus_per_task = min_cpus_per_task
         self.ntasks = ntasks
         self.min_tasks = min_tasks
+        self._cores = cores
+        self._min_cores = min_cores
+        self._may_span_nodes = may_span_nodes
         self.openmp_threads = openmp_threads
         self.gpus_per_task = gpus_per_task
         self.min_gpus_per_task = min_gpus_per_task
         self._gpus = gpus
         self._min_gpus = min_gpus
         _warn_if_gpus_per_task(gpus_per_task, min_gpus_per_task)
-        self.max_memory = max_memory
+        self.memory = memory
         self.min_memory = min_memory
         self.placement = None
 
@@ -356,6 +396,56 @@ class Step:
         # output caching
         self.cached = cached
         self.default_cached = False
+
+    @property
+    def cores(self):
+        """
+        int : the number of cores this step needs, in total
+
+        A non-MPI step says this directly, because it has no meaningful
+        number of ranks and expressing its cores through MPI-shaped fields
+        is how a Python step ends up being told it has three nodes' worth.
+        An MPI step says ranks and cores per rank, and this is their
+        product.
+        """
+        if self._cores is not None:
+            return self._cores
+        return self.cpus_per_task * self.ntasks
+
+    @cores.setter
+    def cores(self, value):
+        self._cores = value
+
+    @property
+    def min_cores(self):
+        """
+        int : the number of cores this step needs in order to run at all
+        """
+        if self._min_cores is not None:
+            return self._min_cores
+        return self.min_cpus_per_task * self.min_tasks
+
+    @min_cores.setter
+    def min_cores(self, value):
+        self._min_cores = value
+
+    @property
+    def may_span_nodes(self):
+        """
+        bool : whether this step's cores and GPUs may come from several nodes
+
+        Defaults to whether the step has more than one MPI task, since a
+        launcher spreading ranks is the one mechanism Polaris has today for
+        reaching another node.  A step that delegates to a distributed pool
+        will set this itself; nothing does in Phase A.
+        """
+        if self._may_span_nodes is not None:
+            return self._may_span_nodes
+        return self.ntasks is not None and self.ntasks > 1
+
+    @may_span_nodes.setter
+    def may_span_nodes(self, value):
+        self._may_span_nodes = value
 
     @property
     def gpus(self):
@@ -398,8 +488,11 @@ class Step:
         min_cpus_per_task=None,
         ntasks=None,
         min_tasks=None,
+        cores=None,
+        min_cores=None,
+        may_span_nodes=None,
         openmp_threads=None,
-        max_memory=None,
+        memory=None,
         min_memory=None,
         gpus=None,
         min_gpus=None,
@@ -435,10 +528,20 @@ class Step:
             few cores to accommodate the number of tasks and cores per task,
             the step will fail
 
+        cores : int, optional
+            the number of cores the step needs in total
+
+        min_cores : int, optional
+            the number of cores the step needs in order to run at all
+
+        may_span_nodes : bool, optional
+            whether the step's cores and GPUs may be drawn from more than
+            one node
+
         openmp_threads : int, optional
             the number of OpenMP threads to use
 
-        max_memory : int, optional
+        memory : int, optional
             the amount of memory in MB the step would ideally be given
 
         min_memory : int, optional
@@ -473,6 +576,12 @@ class Step:
             self.ntasks = ntasks
         if min_tasks is not None:
             self.min_tasks = min_tasks
+        if cores is not None:
+            self.cores = cores
+        if min_cores is not None:
+            self.min_cores = min_cores
+        if may_span_nodes is not None:
+            self.may_span_nodes = may_span_nodes
         if openmp_threads is not None:
             self.openmp_threads = openmp_threads
         if gpus is not None:
@@ -483,8 +592,8 @@ class Step:
             self.gpus_per_task = gpus_per_task
         if min_gpus_per_task is not None:
             self.min_gpus_per_task = min_gpus_per_task
-        if max_memory is not None:
-            self.max_memory = max_memory
+        if memory is not None:
+            self.memory = memory
         if min_memory is not None:
             self.min_memory = min_memory
 
@@ -534,13 +643,13 @@ class Step:
             )
 
         if (
-            self.max_memory is not None
+            self.memory is not None
             and self.min_memory is not None
-            and self.min_memory > self.max_memory
+            and self.min_memory > self.memory
         ):
             raise ValueError(
                 f'Step {self.name} needs at least {self.min_memory} MB of '
-                f'memory but asks for only {self.max_memory} MB.'
+                f'memory but asks for only {self.memory} MB.'
             )
 
         self._constrain_gpus(

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -515,13 +515,6 @@ class Step:
 
         available_cores = available_resources['cores']
         cores_per_node = available_resources['cores_per_node']
-        if self.ntasks == 1:
-            # a single-process step cannot reach cores on another node
-            # without a distributed launcher, so the cores in the rest of
-            # what it was given are not its to count.  `cpus_per_task` is
-            # capped at one node below in any case; saying it here is what
-            # keeps the task count honest too.
-            available_cores = min(available_cores, cores_per_node)
         self.cpus_per_task = min(
             self.cpus_per_task, min(available_cores, cores_per_node)
         )

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -499,6 +499,13 @@ class Step:
             A dictionary containing available resources (cores, tasks, nodes
             and cores_per_node)
         """
+        # read what the step asked for before anything below changes it.
+        # GPUs are constrained in proportion to the tasks that survive, and
+        # the proportion is the one the step declared, not whatever is left
+        # after the cores have already been taken into account.
+        declared_ntasks = self.ntasks
+        declared_gpus = self.gpus
+
         mpi_allowed = available_resources['mpi_allowed']
         if not mpi_allowed and self.ntasks > 1:
             raise ValueError(
@@ -543,32 +550,38 @@ class Step:
                 f'memory but asks for only {self.max_memory} MB.'
             )
 
-        self._constrain_gpus(available_resources)
+        self._constrain_gpus(
+            available_resources, declared_ntasks, declared_gpus
+        )
 
-    def _constrain_gpus(self, available_resources):
+    def _constrain_gpus(
+        self, available_resources, declared_ntasks, declared_gpus
+    ):
         """
         Constrain a step's GPUs, and its tasks, to the GPUs available.
 
         The step asks for a total, but those GPUs are still spread across its
-        tasks, so running fewer tasks means needing fewer GPUs.  The ratio
-        between the two is what is held fixed while scaling down.
+        tasks, so running fewer tasks means needing fewer GPUs.  What is held
+        fixed while scaling down is the proportion the step *declared*: by
+        the time this runs, ``ntasks`` may already have been cut back by the
+        cores available, and measuring the proportion against that would make
+        each surviving task look like it needs more GPUs than it does.
         """
-        gpus = self.gpus
-        if gpus <= 0:
+        if declared_gpus <= 0 or not declared_ntasks:
             return
 
         available_gpus = available_resources.get('gpus')
         if not available_gpus:
             raise ValueError(
-                f'Step {self.name} requests {gpus} GPUs but no GPUs are '
-                f'available on this machine.'
+                f'Step {self.name} requests {declared_gpus} GPUs but no GPUs '
+                f'are available on this machine.'
             )
 
-        available_gpu_tasks = available_gpus * self.ntasks // gpus
+        available_gpu_tasks = available_gpus * declared_ntasks // declared_gpus
         ntasks = min(self.ntasks, available_gpu_tasks)
         # round up, so that scaling down the tasks never scales the GPUs
         # below what the tasks that remain still need
-        self.gpus = -(-gpus * ntasks // self.ntasks)
+        self.gpus = -(-declared_gpus * ntasks // declared_ntasks)
         self.ntasks = ntasks
 
         if self.gpus < self.min_gpus:

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -622,8 +622,25 @@ class Step:
                 'Please switch to a compute node.'
             )
 
+        self._constrain_cores(available_resources)
+        self._constrain_memory(available_resources)
+        self._constrain_gpus(
+            available_resources, declared_ntasks, declared_gpus
+        )
+
+    def _constrain_cores(self, available_resources):
+        """
+        Constrain a step's cores to what it can be given.
+
+        Two bounds apply and they are different questions. One process
+        cannot be given cores on a node it is not running on, so
+        ``cpus_per_task`` is always held to a node. Whether the *step* may
+        draw its cores from several nodes is the step's to say, and a step
+        that may not is held to a node in total as well.
+        """
         available_cores = available_resources['cores']
         cores_per_node = available_resources['cores_per_node']
+
         self.cpus_per_task = min(
             self.cpus_per_task, min(available_cores, cores_per_node)
         )
@@ -633,7 +650,29 @@ class Step:
                 f'minimum of {self.min_cpus_per_task} for step {self.name}'
             )
 
-        available_tasks = available_cores // self.cpus_per_task
+        bound = available_cores
+        if not self.may_span_nodes:
+            bound = min(available_cores, cores_per_node)
+            if self.min_cores > cores_per_node:
+                # a reduction is not available here: the step has said it
+                # cannot run any smaller, and no node is any bigger
+                raise ValueError(
+                    f'Step {self.name} needs at least {self.min_cores} cores '
+                    f'and may not use more than one node, but a node here '
+                    f'has {cores_per_node}. If its work can be spread across '
+                    f'nodes, set may_span_nodes on the step.'
+                )
+
+        if self._cores is not None:
+            self.cores = min(self.cores, bound)
+            if self.cores < self.min_cores:
+                raise ValueError(
+                    f'Available cores ({self.cores}) is below the minimum of '
+                    f'{self.min_cores} for step {self.name}'
+                )
+            return
+
+        available_tasks = bound // self.cpus_per_task
         self.ntasks = min(self.ntasks, available_tasks)
 
         if self.ntasks < self.min_tasks:
@@ -641,6 +680,27 @@ class Step:
                 f'Available number of MPI tasks ({self.ntasks}) is below the '
                 f'minimum of {self.min_tasks} for step {self.name}'
             )
+
+    def _constrain_memory(self, available_resources):
+        """
+        Give a step that declared no memory its proportional share of a node.
+
+        Every step uses memory, so unlike GPUs there is no true statement to
+        default to and the default has to be an assumption. This one is
+        chosen for a property rather than for accuracy: a step's cores times
+        the node's memory per core means a run in which every step defaults
+        packs on memory exactly as it would have packed on cores, so nothing
+        is made worse by memory being accounted for at all. It is rounded
+        down so that the total can never exceed what the nodes hold.
+
+        A step that has been measured says what it needs and is scheduled on
+        that instead.
+        """
+        cores_per_node = available_resources['cores_per_node']
+        memory_per_node = available_resources.get('memory_per_node')
+
+        if self.memory is None and memory_per_node and cores_per_node:
+            self.memory = self.cores * memory_per_node // cores_per_node
 
         if (
             self.memory is not None
@@ -651,10 +711,6 @@ class Step:
                 f'Step {self.name} needs at least {self.min_memory} MB of '
                 f'memory but asks for only {self.memory} MB.'
             )
-
-        self._constrain_gpus(
-            available_resources, declared_ntasks, declared_gpus
-        )
 
     def _constrain_gpus(
         self, available_resources, declared_ntasks, declared_gpus
@@ -679,11 +735,31 @@ class Step:
                 f'are available on this machine.'
             )
 
+        gpus_per_node = available_resources.get('gpus_per_node')
+        if not self.may_span_nodes and gpus_per_node:
+            # a step held to one node has to find its GPUs there too, not
+            # its cores on one node and its GPUs on another
+            if self.min_gpus > gpus_per_node:
+                raise ValueError(
+                    f'Step {self.name} needs at least {self.min_gpus} GPUs '
+                    f'and may not use more than one node, but a node here '
+                    f'has {gpus_per_node}. If its work can be spread across '
+                    f'nodes, set may_span_nodes on the step.'
+                )
+            available_gpus = min(available_gpus, gpus_per_node)
+
+        # a step's GPUs are spread over its tasks, so fewer GPUs means fewer
+        # tasks -- but never fewer than one.  A single-task step asking for
+        # several GPUs has nothing to scale, and scaling it would take its
+        # task count to zero rather than trimming its GPUs.
         available_gpu_tasks = available_gpus * declared_ntasks // declared_gpus
-        ntasks = min(self.ntasks, available_gpu_tasks)
+        ntasks = min(self.ntasks, max(available_gpu_tasks, 1))
         # round up, so that scaling down the tasks never scales the GPUs
         # below what the tasks that remain still need
-        self.gpus = -(-declared_gpus * ntasks // declared_ntasks)
+        gpus = -(-declared_gpus * ntasks // declared_ntasks)
+        # and however the scaling came out, a step cannot have more GPUs
+        # than there are
+        self.gpus = min(gpus, available_gpus)
         self.ntasks = ntasks
 
         if self.gpus < self.min_gpus:

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -643,10 +643,16 @@ class Step:
             )
 
         self._constrain_cores(available_resources)
-        self._constrain_memory(available_resources)
+        # GPUs before memory, because running out of GPUs can cut the task
+        # count again and the memory budget has to describe the cores the
+        # step ends up with.  Budgeting first would hand a step memory for
+        # tasks it no longer has, and break the very thing the default is
+        # chosen for -- that a memory budget stays exactly proportional to
+        # cores, so packing on either comes out the same.
         self._constrain_gpus(
             available_resources, declared_ntasks, declared_gpus
         )
+        self._constrain_memory(available_resources)
 
     def _constrain_cores(self, available_resources):
         """

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -2,6 +2,7 @@ import importlib.resources as imp_res
 import logging
 import os
 import shutil
+import warnings
 
 from mache import MachineInfo
 from mache.permissions import update_permissions
@@ -61,11 +62,26 @@ class Step:
     openmp_threads : int
         the number of OpenMP threads to use
 
+    gpus : int
+        the number of GPUs the step would ideally use, as a total for the
+        step rather than a count per task.  A step uses no GPUs unless it
+        says otherwise, so 0 is the common case
+
+    min_gpus : int
+        the number of GPUs the step requires, again as a total
+
     gpus_per_task : int
         the number of GPUs per task the step would ideally use
 
+        .. deprecated:: 1.1.0
+            Use ``gpus`` instead.  A per-task count does not confine a step
+            to those GPUs when steps run at the same time; a total does
+
     min_gpus_per_task : int
         the number of GPUs per task the step requires
+
+        .. deprecated:: 1.1.0
+            Use ``min_gpus`` instead
 
     max_memory : int
         the amount of memory that the step is allowed to use in MB.
@@ -182,6 +198,8 @@ class Step:
         max_memory=None,
         cached=False,
         run_as_subprocess=False,
+        gpus=None,
+        min_gpus=None,
         gpus_per_task=0,
         min_gpus_per_task=0,
     ):
@@ -232,11 +250,25 @@ class Step:
             This is currently just a placeholder for later use with task
             parallelism
 
+        gpus : int, optional
+            the number of GPUs the step would ideally use, as a total for
+            the step rather than a count per task.  A step uses no GPUs
+            unless it says otherwise
+
+        min_gpus : int, optional
+            the number of GPUs the step requires, again as a total
+
         gpus_per_task : int, optional
             the number of GPUs per task the step would ideally use
 
+            .. deprecated:: 1.1.0
+                Use ``gpus`` instead
+
         min_gpus_per_task : int, optional
             the number of GPUs per task the step requires
+
+            .. deprecated:: 1.1.0
+                Use ``min_gpus`` instead
 
         cached : bool, optional
             Whether to get all of the outputs for the step from the database of
@@ -265,6 +297,9 @@ class Step:
         self.openmp_threads = openmp_threads
         self.gpus_per_task = gpus_per_task
         self.min_gpus_per_task = min_gpus_per_task
+        self._gpus = gpus
+        self._min_gpus = min_gpus
+        _warn_if_gpus_per_task(gpus_per_task, min_gpus_per_task)
         self.max_memory = max_memory
 
         self.path = os.path.join(self.component.name, self.subdir)
@@ -303,6 +338,41 @@ class Step:
         self.cached = cached
         self.default_cached = False
 
+    @property
+    def gpus(self):
+        """
+        int : the number of GPUs this step needs, in total
+
+        A total rather than a count per task, because a per-task count does
+        not confine a step to those GPUs when steps run at the same time.
+        Falls back to the deprecated ``gpus_per_task`` when a step has not
+        been updated to say what it needs as a total.
+        """
+        if self._gpus is not None:
+            return self._gpus
+        if self.gpus_per_task and self.ntasks:
+            return self.gpus_per_task * self.ntasks
+        return 0
+
+    @gpus.setter
+    def gpus(self, value):
+        self._gpus = value
+
+    @property
+    def min_gpus(self):
+        """
+        int : the number of GPUs this step requires, in total
+        """
+        if self._min_gpus is not None:
+            return self._min_gpus
+        if self.min_gpus_per_task and self.min_tasks:
+            return self.min_gpus_per_task * self.min_tasks
+        return 0
+
+    @min_gpus.setter
+    def min_gpus(self, value):
+        self._min_gpus = value
+
     def set_resources(
         self,
         cpus_per_task=None,
@@ -311,6 +381,8 @@ class Step:
         min_tasks=None,
         openmp_threads=None,
         max_memory=None,
+        gpus=None,
+        min_gpus=None,
         gpus_per_task=None,
         min_gpus_per_task=None,
     ):
@@ -351,12 +423,26 @@ class Step:
             This is currently just a placeholder for later use with task
             parallelism
 
+        gpus : int, optional
+            the number of GPUs the step would ideally use, as a total for
+            the step rather than a count per task
+
+        min_gpus : int, optional
+            the number of GPUs the step requires, again as a total
+
         gpus_per_task : int, optional
             the number of GPUs per task the step would ideally use
 
+            .. deprecated:: 1.1.0
+                Use ``gpus`` instead
+
         min_gpus_per_task : int, optional
             the number of GPUs per task the step requires
+
+            .. deprecated:: 1.1.0
+                Use ``min_gpus`` instead
         """
+        _warn_if_gpus_per_task(gpus_per_task, min_gpus_per_task)
         if cpus_per_task is not None:
             self.cpus_per_task = cpus_per_task
         if min_cpus_per_task is not None:
@@ -367,6 +453,10 @@ class Step:
             self.min_tasks = min_tasks
         if openmp_threads is not None:
             self.openmp_threads = openmp_threads
+        if gpus is not None:
+            self.gpus = gpus
+        if min_gpus is not None:
+            self.min_gpus = min_gpus
         if gpus_per_task is not None:
             self.gpus_per_task = gpus_per_task
         if min_gpus_per_task is not None:
@@ -412,30 +502,46 @@ class Step:
                 f'minimum of {self.min_tasks} for step {self.name}'
             )
 
+        self._constrain_gpus(available_resources)
+
+    def _constrain_gpus(self, available_resources):
+        """
+        Constrain a step's GPUs, and its tasks, to the GPUs available.
+
+        The step asks for a total, but those GPUs are still spread across its
+        tasks, so running fewer tasks means needing fewer GPUs.  The ratio
+        between the two is what is held fixed while scaling down.
+        """
+        gpus = self.gpus
+        if gpus <= 0:
+            return
+
         available_gpus = available_resources.get('gpus')
-        if self.gpus_per_task > 0:
-            if available_gpus is None or available_gpus == 0:
-                raise ValueError(
-                    f'Step {self.name} requests {self.gpus_per_task} GPUs '
-                    'per task but no GPUs are available on this machine.'
-                )
+        if not available_gpus:
+            raise ValueError(
+                f'Step {self.name} requests {gpus} GPUs but no GPUs are '
+                f'available on this machine.'
+            )
 
-            available_gpu_tasks = available_gpus // self.gpus_per_task
-            self.ntasks = min(self.ntasks, available_gpu_tasks)
+        available_gpu_tasks = available_gpus * self.ntasks // gpus
+        ntasks = min(self.ntasks, available_gpu_tasks)
+        # round up, so that scaling down the tasks never scales the GPUs
+        # below what the tasks that remain still need
+        self.gpus = -(-gpus * ntasks // self.ntasks)
+        self.ntasks = ntasks
 
-            if self.gpus_per_task < self.min_gpus_per_task:
-                raise ValueError(
-                    f'Available gpus_per_task ({self.gpus_per_task}) is '
-                    f'below the minimum of {self.min_gpus_per_task} for '
-                    f'step {self.name}'
-                )
+        if self.gpus < self.min_gpus:
+            raise ValueError(
+                f'Available GPUs ({self.gpus}) is below the minimum of '
+                f'{self.min_gpus} for step {self.name}'
+            )
 
-            if self.ntasks < self.min_tasks:
-                raise ValueError(
-                    f'Available number of MPI tasks ({self.ntasks}) is '
-                    f'below the minimum of {self.min_tasks} for step '
-                    f'{self.name} after GPU constraints are applied'
-                )
+        if self.ntasks < self.min_tasks:
+            raise ValueError(
+                f'Available number of MPI tasks ({self.ntasks}) is '
+                f'below the minimum of {self.min_tasks} for step '
+                f'{self.name} after GPU constraints are applied'
+            )
 
     def setup(self):
         """
@@ -888,3 +994,17 @@ class Step:
         input_file = os.path.abspath(input_file)
 
         return input_file, database_subdirs
+
+
+def _warn_if_gpus_per_task(gpus_per_task, min_gpus_per_task):
+    """Warn that a per-task GPU count is on its way out."""
+    if not gpus_per_task and not min_gpus_per_task:
+        return
+    warnings.warn(
+        'gpus_per_task and min_gpus_per_task are deprecated. Use gpus and '
+        'min_gpus, which say how many GPUs the step needs in total. A '
+        'per-task count does not confine a step to those GPUs when steps '
+        'run at the same time.',
+        DeprecationWarning,
+        stacklevel=3,
+    )

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -676,7 +676,8 @@ class CombineStep(Step):
             ntasks=self.ntasks,
             openmp_threads=self.openmp_threads,
             logger=self.logger,
-            gpus_per_task=self.gpus_per_task,
+            gpus=self.gpus,
+            placement=self.placement,
         )
 
     def _remap_to_target_grid(

--- a/polaris/tasks/e3sm/init/topo/combine/viz.py
+++ b/polaris/tasks/e3sm/init/topo/combine/viz.py
@@ -42,8 +42,8 @@ class VizCombinedStep(Step):
             component=component,
             name='viz_combine_topo',
             subdir=subdir,
-            cpus_per_task=128,
-            min_cpus_per_task=1,
+            cores=128,
+            min_cores=1,
         )
         self.default_cached = True
         self.combine_step = combine_step
@@ -183,7 +183,7 @@ class VizCombinedStep(Step):
 
         import numba
 
-        numba.set_num_threads(self.cpus_per_task)
+        numba.set_num_threads(self.cores)
 
         image_filename = f'{field_name}.png'
 

--- a/polaris/tasks/e3sm/init/topo/cull/cull.cfg
+++ b/polaris/tasks/e3sm/init/topo/cull/cull.cfg
@@ -2,9 +2,9 @@
 [cull_mesh]
 
 # number of cores to use if available
-cpus_per_task = 128
+cores = 128
 # minimum of cores, below which the step fails
-min_cpus_per_task = 1
+min_cores = 1
 
 # whether to include critical land and ocean transects from geometric_features
 # as part of masking of the coastline

--- a/polaris/tasks/e3sm/init/topo/cull/cull.py
+++ b/polaris/tasks/e3sm/init/topo/cull/cull.py
@@ -73,8 +73,8 @@ class CullMeshStep(Step):
             component,
             name=name,
             subdir=subdir,
-            cpus_per_task=None,
-            min_cpus_per_task=None,
+            cores=None,
+            min_cores=None,
         )
         self.base_mesh_step = base_mesh_step
         self.cull_mask_step = cull_mask_step
@@ -122,13 +122,12 @@ class CullMeshStep(Step):
                 self.cull_mask_step.path, 'cull_masks.nc'
             ),
         )
-        self.cpus_per_task = section.getint('cpus_per_task')
-        self.min_cpus_per_task = section.getint('min_cpus_per_task')
+        self.cores = section.getint('cores')
+        self.min_cores = section.getint('min_cores')
 
     def constrain_resources(self, available_resources):
         """
-        Constrain ``cpus_per_task`` and ``ntasks`` based on the number of
-        cores available to this step
+        Constrain the cores this step uses to the cores available to it
 
         Parameters
         ----------
@@ -137,8 +136,8 @@ class CullMeshStep(Step):
         """
         config = self.config
         section = config['cull_mesh']
-        self.cpus_per_task = section.getint('cpus_per_task')
-        self.min_cpus_per_task = section.getint('min_cpus_per_task')
+        self.cores = section.getint('cores')
+        self.min_cores = section.getint('min_cores')
         super().constrain_resources(available_resources)
 
     def run(self):
@@ -190,7 +189,7 @@ class CullMeshStep(Step):
         ds_map_culled_to_base = map_culled_to_base(
             ds_base=ds_base_mesh,
             ds_culled=ds_culled_mesh,
-            workers=self.cpus_per_task,
+            workers=self.cores,
         )
         write_netcdf(ds_map_culled_to_base, f'{prefix}_map_culled_to_base.nc')
 

--- a/polaris/tasks/e3sm/init/topo/cull/mask.py
+++ b/polaris/tasks/e3sm/init/topo/cull/mask.py
@@ -100,8 +100,8 @@ class CullMaskStep(Step):
             component,
             name=name,
             subdir=subdir,
-            cpus_per_task=None,
-            min_cpus_per_task=None,
+            cores=None,
+            min_cores=None,
         )
         self.base_mesh_step = base_mesh_step
         self.unsmoothed_topo_step = unsmoothed_topo_step
@@ -153,13 +153,12 @@ class CullMaskStep(Step):
                 ),
             )
 
-        self.cpus_per_task = section.getint('cpus_per_task')
-        self.min_cpus_per_task = section.getint('min_cpus_per_task')
+        self.cores = section.getint('cores')
+        self.min_cores = section.getint('min_cores')
 
     def constrain_resources(self, available_resources):
         """
-        Constrain ``cpus_per_task`` and ``ntasks`` based on the number of
-        cores available to this step
+        Constrain the cores this step uses to the cores available to it
 
         Parameters
         ----------
@@ -168,8 +167,8 @@ class CullMaskStep(Step):
         """
         config = self.config
         section = config['cull_mesh']
-        self.cpus_per_task = section.getint('cpus_per_task')
-        self.min_cpus_per_task = section.getint('min_cpus_per_task')
+        self.cores = section.getint('cores')
+        self.min_cores = section.getint('min_cores')
         super().constrain_resources(available_resources)
 
     def define_critical_land_transects(self, gf):
@@ -359,7 +358,7 @@ class CullMaskStep(Step):
         section = config['cull_mesh']
         latitude_threshold = section.getfloat('sea_ice_latitude_threshold')
 
-        cpus_per_task = self.cpus_per_task
+        cores = self.cores
         netcdf_format = mpas_tools.io.default_format
         netcdf_engine = mpas_tools.io.default_engine
 
@@ -387,7 +386,7 @@ class CullMaskStep(Step):
                 '-s',
                 '10e3',
                 '--process_count',
-                f'{cpus_per_task}',
+                f'{cores}',
                 '--format',
                 netcdf_format,
                 '--engine',
@@ -432,7 +431,7 @@ class CullMaskStep(Step):
                 '-s',
                 '10e3',
                 '--process_count',
-                f'{cpus_per_task}',
+                f'{cores}',
                 '--format',
                 netcdf_format,
                 '--engine',

--- a/polaris/tasks/e3sm/init/topo/remap/remap.py
+++ b/polaris/tasks/e3sm/init/topo/remap/remap.py
@@ -331,6 +331,7 @@ class RemapTopoStep(Step):
             openmp_threads=self.openmp_threads,
             logger=self.logger,
             gpus=self.gpus,
+            placement=self.placement,
         )
 
         logger.info('  Done.')

--- a/polaris/tasks/e3sm/init/topo/remap/remap.py
+++ b/polaris/tasks/e3sm/init/topo/remap/remap.py
@@ -330,7 +330,7 @@ class RemapTopoStep(Step):
             ntasks=self.ntasks,
             openmp_threads=self.openmp_threads,
             logger=self.logger,
-            gpus_per_task=self.gpus_per_task,
+            gpus=self.gpus,
         )
 
         logger.info('  Done.')

--- a/polaris/tasks/mesh/spherical/unified/base_mesh/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/base_mesh/viz.py
@@ -73,8 +73,6 @@ class VizBaseMeshStep(Step):
             component=component,
             name='base_mesh_viz',
             subdir=subdir,
-            cpus_per_task=1,
-            min_cpus_per_task=1,
         )
         self.base_mesh_step = base_mesh_step
         self.sizing_step = sizing_step

--- a/polaris/tasks/mesh/spherical/unified/coastline/compute.py
+++ b/polaris/tasks/mesh/spherical/unified/coastline/compute.py
@@ -48,8 +48,6 @@ class ComputeCoastlineStep(Step):
             component=component,
             name='coastline_compute',
             subdir=subdir,
-            cpus_per_task=1,
-            min_cpus_per_task=1,
         )
         self.default_cached = True
         self.combine_step = combine_step
@@ -98,7 +96,7 @@ class ComputeCoastlineStep(Step):
             mask_threshold=mask_threshold,
             sea_level_elevation=sea_level_elevation,
             distance_chunk_size=distance_chunk_size,
-            workers=self.cpus_per_task,
+            workers=self.cores,
             critical_transects=critical_transects,
         )
         for convention, ds_coastline in ds_coastlines.items():

--- a/polaris/tasks/mesh/spherical/unified/coastline/remap.py
+++ b/polaris/tasks/mesh/spherical/unified/coastline/remap.py
@@ -55,8 +55,6 @@ class RemapCoastlineStep(Step):
             component=component,
             name='coastline_remap',
             subdir=subdir,
-            cpus_per_task=1,
-            min_cpus_per_task=1,
         )
         self.default_cached = True
         self.fine_coastline_step = fine_coastline_step

--- a/polaris/tasks/mesh/spherical/unified/coastline/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/coastline/viz.py
@@ -52,8 +52,6 @@ class VizCoastlineStep(Step):
             component=component,
             name='viz_coastline',
             subdir=subdir,
-            cpus_per_task=1,
-            min_cpus_per_task=1,
         )
         self.coastline_step = coastline_step
 

--- a/polaris/tasks/mesh/spherical/unified/river/clip.py
+++ b/polaris/tasks/mesh/spherical/unified/river/clip.py
@@ -48,8 +48,6 @@ class ClipRiverNetworkStep(Step):
             component=component,
             name='river_clip',
             subdir=subdir,
-            cpus_per_task=1,
-            min_cpus_per_task=1,
         )
         self.simplify_step = simplify_step
         self.coastline_step = coastline_step

--- a/polaris/tasks/mesh/spherical/unified/river/rasterize.py
+++ b/polaris/tasks/mesh/spherical/unified/river/rasterize.py
@@ -46,8 +46,6 @@ class RasterizeRiverLatLonStep(Step):
             component=component,
             name='river_rasterize',
             subdir=subdir,
-            cpus_per_task=1,
-            min_cpus_per_task=1,
         )
         self.simplify_step = simplify_step
         self.coastline_step = coastline_step

--- a/polaris/tasks/mesh/spherical/unified/river/simplify.py
+++ b/polaris/tasks/mesh/spherical/unified/river/simplify.py
@@ -121,8 +121,8 @@ class SimplifyRiverNetworkStep(Step):
             component=component,
             name='river_simplify',
             subdir=subdir,
-            cpus_per_task=128,
-            min_cpus_per_task=1,
+            cores=128,
+            min_cores=1,
         )
         self.simplified_filename = 'simplified_river_network.geojson'
 
@@ -148,7 +148,7 @@ class SimplifyRiverNetworkStep(Step):
         import time
 
         logger = self.logger
-        logger.info(f'cpus_per_task = {self.cpus_per_task}')
+        logger.info(f'cores = {self.cores}')
 
         section = self.config['river_network']
         archive_filename = section.get('hydrorivers_archive_filename')
@@ -190,7 +190,7 @@ class SimplifyRiverNetworkStep(Step):
             drainage_area_threshold=drainage_area_threshold,
             branch_distance_tolerance=branch_distance_tolerance,
             tributary_area_ratio=section.getfloat('tributary_area_ratio'),
-            n_cpus=self.cpus_per_task,
+            n_cpus=self.cores,
             logger=logger,
         )
         logger.info(f'simplify: {time.time() - t0:.1f} s')

--- a/polaris/tasks/mesh/spherical/unified/river/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/river/viz.py
@@ -59,8 +59,6 @@ class VizRiverStep(Step):
             component=component,
             name='viz_river_network',
             subdir=subdir,
-            cpus_per_task=1,
-            min_cpus_per_task=1,
         )
         self.simplify_step = simplify_step
         self.rasterize_step = rasterize_step

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/build.py
@@ -102,8 +102,6 @@ class BuildSizingFieldStep(Step):
             component=component,
             name='sizing_field',
             subdir=subdir,
-            cpus_per_task=1,
-            min_cpus_per_task=1,
         )
         self.coastline_step = coastline_step
         self.river_step = river_step
@@ -282,7 +280,7 @@ class BuildSizingFieldStep(Step):
             ocean_mask=effective,
             lon=lon,
             lat=lat,
-            workers=self.cpus_per_task,
+            workers=self.cores,
         )
 
         ds_effective = ds_coastline.copy()

--- a/polaris/tasks/mesh/spherical/unified/sizing_field/viz.py
+++ b/polaris/tasks/mesh/spherical/unified/sizing_field/viz.py
@@ -48,8 +48,6 @@ class VizSizingFieldStep(Step):
             component=component,
             name='sizing_field_viz',
             subdir=subdir,
-            cpus_per_task=1,
-            min_cpus_per_task=1,
         )
         self.sizing_step = sizing_step
         self.output_filenames = [

--- a/tests/test_io_tasks.py
+++ b/tests/test_io_tasks.py
@@ -67,14 +67,16 @@ def _make_step(
     component.parallel_system = _make_parallel_system(
         nodes=nodes, gpu_compiler=gpu_compiler
     )
-    # ModelStep uses openmp_threads as cpus_per_task
+    # ModelStep uses openmp_threads as cpus_per_task, and states its GPU
+    # need as a total for the step rather than a count per task
     return ModelStep(
         component=component,
         name='forward',
         ntasks=ntasks,
         min_tasks=ntasks,
         openmp_threads=cpus_per_task,
-        gpus_per_task=gpus_per_task,
+        gpus=gpus_per_task * ntasks,
+        min_gpus=gpus_per_task * ntasks,
     )
 
 

--- a/tests/test_parallel_requirements.py
+++ b/tests/test_parallel_requirements.py
@@ -1,0 +1,39 @@
+"""
+Tests for what Polaris requires of mache.
+
+Phase A depends on a mache that can confine a launch to part of an
+allocation.  Until that lands in a release, Polaris has to be deployed
+against the branch, and the failure when it is not has to say so.
+"""
+
+import inspect
+
+import pytest
+from mache.parallel import ParallelSystem
+
+from polaris.parallel import check_mache_supports_placement
+
+
+def test_the_deployed_mache_supports_placement():
+    """The environment this runs in has to be one Phase A can use."""
+    check_mache_supports_placement()
+
+
+def test_a_mache_without_placement_is_refused(monkeypatch):
+    """
+    A mache that cannot place would otherwise fail partway through a run,
+    with a TypeError from inside the launcher rather than a reason.
+    """
+
+    def no_placement(self, args, ntasks, cpus_per_task=0, gpus_per_task=0):
+        return []
+
+    monkeypatch.setattr(ParallelSystem, 'get_parallel_command', no_placement)
+    assert (
+        'placement'
+        not in inspect.signature(
+            ParallelSystem.get_parallel_command
+        ).parameters
+    )
+    with pytest.raises(RuntimeError, match='cannot confine a launch'):
+        check_mache_supports_placement()

--- a/tests/test_placement_commands.py
+++ b/tests/test_placement_commands.py
@@ -1,0 +1,300 @@
+"""
+Render a placement against every machine Polaris supports.
+
+mache has its own version of this over the configs *it* ships.  This one
+exists because Polaris assembles the config that mache is given -- its own
+machine files are layered over mache's -- so a Polaris config file can break
+placement on a machine without mache noticing.  Rendering here is what
+catches that, rather than a machine finding out at run time.
+
+No allocation is needed: the batch environment is faked, and both eras of
+Slurm are rendered because the flags differ completely across the 20.11
+change and CI will only ever have one of them.
+"""
+
+import importlib.resources as imp_res
+from unittest import mock
+
+import pytest
+from mache.parallel import PlacementSupport, ResourcePlacement
+from mache.parallel.pbs import PbsSystem
+from mache.parallel.single_node import SingleNodeSystem
+from mache.parallel.slurm import SlurmSystem
+
+from polaris.config import PolarisConfigParser
+
+# both eras of Slurm, since a site can be either and CI is neither
+MODERN_SLURM = (25, 11)
+LEGACY_SLURM = (20, 2)
+
+NODES = ('node0001', 'node0002')
+
+
+def _fixed(value):
+    """Make a callable returning a value, bound now rather than at call."""
+    return lambda: value
+
+
+def _machines():
+    """Every machine Polaris ships a config for."""
+    names = []
+    for entry in imp_res.files('polaris.machines').iterdir():
+        name = entry.name
+        if name.endswith('.cfg') and not name.startswith('default'):
+            names.append(name[: -len('.cfg')])
+    return sorted(names)
+
+
+def _compilers(config):
+    """
+    Every compiler a machine can actually be deployed with.
+
+    Taken from the ``mpi_<compiler>`` options in ``[deploy]``, which are what
+    define the valid combinations, plus any compiler that has parallel
+    options of its own.  The two are not the same set, and the difference is
+    where the interesting cases live: a compiler with no
+    ``[parallel.<compiler>]`` section falls back to the base ``[parallel]``,
+    and on pm-gpu that fallback is the deployment that has the GPUs.
+    """
+    compilers = set()
+    if config.has_section('deploy'):
+        for option in config.options('deploy'):
+            if option.startswith('mpi_'):
+                compilers.add(option[len('mpi_') :])
+    for section in config.sections():
+        if section.startswith('parallel.'):
+            compilers.add(section[len('parallel.') :])
+    if len(compilers) == 0:
+        compilers.add('')
+    return sorted(compilers)
+
+
+def _config(machine, compiler=''):
+    """Assemble the config a Polaris run would see for a machine."""
+    config = PolarisConfigParser()
+    config.add_from_package('polaris', 'default.cfg')
+    config.add_from_package(
+        'mache.machines', f'{machine}.cfg', exception=False
+    )
+    config.add_from_package('polaris.machines', f'{machine}.cfg')
+    config.set('build', 'machine', machine, user=True)
+    config.set('build', 'compiler', compiler, user=True)
+    config.combine()
+    return config.combined
+
+
+def _systems(machine, compiler):
+    """
+    Yield ``(label, system)`` from inside a faked batch environment.
+
+    Each is yielded from inside the context that fakes it and stays there
+    until the caller asks for the next one, because ``placement_support`` is
+    read every time it is asked, not stored.
+    """
+    config = _config(machine, compiler)
+    system_name = config.get('parallel', 'system', fallback=None)
+
+    if system_name == 'slurm':
+        for label, version in (
+            ('modern', MODERN_SLURM),
+            ('legacy', LEGACY_SLURM),
+        ):
+            with mock.patch.dict('os.environ', {'SLURM_JOB_ID': '12345'}):
+                with mock.patch(
+                    'mache.parallel.slurm._get_subprocess_int',
+                    lambda args: len(NODES),
+                ):
+                    with mock.patch(
+                        'mache.parallel.slurm.get_slurm_version',
+                        _fixed(version),
+                    ):
+                        yield label, SlurmSystem(config)
+    elif system_name == 'pbs':
+        with mock.patch.dict('os.environ', {'PBS_JOBID': '1.server'}):
+            with mock.patch.object(
+                PbsSystem,
+                '_get_node_count_from_qstat',
+                lambda self: len(NODES),
+            ):
+                # the launcher is probed by running it, and it is not
+                # installed wherever the tests happen to run
+                with mock.patch(
+                    'mache.parallel.pbs.is_pals_launcher', lambda exe: True
+                ):
+                    yield '', PbsSystem(config)
+    elif system_name == 'single_node':
+        yield '', SingleNodeSystem(config)
+
+
+def _cases():
+    """Every machine, compiler and Slurm era worth rendering."""
+    cases = []
+    for machine in _machines():
+        for compiler in _compilers(_config(machine)):
+            cases.append((machine, compiler))
+    return cases
+
+
+@pytest.mark.parametrize('machine,compiler', _cases())
+def test_no_placement_renders_the_command_polaris_already_built(
+    machine, compiler
+):
+    """A step that does not ask to be confined must not be confined."""
+    for _, system in _systems(machine, compiler):
+        command = system.get_parallel_command(
+            args=['model'], ntasks=2, cpus_per_task=4
+        )
+        rendered = ' '.join(command)
+        assert '--exact' not in rendered
+        assert '--gres=none' not in rendered
+        assert 'mask_cpu' not in rendered
+        assert '--hosts' not in rendered
+        assert ' -w ' not in f' {rendered} '
+
+
+@pytest.mark.parametrize('machine,compiler', _cases())
+def test_a_placement_on_one_node_confines_the_launch(machine, compiler):
+    for label, system in _systems(machine, compiler):
+        if system.placement_support is PlacementSupport.NONE:
+            continue
+        command = system.get_parallel_command(
+            args=['model'],
+            ntasks=2,
+            cpus_per_task=4,
+            placement=_placement(nodes=NODES[:1]),
+        )
+        _assert_confined(system, command, nodes=NODES[:1], label=label)
+
+
+@pytest.mark.parametrize('machine,compiler', _cases())
+def test_a_placement_can_span_several_nodes(machine, compiler):
+    for label, system in _systems(machine, compiler):
+        if system.placement_support is PlacementSupport.NONE:
+            continue
+        placement = _placement(nodes=NODES)
+        if isinstance(system, SingleNodeSystem):
+            # a machine with one node cannot honor a placement naming two,
+            # and says so rather than running on whichever it feels like
+            with pytest.raises(ValueError, match='has only one'):
+                system.get_parallel_command(
+                    args=['model'],
+                    ntasks=2,
+                    cpus_per_task=4,
+                    placement=placement,
+                )
+            continue
+        command = system.get_parallel_command(
+            args=['model'],
+            ntasks=2,
+            cpus_per_task=4,
+            placement=placement,
+        )
+        _assert_confined(system, command, nodes=NODES, label=label)
+
+
+@pytest.mark.parametrize('machine,compiler', _cases())
+def test_needing_no_gpus_says_so_explicitly(machine, compiler):
+    """
+    Silence about GPUs is read as a claim on every one on the node, which is
+    what stopped concurrent steps on the GPU machines.
+    """
+    for label, system in _systems(machine, compiler):
+        if system.placement_support is PlacementSupport.NONE:
+            continue
+        command = system.get_parallel_command(
+            args=['model'],
+            ntasks=2,
+            cpus_per_task=4,
+            placement=_placement(nodes=NODES[:1], gpus=0),
+        )
+        rendered = ' '.join(command)
+        if isinstance(system, SlurmSystem) and label == 'modern':
+            assert '--gres=none' in rendered
+        elif isinstance(system, PbsSystem):
+            variable = system.get_config('gpu_visible_devices_var')
+            if variable:
+                assert f'--env={variable}=' in rendered
+
+
+@pytest.mark.parametrize('machine,compiler', _cases())
+def test_needing_gpus_asks_for_a_total(machine, compiler):
+    """
+    A per-task count was measured not to confine a launch on either GPU
+    machine, while a total does.
+    """
+    for _, system in _systems(machine, compiler):
+        if system.placement_support is PlacementSupport.NONE:
+            continue
+        gpus_per_node = system.gpus_per_node or 0
+        if gpus_per_node < 2:
+            continue
+        placement = _placement(nodes=NODES[:1], gpus=2, system=system)
+        if (
+            isinstance(system, SlurmSystem)
+            and system.placement_support is PlacementSupport.CPU_BINDING
+        ):
+            # a pre-20.11 Slurm has no way to give a step a share of the
+            # node's GPUs, and says so rather than rendering something that
+            # would not confine anything
+            with pytest.raises(ValueError, match='Placing GPUs needs Slurm'):
+                system.get_parallel_command(
+                    args=['model'],
+                    ntasks=2,
+                    cpus_per_task=4,
+                    placement=placement,
+                )
+            continue
+        command = system.get_parallel_command(
+            args=['model'], ntasks=2, cpus_per_task=4, placement=placement
+        )
+        rendered = ' '.join(command)
+        assert '--gpus-per-task' not in rendered
+        if isinstance(system, SlurmSystem):
+            assert '--gpus=2' in rendered
+
+
+def _placement(nodes, gpus=0, system=None):
+    """Build a placement big enough for 2 tasks of 4 cores."""
+    gpu_ids = None
+    if gpus > 0 and system is not None:
+        variable = system.get_config('gpu_visible_devices_var')
+        if variable is not None and variable.strip() != '':
+            gpu_ids = tuple(range(gpus))
+    return ResourcePlacement(
+        nodes=nodes, cores=tuple(range(8)), gpus=gpus, gpu_ids=gpu_ids
+    )
+
+
+def _assert_confined(system, command, nodes, label):
+    """Check that a rendered command names the placement it was given."""
+    rendered = ' '.join(command)
+    if isinstance(system, SlurmSystem):
+        assert f'-w {",".join(nodes)}' in rendered
+        if label == 'modern':
+            assert '--exact' in rendered
+        else:
+            assert 'mask_cpu' in rendered
+    elif isinstance(system, PbsSystem):
+        assert f'--hosts {",".join(nodes)}' in rendered
+        assert '--cpu-bind list:' in rendered
+    elif isinstance(system, SingleNodeSystem):
+        assert command[0] == 'taskset'
+
+
+def test_some_machine_actually_exercises_the_gpu_case():
+    """
+    Guard against the GPU checks above quietly skipping everywhere.
+
+    Each of them bails out on a config that reports no GPUs, which is the
+    right thing to do per config and the wrong thing to discover about the
+    whole suite.
+    """
+    with_gpus = []
+    for machine, compiler in _cases():
+        for _, system in _systems(machine, compiler):
+            if (system.gpus_per_node or 0) >= 2:
+                with_gpus.append(f'{machine}/{compiler}')
+                break
+    assert len(with_gpus) > 0, 'no machine config reports any GPUs'
+    machines = {entry.split('/')[0] for entry in with_gpus}
+    assert {'pm-gpu', 'frontier', 'aurora'} <= machines

--- a/tests/test_placement_commands.py
+++ b/tests/test_placement_commands.py
@@ -213,7 +213,13 @@ def test_needing_no_gpus_says_so_explicitly(machine, compiler):
         elif isinstance(system, PbsSystem):
             variable = system.get_config('gpu_visible_devices_var')
             if variable:
-                assert f'--env={variable}=' in rendered
+                # asserted against the argument list rather than the joined
+                # string: mache moved from `--env=VAR=` to `--env VAR=`
+                # because PALS rejected the first form, and a substring
+                # match on the old spelling would have gone on passing for a
+                # command Aurora could not run
+                assert f'{variable}=' in command
+                assert '--env' in command
 
 
 @pytest.mark.parametrize('machine,compiler', _cases())

--- a/tests/test_placement_commands.py
+++ b/tests/test_placement_commands.py
@@ -298,3 +298,46 @@ def test_some_machine_actually_exercises_the_gpu_case():
     assert len(with_gpus) > 0, 'no machine config reports any GPUs'
     machines = {entry.split('/')[0] for entry in with_gpus}
     assert {'pm-gpu', 'frontier', 'aurora'} <= machines
+
+
+@pytest.mark.parametrize('machine,compiler', _cases())
+def test_polaris_reports_the_memory_mache_says_a_node_has(machine, compiler):
+    """
+    Whatever mache says a node's memory is, Polaris hands on unchanged.
+
+    A machine that says nothing leaves memory undeclared, which is the
+    correct answer rather than a guess: the figure feeds every step's
+    default, so inventing one would be worse than having none.
+    """
+    from polaris import Component
+
+    for _, system in _systems(machine, compiler):
+        component = Component(name='ocean')
+        component.parallel_system = system
+        resources = component.get_available_resources()
+
+        expected = system.get_config_int('memory_per_node') or None
+        assert resources['memory_per_node'] == expected
+        if expected is None:
+            assert resources['memory'] is None
+        else:
+            assert resources['memory'] == expected * system.nodes
+
+
+def test_the_machines_phase_a_targets_all_report_their_memory():
+    """
+    Guard against the memory plumbing above quietly testing nothing.
+
+    Each case degrades gracefully on a machine that says nothing, which is
+    right per machine and would be wrong to discover about the whole suite.
+    """
+    reported = {}
+    for machine, compiler in _cases():
+        for _, system in _systems(machine, compiler):
+            memory = system.get_config_int('memory_per_node')
+            if memory:
+                reported[machine] = memory
+            break
+    assert {'chrysalis', 'pm-cpu', 'pm-gpu', 'frontier', 'aurora'} <= set(
+        reported
+    ), f'machines missing memory_per_node: {reported}'

--- a/tests/test_placement_rendering.py
+++ b/tests/test_placement_rendering.py
@@ -1,0 +1,162 @@
+"""
+Run several placed launches at once and read back where they landed.
+
+Every other placement test checks what a command *says*. This one checks
+what it *does*: it builds disjoint placements, renders each through mache,
+starts them together, and has each report the cores it was actually allowed.
+
+It needs no allocation and no batch system. A single-node launcher confines a
+launch with ordinary process affinity, which is enough to exercise the whole
+path on any Linux machine, so this guards against a rendering regression on
+every commit rather than on whoever remembers to run something inside a job.
+
+It is deliberately self-contained: no import from ``utils/placement_check``,
+which is a temporary harness that will be removed from this branch's history.
+This is the part of it worth keeping.
+"""
+
+import os
+import subprocess
+
+import pytest
+from mache.parallel import PlacementSupport, ResourcePlacement
+from mache.parallel.single_node import SingleNodeSystem
+
+from polaris.config import PolarisConfigParser
+
+# each launch gets this many cores, and sleeps this long so that genuine
+# overlap between them is unambiguous
+CORES_PER_SLOT = 2
+SLEEP_SECONDS = 2
+
+# stands in for mpirun: takes the `-n N -c M` mache renders and runs the
+# payload once.  It is not a launcher -- the placement under test is the
+# `taskset` prefix mache puts in front of it.
+LAUNCHER = """#!/bin/sh
+shift 4
+exec "$@"
+"""
+
+# records the cores it was allowed and when it ran, one file per slot, so
+# that concurrent writers cannot interleave
+PAYLOAD = """#!/bin/sh
+start=$(date +%s.%N)
+cpus=$(awk '/Cpus_allowed_list/ {print $2}' /proc/self/status)
+sleep "$2"
+end=$(date +%s.%N)
+printf 'cpus=%s\\nstart=%s\\nend=%s\\n' "$cpus" "$start" "$end" > "$1"
+"""
+
+
+def test_placed_launches_run_at_once_on_the_cores_they_were_given(tmp_path):
+    """The whole path: build, render, launch together, read back."""
+    usable = sorted(os.sched_getaffinity(0))
+    if len(usable) < 2 * CORES_PER_SLOT:
+        pytest.skip(f'need {2 * CORES_PER_SLOT} cores, have {len(usable)}')
+    slots = min(4, len(usable) // CORES_PER_SLOT)
+
+    launcher = _script(tmp_path, 'launcher.sh', LAUNCHER)
+    payload = _script(tmp_path, 'payload.sh', PAYLOAD)
+    system = _single_node_system(launcher, len(usable))
+    if system.placement_support is PlacementSupport.NONE:
+        pytest.skip('no placement mechanism here (taskset is missing)')
+
+    placements = [
+        ResourcePlacement(
+            nodes=(),
+            cores=tuple(
+                usable[slot * CORES_PER_SLOT : (slot + 1) * CORES_PER_SLOT]
+            ),
+            gpus=0,
+        )
+        for slot in range(slots)
+    ]
+
+    processes = []
+    for slot, placement in enumerate(placements):
+        command = system.get_parallel_command(
+            args=[
+                payload,
+                str(tmp_path / f'slot{slot}.kv'),
+                f'{SLEEP_SECONDS}',
+            ],
+            ntasks=1,
+            cpus_per_task=CORES_PER_SLOT,
+            placement=placement,
+        )
+        assert command[0] == 'taskset', command
+        processes.append(subprocess.Popen(command))
+
+    for process in processes:
+        assert process.wait(timeout=60 + SLEEP_SECONDS) == 0
+
+    runs = [_read(tmp_path / f'slot{slot}.kv') for slot in range(slots)]
+
+    # every launch was confined to exactly the cores it was placed on.  A
+    # single-node launcher binds explicitly, so this is the exact set and
+    # not merely the right number of them.
+    for placement, run in zip(placements, runs, strict=True):
+        assert run['cores'] == set(placement.cores)
+
+    # and they really did run at the same time, which is what makes the
+    # disjointness above mean anything
+    assert _peak_concurrency(runs) == slots
+    seen: set[int] = set()
+    for run in runs:
+        assert seen.isdisjoint(run['cores'])
+        seen |= run['cores']
+
+
+def _single_node_system(launcher, cores_per_node):
+    """Build mache's real single-node system, with a stand-in launcher."""
+    config = PolarisConfigParser()
+    config.add_from_package('polaris', 'default.cfg')
+    config.add_from_package('polaris.machines', 'default.cfg')
+    config.set('parallel', 'parallel_executable', launcher, user=True)
+    config.set('parallel', 'cores_per_node', f'{cores_per_node}', user=True)
+    config.combine()
+    return SingleNodeSystem(config.combined)
+
+
+def _script(tmp_path, name, body):
+    """Write an executable script and return its path."""
+    path = tmp_path / name
+    path.write_text(body)
+    path.chmod(0o755)
+    return str(path)
+
+
+def _read(path):
+    """Read one launch's record: the cores it saw and when it ran."""
+    values = dict(
+        line.split('=', 1)
+        for line in path.read_text().splitlines()
+        if '=' in line
+    )
+    cores: set[int] = set()
+    for chunk in values['cpus'].split(','):
+        if '-' in chunk:
+            low, _, high = chunk.partition('-')
+            cores.update(range(int(low), int(high) + 1))
+        elif chunk:
+            cores.add(int(chunk))
+    return {
+        'cores': cores,
+        'start': float(values['start']),
+        'end': float(values['end']),
+    }
+
+
+def _peak_concurrency(runs):
+    """The largest number of launches running at any one instant."""
+    events = []
+    for run in runs:
+        events.append((run['start'], 1))
+        events.append((run['end'], -1))
+    events.sort()
+    current = 0
+    peak = 0
+    for _, delta in events:
+        current += delta
+        peak = max(peak, current)
+    return peak

--- a/tests/test_step_placement.py
+++ b/tests/test_step_placement.py
@@ -27,6 +27,10 @@ class _RecordingSystem:
         self.gpus = 12
         self.gpus_per_node = 4
         self.mpi_allowed = True
+        self.config = {'memory_per_node': 256000}
+
+    def get_config_int(self, key, default=0):
+        return self.config.get(key, default)
 
     def get_parallel_command(
         self, args, ntasks, cpus_per_task=0, gpus_per_task=0, placement=None
@@ -144,3 +148,33 @@ def test_cores_are_capped_at_one_node_today():
     step = Step(component=component, name='step', ntasks=1, cpus_per_task=192)
     step.constrain_resources(component.get_available_resources())
     assert step.cpus_per_task == 64
+
+
+def test_the_resource_view_carries_memory():
+    """
+    Phase C sizes worker memory from this, and the mistake it prevents is
+    deriving memory from cores.
+    """
+    component = _make_component()
+    resources = component.get_available_resources()
+    assert resources['memory_per_node'] == 256000
+    assert resources['memory'] == 256000 * 3
+
+
+def test_a_placement_carries_a_share_of_the_memory_it_took():
+    """A placement has no memory of its own; no launcher acts on one."""
+    component = _make_component()
+    resources = component.get_available_resources(
+        _placement(nodes=('node0001',), cores=32)
+    )
+    # half a node's cores, so half a node's memory
+    assert resources['memory'] == 128000
+    assert resources['memory_per_node'] == 256000
+
+
+def test_memory_is_left_undeclared_where_a_machine_has_not_said():
+    component = _make_component()
+    component.parallel_system.config = {}
+    resources = component.get_available_resources()
+    assert resources['memory'] is None
+    assert resources['memory_per_node'] is None

--- a/tests/test_step_placement.py
+++ b/tests/test_step_placement.py
@@ -125,10 +125,20 @@ def test_a_confined_step_is_sized_by_its_placement():
     assert step.cpus_per_task == 8
 
 
-def test_a_non_mpi_step_is_capped_at_one_node():
+def test_cores_are_capped_at_one_node_today():
     """
-    A single-process step cannot reach cores on another node without a
-    distributed launcher, so it must not be sized on the allocation.
+    Pin the behavior Polaris has always had, which is under review.
+
+    `cpus_per_task` is capped at one node's cores for every step, and for a
+    single-task step that is the whole core count, so such a step can never
+    be given more than one node's worth.  That is right for a step whose
+    parallelism is shared-memory -- `viz_combine_topo` sets numba's thread
+    count from it -- and wrong for one driving a distributed scheduler,
+    which is what the analysis work will do.  Polaris cannot currently tell
+    the two apart.
+
+    This is not an endorsement, it is a tripwire: whoever changes the cap
+    should have to change this too, deliberately.
     """
     component = _make_component()
     step = Step(component=component, name='step', ntasks=1, cpus_per_task=192)

--- a/tests/test_step_placement.py
+++ b/tests/test_step_placement.py
@@ -1,0 +1,136 @@
+"""
+Tests for confining a step to part of its allocation.
+
+Phase A adds the machinery for saying "run this here" and nothing that
+decides where "here" is.  These tests therefore drive the placement in by
+hand, the way a scheduler will in Phase B, and check two things: that a
+placement reaches the launcher untouched, and that a step given one is told
+about what it was given rather than about the whole job.
+"""
+
+import logging
+
+import pytest
+from mache.parallel import ResourcePlacement
+
+from polaris import Component, Step
+
+
+class _RecordingSystem:
+    """A parallel system that records what it was asked to launch."""
+
+    def __init__(self):
+        self.calls = []
+        self.cores = 192
+        self.nodes = 3
+        self.cores_per_node = 64
+        self.gpus = 12
+        self.gpus_per_node = 4
+        self.mpi_allowed = True
+
+    def get_parallel_command(
+        self, args, ntasks, cpus_per_task=0, gpus_per_task=0, placement=None
+    ):
+        self.calls.append(dict(placement=placement, ntasks=ntasks))
+        return ['true']
+
+
+def _make_component():
+    component = Component(name='ocean')
+    component.parallel_system = _RecordingSystem()
+    return component
+
+
+def _placement(nodes=('node0001',), cores=8, gpus=0):
+    return ResourcePlacement(nodes=nodes, cores=tuple(range(cores)), gpus=gpus)
+
+
+def test_a_step_is_not_confined_by_default():
+    step = Step(component=Component(name='ocean'), name='step')
+    assert step.placement is None
+
+
+def test_no_placement_reaches_the_launcher_as_none():
+    """A step that does not ask to be confined gets today's command."""
+    component = _make_component()
+    component.run_parallel_command(
+        args=['model'],
+        cpus_per_task=1,
+        ntasks=2,
+        openmp_threads=1,
+        logger=logging.getLogger('test'),
+    )
+    assert component.parallel_system.calls[-1]['placement'] is None
+
+
+def test_a_placement_reaches_the_launcher_untouched():
+    component = _make_component()
+    placement = _placement()
+    component.run_parallel_command(
+        args=['model'],
+        cpus_per_task=1,
+        ntasks=2,
+        openmp_threads=1,
+        logger=logging.getLogger('test'),
+        placement=placement,
+    )
+    assert component.parallel_system.calls[-1]['placement'] is placement
+
+
+def test_a_placement_that_disagrees_about_gpus_is_refused():
+    """
+    A placement carries the GPUs itself, so the two saying different things
+    means whatever built the placement has drifted from the step.
+    """
+    component = _make_component()
+    with pytest.raises(ValueError, match='They must agree'):
+        component.run_parallel_command(
+            args=['model'],
+            cpus_per_task=1,
+            ntasks=2,
+            openmp_threads=1,
+            logger=logging.getLogger('test'),
+            gpus=2,
+            placement=_placement(gpus=1),
+        )
+
+
+def test_resources_without_a_placement_are_the_whole_allocation():
+    component = _make_component()
+    resources = component.get_available_resources()
+    assert resources['cores'] == 192
+    assert resources['nodes'] == 3
+    assert resources['gpus'] == 12
+
+
+def test_resources_with_a_placement_are_only_what_it_gives():
+    component = _make_component()
+    resources = component.get_available_resources(
+        _placement(nodes=('node0001', 'node0002'), cores=8, gpus=4)
+    )
+    assert resources['cores'] == 16
+    assert resources['nodes'] == 2
+    assert resources['cores_per_node'] == 8
+    assert resources['gpus'] == 4
+    assert resources['gpus_per_node'] == 2
+    assert resources['mpi_allowed'] is True
+
+
+def test_a_confined_step_is_sized_by_its_placement():
+    """The point of the view: the step must not size itself on the job."""
+    component = _make_component()
+    step = Step(component=component, name='step', ntasks=1, cpus_per_task=64)
+    resources = component.get_available_resources(_placement(cores=8))
+    step.constrain_resources(resources)
+    assert step.cpus_per_task == 8
+
+
+def test_a_non_mpi_step_is_capped_at_one_node():
+    """
+    A single-process step cannot reach cores on another node without a
+    distributed launcher, so it must not be sized on the allocation.
+    """
+    component = _make_component()
+    step = Step(component=component, name='step', ntasks=1, cpus_per_task=192)
+    step.constrain_resources(component.get_available_resources())
+    assert step.cpus_per_task == 64

--- a/tests/test_step_resources.py
+++ b/tests/test_step_resources.py
@@ -1,0 +1,197 @@
+"""
+Tests for how a step says what resources it needs.
+
+Phase A of task parallelism changes GPUs from a count per MPI task to a
+total for the step.  The difference is not cosmetic: measurements on both
+GPU machines showed the per-task form does not confine a step at all when
+steps run at the same time, while a total does.
+"""
+
+import logging
+
+import pytest
+
+from polaris import Component, Step
+
+
+def _make_step(**kwargs):
+    return Step(component=Component(name='ocean'), name='step', **kwargs)
+
+
+def _resources(cores=64, cores_per_node=64, gpus=0, mpi_allowed=True):
+    return dict(
+        cores=cores,
+        nodes=max(1, cores // cores_per_node),
+        cores_per_node=cores_per_node,
+        gpus=gpus,
+        gpus_per_node=gpus,
+        mpi_allowed=mpi_allowed,
+    )
+
+
+def test_a_step_needs_no_gpus_unless_it_says_so():
+    step = _make_step(ntasks=4)
+    assert step.gpus == 0
+    assert step.min_gpus == 0
+
+
+def test_a_step_states_its_gpus_as_a_total():
+    step = _make_step(ntasks=4, gpus=4, min_gpus=2)
+    assert step.gpus == 4
+    assert step.min_gpus == 2
+
+
+def test_zero_gpus_stays_zero_even_with_tasks():
+    """An explicit "none" must not be confused with "unstated"."""
+    step = _make_step(ntasks=8, gpus=0, min_gpus=0)
+    assert step.gpus == 0
+    assert step.min_gpus == 0
+
+
+def test_a_per_task_count_is_deprecated_but_still_understood():
+    with pytest.warns(DeprecationWarning, match='gpus_per_task'):
+        step = _make_step(
+            ntasks=4, min_tasks=2, gpus_per_task=2, min_gpus_per_task=1
+        )
+    assert step.gpus == 8
+    assert step.min_gpus == 2
+
+
+def test_a_per_task_count_follows_a_later_change_in_tasks():
+    """A total derived from a per-task count has to track the task count."""
+    with pytest.warns(DeprecationWarning):
+        step = _make_step(ntasks=4, gpus_per_task=1)
+    step.ntasks = 6
+    assert step.gpus == 6
+
+
+def test_set_resources_takes_the_total():
+    step = _make_step(ntasks=4)
+    step.set_resources(gpus=3, min_gpus=1)
+    assert step.gpus == 3
+    assert step.min_gpus == 1
+
+
+def test_set_resources_warns_about_the_per_task_count():
+    step = _make_step(ntasks=4)
+    with pytest.warns(DeprecationWarning, match='gpus_per_task'):
+        step.set_resources(gpus_per_task=1)
+    assert step.gpus == 4
+
+
+def test_a_step_that_wants_no_gpus_is_left_alone():
+    step = _make_step(ntasks=4, cpus_per_task=1)
+    step.constrain_resources(_resources(gpus=0))
+    assert step.ntasks == 4
+    assert step.gpus == 0
+
+
+def test_gpus_are_capped_by_what_the_machine_has():
+    """Fewer GPUs means fewer tasks, and the two stay in proportion."""
+    step = _make_step(ntasks=8, min_tasks=1, cpus_per_task=1, gpus=8)
+    step.constrain_resources(_resources(gpus=4))
+    assert step.ntasks == 4
+    assert step.gpus == 4
+
+
+def test_gpus_are_left_alone_when_there_are_enough():
+    step = _make_step(ntasks=4, min_tasks=1, cpus_per_task=1, gpus=4)
+    step.constrain_resources(_resources(gpus=8))
+    assert step.ntasks == 4
+    assert step.gpus == 4
+
+
+def test_asking_for_gpus_on_a_machine_without_them_fails():
+    step = _make_step(ntasks=1, cpus_per_task=1, gpus=1)
+    with pytest.raises(ValueError, match='no GPUs are available'):
+        step.constrain_resources(_resources(gpus=0))
+
+
+def test_falling_below_the_minimum_gpus_fails():
+    step = _make_step(
+        ntasks=8, min_tasks=1, cpus_per_task=1, gpus=8, min_gpus=8
+    )
+    with pytest.raises(ValueError, match='below the minimum'):
+        step.constrain_resources(_resources(gpus=4))
+
+
+def test_falling_below_the_minimum_tasks_fails():
+    step = _make_step(ntasks=8, min_tasks=8, cpus_per_task=1, gpus=8)
+    with pytest.raises(ValueError, match='below the minimum'):
+        step.constrain_resources(_resources(gpus=4))
+
+
+def test_the_deprecated_form_constrains_the_same_way():
+    """The translation has to leave the old behavior exactly as it was."""
+    with pytest.warns(DeprecationWarning):
+        step = _make_step(
+            ntasks=8, min_tasks=1, cpus_per_task=1, gpus_per_task=1
+        )
+    step.constrain_resources(_resources(gpus=4))
+    assert step.ntasks == 4
+    assert step.gpus == 4
+
+
+class _RecordingSystem:
+    """A parallel system that records what it was asked to launch."""
+
+    def __init__(self):
+        self.calls = []
+
+    def get_parallel_command(
+        self, args, ntasks, cpus_per_task=0, gpus_per_task=0, placement=None
+    ):
+        self.calls.append(
+            dict(
+                args=args,
+                ntasks=ntasks,
+                cpus_per_task=cpus_per_task,
+                gpus_per_task=gpus_per_task,
+                placement=placement,
+            )
+        )
+        return ['true']
+
+
+def _run(component, **kwargs):
+    component.run_parallel_command(
+        args=['model'],
+        cpus_per_task=1,
+        openmp_threads=1,
+        logger=logging.getLogger('test'),
+        **kwargs,
+    )
+    return component.parallel_system.calls[-1]
+
+
+def test_a_total_reaches_the_launcher_as_a_per_task_count():
+    """
+    mache expresses GPUs per task when there is no placement to carry a
+    total, so the total has to be divided back out.
+    """
+    component = Component(name='ocean')
+    component.parallel_system = _RecordingSystem()
+    call = _run(component, ntasks=4, gpus=4)
+    assert call['gpus_per_task'] == 1
+
+
+def test_a_total_that_does_not_divide_evenly_rounds_up():
+    component = Component(name='ocean')
+    component.parallel_system = _RecordingSystem()
+    call = _run(component, ntasks=4, gpus=6)
+    assert call['gpus_per_task'] == 2
+
+
+def test_no_gpus_asks_the_launcher_for_none():
+    component = Component(name='ocean')
+    component.parallel_system = _RecordingSystem()
+    call = _run(component, ntasks=4, gpus=0)
+    assert call['gpus_per_task'] == 0
+
+
+def test_the_deprecated_per_task_argument_still_works():
+    component = Component(name='ocean')
+    component.parallel_system = _RecordingSystem()
+    with pytest.warns(DeprecationWarning, match='gpus_per_task'):
+        call = _run(component, ntasks=4, gpus_per_task=2)
+    assert call['gpus_per_task'] == 2

--- a/tests/test_step_resources.py
+++ b/tests/test_step_resources.py
@@ -8,6 +8,7 @@ steps run at the same time, while a total does.
 """
 
 import logging
+import pickle
 
 import pytest
 
@@ -431,3 +432,58 @@ def test_needing_more_gpus_than_a_node_has_is_the_same_error():
         step.constrain_resources(
             _resources(cores=192, cores_per_node=64, gpus=12, gpus_per_node=4)
         )
+
+
+def test_the_new_declarations_survive_being_pickled():
+    """
+    Polaris pickles a step at setup and unpickles it to run it.
+
+    Every field added in Phase A therefore has to round-trip, and the ones
+    backed by a property are the risk: `cores`, `min_cores`, `may_span_nodes`
+    and the GPU totals all store their value under a different name than
+    they are read by.  A unit test that never pickles would not notice, and
+    the failure would appear only in a real run, after setup had succeeded.
+    """
+    step = _make_step(
+        ntasks=1,
+        cpus_per_task=1,
+        cores=128,
+        min_cores=1,
+        memory=4096,
+        min_memory=512,
+        gpus=2,
+        min_gpus=1,
+        may_span_nodes=True,
+    )
+    step.memory_budget = 9999
+
+    restored = pickle.loads(pickle.dumps(step))
+
+    for attribute in (
+        'cores',
+        'min_cores',
+        'may_span_nodes',
+        'gpus',
+        'min_gpus',
+        'memory',
+        'min_memory',
+        'memory_budget',
+        'placement',
+    ):
+        assert getattr(restored, attribute) == getattr(step, attribute), (
+            attribute
+        )
+
+
+def test_a_pickled_step_still_constrains_the_same_way():
+    """The properties have to work after a round trip, not just read back."""
+    step = _make_step(ntasks=8, min_tasks=1, cpus_per_task=1, gpus=8)
+    restored = pickle.loads(pickle.dumps(step))
+    restored.constrain_resources(
+        _resources(cores=64, cores_per_node=64, gpus=4, memory_per_node=253000)
+    )
+    assert restored.ntasks == 4
+    assert restored.gpus == 4
+    # the budget describes the four tasks it ended up with, not the eight
+    # it asked for
+    assert restored.memory_budget == 4 * 253000 // 64

--- a/tests/test_step_resources.py
+++ b/tests/test_step_resources.py
@@ -317,7 +317,24 @@ def test_a_step_that_says_nothing_gets_its_share_of_a_node():
     step.constrain_resources(
         _resources(cores=64, cores_per_node=64, memory_per_node=256000)
     )
-    assert step.memory == 8 * 256000 // 64
+    assert step.memory_budget == 8 * 256000 // 64
+
+
+def test_a_defaulted_step_still_declares_nothing():
+    """
+    The distinction the capping decision rests on.
+
+    A declared figure may be enforced as a cap; a defaulted one may not,
+    because capping every step at the framework's own rough guess would
+    make them all carry a measured number before they could run.  Filling
+    `memory` in with the default would erase the difference.
+    """
+    step = _make_step(ntasks=1, cpus_per_task=8)
+    step.constrain_resources(
+        _resources(cores=64, cores_per_node=64, memory_per_node=256000)
+    )
+    assert step.memory is None
+    assert step.memory_budget is not None
 
 
 def test_a_step_that_says_what_it_needs_keeps_it():
@@ -326,6 +343,7 @@ def test_a_step_that_says_what_it_needs_keeps_it():
         _resources(cores=64, cores_per_node=64, memory_per_node=256000)
     )
     assert step.memory == 100
+    assert step.memory_budget == 100
 
 
 def test_no_default_where_the_machine_has_not_said_its_memory():
@@ -333,6 +351,7 @@ def test_no_default_where_the_machine_has_not_said_its_memory():
     step = _make_step(ntasks=1, cpus_per_task=8)
     step.constrain_resources(_resources(cores=64, cores_per_node=64))
     assert step.memory is None
+    assert step.memory_budget is None
 
 
 def test_defaulting_steps_pack_on_memory_exactly_as_they_pack_on_cores():
@@ -357,7 +376,7 @@ def test_defaulting_steps_pack_on_memory_exactly_as_they_pack_on_cores():
                     memory_per_node=memory_per_node,
                 )
             )
-            memories.append(step.memory)
+            memories.append(step.memory_budget)
         fits_on_cores = sum(core_counts) <= cores_per_node * nodes
         fits_in_memory = sum(memories) <= memory_per_node * nodes
         assert fits_on_cores == fits_in_memory, core_counts

--- a/tests/test_step_resources.py
+++ b/tests/test_step_resources.py
@@ -195,3 +195,26 @@ def test_the_deprecated_per_task_argument_still_works():
     with pytest.warns(DeprecationWarning, match='gpus_per_task'):
         call = _run(component, ntasks=4, gpus_per_task=2)
     assert call['gpus_per_task'] == 2
+
+
+def test_a_step_declares_no_memory_by_default():
+    step = _make_step()
+    assert step.max_memory is None
+    assert step.min_memory is None
+
+
+def test_a_step_declares_memory_as_a_target_and_a_minimum():
+    step = _make_step(max_memory=8000, min_memory=2000)
+    assert step.max_memory == 8000
+    assert step.min_memory == 2000
+    step.set_resources(max_memory=16000, min_memory=4000)
+    assert step.max_memory == 16000
+    assert step.min_memory == 4000
+
+
+def test_needing_more_memory_than_it_asks_for_is_a_mistake():
+    step = _make_step(
+        ntasks=1, cpus_per_task=1, max_memory=1000, min_memory=2000
+    )
+    with pytest.raises(ValueError, match='at least 2000 MB'):
+        step.constrain_resources(_resources())

--- a/tests/test_step_resources.py
+++ b/tests/test_step_resources.py
@@ -121,6 +121,32 @@ def test_falling_below_the_minimum_tasks_fails():
         step.constrain_resources(_resources(gpus=4))
 
 
+def test_cores_cutting_the_tasks_first_does_not_cut_the_gpus_twice():
+    """
+    The GPU proportion is the one the step declared.
+
+    By the time GPUs are constrained, `ntasks` may already have been cut back
+    by the cores available.  Measuring one GPU per task against the reduced
+    count makes each surviving task look like it needs two, and cuts the
+    tasks again.
+    """
+    step = _make_step(ntasks=8, min_tasks=1, cpus_per_task=1, gpus=8)
+    step.constrain_resources(_resources(cores=4, cores_per_node=4, gpus=4))
+    assert step.ntasks == 4
+    assert step.gpus == 4
+
+
+def test_the_deprecated_form_survives_the_same_squeeze():
+    """The per-task form is the behavior the total has to reproduce."""
+    with pytest.warns(DeprecationWarning):
+        step = _make_step(
+            ntasks=8, min_tasks=1, cpus_per_task=1, gpus_per_task=1
+        )
+    step.constrain_resources(_resources(cores=4, cores_per_node=4, gpus=4))
+    assert step.ntasks == 4
+    assert step.gpus == 4
+
+
 def test_the_deprecated_form_constrains_the_same_way():
     """The translation has to leave the old behavior exactly as it was."""
     with pytest.warns(DeprecationWarning):

--- a/tests/test_step_resources.py
+++ b/tests/test_step_resources.py
@@ -18,13 +18,25 @@ def _make_step(**kwargs):
     return Step(component=Component(name='ocean'), name='step', **kwargs)
 
 
-def _resources(cores=64, cores_per_node=64, gpus=0, mpi_allowed=True):
+def _resources(
+    cores=64,
+    cores_per_node=64,
+    gpus=0,
+    gpus_per_node=None,
+    memory_per_node=None,
+    mpi_allowed=True,
+):
+    nodes = max(1, cores // cores_per_node)
+    if gpus_per_node is None:
+        gpus_per_node = gpus
     return dict(
         cores=cores,
-        nodes=max(1, cores // cores_per_node),
+        nodes=nodes,
         cores_per_node=cores_per_node,
         gpus=gpus,
-        gpus_per_node=gpus,
+        gpus_per_node=gpus_per_node,
+        memory=None if memory_per_node is None else memory_per_node * nodes,
+        memory_per_node=memory_per_node,
         mpi_allowed=mpi_allowed,
     )
 
@@ -295,3 +307,108 @@ def test_set_resources_takes_the_new_fields():
     assert step.cores == 64
     assert step.min_cores == 8
     assert step.may_span_nodes
+
+
+# ---- the memory default ----
+
+
+def test_a_step_that_says_nothing_gets_its_share_of_a_node():
+    step = _make_step(ntasks=1, cpus_per_task=8)
+    step.constrain_resources(
+        _resources(cores=64, cores_per_node=64, memory_per_node=256000)
+    )
+    assert step.memory == 8 * 256000 // 64
+
+
+def test_a_step_that_says_what_it_needs_keeps_it():
+    step = _make_step(ntasks=1, cpus_per_task=8, memory=100)
+    step.constrain_resources(
+        _resources(cores=64, cores_per_node=64, memory_per_node=256000)
+    )
+    assert step.memory == 100
+
+
+def test_no_default_where_the_machine_has_not_said_its_memory():
+    """A wrong figure here would propagate into every step's default."""
+    step = _make_step(ntasks=1, cpus_per_task=8)
+    step.constrain_resources(_resources(cores=64, cores_per_node=64))
+    assert step.memory is None
+
+
+def test_defaulting_steps_pack_on_memory_exactly_as_they_pack_on_cores():
+    """
+    The property the default exists for.
+
+    A run in which every step defaults must never be rejected by memory
+    when cores would have accepted it, or introducing memory accounting
+    would let Phase B schedule an existing suite worse than it does now.
+    """
+    cores_per_node = 64
+    memory_per_node = 253000
+    nodes = 3
+    for core_counts in ([1] * 192, [8, 16, 32, 64], [3, 5, 7, 11, 13, 64]):
+        memories = []
+        for cores in core_counts:
+            step = _make_step(ntasks=1, cpus_per_task=cores)
+            step.constrain_resources(
+                _resources(
+                    cores=cores_per_node * nodes,
+                    cores_per_node=cores_per_node,
+                    memory_per_node=memory_per_node,
+                )
+            )
+            memories.append(step.memory)
+        fits_on_cores = sum(core_counts) <= cores_per_node * nodes
+        fits_in_memory = sum(memories) <= memory_per_node * nodes
+        assert fits_on_cores == fits_in_memory, core_counts
+
+
+# ---- the node-span rule ----
+
+
+def test_a_step_that_may_not_span_is_held_to_one_node():
+    step = _make_step(cores=200, min_cores=1)
+    step.constrain_resources(_resources(cores=192, cores_per_node=64))
+    assert step.cores == 64
+
+
+def test_a_step_that_may_span_is_held_to_the_allocation():
+    step = _make_step(cores=200, min_cores=1, may_span_nodes=True)
+    step.constrain_resources(_resources(cores=192, cores_per_node=64))
+    assert step.cores == 192
+
+
+def test_a_minimum_that_no_node_can_meet_is_an_error():
+    """Not a silent reduction: the step has said it cannot run smaller."""
+    step = _make_step(cores=200, min_cores=100)
+    with pytest.raises(ValueError, match='may not use more than one node'):
+        step.constrain_resources(_resources(cores=192, cores_per_node=64))
+
+
+def test_that_same_minimum_is_fine_for_a_step_that_may_span():
+    step = _make_step(cores=200, min_cores=100, may_span_nodes=True)
+    step.constrain_resources(_resources(cores=192, cores_per_node=64))
+    assert step.cores == 192
+
+
+def test_an_mpi_step_still_spreads_across_the_allocation():
+    """The rule must leave every step Polaris has today where it was."""
+    step = _make_step(ntasks=192, min_tasks=1, cpus_per_task=1)
+    step.constrain_resources(_resources(cores=192, cores_per_node=64))
+    assert step.ntasks == 192
+
+
+def test_gpus_are_held_to_one_node_for_a_step_that_may_not_span():
+    step = _make_step(ntasks=1, cpus_per_task=1, gpus=8, min_gpus=1)
+    step.constrain_resources(
+        _resources(cores=192, cores_per_node=64, gpus=12, gpus_per_node=4)
+    )
+    assert step.gpus <= 4
+
+
+def test_needing_more_gpus_than_a_node_has_is_the_same_error():
+    step = _make_step(ntasks=1, cpus_per_task=1, gpus=8, min_gpus=8)
+    with pytest.raises(ValueError, match='may not use more than one node'):
+        step.constrain_resources(
+            _resources(cores=192, cores_per_node=64, gpus=12, gpus_per_node=4)
+        )

--- a/tests/test_step_resources.py
+++ b/tests/test_step_resources.py
@@ -225,22 +225,73 @@ def test_the_deprecated_per_task_argument_still_works():
 
 def test_a_step_declares_no_memory_by_default():
     step = _make_step()
-    assert step.max_memory is None
+    assert step.memory is None
     assert step.min_memory is None
 
 
 def test_a_step_declares_memory_as_a_target_and_a_minimum():
-    step = _make_step(max_memory=8000, min_memory=2000)
-    assert step.max_memory == 8000
+    step = _make_step(memory=8000, min_memory=2000)
+    assert step.memory == 8000
     assert step.min_memory == 2000
-    step.set_resources(max_memory=16000, min_memory=4000)
-    assert step.max_memory == 16000
+    step.set_resources(memory=16000, min_memory=4000)
+    assert step.memory == 16000
     assert step.min_memory == 4000
 
 
 def test_needing_more_memory_than_it_asks_for_is_a_mistake():
-    step = _make_step(
-        ntasks=1, cpus_per_task=1, max_memory=1000, min_memory=2000
-    )
+    step = _make_step(ntasks=1, cpus_per_task=1, memory=1000, min_memory=2000)
     with pytest.raises(ValueError, match='at least 2000 MB'):
         step.constrain_resources(_resources())
+
+
+def test_cores_are_the_product_when_a_step_speaks_in_ranks():
+    step = _make_step(
+        ntasks=4, min_tasks=2, cpus_per_task=8, min_cpus_per_task=4
+    )
+    assert step.cores == 32
+    assert step.min_cores == 8
+
+
+def test_a_step_can_state_its_cores_directly():
+    """A non-MPI step has no meaningful number of ranks."""
+    step = _make_step(cores=200, min_cores=16)
+    assert step.cores == 200
+    assert step.min_cores == 16
+
+
+def test_stated_cores_do_not_move_with_the_task_count():
+    step = _make_step(cores=200)
+    step.ntasks = 8
+    assert step.cores == 200
+
+
+def test_derived_cores_follow_the_task_count():
+    step = _make_step(ntasks=2, cpus_per_task=4)
+    step.ntasks = 4
+    assert step.cores == 16
+
+
+def test_an_mpi_step_may_span_nodes_by_default():
+    """A launcher spreading ranks is the one mechanism Polaris has today."""
+    assert _make_step(ntasks=4).may_span_nodes
+
+
+def test_a_single_task_step_may_not_span_by_default():
+    assert not _make_step(ntasks=1).may_span_nodes
+    assert not _make_step(cores=200).may_span_nodes
+
+
+def test_a_step_can_say_it_spans_regardless_of_ranks():
+    """What a distributed pool will set, and nothing sets in Phase A."""
+    step = _make_step(cores=200, may_span_nodes=True)
+    assert step.may_span_nodes
+    step = _make_step(ntasks=4, may_span_nodes=False)
+    assert not step.may_span_nodes
+
+
+def test_set_resources_takes_the_new_fields():
+    step = _make_step(ntasks=1)
+    step.set_resources(cores=64, min_cores=8, may_span_nodes=True)
+    assert step.cores == 64
+    assert step.min_cores == 8
+    assert step.may_span_nodes


### PR DESCRIPTION
Phase A of task parallelism, as set out in [Task Parallelism Phase A: Placement](https://github.com/E3SM-Project/polaris/blob/main/docs/design_docs/task_parallelism_phase_a.md) (merged in #718).

Polaris gains the ability to run a step on a named part of its allocation, and steps gain a way to say what they need. **This adds no concurrency.** Polaris still runs one step at a time, and nothing assigns a placement — the serial path passes `None`, so every command Polaris builds is the command it built before. That boundary is what makes this reviewable on its own: a mistake here shows up as a wrong command rather than a wrong schedule.

Requires `mache` 3.12.0, which `deploy/pins.cfg` already pins.

## What steps can now say

- `gpus` / `min_gpus` as a **per-step total**, replacing `gpus_per_task`, which is deprecated. A per-task count was measured not to confine a launch at all; a total does.
- `cores` / `min_cores` **directly**, for non-MPI steps. A single-process step has no meaningful number of ranks, and "one task of two hundred CPUs" is not something a launcher can act on.
- `memory` / `min_memory`, redeeming the unused `max_memory` placeholder. A step that says nothing gets a proportional share of a node as its `memory_budget`; `memory` stays `None`. The two are deliberately distinct, because only a declared figure may ever be enforced as a cap.
- `may_span_nodes`, saying whether a step's cores and GPUs may come from more than one node. This is **not** inferred from whether the step uses MPI: a thread-based Python step cannot span nodes, while one handing work to a distributed pool can, and "not MPI" covers both.

A step's resource view is now built from its placement, so a confined step is told what it can actually use rather than what the job holds.

## The existing non-MPI steps move onto `cores`

Last commit, deliberately separate. Most declared `cpus_per_task=1`, which is the default and simply goes; four genuinely state a core count. The steps that set `ntasks=1` while being MPI steps at width one were left alone — `ntasks` is the field that means what they mean.

## Not included

No scheduler, no dependency graph, no concurrency. `polaris serial` is unchanged. Reading the node-span property, and reading each allocated node's real memory rather than the configured figure, both wait for Phase B, where the scheduler that consumes them lives.

Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been built locally and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
