### PR TITLE
Fix single_column viz for fields at layer interfaces

### DIFF
--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -130,15 +130,24 @@ class Viz(OceanIOStep):
             ds_init = self.open_model_dataset('init.nc', config=self.config)
             ds_init = ds_init.isel(Time=0)
             z_mid_init = ds_init['zMid'].mean(dim='nCells')
+            z_interface_init = ds_init['zInterface'].mean(dim='nCells')
 
             z_mid_final = z_mid_init
+            z_interface_final = z_interface_init
             self.logger.warn(
-                'Using initial zMid values; may not represent plotted state'
+                'Using the initial vertical coordinate; may not represent '
+                'the plotted state'
             )
+
+            # The depth range of the plots, also used to select the data
+            # that sets the x-axis range
+            ymin = -100.0
+            ymax = 0.0
 
             # Plot depth profiles of variables
             for field_name, field_units in self.variables.items():
                 curves_plotted = 0
+                x_limits: list[tuple[float, float]] = []
                 fig = plt.figure(figsize=(3, 5))
                 colors = ['k', 'b', 'r', 'darkgreen']
                 for comparison_name, ds_comp, t_days, color in zip(
@@ -170,21 +179,29 @@ class Viz(OceanIOStep):
                             f'{comparison_name} at {t_days} days'
                         )
                         var = ds_comp['velocityZonal'].mean(dim='nCells')
+                        z = _vertical_coord(
+                            var, z_mid_final, z_interface_final
+                        )
                         plt.plot(
                             var,
-                            z_mid_final,
+                            z,
                             '-',
                             color=color,
                             label=f'u {comparison_name}, {t_days:2g} days',
                         )
+                        _add_visible_limits(x_limits, var, z, ymin, ymax)
                         var = ds_comp['velocityMeridional'].mean(dim='nCells')
+                        z = _vertical_coord(
+                            var, z_mid_final, z_interface_final
+                        )
                         plt.plot(
                             var,
-                            z_mid_final,
+                            z,
                             '--',
                             color=color,
                             label=f'v {comparison_name}, {t_days:2g} days',
                         )
+                        _add_visible_limits(x_limits, var, z, ymin, ymax)
                         curves_plotted += 1
                     else:
                         if field_name not in ds_comp.keys():
@@ -194,18 +211,20 @@ class Viz(OceanIOStep):
                             )
                             continue
                         var = ds_comp[field_name].mean(dim='nCells')
-                        if 'nVertLevelsP1' in var.dims:
-                            var = var.isel(nVertLevelsP1=slice(0, -1))
+                        z = _vertical_coord(
+                            var, z_mid_final, z_interface_final
+                        )
                         # TODO delete this line when MPAS-O bug is fixed
                         if field_name == 'RiTopOfCell':
                             var[0] = np.nan
                         plt.plot(
                             var,
-                            z_mid_final,
+                            z,
                             '-',
                             color=color,
                             label=f'{comparison_name}, {t_days:2g} days',
                         )
+                        _add_visible_limits(x_limits, var, z, ymin, ymax)
                         curves_plotted += 1
                         # Plot initial state if available and
                         # hasn't already been plotted
@@ -219,8 +238,12 @@ class Viz(OceanIOStep):
                             and 'initial' not in existing_labels
                         ):
                             var_init = ds_init[field_name].mean(dim='nCells')
-                            plt.plot(
-                                var_init, z_mid_init, '--k', label='initial'
+                            z_init = _vertical_coord(
+                                var_init, z_mid_init, z_interface_init
+                            )
+                            plt.plot(var_init, z_init, '--k', label='initial')
+                            _add_visible_limits(
+                                x_limits, var_init, z_init, ymin, ymax
                             )
                             curves_plotted += 1
                 if curves_plotted == 0:
@@ -229,14 +252,17 @@ class Viz(OceanIOStep):
                     )
                     plt.close()
                     continue
-                ymin = -100.0
-                ymax = 0.0
                 plt.ylim(ymin, ymax)
-                visible_x = var[(z_mid_final >= ymin) & (z_mid_final <= ymax)]
-                x_min = float(visible_x.min().values)
-                x_max = float(visible_x.max().values)
-                x_margin = (x_max - x_min) * 0.05
-                plt.xlim(x_min - x_margin, x_max + x_margin)
+                if x_limits:
+                    x_min = min(limits[0] for limits in x_limits)
+                    x_max = max(limits[1] for limits in x_limits)
+                    x_margin = (x_max - x_min) * 0.05
+                    if x_margin == 0.0:
+                        # the field is constant over the visible depths, so
+                        # fall back to a margin that does not collapse the
+                        # axis to a single value
+                        x_margin = 0.05 * max(abs(x_min), 1.0)
+                    plt.xlim(x_min - x_margin, x_max + x_margin)
                 plt.xlabel(f'{field_name} ({field_units})')
                 plt.ylabel('z (m)')
                 # Place a single legend centered below the x-axis
