### PR TITLE
Reconstruct Omega's velocity with least squares everywhere

### DIFF
--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -757,6 +757,7 @@
    OceanIOStep.open_vert_coord_dataset
    OceanIOStep.map_to_native_model_vars
    OceanIOStep.write_model_dataset
+   OceanIOStep.write_horiz_mesh_dataset
    OceanIOStep.map_from_native_model_vars
    OceanIOStep.open_model_dataset
 

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -27,13 +27,17 @@ and writing easier, we also provide
 care of of the mapping in addition to writing and opening a dataset,
 respectively. The `open_model_dataset()` method also supports reconstructing
 normal vector components to their zonal and meridional equivalents by passing
-a list of variable names to
-{py:func}`mpas_tools.vector.reconstruct.reconstruct_variable()`, along with
-the mesh and reconstruction coefficient files. On planar meshes, the "zonal"
-and "meridional" components are the x and y components, respectively,
-following the convention MPAS-Ocean uses for its own reconstruction (as of
-`mpas_tools` 2.1.0, `reconstruct_variable()` follows this convention itself
-when the mesh has `on_a_sphere = 'NO'`). In addition,
+a list of variable names, along with a mesh file carrying the least-squares
+reconstruction weights. This is for Omega, which has no vector reconstruction
+of its own; a variable whose components are already in the dataset is skipped,
+so nothing is reconstructed for MPAS-Ocean, which writes them itself. On
+planar meshes, the "zonal" and "meridional" components are the x and y
+components, respectively, following the convention MPAS-Ocean uses for its own
+reconstruction.
+{py:meth}`polaris.ocean.model.OceanIOStep.write_horiz_mesh_dataset()` is what
+puts the weights in Omega's mesh file: a spherical mesh gets them from the
+step that built it, and a planar mesh, built in the same step that writes it,
+has them computed there and then. In addition,
 `open_model_dataset()` derives `PseudoThickness` from the ocean state when it
 is not present in the dataset. This provides a way of using the same initial
 conditions for MPAS-Ocean and Omega when the geometric thickness is the state

--- a/docs/developers_guide/ocean/tasks/geostrophic.md
+++ b/docs/developers_guide/ocean/tasks/geostrophic.md
@@ -70,10 +70,9 @@ is a step for plotting the initial and final states of the advection test for
 each resolution.  The colormap is controlled by the config options discussed in
 {ref}`ocean-geostrophic-config`.
 
-This step supports only MPAS-Ocean.  It plots `velocityZonal` and
-`velocityMeridional`, which MPAS-Ocean writes to its output stream but Omega
-does not, and neither Omega nor Polaris can yet reconstruct them from the
-normal velocity on edges.
+It plots `velocityZonal` and `velocityMeridional`.  MPAS-Ocean writes those
+to its output stream; Omega does not, so `open_model_dataset()` reconstructs
+them from the normal velocity on edges (see {ref}`dev-ocean-model`).
 
 See {ref}`dev-visualization-global` for more details on the global lat-lon
 plots.

--- a/docs/users_guide/ocean/tasks/geostrophic.md
+++ b/docs/users_guide/ocean/tasks/geostrophic.md
@@ -27,10 +27,9 @@ Visualizations of the fields themselves can be added in viz steps by appending
 
 These tasks support both MPAS-Ocean and Omega.
 
