### PR TITLE
Add writing rules for AI agents

### DIFF
--- a/.claude/skills/design-documents/SKILL.md
+++ b/.claude/skills/design-documents/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: design-documents
+description: Write or revise a design document under docs/design_docs/. Use when proposing a new capability, not when fixing a bug.
+---
+
+# Design documents
+
+Long is fine. A design document is scanned and returned to, not read
+straight through. What must be scannable is the specification.
+
+- Normative statements come first in a section and stand alone. Rationale
+  goes in a marked block below, which a reader can skip.
+- Rejected alternatives and superseded drafts go in one `Decisions`
+  section, cited from the places they affect. Never re-argued in place.
+- A principle is stated once. Later sections cite it by name.
+- Do not pre-empt objections. Drop "worth noting", "not an accident",
+  "deliberately", "this is not a stylistic preference". State the decision
+  and let it stand.
+- Open questions go at the top or in their own section, never
+  mid-paragraph.
+
+## Calibration
+
+The two design documents in `docs/design_docs/` run 9,516 and 24,630 words,
+at 28 and 30 words per sentence, with six and sixteen instances of the
+hedging phrases above. Aim for twenty words per sentence and none of them.
+
+## Enough
+
+> ### Requirement: analysis runs on simulations Polaris did not run
+>
+> An analysis task shall accept a run directory it did not create, and
+> shall read the model's configuration from that directory rather than
+> being told it.
+>
+> > *Rationale.* Users bring runs from E3SM and from hand-built cases.
+> > Requiring Polaris to have set them up would rule those out. Two
+> > alternatives were rejected; see `Decisions: configuration discovery`.

--- a/.claude/skills/design-documents/SKILL.md
+++ b/.claude/skills/design-documents/SKILL.md
@@ -25,14 +25,26 @@ The two design documents in `docs/design_docs/` run 9,516 and 24,630 words,
 at 28 and 30 words per sentence, with six and sixteen instances of the
 hedging phrases above. Aim for twenty words per sentence and none of them.
 
+`docs/design_docs/template.md` is the prescribed structure. It also says
+requirements "should not discuss technical software issues, but rather
+focus on model capability", which is the rule most often broken.
+
 ## Enough
 
-> ### Requirement: analysis runs on simulations Polaris did not run
+From `docs/design_docs/shared_steps.md`. The heading states the
+requirement, the body is one normative sentence, and some requirements need
+no body at all.
+
+> ### Requirement: Shared steps are run once.
 >
-> An analysis task shall accept a run directory it did not create, and
-> shall read the model's configuration from that directory rather than
-> being told it.
+> Shared steps should be run once per invocation of `polaris serial` or
+> `polaris run`.
 >
-> > *Rationale.* Users bring runs from E3SM and from hand-built cases.
-> > Requiring Polaris to have set them up would rule those out. Two
-> > alternatives were rejected; see `Decisions: configuration discovery`.
+> ### Requirement: Shared steps are run before steps that depend on their output.
+>
+> ### Requirement: The output of shared steps may be used by multiple tasks.
+>
+> A step may only be shared across multiple tasks if its output would be
+> identical for each task.
+
+Seven requirements in that document take about 150 words between them.

--- a/.claude/skills/plan-documents/SKILL.md
+++ b/.claude/skills/plan-documents/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: plan-documents
+description: Write a plan for work not yet started, for a colleague or the user to approve before implementation begins.
+---
+
+# Plan documents
+
+The reader is deciding whether to let you proceed.
+
+- Open questions and anything needing a decision go at the top.
+- The steps, in order, one line each.
+- Do not justify each step. Do not list the files you will touch. Do not
+  restate the codebase back.
+- If a step needs a paragraph to explain, it belongs in a design document.
+
+## Enough
+
+> **Open:** should `ekman` come out of `omega_pr` too, or wait for #753?
+>
+> 1. Fix the interface-field trim in the single-column viz step.
+> 2. Restore the tracer expansion in the conservation checks.
+> 3. Take conservation times from the whole dataset, not one slice.
+> 4. Tests for all three.
+> 5. Rerun `omega_pr` and `mpaso_pr` against a `main` baseline.