@@ -248,3 +274,41 @@ class Viz(OceanIOStep):
                 )
                 plt.savefig(f'{field_name}.png', bbox_inches='tight')
                 plt.close()
+
+
+def _vertical_coord(var, z_mid, z_interface):
+    """
+    The vertical coordinate to plot ``var`` against
+
+    A field on ``nVertLevelsP1`` is defined at layer interfaces --- the top
+    of each layer, plus one more for the bottom of the column --- so it is
+    plotted at interface elevations.  Everything else is a layer quantity
+    and is plotted at layer midpoints.
+
+    Which fields those are depends on the model, so this asks the field
+    rather than the name: MPAS-Ocean writes ``RiTopOfCell`` at interfaces
+    and ``BruntVaisalaFreqTop`` at midpoints, while Omega writes
+    ``BruntVaisalaFreqTop`` at interfaces and no ``RiTopOfCell`` at all.
+    """
+    if 'nVertLevelsP1' in var.dims:
+        return z_interface
+    return z_mid
+
+
+def _add_visible_limits(x_limits, var, z, ymin, ymax):
+    """
+    Add the range of ``var`` over the visible depths to the ``x_limits``
+    list
+
+    Depths outside ``ymin`` to ``ymax`` are excluded because they are not
+    plotted, and NaNs are ignored.  Nothing is added if no finite value is
+    visible.
+    """
+    visible = var[(z >= ymin) & (z <= ymax)]
+    if int(visible.count()) == 0:
+        return
+    x_min = float(visible.min().values)
+    x_max = float(visible.max().values)
+    if not (np.isfinite(x_min) and np.isfinite(x_max)):
+        return
+    x_limits.append((x_min, x_max))

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -8,6 +8,17 @@ from polaris.viz import mplstyle_context
 
 # TODO import rho_0 from constants
 
+# Fields defined at the top of each layer that a model nonetheless writes on
+# ``nVertLevels``, leaving the bottom of the column off, rather than on
+# ``nVertLevelsP1``.  MPAS-Ocean writes ``BruntVaisalaFreqTop`` this way
+# while giving ``RiTopOfCell`` and ``vertViscTopOfCell`` the interface
+# dimension; Omega writes ``BruntVaisalaFreqTop`` on ``nVertLevelsP1``.
+# Dimensions cannot tell such a field from a layer average, so it is named
+# here.  A field is only ever read from this list when it arrives on
+# ``nVertLevels``, so listing one that a model writes at interfaces is
+# harmless.
+TOP_OF_LAYER_FIELDS = ('BruntVaisalaFreqTop',)
+
 
 class Viz(OceanIOStep):
     """
@@ -180,7 +191,10 @@ class Viz(OceanIOStep):
                         )
                         var = ds_comp['velocityZonal'].mean(dim='nCells')
                         z = _vertical_coord(
-                            var, z_mid_final, z_interface_final
+                            'velocityZonal',
+                            var,
+                            z_mid_final,
+                            z_interface_final,
                         )
                         plt.plot(
                             var,
@@ -192,7 +206,10 @@ class Viz(OceanIOStep):
                         _add_visible_limits(x_limits, var, z, ymin, ymax)
                         var = ds_comp['velocityMeridional'].mean(dim='nCells')
                         z = _vertical_coord(
-                            var, z_mid_final, z_interface_final
+                            'velocityMeridional',
+                            var,
+                            z_mid_final,
+                            z_interface_final,
                         )
                         plt.plot(
                             var,
@@ -212,7 +229,7 @@ class Viz(OceanIOStep):
                             continue
                         var = ds_comp[field_name].mean(dim='nCells')
                         z = _vertical_coord(
-                            var, z_mid_final, z_interface_final
+                            field_name, var, z_mid_final, z_interface_final
                         )
                         # TODO delete this line when MPAS-O bug is fixed
                         if field_name == 'RiTopOfCell':
@@ -239,7 +256,10 @@ class Viz(OceanIOStep):
                         ):
                             var_init = ds_init[field_name].mean(dim='nCells')
                             z_init = _vertical_coord(
-                                var_init, z_mid_init, z_interface_init
+                                field_name,
+                                var_init,
+                                z_mid_init,
+                                z_interface_init,
                             )
                             plt.plot(var_init, z_init, '--k', label='initial')
                             _add_visible_limits(
@@ -276,23 +296,34 @@ class Viz(OceanIOStep):
                 plt.close()
 
 
-def _vertical_coord(var, z_mid, z_interface):
+def _vertical_coord(field_name, var, z_mid, z_interface):
     """
     The vertical coordinate to plot ``var`` against
 
     A field on ``nVertLevelsP1`` is defined at layer interfaces --- the top
     of each layer, plus one more for the bottom of the column --- so it is
