### PR TITLE
Consolidate time_since_start functions

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -770,7 +770,7 @@
 
    OceanModelFilesMixin
 
-   get_days_since_start
+   get_time_since_start
    get_simulation_years
    days_per_year
    get_time_interval_string

--- a/polaris/ocean/conservation.py
+++ b/polaris/ocean/conservation.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from polaris.constants import get_constant
-from polaris.ocean.model.time import get_days_since_start
 
 # TODO update once this is used by Omega
 # cp_sw = get_constant('seawater_specific_heat_capacity_reference')
@@ -186,39 +185,6 @@ def compute_total_salt(ds_mesh, ds):
     """
     total_salinity = compute_total_tracer(ds_mesh, ds, tracer_name='salinity')
     return (rho_sw / 1000.0) * total_salinity
-
-
-def get_elapsed_seconds(ds, time_index_start=None, time_index_end=-1):
-    """
-    Elapsed seconds between two states of an output dataset, supporting
-    Omega's numeric ``time`` and MPAS-Ocean's ``daysSinceStartOfSim``.
-
-    Parameters
-    ----------
-    ds : xarray.Dataset
-        The output dataset
-
-    time_index_start : int, optional
-        The time index in ``ds`` at the start of the interval.  By default,
-        the interval starts at the beginning of the simulation (the initial
-        condition), rather than at a time in the output file.
-
-    time_index_end : int, optional
-        The time index in ``ds`` at the end of the interval
-
-    Returns
-    -------
-    dt : float
-        The elapsed time in seconds
-    """
-    if time_index_start is None:
-        start_time = 0.0
-    else:
-        start_time = (
-            get_days_since_start(ds.isel(Time=time_index_start)) * 86400.0
-        )
-    end_time = get_days_since_start(ds.isel(Time=time_index_end)) * 86400.0
-    return end_time - start_time
 
 
 def compute_flux_forcing(

--- a/polaris/ocean/model/__init__.py
+++ b/polaris/ocean/model/__init__.py
@@ -7,11 +7,11 @@ from polaris.ocean.model.ocean_model_step import (
 )
 from polaris.ocean.model.time import days_per_year as days_per_year
 from polaris.ocean.model.time import (
-    get_days_since_start as get_days_since_start,
-)
-from polaris.ocean.model.time import (
     get_simulation_years as get_simulation_years,
 )
 from polaris.ocean.model.time import (
     get_time_interval_string as get_time_interval_string,
+)
+from polaris.ocean.model.time import (
+    get_time_since_start as get_time_since_start,
 )

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -23,9 +23,9 @@ from polaris.ocean.conservation import (
     compute_total_mass,
     compute_total_salt,
     compute_total_tracer,
-    get_elapsed_seconds,
 )
 from polaris.ocean.model.ocean_model_files_mixin import OceanModelFilesMixin
+from polaris.ocean.model.time import get_time_since_start
 
 if TYPE_CHECKING:
     # Keep Ocean as a type-only import. Importing it at runtime pulls
@@ -564,12 +564,12 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
             if baseline == 'init':
                 ds_start = ds_init
                 time_index_start = 0
-                dt = get_elapsed_seconds(ds, time_index_end=time_index_end)
+                dt = _elapsed_seconds(ds, time_index_end=time_index_end)
                 baseline_str = 'init'
             else:
                 ds_start = None
                 time_index_start = baseline
-                dt = get_elapsed_seconds(
+                dt = _elapsed_seconds(
                     ds,
                     time_index_start=time_index_start,
                     time_index_end=time_index_end,
@@ -913,3 +913,42 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
                     f'{type(value)}'
                 )
         return option, value
+
+
+def _elapsed_seconds(
+    ds: Any, time_index_start: Optional[int] = None, time_index_end: int = -1
+) -> float:
+    """
+    Elapsed seconds between two states of an output dataset, supporting
+    Omega's numeric ``time`` and MPAS-Ocean's ``daysSinceStartOfSim`` or
+    ``xtime``.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The output dataset
+
+    time_index_start : int, optional
+        The time index in ``ds`` at the start of the interval.  By default,
+        the interval starts at the beginning of the simulation (the initial
+        condition), rather than at a time in the output file.
+
+    time_index_end : int, optional
+        The time index in ``ds`` at the end of the interval
+
+    Returns
+    -------
+    dt : float
+        The elapsed time in seconds
+    """
+    # Take the times from the whole dataset and index the result, rather
+    # than selecting a time slice first.  MPAS-Ocean's times come from
+    # xtime, and a single slice of it is a scalar, which the string parsing
+    # in polaris.mpas.time cannot walk.
+    seconds = get_time_since_start(ds, units='seconds')
+    end_time = float(seconds[time_index_end])
+    if time_index_start is None:
+        start_time = 0.0
+    else:
+        start_time = float(seconds[time_index_start])
+    return end_time - start_time

--- a/polaris/ocean/model/time.py
+++ b/polaris/ocean/model/time.py
@@ -7,23 +7,61 @@ import pandas as pd
 
 from polaris.mpas.time import time_since_start
 
+# seconds per unit, for converting the days computed below to other units
+_SECONDS_PER_UNIT = {
+    'seconds': 1.0,
+    'minutes': 60.0,
+    'hours': 3600.0,
+    'days': 86400.0,
+}
 
-def get_days_since_start(ds):
+
+def get_time_since_start(ds, units):
     """
     Ocean model output may or may not include 'daysSinceStartOfSim'. This