--- a/.claude/skills/plan-documents/SKILL.md
+++ b/.claude/skills/plan-documents/SKILL.md
@@ -15,6 +15,9 @@ The reader is deciding whether to let you proceed.
 
 ## Enough
 
+Plans are approved in conversation rather than committed, so there is no
+human example in these repositories to copy. The following is constructed.
+
 > **Open:** should `ekman` come out of `omega_pr` too, or wait for #753?
 >
 > 1. Fix the interface-field trim in the single-column viz step.

--- a/.claude/skills/pr-descriptions/SKILL.md
+++ b/.claude/skills/pr-descriptions/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: pr-descriptions
+description: Write or update a pull request description, including drafting pr_description.md before opening a PR. Use when opening a pull request or editing its body.
+---
+
+# Pull request descriptions
+
+The reader is deciding whether to review.
+
+- What changed and why, in a few sentences. Not how.
+- Anything needing a reviewer decision goes in its own short list near the
+  top, never mid-paragraph.
+- No commit list. No testing; that goes in a separate `Testing` comment.
+- Link the issue or upstream PR that gives context.
+- Several fixes usually means several pull requests.
+
+## Calibration
+
+Pull request descriptions written by colleagues here run 28 words at the
+median in Polaris and 46 in Omega, and 300 at the seventy-fifth
+percentile. A recent AI-written one ran 1167 words, which is longer than
+any human-written description in either repository.
+
+## Enough
+
+Real descriptions from these repositories.
+
+> Add a missing assignment of the error code returned by
+> `OMEGA::ocnFinalize`. We also clean up the C++/Fortran interface, by
+> making the C++ function return void (now consistent with their Fortran
+> declaration).
+>
+> Error codes are all handled on the C++ side; any logic dependent on the
+> error code value is handled in C++. So, we have no need to pass the
+> return codes to Fortran.
+>
+> Missing assignment came to light when testing E3SM-Project/Omega#526.
+
+> This PR updates the test meshes to the latest versions for Omega tests.
+>
+> In addition, it removes the compiler configurations for AMD compilers on
+> Frontier, whose support has been discontinued.
+>
+> Temporary fixes: #707
+
+## Too much
+
+A real description gave each of five fixes its own section and traced its
+mechanism:
+
+> `polaris.ocean.conservation` gained a module-scope import of
+> `polaris.ocean.model.time`, which runs
+> `polaris/ocean/model/__init__.py`, which imports the step classes, which
+> import `polaris.ocean.conservation` back. The module could no longer be
+> imported on its own; it worked only when something else imported
+> `polaris.ocean.model` first.
+
+Someone deciding whether to review does not need the cycle traced. Two
+sentences would do, and the rest belongs in the commit message.

--- a/.claude/skills/pr-descriptions/SKILL.md
+++ b/.claude/skills/pr-descriptions/SKILL.md
@@ -10,43 +10,43 @@ The reader is deciding whether to review.
 - What changed and why, in a few sentences. Not how.
 - Anything needing a reviewer decision goes in its own short list near the
   top, never mid-paragraph.
+- A list of changed behaviours is fine. A trace of the mechanism is not.
 - No commit list. No testing; that goes in a separate `Testing` comment.
-- Link the issue or upstream PR that gives context.
+- Link the issue or upstream pull request that gives context.
 - Several fixes usually means several pull requests.
 
 ## Calibration
 
-Pull request descriptions written by colleagues here run 28 words at the
-median in Polaris and 46 in Omega, and 300 at the seventy-fifth
-percentile. A recent AI-written one ran 1167 words, which is longer than
-any human-written description in either repository.
+Measured over pull requests from 2023 and 2024, before any agent wrote
+here. Descriptions run 27 to 28 words at the median, 45 to 62 at the
+seventy-fifth percentile, 103 to 110 at the ninetieth, and 354 at the
+longest. A recent agent-written one ran 1167 words, more than three times
+the longest a colleague has written.
 
 ## Enough
 
-Real descriptions from these repositories.
+A bug fix, stated and done:
 
-> Add a missing assignment of the error code returned by
-> `OMEGA::ocnFinalize`. We also clean up the C++/Fortran interface, by
-> making the C++ function return void (now consistent with their Fortran
-> declaration).
->
-> Error codes are all handled on the C++ side; any logic dependent on the
-> error code value is handled in C++. So, we have no need to pass the
-> return codes to Fortran.
->
-> Missing assignment came to light when testing E3SM-Project/Omega#526.
+> When you add an input in a subdirectory and the target is also in the
+> subdirectory of another step, polaris was previously incorrectly creating
+> an absolute path to the input relative to the step's workdir, rather than
+> the subdirectory where the symlink exists. This merge fixes that bug.
 
-> This PR updates the test meshes to the latest versions for Omega tests.
+A port, with the changes as a list:
+
+> This PR ports the `ocean/single_column_model/planar/cvmix_test` from
+> compass-legacy as `ocean/single_column/10km/cvmix`.
 >
-> In addition, it removes the compiler configurations for AMD compilers on
-> Frontier, whose support has been discontinued.
->
-> Temporary fixes: #707
+> The following changes are made from compass-legacy:
+> * creating the initial state in python instead of MPAS-Ocean's init mode
+> * using a uniform vertical grid rather than a custom grid, which was
+>   specified in init mode
+> * adding a viz step
 
 ## Too much
 
-A real description gave each of five fixes its own section and traced its
-mechanism:
+A real agent-written description gave each of five fixes its own section
+and traced its mechanism:
 
 > `polaris.ocean.conservation` gained a module-scope import of
 > `polaris.ocean.model.time`, which runs
@@ -55,5 +55,5 @@ mechanism:
 > imported on its own; it worked only when something else imported
 > `polaris.ocean.model` first.
 
-Someone deciding whether to review does not need the cycle traced. Two
-sentences would do, and the rest belongs in the commit message.
+Someone deciding whether to review does not need the cycle traced. One
+sentence would do; the rest belongs in the commit message.

--- a/.claude/skills/review-comments/SKILL.md
+++ b/.claude/skills/review-comments/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: review-comments
+description: Write a review comment, review findings, or a reply to review feedback on a GitHub pull request. Use when reviewing code, reporting what testing someone else's branch turned up, or answering a reviewer's question.
+---
+
+# Review comments
+
+The reader is deciding what to change.
+
+- Findings first, ordered by how much they matter. At most one sentence
+  before them.
+- One short paragraph per finding: what is wrong, one piece of evidence,
+  stop. Not how it works.
+- No section on what already works. One line for all of it, if any.
+- Reproduction and configuration go in one paragraph at the end.
+- Headings help once there are several findings. Use them.
+
+## Calibration
+
+Review comments written by colleagues in these repositories run 22 to 32
+words at the median, 63 to 92 at the ninetieth percentile, and 170 at the
+longest seen. A recent AI-written review ran 1117 words, with the findings
+starting 444 words in.
+
+## Enough
+
+Real comments from this project. One point each, one suggestion, done.
+
+> It's preferable to use xarray's `isel()` instead of explicit axis
+> indexing whenever possible. It is generally clearer which axis is being
+> indexed and it also means you don't necessarily need to know the axis
+> order.
+
+> Since a user doesn't have control over what tests are in a test suite, I
+> think we should just remove the `default` test case from the test suite.
+> This might be appropriate to have in the developer's guide instead.
+
+With several findings, label them and keep each to a paragraph:
+
+> Three things, one blocking.
+>
+> **blocking — `MOCLatBinBoundaries` carries a time dimension.** It is
+> static, so a consumer reading twelve months gets twelve times as many
+> latitudes as bins. Verified in the January output file.
+>
+> **worth fixing — the streamfunction has no units.** Both attributes are
+> empty; the values are Sverdrups. Raised last review, unchanged.
+>
+> **noted — written bin boundaries differ from what the operator bins on**
+> by 1.8e-4 degrees, below anything that matters for a plot.
+>
+> Reviewed with the analysis suite from E3SM-Project/polaris#743, QU240,
+> one year, intel. Plots on the LCRC portal.
+
+## Too much
+
+The same review, actually posted, spent its first 444 words on "How this
+was reviewed", "What the previous review asked for" and four paragraphs of
+"What works", then traced each finding's mechanism:
+
+> It is static: computed once in the `MOC` constructor from `NumBins`,
+> `MinLat` and `MaxLat`, and never updated. But it is attached to the
+> output streams with `addField()` like any other field, so every reduction
+> in every file carries a copy of the same 61 numbers.