-    plotted at interface elevations.  Everything else is a layer quantity
-    and is plotted at layer midpoints.
-
-    Which fields those are depends on the model, so this asks the field
-    rather than the name: MPAS-Ocean writes ``RiTopOfCell`` at interfaces
-    and ``BruntVaisalaFreqTop`` at midpoints, while Omega writes
-    ``BruntVaisalaFreqTop`` at interfaces and no ``RiTopOfCell`` at all.
+    plotted at interface elevations.  A field in
+    :py:data:`TOP_OF_LAYER_FIELDS` is defined at the top of each layer but
+    written on ``nVertLevels``, so it is plotted at the top interface of
+    each layer.  Everything else is a layer quantity and is plotted at
+    layer midpoints.
     """
     if 'nVertLevelsP1' in var.dims:
         return z_interface
+    if field_name in TOP_OF_LAYER_FIELDS:
+        return _layer_tops(z_interface)
     return z_mid
+
+
+def _layer_tops(z_interface):
+    """
+    The elevation of the top interface of each layer, on ``nVertLevels``
+
+    ``isel()`` changes the length of the dimension but not its name, so the
+    result is renamed to the dimension the field it pairs with is on.
+    """
+    z_top = z_interface.isel(nVertLevelsP1=slice(0, -1))
+    return z_top.rename({'nVertLevelsP1': 'nVertLevels'})
 
 
 def _add_visible_limits(x_limits, var, z, ymin, ymax):

--- a/tests/ocean/test_single_column_viz.py
+++ b/tests/ocean/test_single_column_viz.py
@@ -1,0 +1,128 @@
+"""
+Tests for the single-column plotting helpers.
+
+A field defined at layer interfaces used to be trimmed to mid-level length
+with ``isel()`` and plotted against ``zMid``, which put it half a layer below
+where it is defined.  ``isel()`` also changes the length of a dimension but
+not its name, so building the x-axis range from a mask on ``nVertLevels``
+then raised an ``IndexError``.  Interface fields are now plotted against
+``zInterface``, which is both where they belong and the same dimension.
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.tasks.ocean.single_column.viz import (
+    _add_visible_limits,
+    _vertical_coord,
+)
+
+
+def _interface_field(values):
+    return xr.DataArray(np.array(values), dims=('nVertLevelsP1',))
+
+
+def _mid_level_field(values):
+    return xr.DataArray(np.array(values), dims=('nVertLevels',))
+
+
+@pytest.fixture
+def z_mid():
+    return _mid_level_field([-10.0, -60.0, -150.0])
+
+
+@pytest.fixture
+def z_interface():
+    return _interface_field([0.0, -20.0, -100.0, -200.0])
+
+
+def test_an_interface_field_is_plotted_at_interfaces(z_mid, z_interface):
+    z = _vertical_coord(
+        _interface_field([1.0, 2.0, 3.0, 4.0]), z_mid, z_interface
+    )
+    assert z.dims == ('nVertLevelsP1',)
+    np.testing.assert_array_equal(z.values, z_interface.values)
+
+
+def test_a_mid_level_field_is_plotted_at_midpoints(z_mid, z_interface):
+    z = _vertical_coord(_mid_level_field([1.0, 2.0, 3.0]), z_mid, z_interface)
+    assert z.dims == ('nVertLevels',)
+    np.testing.assert_array_equal(z.values, z_mid.values)
+
+
+def test_an_interface_field_keeps_every_value(z_mid, z_interface):
+    # the bottom interface used to be dropped so that the field could be
+    # plotted against zMid; nothing is dropped now
+    var = _interface_field([1.0, 2.0, 3.0, 4.0])
+    z = _vertical_coord(var, z_mid, z_interface)
+    assert var.sizes['nVertLevelsP1'] == z.sizes['nVertLevelsP1']
+
+
+def test_an_interface_field_can_be_masked_by_depth(z_mid, z_interface):
+    # this is the combination that used to raise an IndexError
+    var = _interface_field([1.0, 2.0, 3.0, 4.0])
+    z = _vertical_coord(var, z_mid, z_interface)
+    x_limits: list[tuple[float, float]] = []
+    _add_visible_limits(x_limits, var, z, -100.0, 0.0)
+    assert x_limits == [(1.0, 3.0)]
+
+
+def test_depths_outside_the_plot_are_excluded():
+    z = _mid_level_field([-10.0, -50.0, -300.0])
+    var = _mid_level_field([1.0, 2.0, 99.0])
+    x_limits: list[tuple[float, float]] = []
+    _add_visible_limits(x_limits, var, z, -100.0, 0.0)
+    assert x_limits == [(1.0, 2.0)]
+
+
+def test_nans_are_ignored():
+    z = _mid_level_field([-10.0, -50.0])
+    var = _mid_level_field([np.nan, 2.0])
+    x_limits: list[tuple[float, float]] = []
+    _add_visible_limits(x_limits, var, z, -100.0, 0.0)
+    assert x_limits == [(2.0, 2.0)]
+
+
+def test_an_all_nan_profile_adds_nothing():
+    z = _mid_level_field([-10.0, -50.0])
+    var = _mid_level_field([np.nan, np.nan])
+    x_limits: list[tuple[float, float]] = []
+    _add_visible_limits(x_limits, var, z, -100.0, 0.0)
+    assert x_limits == []
+
+
+def test_a_profile_with_nothing_visible_adds_nothing():
+    z = _mid_level_field([-300.0, -400.0])
+    var = _mid_level_field([1.0, 2.0])
+    x_limits: list[tuple[float, float]] = []
+    _add_visible_limits(x_limits, var, z, -100.0, 0.0)
+    assert x_limits == []
+
+
+def test_limits_accumulate_over_several_curves():
+    # the x range has to cover every curve drawn, not just the last one
+    z = _mid_level_field([-10.0, -50.0])
+    x_limits: list[tuple[float, float]] = []
+    _add_visible_limits(x_limits, _mid_level_field([1.0, 2.0]), z, -100.0, 0.0)
+    _add_visible_limits(
+        x_limits, _mid_level_field([-5.0, 0.0]), z, -100.0, 0.0
+    )
+    assert min(limits[0] for limits in x_limits) == -5.0
+    assert max(limits[1] for limits in x_limits) == 2.0
+
+
+def test_curves_on_different_coordinates_share_one_range(z_mid, z_interface):
+    # a plot mixes an interface field with the mid-level initial state, so
+    # each curve contributes on its own coordinate
+    x_limits: list[tuple[float, float]] = []
+    var = _interface_field([1.0, 2.0, 3.0, 4.0])
+    _add_visible_limits(
+        x_limits, var, _vertical_coord(var, z_mid, z_interface), -100.0, 0.0
+    )
+    var = _mid_level_field([-1.0, 0.5, 99.0])
+    _add_visible_limits(
+        x_limits, var, _vertical_coord(var, z_mid, z_interface), -100.0, 0.0
+    )
+    assert min(limits[0] for limits in x_limits) == -1.0
+    assert max(limits[1] for limits in x_limits) == 3.0