-The `viz` steps, and therefore the `with_viz` variants of each task, support
-only MPAS-Ocean.  They plot the zonal and meridional components of the
-velocity, which Omega does not yet write out and which Polaris cannot yet
-reconstruct from the normal velocity on edges.
+The `viz` steps plot the zonal and meridional components of the velocity.
+MPAS-Ocean writes those out; for Omega, Polaris reconstructs them from the
+normal velocity on edges.
 
 ## mesh
 

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -588,6 +588,7 @@ def build_reconstruction_weights(
         local_edge_coords = local_edge_coords - get_coordinate_matrix(
             ds, location
         )
+        local_edge_coords = _wrap_planar_separations(ds, local_edge_coords)
 
     # weight the LSTSQ matrix following Renka (1984) pg. 422
     w = compute_lstsq_weights(ds, local_edge_coords, stencil)
@@ -621,6 +622,44 @@ def build_reconstruction_weights(
     weights = rotate_local_to_cartesian(rotation_matrix, weights)
 
     return stencil, weights
+
+
+def _wrap_planar_separations(
+    ds: xr.Dataset, separations: xr.DataArray
+) -> xr.DataArray:
+    """
+    Wrap separations on a periodic planar mesh into the nearest periodic
+    image of the reconstruction point.
+
+    A stencil edge on the far side of a periodic boundary is a whole
+    period away in the mesh's absolute coordinates.  Left that way it
+    lands far outside the reconstruction point's neighborhood, which
+    gives it both the wrong position in the least-squares fit and, since
+    the Renka weight goes as one over the distance, almost no say in it.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        MPAS mesh dataset, whose ``x_period`` and ``y_period`` attributes
+        give the periods (zero where the mesh is not periodic)
+
+    separations: xr.DataArray (..., R3)
+        Coordinates relative to the reconstruction point
+
+    Returns
+    -------
+    xr.DataArray
+        The same separations, each wrapped into its nearest image
+    """
+    components = [separations.isel(R3=index) for index in range(3)]
+    for index, name in enumerate(['x_period', 'y_period']):
+        period = float(ds.attrs.get(name, 0.0))
+        if period <= 0.0:
+            continue
+        component = components[index]
+        components[index] = component - period * np.round(component / period)
+
+    return xr.concat(components, dim='R3').transpose(*separations.dims)
 
 
 def tangential_reconstruction(

--- a/polaris/ocean/config/coeffs_reconstruct.yaml
+++ b/polaris/ocean/config/coeffs_reconstruct.yaml
@@ -1,9 +1,0 @@
-mpas-ocean:
-  streams:
-    coeffs_reconstruct:
-      type: output
-      filename_template: coeffs_reconstruct.nc
-      output_interval: 0000_00:00:01
-      clobber_mode: truncate
-      contents:
-      - coeffs_reconstruct

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -66,17 +66,11 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
     graph_target : str
         The name of the graph partition file to link to (relative to the base
         working directory)
-
-    write_coeffs_reconstruct : bool
-        Whether to write the coefficients for reconstructing vector
-        quantities during the forward run
     """
 
     # make sure component is of type Ocean, using a string to avoid circular
     # imports
     component: 'Ocean'
-
-    write_coeffs_reconstruct: bool
 
     def __init__(
         self,
@@ -277,19 +271,6 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
 
         if self.update_eos:
             self.update_namelist_eos()
-        self.write_coeffs_reconstruct = self.config.getboolean(
-            'ocean', 'write_coeffs_reconstruct', fallback=False
-        )
-        if self.write_coeffs_reconstruct:
-            model = self.config.get('ocean', 'model')
-            if model != 'mpas-ocean':
-                raise ValueError(
-                    'Coefficients for vector reconstruction can only be '
-                    'written for ocean model MPAS-Ocean'
-                )
-            self.add_yaml_file(
-                'polaris.ocean.config', 'coeffs_reconstruct.yaml'
-            )
 
     def constrain_resources(self, available_cores: Dict[str, Any]) -> None:
         """

--- a/polaris/ocean/mpas_ocean.cfg
+++ b/polaris/ocean/mpas_ocean.cfg
@@ -1,11 +1,5 @@
 # This config file has default config options for MPAS-Ocean
 
-[ocean]
-
-# Whether to write coeffs for reconstructing vector quantities during
-# the forward run
-write_coeffs_reconstruct = True
-
 # The paths section points polaris to external paths
 [paths]
 

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -12,6 +12,7 @@ from polaris import Component
 from polaris.constants import get_constant
 from polaris.mesh.info import is_planar, is_spherical
 from polaris.mesh.reconstruct import (
+    add_reconstruction_weights_to_dataset,
     cartesian_to_local_geographic,
     tangential_reconstruction,
 )
@@ -54,11 +55,6 @@ class Ocean(Component):
     vert_coord_vars : list of str
         Variables that belong in the vertical coordinate file (Omega only)
         rather than the initial condition file
-
-    omega_only_horiz_mesh_vars : list of str
-        Horizontal mesh variables that are specific to Omega (currently
-        just the cell-centered vector-reconstruction fields), read from
-        the ``Omega`` section of variables.yaml
     """
 
     def __init__(self):
@@ -72,7 +68,6 @@ class Ocean(Component):
         self.horiz_mesh_vars: Union[None, list[str]] = None
         self.vert_coord_vars: Union[None, list[str]] = None
         self.state_vars: Union[None, list[str]] = None
-        self.omega_only_horiz_mesh_vars: Union[None, list[str]] = None
 
     def configure(self, config, tasks):
         """
@@ -274,18 +269,21 @@ class Ocean(Component):
         Write a horizontal mesh dataset, validating that all expected mesh
         variables are present.
 
-        For Omega on spherical meshes, the vector-reconstruction stencil
-        and weight fields are merged in from ``reconstruction_weights.nc``
-        in the current working directory, since MPAS-Ocean does not
-        support least-squares vector reconstruction. This file must be
-        added as an input to the step, pointing at whichever mesh ``ds``
-        was built from: the base mesh's ``reconstruction_weights.nc``
-        (from ``polaris.mesh.spherical.SphericalBaseStep``) or, for
-        culled meshes, a culled mesh's
+        Omega has no vector reconstruction of its own, so its mesh file
+        must carry the least-squares stencil and weight fields.  Where
+        they come from depends on the mesh.  A spherical mesh is built by
+        an earlier step, which computes the weights along with it, so
+        they are merged in from ``reconstruction_weights.nc`` in the
+        current working directory.  That file must be added as an input
+        to the step, pointing at whichever mesh ``ds`` was built from:
+        the base mesh's ``reconstruction_weights.nc`` (from
+        ``polaris.mesh.spherical.SphericalBaseStep``) or, for culled
+        meshes, a culled mesh's
         ``culled_{prefix}_reconstruction_weights.nc`` (from
-        ``polaris.tasks.e3sm.init.topo.cull.CullMeshStep``). Planar
-        meshes (``on_a_sphere == 'NO'``) never compute or require these
-        fields.
+        ``polaris.tasks.e3sm.init.topo.cull.CullMeshStep``).  A planar
+        mesh is built and culled in the step that writes it, so there is
+        no earlier step to have computed its weights and they are
+        computed here instead.
 
         Parameters
         ----------
@@ -307,30 +305,24 @@ class Ocean(Component):
 
         spherical = is_spherical(ds)
 
-        if self.model == 'omega' and spherical:
-            recon_filename = 'reconstruction_weights.nc'
-            if not os.path.exists(recon_filename):
-                raise FileNotFoundError(
-                    f'{recon_filename} not found but is required to write '
-                    'the horizontal mesh dataset for Omega. Make sure the '
-                    'base mesh (or culled mesh) step ran with '
-                    'vector-reconstruction weight generation enabled and '
-                    'that its weights file is added as an input to this '
-                    'step, renamed to reconstruction_weights.nc.'
-                )
-            ds_recon = open_dataset(recon_filename)
-            ds = ds.merge(ds_recon)
+        if self.model == 'omega':
+            if spherical:
+                recon_filename = 'reconstruction_weights.nc'
+                if not os.path.exists(recon_filename):
+                    raise FileNotFoundError(
+                        f'{recon_filename} not found but is required to '
+                        'write the horizontal mesh dataset for Omega. Make '
+                        'sure the base mesh (or culled mesh) step ran with '
+                        'vector-reconstruction weight generation enabled '
+                        'and that its weights file is added as an input to '
+                        'this step, renamed to reconstruction_weights.nc.'
+                    )
+                ds_recon = open_dataset(recon_filename)
+                ds = ds.merge(ds_recon)
+            else:
+                ds = add_reconstruction_weights_to_dataset(ds, 'cell')
         ds = self.map_to_native_model_vars(ds)
-        horiz_mesh_vars = self.horiz_mesh_vars
-        if self.model == 'omega' and not spherical:
-            # planar meshes never have reconstruction weights and don't
-            # need them (least-squares vector reconstruction is only used
-            # on spherical meshes)
-            omega_only = self.omega_only_horiz_mesh_vars or []
-            horiz_mesh_vars = [
-                var for var in horiz_mesh_vars if var not in omega_only
-            ]
-        native_vars = self.map_var_list_to_native_model(horiz_mesh_vars)
+        native_vars = self.map_var_list_to_native_model(self.horiz_mesh_vars)
         self._check_vars_present(ds, native_vars, 'write_horiz_mesh_dataset')
         write_netcdf(ds=ds, fileName=filename)
 
@@ -967,9 +959,6 @@ class Ocean(Component):
         if model_key:
             extra = nested_dict.get(model_key, {}).get(
                 'horiz_mesh_variables', []
-            )
-            self.omega_only_horiz_mesh_vars = (
-                list(extra) if model_key == 'Omega' else []
             )
             self.horiz_mesh_vars.extend(extra)
             extra = nested_dict.get(model_key, {}).get(

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -1,11 +1,10 @@
 import importlib.resources as imp_res
 import os
-from typing import Dict, Literal, Tuple, Union
+from typing import Dict, Tuple, Union
 
 import numpy as np
 import xarray as xr
 from mpas_tools.io import open_dataset, write_netcdf
-from mpas_tools.vector.reconstruct import reconstruct_variable
 from ruamel.yaml import YAML
 
 from polaris import Component
@@ -601,8 +600,6 @@ class Ocean(Component):
         mesh_filename=None,
         vert_filename=None,
         reconstruct_variables=None,
-        coeffs_filename=None,
-        reconstruct_method: Literal['RBF', 'LSTSQ'] = 'LSTSQ',
         tracer_convention=None,
         lon=None,
         lat=None,
@@ -623,9 +620,10 @@ class Ocean(Component):
             compute geometric layer thickness from pseudo-thickness.
 
         mesh_filename : str, optional
-            Path to the mesh NetCDF file. Should contain the reconstruction
-            weights if using the LSTSQ reconstruction method.  It is also
-            where the locations needed for a tracer conversion come from.
+            Path to the mesh NetCDF file.  It must contain the least-squares
+            reconstruction weights if anything is to be reconstructed, and it
+            is also where the locations needed for a tracer conversion come
+            from.
 
         reconstruct_variables : list of str, optional
             List of variable names to reconstruct in the dataset.  A variable
@@ -633,14 +631,6 @@ class Ocean(Component):
             (as they are in MPAS-Ocean output, which the model reconstructs
             itself) is skipped, and nothing is reconstructed if that is true
             of all of them.
-
-        coeffs_filename : str, optional
-            Path to the coefficients NetCDF file.
-
-        reconstruct_method : {'RBF', 'LSTSQ'}, optional
-            Method to use for reconstructing vector variables.
-            RBF: Radial Basis Function; approach used in MPAS-Ocean.
-            LSTSQ: Least-squares reconstruction; new approach in Omega
 
         tracer_convention : {'teos-10', 'mpas-ocean'}, optional
             The convention of ``temperature`` and ``salinity`` in the dataset
@@ -766,8 +756,8 @@ class Ocean(Component):
         out_var_names = _vars_to_reconstruct(ds, reconstruct_variables)
         if len(out_var_names) == 0:
             # the model already wrote the zonal and meridional components, as
-            # MPAS-Ocean does with its own RBF reconstruction, so no mesh,
-            # weights or coefficients are needed
+            # MPAS-Ocean does with its own RBF reconstruction, so neither the
+            # mesh nor its weights are needed
             return ds
 
         if mesh_filename is None:
@@ -775,27 +765,15 @@ class Ocean(Component):
                 'mesh_filename must be provided to open_model_dataset '
                 'for variable reconstruction'
             )
-        if reconstruct_method == 'RBF' and coeffs_filename is None:
-            raise ValueError(
-                'coeffs_filename must be provided to open_model_dataset '
-                'for variable reconstruction'
-            )
         ds_mesh = self.open_model_dataset(mesh_filename, config)
-        if (
-            reconstruct_method == 'LSTSQ'
-            and not _reconstruction_weights_in_dataset(ds_mesh)
-        ):
+        if not _reconstruction_weights_in_dataset(ds_mesh):
             raise ValueError(
                 'Reconstruction weights are not present in the mesh '
-                'dataset; cannot reconstruct variables using LSTSQ method'
+                'dataset; cannot reconstruct variables'
             )
 
         ds = _add_reconstructed_variables_to_dataset(
-            ds,
-            out_var_names,
-            ds_mesh,
-            coeffs_filename,
-            reconstruct_method,
+            ds, out_var_names, ds_mesh
         )
         return ds
 
@@ -1160,13 +1138,7 @@ def _vars_to_reconstruct(ds, reconstruct_variables):
     return out_var_names
 
 
-def _add_reconstructed_variables_to_dataset(
-    ds,
-    out_var_names,
-    ds_mesh,
-    coeffs_filename,
-    reconstruct_method: Literal['RBF', 'LSTSQ'],
-):
+def _add_reconstructed_variables_to_dataset(ds, out_var_names, ds_mesh):
     """
     Add reconstructed vector variables to the dataset.
 
@@ -1180,66 +1152,34 @@ def _add_reconstructed_variables_to_dataset(
         reconstructed components, as returned by ``_vars_to_reconstruct()``.
 
     ds_mesh : xarray.Dataset
-        Mesh dataset on which to perform the reconstruction.
-
-    coeffs_filename : str
-        Path to the coefficients NetCDF file.
-
-    reconstruct_method : {'RBF', 'LSTSQ'}
-        Method to use for reconstructing vector variables.
+        Mesh dataset on which to perform the reconstruction, including the
+        least-squares reconstruction stencil and weights.
 
     Returns
     -------
     ds : xarray.Dataset
         The dataset with reconstructed variables added.
     """
-    if reconstruct_method == 'RBF':
-        ds_coeff = open_dataset(coeffs_filename)
-        coeffs_reconstruct = ds_coeff.coeffs_reconstruct
-
-        if ds_coeff.sizes['nCells'] != ds_mesh.sizes['nCells']:
-            print(
-                f'The sizes of coefficient dataset do not match mesh dataset;'
-                f' exiting without reconstructing {list(out_var_names)}'
-            )
-            return ds
+    stencil = ds_mesh.reconstructStencilCell
+    weights = ds_mesh.reconstructWeightsCell
 
     for variable, out_var_name in out_var_names.items():
-        if reconstruct_method == 'RBF':
-            reconstruct_variable(
-                out_var_name,
-                ds[variable],
-                ds_mesh,
-                coeffs_reconstruct,
-                ds,
-                quiet=True,
+        u_x, u_y, u_z = tangential_reconstruction(
+            ds_mesh, ds[variable], stencil=stencil, weights=weights
+        )
+        if is_planar(ds_mesh):
+            # on a planar mesh, the x and y axes are the "zonal" and
+            # "meridional" directions, following the convention MPAS-Ocean
+            # uses for its own reconstruction
+            u_zonal = u_x
+            u_merid = u_y
+        else:
+            u_zonal, u_merid, _ = cartesian_to_local_geographic(
+                ds_mesh, u_x, u_y, u_z
             )
 
-        elif reconstruct_method == 'LSTSQ':
-            stencil = ds_mesh.reconstructStencilCell
-            weights = ds_mesh.reconstructWeightsCell
-
-            u_x, u_y, u_z = tangential_reconstruction(
-                ds_mesh, ds[variable], stencil=stencil, weights=weights
-            )
-            if is_planar(ds_mesh):
-                # on a planar mesh, the x and y axes are the "zonal" and
-                # "meridional" directions, as in MPAS-Ocean and in
-                # mpas_tools' reconstruct_variable()
-                u_zonal = u_x
-                u_merid = u_y
-            else:
-                u_zonal, u_merid, _ = cartesian_to_local_geographic(
-                    ds_mesh, u_x, u_y, u_z
-                )
-
-            ds[f'{out_var_name}Zonal'] = u_zonal
-            ds[f'{out_var_name}Meridional'] = u_merid
-
-        if not (
-            f'{out_var_name}Zonal' in ds and f'{out_var_name}Meridional' in ds
-        ):
-            print(f'Failed to reconstruct {out_var_name}')
+        ds[f'{out_var_name}Zonal'] = u_zonal
+        ds[f'{out_var_name}Meridional'] = u_merid
 
     return ds
 

--- a/polaris/tasks/ocean/barotropic_channel/forward.py
+++ b/polaris/tasks/ocean/barotropic_channel/forward.py
@@ -92,17 +92,6 @@ class Forward(OceanModelStep):
             ],
         )
 
-    def setup(self):
-        super().setup()
-        model = self.config.get('ocean', 'model')
-        if model == 'omega':
-            self.add_input_file(
-                filename='coeffs.nc',
-                target='coeffs.nc',
-                database_component='ocean',
-                database='barotropic_channel',
-            )
-
     def dynamic_model_config(self, at_setup):
         super().dynamic_model_config(at_setup=at_setup)
 

--- a/polaris/tasks/ocean/barotropic_channel/viz.py
+++ b/polaris/tasks/ocean/barotropic_channel/viz.py
@@ -34,15 +34,6 @@ class Viz(OceanIOStep):
             filename='output.nc', target='../forward/output.nc'
         )
 
-    def setup(self):
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer needs this file
-        if model == 'omega':
-            self.add_input_file(
-                filename='coeffs.nc',
-                target='../forward/coeffs.nc',
-            )
-
     def run(self):
         """
         Run this step of the task
@@ -55,8 +46,6 @@ class Viz(OceanIOStep):
             self.config,
             reconstruct_variables=['normalVelocity'],
             mesh_filename='mesh.nc',
-            coeffs_filename='coeffs.nc',
-            reconstruct_method='RBF',
         )
 
         cell_mask = ds_vert_coord.maxLevelCell >= 1

--- a/polaris/tasks/ocean/barotropic_gyre/forward.py
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.py
@@ -263,16 +263,6 @@ class Forward(OceanModelStep):
             template_replacements=replacements,
         )
 
-    def setup(self):
-        super().setup()
-        model = self.config.get('ocean', 'model')
-        if model == 'omega':
-            self.add_input_file(
-                target='coeffs.nc',
-                filename='coeffs.nc',
-                database='barotropic_gyre',
-            )
-
     def compute_max_time_step(self, config):
         """
         Compute the approximate maximum time step for stability