--- a/.claude/skills/review-comments/SKILL.md
+++ b/.claude/skills/review-comments/SKILL.md
@@ -35,7 +35,9 @@ Real comments from this project. One point each, one suggestion, done.
 > think we should just remove the `default` test case from the test suite.
 > This might be appropriate to have in the developer's guide instead.
 
-With several findings, label them and keep each to a paragraph:
+With several findings, label them and keep each to a paragraph. No
+human example of this shape exists in these repositories, so the following
+is constructed:
 
 > Three things, one blocking.
 >

--- a/.claude/skills/review-comments/SKILL.md
+++ b/.claude/skills/review-comments/SKILL.md
@@ -7,24 +7,26 @@ description: Write a review comment, review findings, or a reply to review feedb
 
 The reader is deciding what to change.
 
-- Findings first, ordered by how much they matter. At most one sentence
-  before them.
-- One short paragraph per finding: what is wrong, one piece of evidence,
-  stop. Not how it works.
+- Put each finding as an inline comment on the line it concerns, one point
+  each. That is where colleagues put them, and it is why their review
+  bodies are short.
+- The review body summarizes: what you ran, and the verdict. Two or three
+  sentences.
+- Use a list in the body only for requests that span files.
 - No section on what already works. One line for all of it, if any.
-- Reproduction and configuration go in one paragraph at the end.
-- Headings help once there are several findings. Use them.
+- Say what you could not check.
 
 ## Calibration
 
-Review comments written by colleagues in these repositories run 22 to 32
-words at the median, 63 to 92 at the ninetieth percentile, and 170 at the
-longest seen. A recent AI-written review ran 1117 words, with the findings
-starting 444 words in.
+Measured over review comments from 2023, before any agent wrote here.
+Review bodies run 14 words at the median, 55 at the ninetieth percentile,
+and 239 at the longest. Inline comments run 22 to 32 words at the median
+and 170 at the longest. A recent agent-written review ran 1117 words, with
+the findings starting 444 words in.
 
 ## Enough
 
-Real comments from this project. One point each, one suggestion, done.
+Inline, one point and a suggestion:
 
 > It's preferable to use xarray's `isel()` instead of explicit axis
 > indexing whenever possible. It is generally clearer which axis is being
@@ -35,29 +37,21 @@ Real comments from this project. One point each, one suggestion, done.
 > think we should just remove the `default` test case from the test suite.
 > This might be appropriate to have in the developer's guide instead.
 
-With several findings, label them and keep each to a paragraph. No
-human example of this shape exists in these repositories, so the following
-is constructed:
+In the body, when several requests span the whole change:
 
-> Three things, one blocking.
+> Thanks for putting this together and the overall system looks good.
+> However, I think we need to make this a cleaner, simpler PR with the
+> following changes:
 >
-> **blocking — `MOCLatBinBoundaries` carries a time dimension.** It is
-> static, so a consumer reading twelve months gets twelve times as many
-> latitudes as bins. Verified in the January output file.
->
-> **worth fixing — the streamfunction has no units.** Both attributes are
-> empty; the values are Sverdrups. Raised last review, unchanged.
->
-> **noted — written bin boundaries differ from what the operator bins on**
-> by 1.8e-4 degrees, below anything that matters for a plot.
->
-> Reviewed with the analysis suite from E3SM-Project/polaris#743, QU240,
-> one year, intel. Plots on the LCRC portal.
+> - For the CIME changes and YAKL submodule, I think we need to sync the
+>   OMEGA repo so it's up to date with E3SM.
+> - Can you please remove the logger and spdlog. This will need a separate
+>   PR and discussion.
 
 ## Too much
 
-The same review, actually posted, spent its first 444 words on "How this
-was reviewed", "What the previous review asked for" and four paragraphs of
+A real agent-written review spent its first 444 words on "How this was
+reviewed", "What the previous review asked for" and four paragraphs of
 "What works", then traced each finding's mechanism:
 
 > It is static: computed once in the `MOC` constructor from `NumBins`,

--- a/.claude/skills/testing-comments/SKILL.md
+++ b/.claude/skills/testing-comments/SKILL.md
@@ -22,7 +22,8 @@ A colleague's whole testing report:
 >
 > All CTests passed.
 
-With suite results, let the table do it:
+With suite results, let the table do it. Constructed, since no human
+example here reports a suite this way:
 
 > Chrysalis, gnu, MPAS-Ocean at `b7759691a5`. 840 tests pass, pre-commit
 > clean.

--- a/.claude/skills/testing-comments/SKILL.md
+++ b/.claude/skills/testing-comments/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: testing-comments
+description: Write a Testing comment on a pull request, recording what was run and what the results were. Use after running suites, tests or linting for a PR.
+---
+
+# Testing comments
+
+Scanned now, re-audited later. Tables carry the results.
+
+- One line of configuration: machine, compiler, submodule hashes.
+- Results go in tables. Prose only for what a table cannot say.
+- Do not restate in prose what the table already shows.
+- Do not repeat the pull request description.
+- Failures unrelated to the branch go under their own heading at the end.
+
+## Enough
+
+A colleague's whole testing report:
+
+> Builds were successful on pm-cpu (gnu), pm-gpu (gnugpu), Frontier CPU
+> (craygnu), and Frontier GPU (craygnu-mphipcc).
+>
+> All CTests passed.
+
+With suite results, let the table do it:
+
+> Chrysalis, gnu, MPAS-Ocean at `b7759691a5`. 840 tests pass, pre-commit
+> clean.
+>
+> | suite | main | this branch |
+> | --- | --- | --- |
+> | `mpaso_pr` execution failures | 7 of 24 | 0 |
+> | `mpaso_pr` baseline diffs | not reached | 5 |
+>
+> The five diffs are missing baseline files; `main` never wrote those
+> outputs.
+
+## Too much
+
+A real comment put the table in, then said the same thing again in prose:
+
+> Every task now runs to completion. The five diffs are all of the form
+> `File ... does not exist`: `main` crashed before writing those outputs,
+> so there is nothing to compare against. Every comparison that had a file
+> on both sides passed. A clean like-for-like comparison for those five
+> tasks needs a fresh baseline once this lands.

--- a/.claude/skills/testing-comments/SKILL.md
+++ b/.claude/skills/testing-comments/SKILL.md
@@ -5,40 +5,51 @@ description: Write a Testing comment on a pull request, recording what was run a
 
 # Testing comments
 
-Scanned now, re-audited later. Tables carry the results.
+What you ran, where, and whether it passed.
 
-- One line of configuration: machine, compiler, submodule hashes.
-- Results go in tables. Prose only for what a table cannot say.
-- Do not restate in prose what the table already shows.
-- Do not repeat the pull request description.
+- Name the suite, the machine and the compiler. One sentence.
+- Give the work directory or the baseline you compared against.
+- Say the result. Bit-for-bit, passed, or the numbers if they matter.
+- Use a table only when there are several runs to compare.
+- Do not restate in prose what a table or a pasted result already shows.
 - Failures unrelated to the branch go under their own heading at the end.
+
+## Calibration
+
+Measured over Testing comments from 2023, before any agent wrote here.
+They run 21 to 43 words. A recent agent-written one ran 606 words.
 
 ## Enough
 
-A colleague's whole testing report:
-
-> Builds were successful on pm-cpu (gnu), pm-gpu (gnugpu), Frontier CPU
-> (craygnu), and Frontier GPU (craygnu-mphipcc).
+> ## Testing
 >
-> All CTests passed.
+> I ran the cosine bell test suite on Chrysalis with Intel and OpenMPI:
+> ```
+> /lcrc/group/e3sm/ac.xylar/polaris_0.1/chrysalis/test_20230304/cosine_bell_yaml
+> ```
+> Results are bit-for-bit with the current `main`.
 
-With suite results, let the table do it. Constructed, since no human
-example here reports a suite this way:
+> ## Testing
+>
+> I tested this by successfully running several baroclinic channel and
+> cosine bell tests on Chrysalis (comparing with a baseline).
 
-> Chrysalis, gnu, MPAS-Ocean at `b7759691a5`. 840 tests pass, pre-commit
-> clean.
+When the results are worth pasting, paste them and stop:
+
+> ## Testing
 >
