### PR TITLE
Fix MPAS-Ocean elapsed time in analysis and viz steps

### DIFF
--- a/polaris/mpas/time.py
+++ b/polaris/mpas/time.py
@@ -28,7 +28,7 @@ def time_index_from_xtime(xtime, dt_target, start_xtime=None):
     return time_index
 
 
-def time_since_start(xtime, start_xtime='0001-01-01_01:00:00'):
+def time_since_start(xtime, start_xtime=None):
     """
     Determine the time elapsed since the start of the simulation
 

--- a/polaris/ocean/convergence/analysis.py
+++ b/polaris/ocean/convergence/analysis.py
@@ -480,7 +480,7 @@ class ConvergenceAnalysis(OceanIOStep):
         )
 
         model = config.get('ocean', 'model')
-        if model == 'mpas-o':
+        if model == 'mpas-ocean':
             dt = time_since_start(ds_out.xtime.values)
         else:
             # time is seconds since the start of the simulation in Omega

--- a/polaris/tasks/ocean/inertial_gravity_wave/viz.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/viz.py
@@ -165,7 +165,7 @@ class Viz(OceanIOStep):
                 )
                 exact = ExactSolution(ds_mesh, config)
 
-                if model == 'mpas-o':
+                if model == 'mpas-ocean':
                     dt = time_since_start(ds.xtime.values)
                     t = float(dt[-1])
                 else:

--- a/polaris/tasks/ocean/manufactured_solution/viz.py
+++ b/polaris/tasks/ocean/manufactured_solution/viz.py
@@ -171,7 +171,7 @@ class Viz(OceanIOStep):
 
                 exact = ExactSolution(config, ds_mesh)
 
-                if model == 'mpas-o':
+                if model == 'mpas-ocean':
                     dt = time_since_start(ds.xtime.values)
                 else:
                     # time is seconds since the start of the

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -124,7 +124,7 @@ class Viz(OceanIOStep):
             )
             y = y_mid * xr.ones_like(x)
 
-            if model == 'mpas-o':
+            if model == 'mpas-ocean':
                 dt = time_since_start(ds.xtime.values)
             else:
                 # time is seconds since the start of the simulation in Omega

--- a/polaris/tasks/ocean/merry_go_round/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/viz.py
@@ -190,7 +190,7 @@ class Viz(OceanIOStep):
                 )
                 y = y_mid * xr.ones_like(x)
 
-                if model == 'mpas-o':
+                if model == 'mpas-ocean':
                     dt = time_since_start(ds.xtime.values)
                 else:
                     # time is seconds since the start of the

--- a/polaris/tasks/ocean/sphere_transport/viz.py
+++ b/polaris/tasks/ocean/sphere_transport/viz.py
@@ -110,7 +110,7 @@ class Viz(OceanIOStep):
         # Visualization at halfway around the globe (provided run duration is
         # set to the time needed to circumnavigate the globe)
         time = run_duration * s_per_hour
-        if model == 'mpas-o':
+        if model == 'mpas-ocean':
             dt = time_since_start(ds_out.xtime.values)
         else:
             # time is seconds since the start of the simulation in Omega

--- a/tests/mpas/test_mpas_time.py
+++ b/tests/mpas/test_mpas_time.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from polaris.mpas.time import time_index_from_xtime, time_since_start
+
+# the times the test datasets sample, and the seconds since the first of
+# them
+XTIME = np.array(
+    [
+        b'0001-01-01_00:00:00',
+        b'0001-01-02_12:00:00',
+        b'0001-01-11_06:00:00',
+    ]
+)
+
+SECONDS = np.array([0.0, 129600.0, 885600.0])
+
+
+def test_default_start_is_first_entry():
+    """The default start time is the first entry in ``xtime``, so the
+    first time is zero rather than an offset from a fixed date."""
+    assert_allclose(time_since_start(XTIME), SECONDS)
+
+
+def test_explicit_start_is_honored():
+    """An explicit start time shifts the whole series."""
+    dt = time_since_start(XTIME, start_xtime='0001-01-01_01:00:00')
+    assert_allclose(dt, SECONDS - 3600.0)
+
+
+def test_decimal_seconds_format():
+    """Times written with decimal seconds still parse."""
+    xtime = np.array([b'0001-01-01_00:00:00.00', b'0001-01-01_00:00:01.50'])
+    assert_allclose(time_since_start(xtime), [0.0, 1.5])
+
+
+@pytest.mark.parametrize(
+    ('dt_target', 'expected'), [(0.0, 0), (129600.0, 1), (1.0e6, 2)]
+)
+def test_time_index_from_xtime(dt_target, expected):
+    """The index closest to the target is measured from the first time."""
+    assert time_index_from_xtime(XTIME, dt_target) == expected

--- a/tests/ocean/test_time.py
+++ b/tests/ocean/test_time.py
@@ -127,3 +127,17 @@ def test_omega_numeric_time_variable():
     """Omega's raw numeric 'time' coordinate is already elapsed seconds."""
     ds = xr.Dataset({'time': ('Time', DAYS * 86400.0)})
     assert_allclose(get_time_since_start(ds, units='days'), DAYS)
+
+
+def test_xtime_variable():
+    """MPAS-Ocean's xtime is measured from the first time in the file, so
+    the initial condition is at zero."""
+    xtime = np.array(
+        [
+            b'0001-01-01_00:00:00',
+            b'0001-01-02_12:00:00',
+            b'0001-01-11_06:00:00',
+        ]
+    )
+    ds = xr.Dataset({'xtime': ('Time', xtime)})
+    assert_allclose(get_time_since_start(ds, units='days'), DAYS)


### PR DESCRIPTION
MPAS-Ocean elapsed time was measured from a fixed date an hour past midnight rather than from the first time in the file, so output from a run starting at midnight read -3600 s at its initial condition. Separately, the ocean model was compared against `'mpas-o'`, which `Ocean._detect_model()` never returns, so MPAS-Ocean fell through to the branch meant for Omega in the convergence analysis and five viz steps.

Plotted MPAS-Ocean time axes shift by an hour as a result. No model output changes.

Fixes #765.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite

---

*Posted by Claude Code on @xylar's behalf. The testing, analysis and wording above are AI-authored; please check them accordingly.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
