### PR TITLE
Stop dropping the dependency pickle from a rebuilt step

### DIFF
--- a/polaris/tasks/ocean/analysis/publish.py
+++ b/polaris/tasks/ocean/analysis/publish.py
@@ -5,10 +5,6 @@ from polaris.analysis import generate_site, publish
 from polaris.analysis.manifest import FRAGMENT_FILENAME
 from polaris.provenance import get_summary
 
-#: The pickle a dependency leaves behind, which is what makes a step that
-#: did not run report itself by name rather than as an empty gallery
-DEPENDENCY_PICKLE = 'step_after_run.pickle'
-
 #: The subdirectory the fragments are linked into, one per step
 FRAGMENTS_DIRNAME = 'fragments'
 
@@ -125,14 +121,12 @@ class Publish(Step):
 
         The task rebuilds its steps whenever the config is read, so a step
         whose work directory did not change is asked a second time for the
-        pickle it already owes.  The duplicate is dropped rather than left
-        for Polaris to check twice.
+        pickle it already owes.  ``add_output_file()`` keeps only the first
+        of those, so the pickle is listed once however often the step is
+        rebuilt.
         """
-        already_a_dependency = DEPENDENCY_PICKLE in step.outputs
         name = step.subdir.replace('/', '_')
         self.add_dependency(step, name=name)
-        if already_a_dependency:
-            step.outputs.remove(DEPENDENCY_PICKLE)
 
         filename = os.path.join(FRAGMENTS_DIRNAME, f'{name}.json')
         self.add_input_file(


### PR DESCRIPTION
This fixes the publish step's dependencies losing the pickle that Polaris uses to tell a step that ran from one that never did. The two pull requests that combine to cause it each passed on their own, so the failure only appeared once both were on `main`.

## The cause

`Step.add_dependency()` adds `step_after_run.pickle` to the dependency's outputs. A task rebuilds its steps whenever its config is read, so a step whose work directory did not change is asked a second time for the pickle it already owes. #736 handled that duplicate in `Publish._add_product_dependency()` by noting the pickle was already listed and removing one copy after `add_dependency()` returned.

#663 then made `add_output_file()` skip a filename that is already in `outputs`. The second call now adds nothing, so the removal takes out the only copy and the step is left without the pickle the publish step waits on.

## The fix

Drop the workaround and let `add_output_file()` do the deduplication, which is where it belongs now that it does it. The `DEPENDENCY_PICKLE` constant existed only for the workaround and goes with it.

Fixes #745

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