-> | suite | main | this branch |
-> | --- | --- | --- |
-> | `mpaso_pr` execution failures | 7 of 24 | 0 |
-> | `mpaso_pr` baseline diffs | not reached | 5 |
->
-> The five diffs are missing baseline files; `main` never wrote those
-> outputs.
+> I ran 4 baroclinic channel test cases on Chrysalis and verified that they
+> are BFB with a baseline from 2 days ago:
+> ```
+> Test Runtimes:
+> 00:07 PASS ocean/baroclinic_channel/10km/decomp_test
+> 00:04 PASS ocean/baroclinic_channel/10km/restart_test
+> ```
 
 ## Too much
 
-A real comment put the table in, then said the same thing again in prose:
+A real agent-written comment put the table in, then said the same thing
+again in prose:
 
 > Every task now runs to completion. The five diffs are all of the form
 > `File ... does not exist`: `main` crashed before writing those outputs,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,46 @@ These instructions apply to the whole repository unless a deeper
 - An issue should say what happens, what was expected instead, and
   enough about the configuration and commands used to reproduce it.
 
+## Writing for human readers
+
+These rules apply to anything a colleague reads: GitHub comments, pull
+request descriptions, issues, plans, design notes. Not code comments or
+commit messages, where a reader who wants the mechanism is already in the
+right place. Per-artifact rules and worked examples are in
+`.claude/skills/<artifact>/SKILL.md`, as plain markdown. Claude Code loads
+the matching one automatically; other agents should read it before writing.
+
+Write less; do not pack the same content into denser sentences. Keep
+headings, tables and links. Colleagues mostly write unstructured prose, and
+structure is an improvement on it. The problem is length.
+
+- **Lead with the answer.** The first two sentences say what you found,
+  changed, or propose. Setup and reproduction go last.
+- **One point per paragraph, and few paragraphs.** Colleagues write one to
+  three per comment; recent AI-written ones ran to eighteen. That gap is
+  the complaint. Say each thing once.
+- **Do not narrate the mechanism.** The chain of calls, and why the fix is
+  right, go in the commit message. Here, say what broke and where to look.
+- **Cut clauses that qualify rather than inform**, and any sentence whose
+  only job is to justify the one before it. One clause per sentence where
+  one will do.
+- **Use backticks about half as often as feels natural.** They are for what
+  a reader would type or grep. Code blocks hold artifacts you did not
+  write, never authored prose.
+- **One document, one decision.** Anything still relevant after this merges
+  is an issue, not a comment.
+
+Sign anything posted to GitHub on someone's behalf:
+
+```
+---
+
+*Posted by <agent> on @<user>'s behalf. The testing, analysis and wording
+above are AI-authored; please check them accordingly.*
+```
+
+Name the agent, not the vendor: `Claude Code`, `Codex`, and so on.
+
 ## Supported machines
 
 - `docs/developers_guide/supported_machines.yaml` is the source of the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,16 @@ right place. Per-artifact rules and worked examples are in
 `.claude/skills/<artifact>/SKILL.md`, as plain markdown. Claude Code loads
 the matching one automatically; other agents should read it before writing.
 
+Assume that the audience or readership is a polaris developer with
+familiarity at a high level with the overall structure and intention of the
+code base.
+
+Never repeat explanations of existing, unchanged features already explained
+in `docs`; instead, provide links to the relevant sections in `docs`.
+Explanations are appropriate where there is a change, particularly one of a
+conceptual nature. Explanations are also appropriate to highlight nuance
+that informs the current discussion.
+
 Write less; do not pack the same content into denser sentences. Keep
 headings, tables and links. Colleagues mostly write unstructured prose, and
 structure is an improvement on it. The problem is length.


### PR DESCRIPTION
Agent-written comments and pull request descriptions here have been running an order of magnitude longer than colleagues write. This adds rules for them: a short shared section in `AGENTS.md`, and per-artifact rules with worked examples under `.claude/skills/`.

They are calibrated against pull requests, issues and review comments from 2023 and 2024, before any agent wrote here. Every worked example is real text from that period, apart from one for plan documents, which says so.

Worth a look: the backtick rule says "about half as often as feels natural", which an agent cannot check while writing, so it may be too vague to bite.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

---

*Posted by Claude Code on @xylar's behalf. The testing, analysis and wording above are AI-authored; please check them accordingly.*
