### PR TITLE
Make ocean viz and analysis steps work for both models

### DIFF
--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -636,12 +636,16 @@ class Ocean(Component):
             where the locations needed for a tracer conversion come from.
 
         reconstruct_variables : list of str, optional
-            List of variable names to reconstruct in the dataset.
+            List of variable names to reconstruct in the dataset.  A variable
+            whose zonal and meridional components are already in the dataset
+            (as they are in MPAS-Ocean output, which the model reconstructs
+            itself) is skipped, and nothing is reconstructed if that is true
+            of all of them.
 
         coeffs_filename : str, optional
             Path to the coefficients NetCDF file.
 
-        reonstruct_method : {'RBF', 'LSTSQ'}, optional
+        reconstruct_method : {'RBF', 'LSTSQ'}, optional
             Method to use for reconstructing vector variables.
             RBF: Radial Basis Function; approach used in MPAS-Ocean.
             LSTSQ: Least-squares reconstruction; new approach in Omega
@@ -764,34 +768,43 @@ class Ocean(Component):
             lat=lat,
             logger=logger,
         )
-        if reconstruct_variables is not None:
-            if mesh_filename is None:
-                raise ValueError(
-                    'mesh_filename must be provided to open_model_dataset '
-                    'for variable reconstruction'
-                )
-            if reconstruct_method == 'RBF' and coeffs_filename is None:
-                raise ValueError(
-                    'coeffs_filename must be provided to open_model_dataset '
-                    'for variable reconstruction'
-                )
-            ds_mesh = self.open_model_dataset(mesh_filename, config)
-            if (
-                reconstruct_method == 'LSTSQ'
-                and not _reconstruction_weights_in_dataset(ds_mesh)
-            ):
-                raise ValueError(
-                    'Reconstruction weights are not present in the mesh '
-                    'dataset; cannot reconstruct variables using LSTSQ method'
-                )
+        if reconstruct_variables is None:
+            return ds
 