--- a/tests/ocean/test_single_column_viz.py
+++ b/tests/ocean/test_single_column_viz.py
@@ -7,6 +7,10 @@ where it is defined.  ``isel()`` also changes the length of a dimension but
 not its name, so building the x-axis range from a mask on ``nVertLevels``
 then raised an ``IndexError``.  Interface fields are now plotted against
 ``zInterface``, which is both where they belong and the same dimension.
+
+A field written at layer tops on ``nVertLevels`` cannot be told from a
+layer average by its dimensions, so it is named in ``TOP_OF_LAYER_FIELDS``
+and paired with the top interface of each layer.
 """
 
 import numpy as np
@@ -17,6 +21,9 @@ from polaris.tasks.ocean.single_column.viz import (
     _add_visible_limits,
     _vertical_coord,
 )
+
+# a field the models agree is a layer quantity
+MID = 'temperature'
 
 
 def _interface_field(values):
@@ -39,30 +46,69 @@ def z_interface():
 
 def test_an_interface_field_is_plotted_at_interfaces(z_mid, z_interface):
     z = _vertical_coord(
-        _interface_field([1.0, 2.0, 3.0, 4.0]), z_mid, z_interface
+        MID, _interface_field([1.0, 2.0, 3.0, 4.0]), z_mid, z_interface
     )
     assert z.dims == ('nVertLevelsP1',)
     np.testing.assert_array_equal(z.values, z_interface.values)
 
 
 def test_a_mid_level_field_is_plotted_at_midpoints(z_mid, z_interface):
-    z = _vertical_coord(_mid_level_field([1.0, 2.0, 3.0]), z_mid, z_interface)
+    z = _vertical_coord(
+        MID, _mid_level_field([1.0, 2.0, 3.0]), z_mid, z_interface
+    )
     assert z.dims == ('nVertLevels',)
     np.testing.assert_array_equal(z.values, z_mid.values)
+
+
+def test_a_named_top_of_layer_field_is_plotted_at_layer_tops(
+    z_mid, z_interface
+):
+    # MPAS-Ocean writes BruntVaisalaFreqTop at layer tops but on
+    # nVertLevels, so the dimensions alone would send it to zMid
+    z = _vertical_coord(
+        'BruntVaisalaFreqTop',
+        _mid_level_field([1.0, 2.0, 3.0]),
+        z_mid,
+        z_interface,
+    )
+    assert z.dims == ('nVertLevels',)
+    np.testing.assert_array_equal(z.values, z_interface.values[:-1])
+
+
+def test_a_named_field_on_interfaces_is_left_on_interfaces(z_mid, z_interface):
+    # Omega writes the same field on nVertLevelsP1; the dimensions win, so
+    # naming a field is harmless for the model that gets it right
+    z = _vertical_coord(
+        'BruntVaisalaFreqTop',
+        _interface_field([1.0, 2.0, 3.0, 4.0]),
+        z_mid,
+        z_interface,
+    )
+    assert z.dims == ('nVertLevelsP1',)
+    np.testing.assert_array_equal(z.values, z_interface.values)
 
 
 def test_an_interface_field_keeps_every_value(z_mid, z_interface):
     # the bottom interface used to be dropped so that the field could be
     # plotted against zMid; nothing is dropped now
     var = _interface_field([1.0, 2.0, 3.0, 4.0])
-    z = _vertical_coord(var, z_mid, z_interface)
+    z = _vertical_coord(MID, var, z_mid, z_interface)
     assert var.sizes['nVertLevelsP1'] == z.sizes['nVertLevelsP1']
 
 
 def test_an_interface_field_can_be_masked_by_depth(z_mid, z_interface):
     # this is the combination that used to raise an IndexError
     var = _interface_field([1.0, 2.0, 3.0, 4.0])
-    z = _vertical_coord(var, z_mid, z_interface)
+    z = _vertical_coord(MID, var, z_mid, z_interface)
+    x_limits: list[tuple[float, float]] = []
+    _add_visible_limits(x_limits, var, z, -100.0, 0.0)
+    assert x_limits == [(1.0, 3.0)]
+
+
+def test_a_top_of_layer_field_can_be_masked_by_depth(z_mid, z_interface):
+    # the renamed coordinate has to match the field's own dimension
+    var = _mid_level_field([1.0, 2.0, 3.0])
+    z = _vertical_coord('BruntVaisalaFreqTop', var, z_mid, z_interface)
     x_limits: list[tuple[float, float]] = []
     _add_visible_limits(x_limits, var, z, -100.0, 0.0)
     assert x_limits == [(1.0, 3.0)]
@@ -118,11 +164,19 @@ def test_curves_on_different_coordinates_share_one_range(z_mid, z_interface):
     x_limits: list[tuple[float, float]] = []
     var = _interface_field([1.0, 2.0, 3.0, 4.0])
     _add_visible_limits(
-        x_limits, var, _vertical_coord(var, z_mid, z_interface), -100.0, 0.0
+        x_limits,
+        var,
+        _vertical_coord(MID, var, z_mid, z_interface),
+        -100.0,
+        0.0,
     )
     var = _mid_level_field([-1.0, 0.5, 99.0])
     _add_visible_limits(
-        x_limits, var, _vertical_coord(var, z_mid, z_interface), -100.0, 0.0
+        x_limits,
+        var,
+        _vertical_coord(MID, var, z_mid, z_interface),
+        -100.0,
+        0.0,
     )
     assert min(limits[0] for limits in x_limits) == -1.0
     assert max(limits[1] for limits in x_limits) == 3.0


### PR DESCRIPTION
`ocean/column/vmix_stable` and `vmix_unstable` fail in the `omega_pr`, `mpaso_pr` and `mpaso_nightly` suites: the `viz` step raises `IndexError` on a field defined at layer interfaces. Such a field was trimmed and plotted against `zMid`, half a layer below where it belongs. It is now plotted against `zInterface`, which fixes both the crash and the offset.

The x-axis range now comes from every curve drawn rather than whichever was drawn last.

First of several pieces split out of the closed #747, and independent of the others.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes
