### PR TITLE
Declare two step dependencies that were only implied by setup order

### DIFF
--- a/polaris/tasks/ocean/cosine_bell/restart/__init__.py
+++ b/polaris/tasks/ocean/cosine_bell/restart/__init__.py
@@ -77,6 +77,7 @@ class Restart(Task):
         self.add_step(init_step, symlink=f'init/{mesh_name}')
 
         step_names = ['full_run', 'restart_run']
+        steps = {}
         for name in step_names:
             subdir = f'{task_subdir}/{name}'
             do_restart = name == 'restart_run'
@@ -91,7 +92,17 @@ class Restart(Task):
                 do_restart=do_restart,
             )
             step.set_shared_config(config, link=config_filename)
-            self.add_step(step)
+            steps[name] = step
+
+        # The restart run reads the restart file that the full run writes to
+        # the shared ``restarts`` directory.  The name of that file comes from
+        # a time stamp that is not known at setup, so the ordering has to be
+        # declared as a dependency rather than as an input file.
+        full_run = steps['full_run']
+        steps['restart_run'].add_dependency(full_run, full_run.name)
+
+        for name in step_names:
+            self.add_step(steps[name])
 
         self.add_step(
             Validate(

--- a/polaris/tasks/ocean/single_column/forward.py
+++ b/polaris/tasks/ocean/single_column/forward.py
@@ -99,6 +99,7 @@ class Forward(OceanModelStep):
             ntasks=ntasks,
             min_tasks=min_tasks,
             openmp_threads=openmp_threads,
+            graph_target=f'{init.path}/culled_graph.info',
         )
 
         self.add_horiz_mesh_input_file(
@@ -110,10 +111,6 @@ class Forward(OceanModelStep):
         self.add_init_input_file(work_dir_target=f'{init.path}/init.nc')
         self.add_input_file(
             filename='forcing.nc', work_dir_target=f'{init.path}/forcing.nc'
-        )
-        self.add_input_file(
-            filename='graph.info',
-            work_dir_target=f'{init.path}/culled_graph.info',
         )
 
         self.add_yaml_file('polaris.ocean.config', 'output.yaml')


### PR DESCRIPTION
Two steps in Polaris are ordered only by the order setup happens to list them, not by anything either step declares. This fixes both so that the ordering follows from the declarations, which is what the serial runner has always claimed to honor and what any concurrent runner would have to rely on.

Nothing here changes what a task-serial run does. In both cases the serial runner already produced the fixed order; it just produced it by accident.

## The cosine bell restart run does not say it follows the full run

`full_run` and `restart_run` share a `restarts` directory one level above each of them. `full_run` writes a restart file there and `restart_run` reads it back, but the path appears only in `forward.yaml`, as a template the model expands at run time. No `add_input_file`, no `add_output_file`, no `add_dependency` — nothing in the step declarations connects the two steps at all.

The restart file is named for a time stamp that setup does not know, so this is the case `add_dependency` exists for. It is also what the three sibling restart tasks already do: `baroclinic_channel/restart`, `ice_shelf_2d/default` and the sea ice `exact_restart` all declare the same edge. Only the cosine bell task was missing it.

## The single-column forward step declares an input nothing produces

`OceanModelStep` adds `graph.info` as an input only for MPAS-Ocean, and `add_output_files_for_ocean_model_input` declares it as an output only for MPAS-Ocean. The two agree: Omega does not partition a graph, so under Omega neither end of the file is declared.

The single-column forward step went around that and added the input itself, unconditionally. Under Omega it therefore declared an input that no step declares as an output — a file appearing from nowhere, as far as anything reading the declarations can tell. Passing `graph_target` up to the base class gives MPAS-Ocean exactly the input it had before, from the same target, and leaves Omega declaring neither end.

## Why this is worth fixing now

Both were found while running suites with their steps at the same time, on the `add-task-parallelism-phase-b` branch. That work builds a run order from what steps declare, so the second defect is a graph with an unproducible input and is reported before anything starts, and the first is a live race: `restart_run` starts while `full_run` is still writing and the model segfaults reading a restart file that is absent or half written. It failed at 3, 8 and 13 nodes, passed at 5, and always passed in serial.

Neither fix depends on that branch, and neither is framework work, so they are better reviewed and merged on their own.

## What this does not do

There is no regression test. The two classes of defect differ in how findable they are: an input with no producer is caught by construction as soon as a run order is built from declarations, so Phase B reports it at startup. An undeclared file exchange between two steps is invisible to any such check, because neither step mentions the file — the only thing that would catch it is a test asserting the edge exists. Importing `polaris.tasks.ocean` costs about 30 seconds and building all four components about 40, against a test suite that currently runs in well under two minutes, so a test covering these tasks is not cheap enough to add without a decision about that import cost. Worth raising separately.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes
