### PR TITLE
Fix sphere_transport viz step

### DIFF
--- a/polaris/tasks/ocean/sphere_transport/viz.py
+++ b/polaris/tasks/ocean/sphere_transport/viz.py
@@ -48,7 +48,7 @@ class Viz(OceanIOStep):
         super().__init__(component=component, name=name, subdir=subdir)
         self.add_input_file(
             filename='mesh.nc',
-            work_dir_target=f'{init.path}/base_mesh_with_weights.nc',
+            work_dir_target=f'{init.path}/culled_mesh.nc',
         )
         self.add_input_file(
             filename='initial_state.nc',


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
Fixes `sphere_transport` viz step that was complaining about a missing file.

https://github.com/E3SM-Project/polaris/commit/e7de70dbc54125d25dcf5b5f4a4133e71a04ed03 removed creation of `base_mesh_with_weights.nc`. Reconstruction weights are now merged into `culled_mesh.nc`.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes
<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
