### PR TITLE
Take vmix_stable and ideal_age out of mpaso_pr

### DIFF
--- a/polaris/suites/ocean/mpaso_pr.txt
+++ b/polaris/suites/ocean/mpaso_pr.txt
@@ -1,7 +1,11 @@
 ocean/column/ekman
-ocean/column/vmix_stable
+# fails its conservation checks with MPAS-Ocean, see
+# https://github.com/E3SM-Project/polaris/issues/748
+#ocean/column/vmix_stable
 ocean/column/vmix_unstable
-ocean/column/ideal_age
+# fails its conservation checks with MPAS-Ocean, see
+# https://github.com/E3SM-Project/polaris/issues/748
+#ocean/column/ideal_age
 ocean/column/inertial
 ocean/planar/baroclinic_channel/10km/threads
 ocean/planar/baroclinic_channel/10km/decomp


### PR DESCRIPTION
Every forward step of `ocean/column/vmix_stable`, and the `ocean/column/ideal_age` forward step, fail their conservation checks with MPAS-Ocean by amounts far too large to be round-off. The cause is not yet understood, and a test that fails on `main` is a setback for everyone developing against it, so this comments the two tasks out of the `mpaso_pr` suite until it is.

The tasks stay in the file, commented, each with a pointer to #748, so that restoring them is a one-line change once the cause is found. They remain in `mpaso_nightly`, which is where the failures stay visible.

This is deliberately separate from #747, which is what makes these failures count in the first place: before it, a failed conservation check was written to a log file and then discarded, so the tasks reported PASS. The two changes touch no common files and can merge in either order. #748 records what is known about the failures and what has not been checked.

Note that this does not make `mpaso_pr` pass. `ocean/column/vmix_unstable` still fails, for the unrelated reasons discussed in #747: round-off larger than the tolerance in the steps with active convective and shear mixing, and a salt budget that cannot close where surface salinity restoring is enabled. Whether the tolerances there should move, and whether that task should also come out of the suite, is a question for the review of #747 rather than something decided here.

Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