-            ds = _add_reconstructed_variables_to_dataset(
-                ds,
-                reconstruct_variables,
-                ds_mesh,
-                coeffs_filename,
-                reconstruct_method,
+        out_var_names = _vars_to_reconstruct(ds, reconstruct_variables)
+        if len(out_var_names) == 0:
+            # the model already wrote the zonal and meridional components, as
+            # MPAS-Ocean does with its own RBF reconstruction, so no mesh,
+            # weights or coefficients are needed
+            return ds
+
+        if mesh_filename is None:
+            raise ValueError(
+                'mesh_filename must be provided to open_model_dataset '
+                'for variable reconstruction'
             )
+        if reconstruct_method == 'RBF' and coeffs_filename is None:
+            raise ValueError(
+                'coeffs_filename must be provided to open_model_dataset '
+                'for variable reconstruction'
+            )
+        ds_mesh = self.open_model_dataset(mesh_filename, config)
+        if (
+            reconstruct_method == 'LSTSQ'
+            and not _reconstruction_weights_in_dataset(ds_mesh)
+        ):
+            raise ValueError(
+                'Reconstruction weights are not present in the mesh '
+                'dataset; cannot reconstruct variables using LSTSQ method'
+            )
+
+        ds = _add_reconstructed_variables_to_dataset(
+            ds,
+            out_var_names,
+            ds_mesh,
+            coeffs_filename,
+            reconstruct_method,
+        )
         return ds
 
     def _convert_tracers_for_model(
@@ -1118,22 +1131,64 @@ def _lon_lat_for_tracer_conversion(
     return section.getfloat('nominal_lon'), section.getfloat('nominal_lat')
 
 
+def _vars_to_reconstruct(ds, reconstruct_variables):
+    """
+    Find the variables that still need to be reconstructed and the base name
+    of the zonal and meridional components each one produces.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset the variables will be reconstructed in.
+
+    reconstruct_variables : list of str
+        List of variable names to reconstruct.
+
+    Returns
+    -------
+    out_var_names : dict
+        A map from each variable that still needs to be reconstructed to the
+        base name of its reconstructed components.  Variables whose components
+        are already in ``ds`` are left out.
+    """
+    out_var_names = {}
+    for variable in reconstruct_variables:
+        out_var_name = (
+            variable.replace('normal', '').lower()
+            if 'normal' in variable
+            else variable
+        )
+        if f'{out_var_name}Zonal' in ds and f'{out_var_name}Meridional' in ds:
+            # already reconstructed, e.g. by MPAS-Ocean itself
+            continue
+        if variable not in ds:
+            raise ValueError(
+                f"User requested vector reconstruction for '{variable}' "
+                "but it isn't present in the dataset."
+            )
+        out_var_names[variable] = out_var_name
+
+    return out_var_names
+
+
 def _add_reconstructed_variables_to_dataset(
     ds,
-    reconstruct_variables,
+    out_var_names,
     ds_mesh,
     coeffs_filename,
     reconstruct_method: Literal['RBF', 'LSTSQ'],
 ):
     """
-    Add reconstructed vector variables to the dataset if requested.
+    Add reconstructed vector variables to the dataset.
+
     Parameters
     ----------
     ds : xarray.Dataset
         The dataset to add reconstructed variables to.
 
-    reconstruct_variables : list of str or None
-        List of variable names to reconstruct.
+    out_var_names : dict
+        A map from each variable to reconstruct to the base name of its
+        reconstructed components, as returned by ``_vars_to_reconstruct()``.
 
     ds_mesh : xarray.Dataset
         Mesh dataset on which to perform the reconstruction.
@@ -1149,31 +1204,6 @@ def _add_reconstructed_variables_to_dataset(
     ds : xarray.Dataset
         The dataset with reconstructed variables added.
     """
-    if reconstruct_variables is None:
-        return ds
-
-    out_var_names = {}
-    for variable in reconstruct_variables:
-        out_var_name = (
-            variable.replace('normal', '').lower()
-            if 'normal' in variable
-            else variable
-        )
-        if f'{out_var_name}Zonal' in ds and f'{out_var_name}Meridional' in ds:
-            # already reconstructed, e.g. by MPAS-Ocean itself
-            continue
-        out_var_names[variable] = out_var_name
-
-    if len(out_var_names) == 0:
-        return ds
-
-    for variable in out_var_names:
-        if variable not in ds:
-            raise ValueError(
-                f"User requested vector reconstruction for '{variable}' "
-                "but it isn't present in the dataset."
-            )
-
     if reconstruct_method == 'RBF':
         ds_coeff = open_dataset(coeffs_filename)
         coeffs_reconstruct = ds_coeff.coeffs_reconstruct
@@ -1181,7 +1211,7 @@ def _add_reconstructed_variables_to_dataset(
         if ds_coeff.sizes['nCells'] != ds_mesh.sizes['nCells']:
             print(
                 f'The sizes of coefficient dataset do not match mesh dataset;'
-                f' exiting without reconstructing {reconstruct_variables}'
+                f' exiting without reconstructing {list(out_var_names)}'
             )
             return ds
 

--- a/polaris/tasks/ocean/geostrophic/viz.py
+++ b/polaris/tasks/ocean/geostrophic/viz.py
@@ -76,11 +76,11 @@ class Viz(OceanIOStep):
             v='geostrophic_viz_vel',
         )
 
+        # the init step writes velocityZonal and velocityMeridional
+        # analytically for both models, so there is nothing to reconstruct
         ds_init = self.open_model_dataset(
             'initial_state.nc',
             config,
-            mesh_filename='mesh.nc',
-            reconstruct_variables=['normalVelocity'],
         )
         ds_vert_coord = self.open_vert_coord_dataset(ds_init)
         bottom_depth = ds_vert_coord.bottomDepth

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -151,18 +151,17 @@ class Viz(OceanIOStep):
             data_max = np.max(np.abs(tracer_exact.values))
             error_range = np.max(np.abs(tracer_error.values))
 
-            if 'velocityX' in ds.keys():
-                horz_velocity = ds.velocityX.isel(Time=tidx)
-                plot_transect(
-                    ds_transect=ds_transect,
-                    mpas_field=horz_velocity,
-                    ax=axes[0, 0],
-                    vmin=-0.008,
-                    vmax=0.008,
-                    cmap='cmo.balance',
-                    colorbar_label='horizontal velocity',
-                    color_start_and_end=False,
-                )
+            horz_velocity = ds.velocityZonal.isel(Time=tidx)
+            plot_transect(
+                ds_transect=ds_transect,
+                mpas_field=horz_velocity,
+                ax=axes[0, 0],
+                vmin=-0.008,
+                vmax=0.008,
+                cmap='cmo.balance',
+                colorbar_label='horizontal velocity',
+                color_start_and_end=False,
+            )
 
             plot_transect(
                 ds_transect=ds_transect,

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -72,7 +72,8 @@ mpas-ocean:
       - refLayerThickness
       - kineticEnergyCell
       - relativeVorticityCell
-      - velocityX
+      - velocityZonal
+      - velocityMeridional
       - vertVelocityTop
 
 Omega:

--- a/polaris/tasks/ocean/sphere_transport/filament_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/filament_analysis.py
@@ -97,7 +97,6 @@ class FilamentAnalysis(OceanIOStep):
         config = self.config
         section = config[self.case_name]
         eval_time = section.getfloat('filament_evaluation_time')
-        s_per_day = 86400.0
         zidx = 0
         variable_name = 'tracer2'
         num_tau = 21
@@ -114,9 +113,7 @@ class FilamentAnalysis(OceanIOStep):
                     f'output_r{refinement_factor:02g}.nc', self.config
                 )
                 t_days = get_time_since_start(ds, units='days')
-                time_index = np.argmin(
-                    np.abs(np.subtract(t_days, eval_time * s_per_day))
-                )
+                time_index = np.argmin(np.abs(np.subtract(t_days, eval_time)))
                 tracer = ds[variable_name]
                 area_cell = ds_mesh['areaCell']
                 for j, tau in enumerate(filament_tau):

--- a/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
+++ b/polaris/tasks/ocean/sphere_transport/mixing_analysis.py
@@ -106,7 +106,6 @@ class MixingAnalysis(OceanIOStep):
         config = self.config
         section = config[self.case_name]
         eval_time = section.getfloat('mixing_evaluation_time')
-        s_per_day = 86400.0
         zidx = 0
         nrows = int(ceil(len(resolutions) / 2))
         with mplstyle_context():
@@ -130,9 +129,7 @@ class MixingAnalysis(OceanIOStep):
                 if int(i / 2) == nrows - 1:
                     ax.set_xlabel('tracer2')
                 t_days = get_time_since_start(ds, units='days')
-                time_index = np.argmin(
-                    np.abs(np.subtract(t_days, eval_time * s_per_day))
-                )
+                time_index = np.argmin(np.abs(np.subtract(t_days, eval_time)))
                 ds = ds.isel(Time=time_index)
                 ds = ds.isel(nVertLevels=zidx)
                 tracer2 = ds['tracer2'].values

--- a/polaris/tasks/ocean/sphere_transport/viz.py
+++ b/polaris/tasks/ocean/sphere_transport/viz.py
@@ -86,12 +86,12 @@ class Viz(OceanIOStep):
 
         variables_to_plot = self.variables_to_plot
 
+        # the init step writes velocityZonal and velocityMeridional
+        # analytically for both models, so there is nothing to reconstruct
         ds_init = self.open_model_dataset(
             'initial_state.nc',
             config,
             decode_times=False,
-            mesh_filename='mesh.nc',
-            reconstruct_variables=['normalVelocity'],
         )
         variables_in_init = [
             var for var in variables_to_plot.keys() if var in ds_init.variables

--- a/polaris/tasks/ocean/sphere_transport/viz.py
+++ b/polaris/tasks/ocean/sphere_transport/viz.py
@@ -48,7 +48,7 @@ class Viz(OceanIOStep):
         super().__init__(component=component, name=name, subdir=subdir)
         self.add_input_file(
             filename='mesh.nc',
-            work_dir_target=f'{init.path}/base_mesh_with_weights.nc',
+            work_dir_target=f'{init.path}/culled_mesh.nc',
         )
         self.add_input_file(
             filename='initial_state.nc',

--- a/tests/ocean/test_open_model_dataset.py
+++ b/tests/ocean/test_open_model_dataset.py
@@ -383,3 +383,73 @@ def test_open_model_dataset_raises_without_a_pressure(tmp_path):
             lon=0.0,
             lat=0.0,
         )
+
+
+def _write_velocity_file(path, zonal_and_meridional, normal_velocity=True):
+    """Write a file with ``normalVelocity`` and, if requested, the zonal and
+    meridional components MPAS-Ocean reconstructs for itself."""
+    data_vars = {}
+    if normal_velocity:
+        data_vars['normalVelocity'] = (('nEdges',), np.array([1.0, 2.0]))
+    if zonal_and_meridional:
+        data_vars['velocityZonal'] = (('nCells',), np.array([1.0, 2.0]))
+        data_vars['velocityMeridional'] = (('nCells',), np.array([3.0, 4.0]))
+    xr.Dataset(data_vars=data_vars).to_netcdf(path)
+    return str(path)
+
+
+def test_open_model_dataset_skips_present_reconstruction(tmp_path):
+    """MPAS-Ocean reconstructs the zonal and meridional velocity itself, so a
+    step asking for the reconstruction needs neither a mesh nor least-squares
+    weights to read that output."""
+    component = _make_component('mpas-ocean')
+    filename = _write_velocity_file(
+        tmp_path / 'output.nc', zonal_and_meridional=True
+    )
+
+    ds = component.open_model_dataset(
+        filename,
+        _make_config('mpas-ocean', eos_type='linear'),
+        reconstruct_variables=['normalVelocity'],
+    )
+
+    assert_allclose(ds.velocityZonal.values, [1.0, 2.0])
+    assert_allclose(ds.velocityMeridional.values, [3.0, 4.0])
+
+
+def test_open_model_dataset_raises_without_lstsq_weights(tmp_path):
+    """A reconstruction that has to be done needs the weights, so a mesh
+    without them is still an error."""
+    component = _make_component('mpas-ocean')
+    filename = _write_velocity_file(
+        tmp_path / 'output.nc', zonal_and_meridional=False
+    )
+    mesh_filename = _write_mesh_file(tmp_path / 'mesh.nc', on_a_sphere='NO')
+
+    with pytest.raises(ValueError, match='Reconstruction weights'):
+        component.open_model_dataset(
+            filename,
+            _make_config('mpas-ocean', eos_type='linear'),
+            mesh_filename=mesh_filename,
+            reconstruct_variables=['normalVelocity'],
+        )
+
+
+def test_open_model_dataset_raises_on_missing_reconstruct_variable(tmp_path):
+    """Asking to reconstruct a variable that is in neither the file nor its
+    reconstructed form is a mistake rather than something to skip silently."""
+    component = _make_component('mpas-ocean')
+    filename = _write_velocity_file(
+        tmp_path / 'output.nc',
+        zonal_and_meridional=False,
+        normal_velocity=False,
+    )
+    mesh_filename = _write_mesh_file(tmp_path / 'mesh.nc', on_a_sphere='NO')
+
+    with pytest.raises(ValueError, match='normalVelocity'):
+        component.open_model_dataset(
+            filename,
+            _make_config('mpas-ocean', eos_type='linear'),
+            mesh_filename=mesh_filename,
+            reconstruct_variables=['normalVelocity'],
+        )


### PR DESCRIPTION
Makes the `sphere_transport` and `geostrophic` viz steps run for MPAS-Ocean, which they never had, and gives the merry-go-round its horizontal velocity panel under Omega. This replaces #757: @mwarusz's fix was necessary but not sufficient, and his commit is included here with him as the author.

One thing needs a reviewer's eye: the filament and mixing diagnostics were evaluated at the last output rather than the configured time, so **this changes answers** — `nondivergent_2d`'s filament diagnostic moves from day 12 to day 6, which is what `filament_evaluation_time` asks for.

The rest changes no answer:

* `open_model_dataset()` asked for least-squares reconstruction weights before working out whether anything needed reconstructing. Only Omega's `culled_mesh.nc` carries them, so reading MPAS-Ocean output raised an error even though MPAS-Ocean writes `velocityZonal` and `velocityMeridional` itself.
* The merry-go-round viz asked for a reconstruction nothing read, and would have failed on a missing coefficients file for MPAS-Ocean. Its `mpas-ocean` stream now lists the components the plot reads, which on a planar mesh are the `velocityX` and `velocityY` it plotted before.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

Fixes #762
Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