-    routine uses 'daysSinceStartOfSim' if available, otherwise it uses 'Time'
+    routine uses 'daysSinceStartOfSim' if available, otherwise it uses a
+    numeric 'time' variable (Omega's elapsed seconds), 'xtime' or 'Time' to
+    compute the time elapsed since the start of the simulation.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The output dataset
+
+    units : {'seconds', 'minutes', 'hours', 'days'}
+        The units of time elapsed since the start of the simulation to
+        return
+
+    Returns
+    -------
+    t_arr : numpy.ndarray
+        The time elapsed since the start of the simulation in the
+        requested units
+
+    Raises
+    ------
+    ValueError
+        If ``units`` is not one of the supported units
     """
+    if units not in _SECONDS_PER_UNIT:
+        known = ', '.join(_SECONDS_PER_UNIT)
+        raise ValueError(
+            f"Unknown time units '{units}'.  Supported units are: {known}."
+        )
     if 'daysSinceStartOfSim' in ds.keys():
-        t_arr = ds.daysSinceStartOfSim.values.astype(float)
+        days = ds.daysSinceStartOfSim.values.astype(float)
+    elif 'time' in ds.keys() and np.issubdtype(ds['time'].dtype, np.number):
+        # Omega's numeric 'time' coordinate is already elapsed seconds
+        days = ds['time'].values.astype(float) / 86400.0
     elif 'xtime' in ds.keys():
         # Calculate seconds since the first timestamp
         seconds_since_start = time_since_start(ds.xtime.values)
         # Convert to days
-        t_arr = np.array(seconds_since_start, dtype=float) / 86400.0
+        days = np.array(seconds_since_start, dtype=float) / 86400.0
     elif 'Time' in ds.keys():
         # This option works if decode_times=True when loading xr.Dataset
         if 'Time' in ds['Time'].coords:
-            t_arr = cftime.date2num(
+            days = cftime.date2num(
                 ds['Time'].values,
                 units=_get_days_since_units(ds['Time']),
                 calendar=ds['Time'].dt.calendar,
@@ -31,11 +69,11 @@ def get_days_since_start(ds):
             )
         else:
             t_pd = pd.to_datetime(ds['Time'].values)
-            t_arr = 1.0e9 * (t_pd - t_pd[0]) / np.timedelta64(1, 's')
-            t_arr = t_arr.astype(float) / 86400.0
+            days = 1.0e9 * (t_pd - t_pd[0]) / np.timedelta64(1, 's')
+            days = days.astype(float) / 86400.0
     else:
         raise ValueError('Could not find a time variable in dataset')
-    return t_arr
+    return days * 86400.0 / _SECONDS_PER_UNIT[units]
 
 
 # the number of days in a year of each calendar cftime supports; the mixed

--- a/polaris/ocean/rpe.py
+++ b/polaris/ocean/rpe.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 
 from polaris.constants import get_constant
-from polaris.ocean.model import get_days_since_start
+from polaris.ocean.model import get_time_since_start
 
 
 def compute_rpe(ds_mesh, ds_init, ds_outputs, config=None, ds_vert_coord=None):
@@ -77,7 +77,7 @@ def compute_rpe(ds_mesh, ds_init, ds_outputs, config=None, ds_vert_coord=None):
 
     for file_index, ds in enumerate(ds_outputs):
         if ds.sizes['Time'] == nt:
-            days = get_days_since_start(ds)
+            days = get_time_since_start(ds, units='days')
         hFull = ds.layerThickness.values
         if 'density' in ds:
             densityFull = ds.density.values

--- a/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
+++ b/polaris/tasks/ocean/baroclinic_channel/rpe/analysis.py
@@ -2,7 +2,7 @@ import cmocean  # noqa: F401
 import matplotlib.pyplot as plt
 import numpy as np
 
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 from polaris.ocean.rpe import compute_rpe
 from polaris.viz import mplstyle_context, plot_horiz_field
 
@@ -89,7 +89,7 @@ class Analysis(OceanIOStep):
         ds = self.open_model_dataset(
             f'output_nu_{nus[0]:g}.nc', self.config, decode_times=True
         )
-        times = get_days_since_start(ds)
+        times = get_time_since_start(ds, units='days')
 
         with mplstyle_context():
             fig = plt.figure()
@@ -115,7 +115,7 @@ class Analysis(OceanIOStep):
                     f'output_nu_{nu:g}.nc', self.config, decode_times=True
                 )
                 ds = ds.isel(nVertLevels=0)
-                times = get_days_since_start(ds)
+                times = get_time_since_start(ds, units='days')
                 time_index = np.argmin(np.abs(times - time))
 
                 cell_mask = ds_vert_coord.maxLevelCell >= 1

--- a/polaris/tasks/ocean/internal_wave/rpe/analysis.py
+++ b/polaris/tasks/ocean/internal_wave/rpe/analysis.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 from polaris.ocean.rpe import compute_rpe
 from polaris.viz import mplstyle_context
 
@@ -86,7 +86,7 @@ class Analysis(OceanIOStep):
         ds = self.open_model_dataset(
             f'output_nu_{nus[0]:g}.nc', self.config, decode_times=True
         )
-        times = get_days_since_start(ds)
+        times = get_time_since_start(ds, units='days')
 
         with mplstyle_context():
             fig = plt.figure()
@@ -117,7 +117,7 @@ class Analysis(OceanIOStep):
                 ds = self.open_model_dataset(
                     f'output_nu_{nu:g}.nc', self.config, decode_times=True
                 )
-                times = get_days_since_start(ds)
+                times = get_time_since_start(ds, units='days')
                 time_index = np.argmin(np.abs(times - time))
                 ds_transect = compute_transect(
                     x=x,

--- a/polaris/tasks/ocean/overflow/rpe/analysis.py
+++ b/polaris/tasks/ocean/overflow/rpe/analysis.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 from polaris.ocean.rpe import compute_rpe
 from polaris.viz import mplstyle_context
 
@@ -97,7 +97,7 @@ class Analysis(OceanIOStep):
         ds = self.open_model_dataset(
             f'output_nu_{nus[0]:g}.nc', config=self.config, decode_times=True
         )
-        times = get_days_since_start(ds)
+        times = get_time_since_start(ds, units='days')
 
         with mplstyle_context():
             fig = plt.figure()
@@ -134,7 +134,7 @@ class Analysis(OceanIOStep):
                     config=self.config,
                     decode_times=True,
                 )
-                times = get_days_since_start(ds)
+                times = get_time_since_start(ds, units='days')
                 time_index = np.argmin(np.abs(times - time))
                 time = times[time_index]
                 ds_transect = compute_transect(

--- a/polaris/tasks/ocean/realistic_global/analysis_members/stats_analysis.py
+++ b/polaris/tasks/ocean/realistic_global/analysis_members/stats_analysis.py
@@ -7,7 +7,7 @@ from polaris.ocean.global_stats_names import (
     select_global_stats,
 )
 from polaris.ocean.model import OceanIOStep
-from polaris.ocean.model.time import get_days_since_start
+from polaris.ocean.model.time import get_time_since_start
 
 
 class StatsAnalysis(OceanIOStep):
@@ -66,7 +66,7 @@ class StatsAnalysis(OceanIOStep):
         )
 
         ds_time = ds.rename({'time': 'Time'}) if 'time' in ds.dims else ds
-        time = get_days_since_start(ds_time)
+        time = get_time_since_start(ds_time, units='days')
         for field, field_stats in found.items():
             values = {
                 stat: ds[var_name].values.astype(float)

--- a/polaris/tasks/ocean/realistic_global/viz.py
+++ b/polaris/tasks/ocean/realistic_global/viz.py
@@ -1,7 +1,7 @@
 import cmocean  # noqa: F401
 
 from polaris.ocean.model import OceanIOStep
-from polaris.ocean.model.time import get_days_since_start
+from polaris.ocean.model.time import get_time_since_start
 from polaris.viz import plot_global_mpas_field
 
 
@@ -86,7 +86,7 @@ class Viz(OceanIOStep):
             mesh_filename='mesh.nc',
         )
 
-        time = get_days_since_start(ds_out)
+        time = get_time_since_start(ds_out, units='days')
         ds_final = ds_out.isel(Time=-1, nVertLevels=0)
         t_days = int(round(time[-1]))
 

--- a/polaris/tasks/ocean/seamount/viz.py
+++ b/polaris/tasks/ocean/seamount/viz.py
@@ -5,7 +5,7 @@ import xarray as xr
 from mpas_tools.ocean.viz.transect import compute_transect, plot_transect
 
 from polaris.mpas import cell_mask_to_edge_mask
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 from polaris.viz import plot_horiz_field
 
 
@@ -118,7 +118,7 @@ class Viz(OceanIOStep):
         # Plot the time series of max velocity
         plt.figure(figsize=[12, 6], dpi=100)
         umax = np.amax(ds.normalVelocity[:, :, 0].values, axis=1)
-        t_days = get_days_since_start(ds)
+        t_days = get_time_since_start(ds, units='days')
         plt.plot(t_days, umax, 'k-o', label='max(normalVelocity)')
         plt.xlabel('Time (days)')
         plt.ylabel('Maximum Velocity (m/s)')

--- a/polaris/tasks/ocean/single_column/ekman/analysis.py
+++ b/polaris/tasks/ocean/single_column/ekman/analysis.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from polaris.constants import get_constant
 from polaris.mpas import area_for_field
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 from polaris.viz import mplstyle_context
 
 
@@ -80,7 +80,7 @@ class Analysis(OceanIOStep):
 
             t_index = -1
             ds = ds.isel(Time=t_index)
-            t_days = get_days_since_start(ds)
+            t_days = get_time_since_start(ds, units='days')
             z_mid = ds.zMid.mean(dim='nCells').values
             if 'density' in ds.keys():
                 rho_0 = (

--- a/polaris/tasks/ocean/single_column/inertial/analysis.py
+++ b/polaris/tasks/ocean/single_column/inertial/analysis.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 from polaris.viz import mplstyle_context
 
 
@@ -65,7 +65,7 @@ class Analysis(OceanIOStep):
                 reconstruct_method='RBF',
                 coeffs_filename='../forward/coeffs.nc',
             )
-            t = get_days_since_start(ds)
+            t = get_time_since_start(ds, units='days')
             s_per_day = 24.0 * 3600.0
             dt = (t[1] - t[0]) * s_per_day
             u = ds['velocityZonal'].mean(dim='nCells')

--- a/polaris/tasks/ocean/single_column/thermo/analysis.py
+++ b/polaris/tasks/ocean/single_column/thermo/analysis.py
@@ -2,7 +2,7 @@ import numpy as np
 import xarray as xr
 
 from polaris.constants import get_constant
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 
 # Omega hard-codes the TEOS-10 reference specific heat of seawater in
 # GlobalConstants.h (Cp0Sw = 1 / HFluxFac / RhoSw).  This differs from the PCD
@@ -150,7 +150,7 @@ class Analysis(OceanIOStep):
         ds_out = xr.open_dataset(f'output_{name}.nc', decode_times=False)
 
         # elapsed time from the initial condition (t=0) to the final snapshot
-        dt = _elapsed_seconds(ds_out)
+        dt = get_time_since_start(ds_out, units='seconds')[-1]
 
         # column-integrated content per cell (mass, heat, salt) at t=0 and at
         # the final snapshot
@@ -312,21 +312,3 @@ def _surface_field(ds, name):
     elif 'time' in da.dims:
         da = da.isel(time=0)
     return da.values.astype(float)
-
-
-def _elapsed_seconds(ds):
-    """
-    Return the elapsed time in seconds from the start of the simulation (the
-    time of the initial condition) to the final snapshot of ``ds``.  Omega
-    writes a numeric ``time`` variable holding elapsed seconds since the start
-    of the simulation; MPAS-Ocean writes ``daysSinceStartOfSim``.
-    """
-    if 'daysSinceStartOfSim' in ds:
-        days = ds['daysSinceStartOfSim'].values.astype(float)
-        return float(days[-1]) * 86400.0
-    if 'time' in ds.variables:
-        t = np.asarray(ds['time'].values)
-        if np.issubdtype(t.dtype, np.number):
-            return float(t[-1])
-    t_days = get_days_since_start(ds)
-    return float(t_days[-1] * 86400.0)

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -3,7 +3,7 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 from polaris.viz import mplstyle_context
 
 # TODO import rho_0 from constants
@@ -123,7 +123,7 @@ class Viz(OceanIOStep):
                         decode_times=True,
                         config=self.config,
                     )
-                t_arr = get_days_since_start(ds_comp)
+                t_arr = get_time_since_start(ds_comp, units='days')
                 t_index = np.argmin(np.abs(t_arr - t_target))
                 time_ds.append(float(t_arr[t_index]))
                 ds_list.append(ds_comp.isel(Time=t_index))

--- a/polaris/tasks/ocean/single_column/vmix/analysis.py
+++ b/polaris/tasks/ocean/single_column/vmix/analysis.py
@@ -3,7 +3,7 @@ import numpy as np
 from polaris.constants import get_constant
 from polaris.ocean.model import (
     OceanIOStep,
-    get_days_since_start,
+    get_time_since_start,
 )
 from polaris.ocean.vertical import (
     compute_zint_zmid_from_layer_thickness,
@@ -54,7 +54,7 @@ class Analysis(OceanIOStep):
                 )
                 continue
             t_target = 1.0  # empirical relationship hold for up to 30h
-            t_arr = get_days_since_start(ds_diags)
+            t_arr = get_time_since_start(ds_diags, units='days')
             t_index = np.argmin(np.abs(t_arr - t_target))
             t_days = float(t_arr[t_index])
             if abs(t_days - t_target) > (1 / 24):

--- a/polaris/tasks/ocean/sphere_transport/filament_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/filament_analysis.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 
 from polaris.ocean.convergence import get_resolution_for_task
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 from polaris.resolution import resolution_to_string
 from polaris.viz import mplstyle_context
 
@@ -113,7 +113,7 @@ class FilamentAnalysis(OceanIOStep):
                 ds = self.open_model_dataset(
                     f'output_r{refinement_factor:02g}.nc', self.config
                 )
-                t_days = get_days_since_start(ds)
+                t_days = get_time_since_start(ds, units='days')
                 time_index = np.argmin(
                     np.abs(np.subtract(t_days, eval_time * s_per_day))
                 )

--- a/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
@@ -10,7 +10,7 @@ from polaris.ocean.convergence import (
 from polaris.ocean.convergence import (
     get_timestep_for_task as get_timestep_for_task,
 )
-from polaris.ocean.model import OceanIOStep, get_days_since_start
+from polaris.ocean.model import OceanIOStep, get_time_since_start
 from polaris.resolution import resolution_to_string
 from polaris.viz import mplstyle_context
 
@@ -129,7 +129,7 @@ class MixingAnalysis(OceanIOStep):
                     ax.set_ylabel('tracer3')
                 if int(i / 2) == nrows - 1:
                     ax.set_xlabel('tracer2')
-                t_days = get_days_since_start(ds)
+                t_days = get_time_since_start(ds, units='days')
                 time_index = np.argmin(
                     np.abs(np.subtract(t_days, eval_time * s_per_day))
                 )

--- a/tests/ocean/test_time.py
+++ b/tests/ocean/test_time.py
@@ -4,7 +4,7 @@ import pytest
 import xarray as xr
 from numpy.testing import assert_allclose
 
-from polaris.ocean.model.time import get_days_since_start
+from polaris.ocean.model.time import get_time_since_start
 
 # days since the reference date below that the test datasets sample
 DAYS = np.array([0.0, 1.5, 10.25])
@@ -54,7 +54,7 @@ def test_xarray_round_trip(tmp_path):
     assert 'Units' not in ds['Time'].attrs
     assert 'units' not in ds['Time'].attrs
     assert ds['Time'].encoding['units'].startswith('seconds since')
-    assert_allclose(get_days_since_start(ds), DAYS)
+    assert_allclose(get_time_since_start(ds, units='days'), DAYS)
 
 
 @pytest.mark.parametrize('units', ['seconds', 'hours', 'days'])
@@ -64,7 +64,7 @@ def test_omega_style_file(units, tmp_path):
     that Omega writes, and is now right for other reference units too."""
     ds = _round_trip(_make_dataset(units=units, omega_attrs=True), tmp_path)
     assert ds['Time'].attrs['Units'] == f'{units} since {REFERENCE}'
-    assert_allclose(get_days_since_start(ds), DAYS)
+    assert_allclose(get_time_since_start(ds, units='days'), DAYS)
 
 
 def test_undecoded_units_in_attrs():
@@ -73,21 +73,21 @@ def test_undecoded_units_in_attrs():
     ds = _make_dataset()
     units = ds['Time'].encoding.pop('units')
     ds['Time'].attrs['units'] = units
-    assert_allclose(get_days_since_start(ds), DAYS)
+    assert_allclose(get_time_since_start(ds, units='days'), DAYS)
 
 
 @pytest.mark.parametrize('units', ['seconds', 'hours', 'days'])
 def test_reference_units(units, tmp_path):
     """The reference units are not assumed to be seconds."""
     ds = _round_trip(_make_dataset(units=units), tmp_path)
-    assert_allclose(get_days_since_start(ds), DAYS)
+    assert_allclose(get_time_since_start(ds, units='days'), DAYS)
 
 
 def test_missing_units_raises():
     """A time variable with no CF units at all is named in the error."""
     ds = _make_dataset(with_units=False)
     with pytest.raises(ValueError, match="'units' for time variable 'Time'"):
-        get_days_since_start(ds)
+        get_time_since_start(ds, units='days')
 
 
 def test_malformed_units_raises():
@@ -95,11 +95,35 @@ def test_malformed_units_raises():
     ds = _make_dataset()
     ds['Time'].encoding['units'] = 'seconds'
     with pytest.raises(ValueError, match="time variable 'Time'"):
-        get_days_since_start(ds)
+        get_time_since_start(ds, units='days')
 
 
 def test_no_time_variable():
     """The existing error for a dataset with no time variable is kept."""
     ds = xr.Dataset({'SomeField': xr.DataArray(np.zeros(3), dims=('x',))})
     with pytest.raises(ValueError, match='Could not find a time variable'):
-        get_days_since_start(ds)
+        get_time_since_start(ds, units='days')
+
+
+@pytest.mark.parametrize(
+    ('units', 'factor'),
+    [('seconds', 86400.0), ('minutes', 1440.0), ('hours', 24.0)],
+)
+def test_units_conversion(units, factor):
+    """Seconds, minutes and hours are the days converted by the expected
+    factor."""
+    ds = xr.Dataset({'daysSinceStartOfSim': ('Time', DAYS)})
+    assert_allclose(get_time_since_start(ds, units=units), DAYS * factor)
+
+
+def test_unknown_units_raises():
+    """An unsupported units string is named in the error."""
+    ds = xr.Dataset({'daysSinceStartOfSim': ('Time', DAYS)})
+    with pytest.raises(ValueError, match="Unknown time units 'years'"):
+        get_time_since_start(ds, units='years')
+
+
+def test_omega_numeric_time_variable():
+    """Omega's raw numeric 'time' coordinate is already elapsed seconds."""
+    ds = xr.Dataset({'time': ('Time', DAYS * 86400.0)})
+    assert_allclose(get_time_since_start(ds, units='days'), DAYS)


### PR DESCRIPTION
Consolidate `polaris.ocean.conservation.get_elapsed_seconds` and `polaris.ocean.model.time.get_days_since_start` into a single `get_time_since_start(ds, units)` in `polaris.ocean.model.time`, where units is a required argument ('seconds', 'minutes', 'hours', or 'days'). Update all call sites accordingly.

Also extend get_time_since_start to recognize Omega's raw numeric 'time' coordinate, and remove the now-redundant local `_elapsed_seconds` duplicate in `single_column/thermo/analysis.py` in favor of calling `get_time_since_start` directly.

Checklist
* [X] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [X] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [X] `Testing` comment in the PR documents testing used to verify the changes