--- a/polaris/tasks/ocean/cosine_bell/forward.py
+++ b/polaris/tasks/ocean/cosine_bell/forward.py
@@ -72,20 +72,3 @@ class Forward(SphericalConvergenceForward):
             refinement=refinement,
         )
         self.do_restart = do_restart
-        self.mesh_path = mesh.path
-
-    def setup(self):
-        super().setup()
-        from polaris.mesh.base import parse_mesh_filepath
-
-        model = self.config.get('ocean', 'model')
-        if model == 'omega':
-            component, database, mesh_name = parse_mesh_filepath(
-                self.mesh_path
-            )
-            self.add_input_file(
-                filename='coeffs.nc',
-                target=f'{mesh_name}_coeffs.nc',
-                database_component=component,
-                database=database,
-            )

--- a/polaris/tasks/ocean/manufactured_solution/forward.py
+++ b/polaris/tasks/ocean/manufactured_solution/forward.py
@@ -88,18 +88,8 @@ class Forward(ConvergenceForward):
             validate_vars=['layerThickness', 'normalVelocity'],
             check_properties=['mass conservation'],
         )
-        self.init = init
         self.del2 = del2
         self.del4 = del4
-
-    def setup(self):
-        super().setup()
-        mesh_name = self.init.path.split('/')[-1]
-        self.add_input_file(
-            target=f'{mesh_name}_coeffs.nc',
-            filename='coeffs.nc',
-            database='manufactured_solution',
-        )
 
     def compute_cell_count(self):
         """

--- a/polaris/tasks/ocean/merry_go_round/default/viz.py
+++ b/polaris/tasks/ocean/merry_go_round/default/viz.py
@@ -70,13 +70,6 @@ class Viz(OceanIOStep):
             filename='output.nc',
             work_dir_target=f'{forward.path}/output.nc',
         )
-        model = self.config.get('ocean', 'model')
-        # TODO: remove as soon as Omega no longer needs this file
-        if model == 'omega':
-            self.add_input_file(
-                filename='coeffs.nc',
-                work_dir_target=f'{forward.path}/coeffs.nc',
-            )
 
     def run(self):
         """
@@ -110,10 +103,8 @@ class Viz(OceanIOStep):
                 config,
                 mesh_filename='mesh.nc',
                 vert_filename='vert_coord.nc',
-                coeffs_filename='coeffs.nc',
                 decode_times=False,
                 reconstruct_variables=['normalVelocity'],
-                reconstruct_method='RBF',
             )
             x_min = ds_mesh.xVertex.min().values
             x_max = ds_mesh.xVertex.max().values

--- a/polaris/tasks/ocean/merry_go_round/forward.py
+++ b/polaris/tasks/ocean/merry_go_round/forward.py
@@ -74,15 +74,6 @@ class Forward(ConvergenceForward):
         )
         self.order = vert_adv_order
         self.limiter = limiter
-        self.mesh_name = init.path.split('/')[-1]
-
-    def setup(self):
-        super().setup()
-        self.add_input_file(
-            target=f'{self.mesh_name}_coeffs.nc',
-            filename='coeffs.nc',
-            database='merry_go_round',
-        )
 
     def dynamic_model_config(self, at_setup):
         """

--- a/polaris/tasks/ocean/single_column/ekman/analysis.py
+++ b/polaris/tasks/ocean/single_column/ekman/analysis.py
@@ -46,11 +46,6 @@ class Analysis(OceanIOStep):
             filename='output.nc',
             target=f'{self.base_work_dir}/{self.forward.path}/output.nc',
         )
-        if self.config.get('ocean', 'model') == 'omega':
-            self.add_input_file(
-                filename='coeffs.nc',
-                target=f'{self.base_work_dir}/{self.forward.path}/coeffs.nc',
-            )
 
     def run(self):
         """
@@ -74,8 +69,6 @@ class Analysis(OceanIOStep):
                 decode_times=True,
                 mesh_filename='mesh.nc',
                 reconstruct_variables=['normalVelocity'],
-                reconstruct_method='RBF',
-                coeffs_filename='coeffs.nc',
             )
 
             t_index = -1

--- a/polaris/tasks/ocean/single_column/ekman/ekman.cfg
+++ b/polaris/tasks/ocean/single_column/ekman/ekman.cfg
@@ -13,5 +13,14 @@ run_duration = 5.
 # Constant vertical eddy diffusivity
 vertical_viscosity = 1.e-3
 
-# Maximum value of the L2 norm over which the test fails
-L2_error_norm_max = 3.e-14
+# Maximum value of the L2 norm over which the test fails.  The norm measures
+# whether reconstructing the velocity and projecting it back onto the edges
+# recovers the normal velocity, which on this horizontally uniform column is
+# a round-trip test of the reconstruction.  MPAS-Ocean, whose own
+# reconstruction Polaris reads rather than repeating, round-trips at machine
+# precision.  Omega's least-squares reconstruction reaches 2e-12 on this 4x4
+# doubly periodic mesh, where a two-ring stencil wraps most of the way around
+# the domain and the fit is poorly conditioned.  A reconstruction that is
+# actually broken misses by a part in a hundred or worse, so this still
+# catches one.
+L2_error_norm_max = 1.e-10

--- a/polaris/tasks/ocean/single_column/forward.py
+++ b/polaris/tasks/ocean/single_column/forward.py
@@ -157,13 +157,6 @@ class Forward(OceanModelStep):
         # TODO: remove as soon as Omega no longer hard-codes this file
         if model == 'omega':
             self.add_input_file(filename='OmegaMesh.nc', target='init.nc')
-            # Uncomment these lines when coeffs.nc has been added to the
-            # database
-            self.add_input_file(
-                target='coeffs.nc',
-                filename='coeffs.nc',
-                database='single_column',
-            )
 
     def dynamic_model_config(self, at_setup):
         super().dynamic_model_config(at_setup=at_setup)

--- a/polaris/tasks/ocean/single_column/inertial/analysis.py
+++ b/polaris/tasks/ocean/single_column/inertial/analysis.py
@@ -31,18 +31,11 @@ class Analysis(OceanIOStep):
         super().__init__(component=component, name='analysis', indir=indir)
         self.config = config
         self.add_input_file(
+            filename='mesh.nc', target='../init/culled_mesh.nc'
+        )
+        self.add_input_file(
             filename='output.nc', target='../forward/output.nc'
         )
-
-    # def setup(self):
-    #    model = self.config.get('ocean', 'model')
-    #    # TODO: remove as soon as Omega no longer needs this file
-    #    if model == 'omega':
-    #        self.add_input_file(
-    #            target='coeffs.nc',
-    #            filename='coeffs.nc',
-    #            database='single_column',
-    #        )
 
     def run(self):
         """
@@ -60,10 +53,8 @@ class Analysis(OceanIOStep):
                 'output.nc',
                 config=config,
                 decode_times=True,
-                mesh_filename='../init/culled_mesh.nc',
+                mesh_filename='mesh.nc',
                 reconstruct_variables=['normalVelocity'],
-                reconstruct_method='RBF',
-                coeffs_filename='../forward/coeffs.nc',
             )
             t = get_time_since_start(ds, units='days')
             s_per_day = 24.0 * 3600.0

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -85,13 +85,6 @@ class Viz(OceanIOStep):
                 target=f'{comparison_path}/{output_file}',
             )
 
-    def setup(self):
-        if self.config.get('ocean', 'model') == 'omega':
-            self.add_input_file(
-                filename='coeffs.nc',
-                target=f'{next(iter(self.comparisons.values()))}/coeffs.nc',
-            )
-
     def run(self):
         """
         Run this step of the test case
@@ -118,22 +111,13 @@ class Viz(OceanIOStep):
                     ]
                 else:
                     continue
-                if os.path.exists('coeffs.nc'):
-                    ds_comp = self.open_model_dataset(
-                        f'{comparison_name}.nc',
-                        decode_times=True,
-                        mesh_filename='mesh.nc',
-                        reconstruct_variables=['normalVelocity'],
-                        reconstruct_method='RBF',
-                        coeffs_filename='coeffs.nc',
-                        config=self.config,
-                    )
-                else:
-                    ds_comp = self.open_model_dataset(
-                        f'{comparison_name}.nc',
-                        decode_times=True,
-                        config=self.config,
-                    )
+                ds_comp = self.open_model_dataset(
+                    f'{comparison_name}.nc',
+                    decode_times=True,
+                    mesh_filename='mesh.nc',
+                    reconstruct_variables=['normalVelocity'],
+                    config=self.config,
+                )
                 t_arr = get_time_since_start(ds_comp, units='days')
                 t_index = np.argmin(np.abs(t_arr - t_target))
                 time_ds.append(float(t_arr[t_index]))

--- a/tests/mesh/test_reconstruct.py
+++ b/tests/mesh/test_reconstruct.py
@@ -171,6 +171,40 @@ def test_planar_reconstruction_of_uniform_field_is_exact(location):
     np.testing.assert_array_equal(u_z.values, 0.0)
 
 
+def test_planar_reconstruction_wraps_across_a_periodic_boundary():
+    """
+    A stencil edge on the far side of a periodic boundary is a whole period
+    away in the mesh's absolute coordinates.  Unwrapped, it enters the fit
+    at the wrong position and carries almost no Renka weight, so a cell at
+    the seam reconstructs a field that has no cross-flow component with a
+    spurious one of about a percent.
+
+    Every cell of a uniform doubly periodic hex mesh has the same local
+    neighborhood, so reconstructing a field with the domain's own period
+    must give the same error at the seam as in the interior.
+    """
+    ds = periodic_hex_mesh()
+    k_x = 2.0 * np.pi / ds.x_period
+
+    u_x, u_y, _ = reconstruct_planar_field(
+        ds,
+        lambda x, y: np.cos(k_x * x),
+        lambda x, y: 0.0 * x,
+        location='cell',
+    )
+
+    x, y = point_coords(ds, 'cell')
+    error = np.abs(u_x - np.cos(k_x * x))
+    inside = interior_points(ds, margin=3.0 * ds.dc)
+    seam = ~inside
+    assert int(seam.sum()) > 0
+
+    assert float(error.where(seam).max()) < 1.05 * float(
+        error.where(inside).max()
+    )
+    np.testing.assert_allclose(u_y.values, 0.0, atol=1e-12)
+
+
 @pytest.mark.parametrize('location', ['cell', 'vertex'])
 def test_planar_reconstruction_of_linear_field_is_exact(location):
     """

--- a/tests/ocean/test_mesh_init_split.py
+++ b/tests/ocean/test_mesh_init_split.py
@@ -6,6 +6,7 @@ import gsw
 import numpy as np
 import pytest
 import xarray as xr
+from mpas_tools.planar_hex import make_planar_hex_mesh
 from numpy.testing import assert_allclose
 
 from polaris.model_step import ModelStep
@@ -586,13 +587,27 @@ def test_write_horiz_mesh_dataset_raises_without_on_a_sphere(tmp_path):
         component.write_horiz_mesh_dataset(ds, str(filename), config)
 
 
+def _make_planar_horiz_mesh_ds(nx=4, ny=4, dc=1000.0):
+    """A real planar hex mesh with the Coriolis fields filled in.
+
+    Omega's reconstruction weights are computed from the mesh itself, so
+    the dummy dataset above will not do.
+    """
+    ds = make_planar_hex_mesh(
+        nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=False
+    )
+    for location in ['Cell', 'Edge', 'Vertex']:
+        ds[f'f{location}'] = xr.zeros_like(ds[f'x{location}'])
+    return ds
+
+
 def test_write_horiz_mesh_dataset_writes_omega(tmp_path):
     component = Ocean()
     component.model = 'omega'
     component._read_var_map()
 
     config = MagicMock()
-    ds = _make_horiz_mesh_ds(component)
+    ds = _make_planar_horiz_mesh_ds()
 
     filename = tmp_path / 'mesh.nc'
     component.write_horiz_mesh_dataset(ds, str(filename), config)
@@ -601,6 +616,44 @@ def test_write_horiz_mesh_dataset_writes_omega(tmp_path):
     assert 'XCell' in ds_out
     assert 'FCell' in ds_out
     assert 'xCell' not in ds_out
+
+
+def test_write_horiz_mesh_dataset_computes_planar_weights(tmp_path):
+    """Nothing computes weights for a planar mesh before this point, so
+    Omega's mesh file gets them here."""
+    component = Ocean()
+    component.model = 'omega'
+    component._read_var_map()
+
+    config = MagicMock()
+    ds = _make_planar_horiz_mesh_ds()
+
+    filename = tmp_path / 'mesh.nc'
+    component.write_horiz_mesh_dataset(ds, str(filename), config)
+
+    ds_out = xr.open_dataset(filename)
+    for var in ['ReconStencilCell', 'NEdgesReconOnCell', 'ReconWeightsCell']:
+        assert var in ds_out
+
+
+def test_write_horiz_mesh_dataset_skips_planar_weights_for_mpas_ocean(
+    tmp_path,
+):
+    """MPAS-Ocean reconstructs vectors itself and has no use for the
+    least-squares weights."""
+    component = Ocean()
+    component.model = 'mpas-ocean'
+    component._read_var_map()
+
+    config = MagicMock()
+    ds = _make_planar_horiz_mesh_ds()
+
+    filename = tmp_path / 'mesh.nc'
+    component.write_horiz_mesh_dataset(ds, str(filename), config)
+
+    ds_out = xr.open_dataset(filename)
+    assert 'reconstructWeightsCell' not in ds_out
+    assert 'ReconWeightsCell' not in ds_out
 
 
 def test_process_inputs_and_outputs_resolves_model_input_filenames(


### PR DESCRIPTION
Omega has no vector reconstruction of its own, so Polaris reconstructs zonal and meridional velocity for it. The planar tasks did that with RBF, using coefficients an MPAS-Ocean run wrote on the same mesh and Polaris ships in its input databases. This computes least-squares weights on the planar mesh instead, the way the spherical tasks already work, and retires the RBF path along with the `coeffs.nc` staging and the `write_coeffs_reconstruct` option. Follow-on to #767.

Doing so uncovered a bug in the planar least-squares reconstruction: stencil edges across a periodic boundary were left a whole period away in the mesh's absolute coordinates. On the barotropic channel that was 33% of the peak velocity plus a spurious meridional component; it is now 7e-04 and round-off.

For review:

* `single_column_ekman/L2_error_norm_max` goes from 3e-14 to 1e-10. That norm is a round-trip test of the reconstruction rather than of the physics, and RBF is exact on a uniform field where the least-squares fit reaches 2e-12 on the single column's 4x4 doubly periodic mesh.
* Omega's planar answers change. This cannot be bit-for-bit.

Before-and-after images: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/xasaydavis/polaris_omega_lstsq_20260910/

Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
