### PR TITLE
Make three single_column steps run with MPAS-Ocean

### DIFF
--- a/polaris/tasks/ocean/single_column/ideal_age/forward.yaml
+++ b/polaris/tasks/ocean/single_column/ideal_age/forward.yaml
@@ -10,5 +10,17 @@ mpas-ocean:
     config_use_idealAgeTracers_idealAge_forcing: true
   streams:
     output:
+      type: output
+      filename_template: output.nc
+      output_interval: 0001_00:00:00
+      clobber_mode: truncate
       contents:
+      - tracers
+      - xtime
+      - daysSinceStartOfSim
+      - zMid
+      - normalVelocity
+      - velocityZonal
+      - velocityMeridional
+      - layerThickness
       - idealAgeTracers

--- a/polaris/tasks/ocean/single_column/inertial/forward.yaml
+++ b/polaris/tasks/ocean/single_column/inertial/forward.yaml
@@ -13,6 +13,21 @@ mpas-ocean:
     config_implicit_constant_bottom_drag_coeff: 0.0
   cvmix:
     config_use_cvmix: false
+  streams:
+    output:
+      type: output
+      filename_template: output.nc
+      output_interval: 0000_01:00:00
+      clobber_mode: truncate
+      contents:
+      - tracers
+      - xtime
+      - daysSinceStartOfSim
+      - zMid
+      - normalVelocity
+      - velocityZonal
+      - velocityMeridional
+      - layerThickness
 
 Omega:
   IOStreams:

--- a/polaris/tasks/ocean/single_column/vmix/analysis.py
+++ b/polaris/tasks/ocean/single_column/vmix/analysis.py
@@ -22,9 +22,11 @@ class Analysis(OceanIOStep):
         comparisons=None,
     ):
         super().__init__(component=component, name='analysis', indir=indir)
-        self.add_input_file(
-            filename='vert_coord.nc', target='../init/vert_coord.nc'
-        )
+        # Only Omega needs this: it has no zTop in its output, so interface
+        # depths have to be rebuilt from the vertical coordinate.  MPAS-Ocean
+        # writes zTop and has no separate vert_coord file, so the entry is
+        # dropped for it.
+        self.add_vert_coord_input_file(target='../init/vert_coord.nc')
         self.comparisons = (
             dict(comparisons)
             if comparisons
@@ -40,11 +42,7 @@ class Analysis(OceanIOStep):
         """
         Run this step of the test case
         """
-        ds_vert = self.open_model_dataset(
-            'vert_coord.nc',
-            decode_times=False,
-            config=self.config,
-        )
+        ds_vert = None
         for comparison_name in self.comparisons.keys():
             ds_diags = self.open_model_dataset(
                 f'{comparison_name}.nc', decode_times=True, config=self.config
@@ -69,6 +67,12 @@ class Analysis(OceanIOStep):
             if 'zTop' in ds_diags_1day.keys():
                 z_top_final = ds_diags_1day['zTop'].mean(dim='nCells')
             else:
+                if ds_vert is None:
+                    ds_vert = self.open_model_dataset(
+                        self.get_vert_coord_filename(),
+                        decode_times=False,
+                        config=self.config,
+                    )
                 z_int_final, _ = compute_zint_zmid_from_layer_thickness(
                     layer_thickness=ds_diags_1day['layerThickness'],
                     bottom_depth=ds_vert['bottomDepth'],


### PR DESCRIPTION
Three single-column steps never ran with MPAS-Ocean. `ocean/column/inertial` and `ocean/column/ideal_age` failed `mpaso_pr` with a missing `output.nc`, and the `analysis` step of `ocean/column/vmix_stable` failed on a missing `vert_coord.nc`. All three pass with Omega, which is why this was not noticed.

This is one of several pieces split out of the closed #747, which grew too large to review in one go. It is independent of the others.

## inertial and ideal_age wrote no output.nc

Neither task set `filename_template` on its output stream, so MPAS-Ocean used its default of `output/output.$Y-$M-$D_$h.$m.$s.nc` while the forward step declares `output.nc`. Omega's History stream names `output.nc` directly, so only MPAS-Ocean was affected. This predates #663.

Naming the file is not sufficient on its own. Listing `contents` replaces MPAS-Ocean's default contents rather than adding to them, which is why `ideal_age` wrote `iAge` but no temperature, salinity or time; and neither task's default output carries `normalVelocity` or the reconstructed velocities that baseline validation and the analysis steps use. Both streams now list what those steps need, following `vmix` and `ekman`.

`inertial` writes hourly, matching its Omega stream. Its analysis takes an FFT of the velocity time series to recover the inertial period, and cannot do that from daily output.

## The vmix analysis required a file only Omega writes

The `analysis` step declared `vert_coord.nc` as a plain input and opened it unconditionally, but MPAS-Ocean has no separate vertical coordinate file and the init step does not produce one. The framework already has a mechanism for this: `add_vert_coord_input_file()` uses a placeholder that is dropped for MPAS-Ocean. The step now uses it, and opens the file only on the branch that needs it, which rebuilds interface depths when `zTop` is absent from the output. That is the Omega case; MPAS-Ocean writes `zTop` and never reaches it.

This was invisible until now because `viz` runs before `analysis` in the same task and crashed first, so no MPAS-Ocean run ever got as far as the analysis step. #750 fixes that crash and is what makes this reachable, but the two changes are independent and can merge in either order.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
