### PR TITLE
Correct the documented conservation tolerances

### DIFF
--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -244,23 +244,31 @@ class Forward(OceanModelStep):
 
 ## Conservation checks
 
-Mass, salt and energy conservation checks are available for ocean model output.
-The checks will fail if the relative change in the total quantity exceeds the
-tolerance given in
+Mass, salt, tracer and energy conservation checks are available for ocean
+model output.  A check fails if the relative error in the budget exceeds the
+tolerance given in `polaris/ocean/ocean.cfg`:
 
 ```cfg
 # Options related the ocean component
 [ocean]
 
 # Tolerance for mass conservation, normalized by total mass
-mass_conservation_tolerance = 1e-8
+mass_conservation_tolerance = 1e-14
 
 # Tolerance for salt conservation, normalized by total salt
-salt_conservation_tolerance = 1e-8
+salt_conservation_tolerance = 1e-14
+
+# Tolerance for tracer conservation, normalized by total tracer value
+tracer_conservation_tolerance = 1e-14
 
 # Tolerance for thermal energy conservation, normalized by total energy
-energy_conservation_tolerance = 1e-8
+energy_conservation_tolerance = 1e-14
 ```
+
+A failed check does not currently fail its step or task.  The result is
+logged and recorded, and nothing else acts on it.  Whether that should
+change, and what the tolerances should be, is under discussion in
+[issue #753](https://github.com/E3SM-Project/polaris/issues/753).
 
 As shown in the previous example, we have added a mesh file with the name
 'mesh.nc' because conservation checks require the area of cells.


### PR DESCRIPTION
The Developer's Guide gives the ocean conservation tolerances as `1e-8` for mass, salt and energy. `polaris/ocean/ocean.cfg` has them at `1e-14`, and also has a tracer tolerance the guide does not mention at all. Six orders of magnitude is enough to mislead someone deciding whether a conservation error matters.

This also states that a failed check does not fail its step or task. That is easy to assume from "the checks will fail", and assuming it is what led to the behavior being reported as a bug rather than as the deliberate choice it was. Whether it should change, and what the tolerances should be, is under discussion in #753, which the note points at.

Documentation only. This is one of several pieces split out of the closed #747 and is independent of the others.

Checklist
* [x] Developer's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
