### PR TITLE
Clean up vertical coordinate functions

### DIFF
--- a/docs/design_docs/ocean_analysis_initial.md
+++ b/docs/design_docs/ocean_analysis_initial.md
@@ -1369,7 +1369,6 @@ which already maps the vertical geometry this design depends on:
 
 ```yaml
   zMid: GeomZMid
-  zInterface: GeomZInterface
 ```
 
 **The mapping reconciles two spellings; it is not a naming authority.**  An

--- a/polaris/ocean/model/mpaso_to_omega.yaml
+++ b/polaris/ocean/model/mpaso_to_omega.yaml
@@ -107,7 +107,6 @@ variables:
 
   # vertical coordinate diagnostics
   zMid: GeomZMid
-  zInterface: GeomZInterface
   pressure: PressureMid
 
   # eos

--- a/polaris/ocean/model/variables.yaml
+++ b/polaris/ocean/model/variables.yaml
@@ -54,6 +54,16 @@ mpas-ocean:
     - restingThickness
   state_variables:
     - layerThickness
+# Fields defined at the top of each layer that a model nonetheless writes on
+# ``nVertLevels``, leaving the bottom of the column off, rather than on
+# ``nVertLevelsP1``.  MPAS-Ocean writes ``BruntVaisalaFreqTop`` this way.
+# Dimensions cannot tell such a field from a layer average, so it is named
+# here.  A field is only ever read from this list when it arrives on
+# ``nVertLevels``. This is not an exhaustive list. Variables are added as they
+# are used in Polaris.
+  variables_at_layer_tops:
+    - BruntVaisalaFreqTop
+
 
 Omega:
   horiz_mesh_variables:

--- a/polaris/ocean/vertical/__init__.py
+++ b/polaris/ocean/vertical/__init__.py
@@ -115,7 +115,7 @@ def init_vertical_coord(config, ds):
         dim='Time', axis=0
     )
 
-    ds['zInterface'], ds['zMid'] = compute_zint_zmid_from_layer_thickness(
+    ds['GeomZInterface'], ds['zMid'] = compute_zint_zmid_from_layer_thickness(
         layer_thickness=ds.layerThickness,
         bottom_depth=ds.bottomDepth,
         min_level_cell=ds.minLevelCell,

--- a/polaris/ocean/vertical/__init__.py
+++ b/polaris/ocean/vertical/__init__.py
@@ -1,6 +1,7 @@
 import numpy as np
 import xarray as xr
 
+from polaris.ocean.vertical.diagnostics import _z_from_thickness
 from polaris.ocean.vertical.sigma import (
     init_sigma_vertical_coord as init_sigma_vertical_coord,
 )
@@ -207,52 +208,12 @@ def compute_zint_zmid_from_layer_thickness(
     z_mid : xarray.DataArray
         The elevation of layer midpoints.
     """
-
-    n_vert_levels = layer_thickness.sizes['nVertLevels']
-
-    z_index = xr.DataArray(np.arange(n_vert_levels), dims=['nVertLevels'])
-    mask_mid = np.logical_and(
-        z_index >= min_level_cell, z_index <= max_level_cell
+    z_mid, z_interface = _z_from_thickness(
+        layer_thickness=layer_thickness,
+        bottom_depth=bottom_depth,
+        min_level_cell=min_level_cell,
+        max_level_cell=max_level_cell,
     )
-
-    dz = layer_thickness.where(mask_mid, 0.0)
-    dz_rev = dz.isel(nVertLevels=slice(None, None, -1))
-    sum_from_level = dz_rev.cumsum(dim='nVertLevels').isel(
-        nVertLevels=slice(None, None, -1)
-    )
-
-    z_bot = (
-        xr.zeros_like(layer_thickness.isel(nVertLevels=0, drop=True))
-        - bottom_depth
-    )
-    z_interface_top = z_bot + sum_from_level
-    z_interface = z_interface_top.pad(nVertLevels=(0, 1), mode='constant')
-    z_interface[dict(nVertLevels=n_vert_levels)] = z_bot
-    z_interface = z_interface.rename({'nVertLevels': 'nVertLevelsP1'})
-
-    z_index_p1 = xr.DataArray(
-        np.arange(n_vert_levels + 1), dims=['nVertLevelsP1']
-    )
-    mask_interface = np.logical_and(
-        z_index_p1 >= min_level_cell,
-        z_index_p1 - 1 <= max_level_cell,
-    )
-    z_interface = z_interface.where(mask_interface)
-
-    z_interface_upper = z_interface.isel(nVertLevelsP1=slice(0, -1)).rename(
-        {'nVertLevelsP1': 'nVertLevels'}
-    )
-    z_interface_lower = z_interface.isel(nVertLevelsP1=slice(1, None)).rename(
-        {'nVertLevelsP1': 'nVertLevels'}
-    )
-    z_mid = (0.5 * (z_interface_upper + z_interface_lower)).where(mask_mid)
-
-    dims = list(layer_thickness.dims)
-    interface_dims = [dim for dim in dims if dim != 'nVertLevels']
-    interface_dims.append('nVertLevelsP1')
-    z_interface = z_interface.transpose(*interface_dims)
-    z_mid = z_mid.transpose(*dims)
-
     return z_interface, z_mid
 
 

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -181,9 +181,9 @@ def get_z_mid_and_interface(ds, allow_reconstruct=False):
     ValueError
         If the data set lacks the geometry and it may not be reconstructed
     """
-    missing = [name for name in ('zMid', 'zInterface') if name not in ds]
+    missing = [name for name in ('zMid', 'GeomZInterface') if name not in ds]
     if not missing:
-        return ds.zMid, ds.zInterface
+        return ds.zMid, ds.GeomZInterface
     if not allow_reconstruct:
         raise ValueError(
             f'The data set has no {", ".join(missing)}, which is the '
@@ -226,7 +226,7 @@ _VERT_COORD_VAR_NAMES = {
 }
 
 
-def vertical_coord_from_location(ds, location):
+def vertical_coord_from_location(ds, location, allow_reconstruct=False):
     """
     Get the vertical coordinate field appropriate for a variable at a given
     location in ``ds``
@@ -241,10 +241,17 @@ def vertical_coord_from_location(ds, location):
         Where the variable is defined: layer midpoints, layer interfaces,
         or the top of each layer
 
+    allow_reconstruct : bool, optional
+        Whether to reconstruct the coordinate from ``layerThickness`` via
+        :py:func:`_z_from_thickness` when the data set does not carry the
+        field directly
+
     Returns
     -------
     coord : xarray.DataArray
-        The elevation of ``ds[var_name]``, in m, positive up, where
+        The elevation of ``ds[var_name]``, in m, positive up, on
+        ``nCells`` and the vertical dimension appropriate to ``location``.
+        A ``Time`` dimension of length one is retained if present.
         ``var_name`` is ``zMid``, ``GeomZInterface`` or ``zTop`` for
         ``location`` ``'cell-center'``, ``'cell-interfaces'`` or
         ``'cell-top'``, respectively
@@ -252,8 +259,10 @@ def vertical_coord_from_location(ds, location):
     Raises
     ------
     ValueError
-        If ``location`` is not one of the supported values, or the
-        corresponding field is not present in the dataset
+        If ``location`` is not one of the supported values, the
+        corresponding field is not present in the dataset and it may not
+        be reconstructed, or ``ds`` has a ``Time`` dimension of length
+        other than one
     """
     if location not in _VERT_COORD_VAR_NAMES:
         raise ValueError(
@@ -261,19 +270,28 @@ def vertical_coord_from_location(ds, location):
             f'{sorted(_VERT_COORD_VAR_NAMES)}'
         )
     var_name = _VERT_COORD_VAR_NAMES[location]
-    if var_name not in ds:
-        raise ValueError(
-            f'{var_name} ({location}) is not present in the dataset'
-        )
-    coord = ds[var_name]
-    if 'Time' in coord.dims:
-        if ds.sizes['Time'] != 1:
+    if var_name in ds:
+        coord = ds[var_name]
+        if 'Time' in coord.dims and ds.sizes['Time'] != 1:
             raise ValueError(
                 'vertical_coord_from_location() requires ds to have no '
                 'Time dimension or a Time dimension of length one'
             )
-        coord = coord.isel(Time=0)
-    return coord.mean(dim='nCells')
+        return coord
+    if not allow_reconstruct:
+        raise ValueError(
+            f'{var_name} ({location}) is not present in the dataset'
+        )
+    z_mid, z_interface = _z_from_thickness(ds)
+    if location == 'cell-center':
+        coord = z_mid
+    elif location == 'cell-interfaces':
+        coord = z_interface
+    else:
+        coord = z_interface.isel(nVertLevelsP1=slice(0, -1)).rename(
+            {'nVertLevelsP1': 'nVertLevels'}
+        )
+    return coord
 
 
 def location_for_field(var, field_name=None):
@@ -351,7 +369,7 @@ def _z_from_thickness(ds):
     if 'nCells' not in ds.sizes and 'nVertLevels' not in ds.sizes:
         raise ValueError('nCells, and nVertLevels must be dimensions of ds')
     if 'ssh' in ds.keys():
-        ssh = ds.ssh.isel(nVertLevels=0).values
+        ssh = ds.ssh.values
     # TODO remove this because it could lead to errors
     else:
         ssh = np.zeros((ds.sizes['nCells']))

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -1,5 +1,8 @@
+import importlib.resources as imp_res
+
 import numpy as np
 import xarray as xr
+from ruamel.yaml import YAML
 
 from polaris.constants import get_constant
 from polaris.ocean.vertical.ztilde import (
@@ -9,6 +12,20 @@ from polaris.ocean.vertical.ztilde import (
 )
 
 RhoSw = get_constant('seawater_density_reference')
+
+
+def _variables_at_layer_tops():
+    """
+    The MPAS-Ocean variables that ``variables.yaml`` lists as defined at
+    the top of each layer but written on ``nVertLevels``
+    """
+    text = (
+        imp_res.files('polaris.ocean.model')
+        .joinpath('variables.yaml')
+        .read_text()
+    )
+    nested_dict = YAML(typ='rt').load(text)
+    return nested_dict['mpas-ocean']['variables_at_layer_tops']
 
 
 def geom_thickness_from_ds(ds, config):
@@ -200,6 +217,95 @@ def depth_from_thickness(ds):
     """
     z_mid, _ = get_z_mid_and_interface(ds, allow_reconstruct=True)
     return z_mid
+
+
+_VERT_COORD_VAR_NAMES = {
+    'cell-center': 'zMid',
+    'cell-interfaces': 'GeomZInterface',
+    'cell-top': 'zTop',
+}
+
+
+def vertical_coord_from_location(ds, location):
+    """
+    Get the vertical coordinate field appropriate for a variable at a given
+    location in ``ds``
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset with no ``Time`` dimension or a ``Time`` dimension of
+        length one
+
+    location : {'cell-center', 'cell-interfaces', 'cell-top'}
+        Where the variable is defined: layer midpoints, layer interfaces,
+        or the top of each layer
+
+    Returns
+    -------
+    coord : xarray.DataArray
+        The elevation of ``ds[var_name]``, in m, positive up, where
+        ``var_name`` is ``zMid``, ``GeomZInterface`` or ``zTop`` for
+        ``location`` ``'cell-center'``, ``'cell-interfaces'`` or
+        ``'cell-top'``, respectively
+
+    Raises
+    ------
+    ValueError
+        If ``location`` is not one of the supported values, or the
+        corresponding field is not present in the dataset
+    """
+    if location not in _VERT_COORD_VAR_NAMES:
+        raise ValueError(
+            f'Unsupported variable location {location!r}, expected one of '
+            f'{sorted(_VERT_COORD_VAR_NAMES)}'
+        )
+    var_name = _VERT_COORD_VAR_NAMES[location]
+    if var_name not in ds:
+        raise ValueError(
+            f'{var_name} ({location}) is not present in the dataset'
+        )
+    coord = ds[var_name]
+    if 'Time' in coord.dims:
+        if ds.sizes['Time'] != 1:
+            raise ValueError(
+                'vertical_coord_from_location() requires ds to have no '
+                'Time dimension or a Time dimension of length one'
+            )
+        coord = coord.isel(Time=0)
+    return coord.mean(dim='nCells')
+
+
+def location_for_field(var, field_name=None):
+    """
+    The variable location of ``var`` to look up its vertical coordinate
+
+    A field on ``nVertLevelsP1`` is defined at layer interfaces --- the top
+    of each layer, plus one more for the bottom of the column.  A field
+    listed under ``variables_at_layer_tops`` in ``variables.yaml`` is
+    defined at the top of each layer but written on ``nVertLevels``.
+    Everything else is a layer quantity, defined at layer midpoints.
+
+    Parameters
+    ----------
+    var : xarray.DataArray
+        The field to plot or analyze
+
+    field_name : str, optional
+        The name of ``var`` in its dataset, used to check whether it is a
+        layer-top field
+
+    Returns
+    -------
+    location : {'cell-center', 'cell-interfaces', 'cell-top'}
+        The variable location suitable for
+        :py:func:`vertical_coord_from_location`
+    """
+    if 'nVertLevelsP1' in var.dims:
+        return 'cell-interfaces'
+    if field_name in _variables_at_layer_tops():
+        return 'cell-top'
+    return 'cell-center'
 
 
 def _z_from_thickness(ds):

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -149,7 +149,7 @@ def pseudothickness_from_ds(
     return pseudothickness, spec_vol
 
 
-def get_z_mid_and_interface(ds, allow_reconstruct=False):
+def get_z_mid_and_interface(ds, allow_reconstruct=False, ds_vert=None):
     """
     Get the elevation of layer midpoints and of layer interfaces
 
@@ -167,6 +167,11 @@ def get_z_mid_and_interface(ds, allow_reconstruct=False):
     allow_reconstruct : bool, optional
         Whether to reconstruct the geometry from ``layerThickness`` when the
         data set does not carry it
+
+    ds_vert : xarray.Dataset, optional
+        The vertical coordinate dataset containing ``bottomDepth`` and
+        optionally ``minLevelCell`` and ``maxLevelCell``, used when
+        reconstructing the geometry
 
     Returns
     -------
@@ -192,10 +197,15 @@ def get_z_mid_and_interface(ds, allow_reconstruct=False):
             f'fields, so a simulation has to write it for its output to be '
             f'analysed at an elevation.'
         )
-    return _reconstruct_z_mid_and_interface(ds)
+    if ds_vert is None:
+        raise ValueError(
+            'Cannot reconstruct vertical geometry without the vertical '
+            'coordinate dataset.'
+        )
+    return _reconstruct_z_mid_and_interface(ds, ds_vert)
 
 
-def depth_from_thickness(ds):
+def depth_from_thickness(ds, ds_vert=None):
     """
     Get the elevation of the midpoint of each layer
 
@@ -209,13 +219,20 @@ def depth_from_thickness(ds):
         An ocean dataset carrying the geometry or ``layerThickness``, and
         optionally ``ssh`` and ``bottomDepth``
 
+    ds_vert : xarray.Dataset, optional
+        The vertical coordinate dataset containing ``bottomDepth`` and
+        optionally ``minLevelCell`` and ``maxLevelCell``, used when
+        reconstructing the geometry
+
     Returns
     -------
     z_mid : xarray.DataArray
         The location in meters from the sea surface of the midpoint of each
         layer, positive upward
     """
-    z_mid, _ = get_z_mid_and_interface(ds, allow_reconstruct=True)
+    z_mid, _ = get_z_mid_and_interface(
+        ds, allow_reconstruct=True, ds_vert=ds_vert
+    )
     return z_mid
 
 
@@ -226,7 +243,9 @@ _VERT_COORD_VAR_NAMES = {
 }
 
 
-def vertical_coord_from_location(ds, location, allow_reconstruct=False):
+def vertical_coord_from_location(
+    ds, location, allow_reconstruct=False, ds_vert=None
+):
     """
     Get the vertical coordinate field appropriate for a variable at a given
     location in ``ds``
@@ -245,6 +264,11 @@ def vertical_coord_from_location(ds, location, allow_reconstruct=False):
         Whether to reconstruct the coordinate from ``layerThickness`` via
         :py:func:`_reconstruct_z_mid_and_interface` when the data set does
         not carry the field directly
+
+    ds_vert : xarray.Dataset, optional
+        The vertical coordinate dataset containing ``bottomDepth`` and
+        optionally ``minLevelCell`` and ``maxLevelCell``, used when
+        reconstructing the geometry
 
     Returns
     -------
@@ -282,7 +306,12 @@ def vertical_coord_from_location(ds, location, allow_reconstruct=False):
         raise ValueError(
             f'{var_name} ({location}) is not present in the dataset'
         )
-    z_mid, z_interface = _reconstruct_z_mid_and_interface(ds)
+    if ds_vert is None:
+        raise ValueError(
+            'Cannot reconstruct vertical geometry without the vertical '
+            'coordinate dataset.'
+        )
+    z_mid, z_interface = _reconstruct_z_mid_and_interface(ds, ds_vert)
     if location == 'cell-center':
         coord = z_mid
     elif location == 'cell-interfaces':
@@ -409,7 +438,7 @@ def _z_from_thickness(
     return z_mid, z_interface
 
 
-def _reconstruct_z_mid_and_interface(ds):
+def _reconstruct_z_mid_and_interface(ds, ds_vert):
     """
     Reconstruct z_mid and z_interface for a dataset that did not write them,
     anchored at ``bottomDepth`` via :py:func:`_z_from_thickness`
@@ -419,8 +448,11 @@ def _reconstruct_z_mid_and_interface(ds):
     ds : xarray.Dataset
         An ocean dataset containing the geometric layer thickness (or the
         fields needed to compute it, see :py:func:`geom_thickness_from_ds`)
-        and ``bottomDepth``, and optionally ``minLevelCell``,
-        ``maxLevelCell`` and a ``Time`` dimension of length one
+
+    ds_vert : xarray.Dataset, optional
+        The vertical coordinate dataset containing ``bottomDepth``, and
+        optionally ``minLevelCell``, ``maxLevelCell`` and a ``Time`` dimension
+        of length one
 
     Returns
     -------
@@ -438,7 +470,7 @@ def _reconstruct_z_mid_and_interface(ds):
         obtained from the dataset, or if required dimensions are missing
     """
     layer_thickness = geom_thickness_from_ds(ds, config=None)
-    if 'bottomDepth' not in ds.keys():
+    if 'bottomDepth' not in ds_vert.keys():
         raise ValueError(
             'Could not reconstruct zMid, GeomZInterface: bottomDepth is '
             'not present in the dataset'
@@ -450,13 +482,13 @@ def _reconstruct_z_mid_and_interface(ds):
     if 'nCells' not in ds.sizes and 'nVertLevels' not in ds.sizes:
         raise ValueError('nCells, and nVertLevels must be dimensions of ds')
 
-    bottom_depth = ds.bottomDepth
-    if 'minLevelCell' in ds.keys():
-        min_level_cell = ds.minLevelCell
+    bottom_depth = ds_vert.bottomDepth
+    if 'minLevelCell' in ds_vert.keys():
+        min_level_cell = ds_vert.minLevelCell - 1
     else:
         min_level_cell = xr.zeros_like(bottom_depth)
-    if 'maxLevelCell' in ds.keys():
-        max_level_cell = ds.maxLevelCell
+    if 'maxLevelCell' in ds_vert.keys():
+        max_level_cell = ds_vert.maxLevelCell - 1
     else:
         max_level_cell = (ds.sizes['nVertLevels'] - 1) * xr.ones_like(
             bottom_depth

--- a/polaris/ocean/vertical/diagnostics.py
+++ b/polaris/ocean/vertical/diagnostics.py
@@ -192,7 +192,7 @@ def get_z_mid_and_interface(ds, allow_reconstruct=False):
             f'fields, so a simulation has to write it for its output to be '
             f'analysed at an elevation.'
         )
-    return _z_from_thickness(ds)
+    return _reconstruct_z_mid_and_interface(ds)
 
 
 def depth_from_thickness(ds):
@@ -243,8 +243,8 @@ def vertical_coord_from_location(ds, location, allow_reconstruct=False):
 
     allow_reconstruct : bool, optional
         Whether to reconstruct the coordinate from ``layerThickness`` via
-        :py:func:`_z_from_thickness` when the data set does not carry the
-        field directly
+        :py:func:`_reconstruct_z_mid_and_interface` when the data set does
+        not carry the field directly
 
     Returns
     -------
@@ -282,7 +282,7 @@ def vertical_coord_from_location(ds, location, allow_reconstruct=False):
         raise ValueError(
             f'{var_name} ({location}) is not present in the dataset'
         )
-    z_mid, z_interface = _z_from_thickness(ds)
+    z_mid, z_interface = _reconstruct_z_mid_and_interface(ds)
     if location == 'cell-center':
         coord = z_mid
     elif location == 'cell-interfaces':
@@ -326,20 +326,101 @@ def location_for_field(var, field_name=None):
     return 'cell-center'
 
 
-def _z_from_thickness(ds):
+def _z_from_thickness(
+    layer_thickness, bottom_depth, min_level_cell, max_level_cell
+):
     """
-    Compute the depth of the midpoint of each layer from `layerThickness`.
+    Compute z at layer interfaces and midpoints from layer thickness,
+    anchored at ``bottom_depth`` and summed upward from the seafloor.
 
-    It is assumed that the `layerThickness` of invalid levels is 0. If
-    `ssh` is present in the dataset, depths will be offset by `ssh`. If
-    `bottomDepth` is present in the dataset, the location of the bottom
-    of the bottommost vertical level will be compared with `bottomDepth`.
+    This is the shared core used both by
+    :py:func:`polaris.ocean.vertical.compute_zint_zmid_from_layer_thickness`,
+    which builds the vertical coordinate at init time, and by
+    :py:func:`_reconstruct_z_mid_and_interface`, which reconstructs it for
+    analysis when a simulation did not write it.
+
+    Parameters
+    ----------
+    layer_thickness : xarray.DataArray
+        The layer thickness of each layer
+
+    bottom_depth : xarray.DataArray
+        The positive-down depth of the seafloor
+
+    min_level_cell : xarray.DataArray
+        The zero-based minimum vertical index of each column
+
+    max_level_cell : xarray.DataArray
+        The zero-based maximum vertical index of each column
+
+    Returns
+    -------
+    z_mid : xarray.DataArray
+        The elevation of layer midpoints, in m, positive up
+
+    z_interface : xarray.DataArray
+        The elevation of layer interfaces, in m, positive up
+    """
+    n_vert_levels = layer_thickness.sizes['nVertLevels']
+
+    z_index = xr.DataArray(np.arange(n_vert_levels), dims=['nVertLevels'])
+    mask_mid = np.logical_and(
+        z_index >= min_level_cell, z_index <= max_level_cell
+    )
+
+    dz = layer_thickness.where(mask_mid, 0.0)
+    dz_rev = dz.isel(nVertLevels=slice(None, None, -1))
+    sum_from_level = dz_rev.cumsum(dim='nVertLevels').isel(
+        nVertLevels=slice(None, None, -1)
+    )
+
+    z_bot = (
+        xr.zeros_like(layer_thickness.isel(nVertLevels=0, drop=True))
+        - bottom_depth
+    )
+    z_interface_top = z_bot + sum_from_level
+    z_interface = z_interface_top.pad(nVertLevels=(0, 1), mode='constant')
+    z_interface[dict(nVertLevels=n_vert_levels)] = z_bot
+    z_interface = z_interface.rename({'nVertLevels': 'nVertLevelsP1'})
+
+    z_index_p1 = xr.DataArray(
+        np.arange(n_vert_levels + 1), dims=['nVertLevelsP1']
+    )
+    mask_interface = np.logical_and(
+        z_index_p1 >= min_level_cell,
+        z_index_p1 - 1 <= max_level_cell,
+    )
+    z_interface = z_interface.where(mask_interface)
+
+    z_interface_upper = z_interface.isel(nVertLevelsP1=slice(0, -1)).rename(
+        {'nVertLevelsP1': 'nVertLevels'}
+    )
+    z_interface_lower = z_interface.isel(nVertLevelsP1=slice(1, None)).rename(
+        {'nVertLevelsP1': 'nVertLevels'}
+    )
+    z_mid = (0.5 * (z_interface_upper + z_interface_lower)).where(mask_mid)
+
+    dims = list(layer_thickness.dims)
+    interface_dims = [dim for dim in dims if dim != 'nVertLevels']
+    interface_dims.append('nVertLevelsP1')
+    z_interface = z_interface.transpose(*interface_dims)
+    z_mid = z_mid.transpose(*dims)
+
+    return z_mid, z_interface
+
+
+def _reconstruct_z_mid_and_interface(ds):
+    """
+    Reconstruct z_mid and z_interface for a dataset that did not write them,
+    anchored at ``bottomDepth`` via :py:func:`_z_from_thickness`
 
     Parameters
     ----------
     ds : xarray.Dataset
-        An ocean dataset containing `layerThickness` and optionally `ssh`
-        and `bottomDepth`
+        An ocean dataset containing the geometric layer thickness (or the
+        fields needed to compute it, see :py:func:`geom_thickness_from_ds`)
+        and ``bottomDepth``, and optionally ``minLevelCell``,
+        ``maxLevelCell`` and a ``Time`` dimension of length one
 
     Returns
     -------
@@ -347,72 +428,43 @@ def _z_from_thickness(ds):
         The location in meters from the sea surface of the midpoint of
         each layer (level), positive upward
 
+    z_interface : xarray.DataArray
+        The elevation of layer interfaces, in m, positive up
+
     Raises
     ------
     ValueError
-        If `layerThickness` is not present in the dataset, or if required
-        dimensions are missing
+        If ``bottomDepth`` or the geometric layer thickness cannot be
+        obtained from the dataset, or if required dimensions are missing
     """
-    # TODO when Omega supports these variables, just fetch them
-    # if 'zMid' in ds.keys():
-    #    z_mid = ds['zMid']
-    # elif 'layerThickness' in ds.keys():
-
-    if 'layerThickness' not in ds.keys():
+    layer_thickness = geom_thickness_from_ds(ds, config=None)
+    if 'bottomDepth' not in ds.keys():
         raise ValueError(
-            'Could not reconstruct zMid, zinterface: '
-            'Could not find layerThickness in dataset'
+            'Could not reconstruct zMid, GeomZInterface: bottomDepth is '
+            'not present in the dataset'
         )
     if 'Time' in ds.dims:
         print('Time dimension present in dataset; using first time index')
         ds = ds.isel(Time=0)
+        layer_thickness = layer_thickness.isel(Time=0)
     if 'nCells' not in ds.sizes and 'nVertLevels' not in ds.sizes:
         raise ValueError('nCells, and nVertLevels must be dimensions of ds')
-    if 'ssh' in ds.keys():
-        ssh = ds.ssh.values
-    # TODO remove this because it could lead to errors
-    else:
-        ssh = np.zeros((ds.sizes['nCells']))
-    if 'nVertLevelsP1' in ds.dims:
-        nz = ds.sizes['nVertLevelsP1']
-    else:
-        nz = ds.sizes['nVertLevels'] + 1
 
-    # mask out thickness where vertical index exceeds maxLevelCell
-    layer_thickness = ds.layerThickness
+    bottom_depth = ds.bottomDepth
+    if 'minLevelCell' in ds.keys():
+        min_level_cell = ds.minLevelCell
+    else:
+        min_level_cell = xr.zeros_like(bottom_depth)
     if 'maxLevelCell' in ds.keys():
         max_level_cell = ds.maxLevelCell
     else:
-        max_level_cell = xr.DataArray(nz * np.ones_like(ssh), dims=('nCells'))
-    z_idx = xr.DataArray(
-        np.tile(
-            np.arange(1, ds.sizes['nVertLevels'] + 1),
-            (ds.sizes['nCells'], 1),
-        ),
-        dims=('nCells', 'nVertLevels'),
+        max_level_cell = (ds.sizes['nVertLevels'] - 1) * xr.ones_like(
+            bottom_depth
+        )
+
+    return _z_from_thickness(
+        layer_thickness=layer_thickness,
+        bottom_depth=bottom_depth,
+        min_level_cell=min_level_cell,
+        max_level_cell=max_level_cell,
     )
-    layer_thickness = layer_thickness.where(z_idx <= max_level_cell, np.nan)
-    z_int_array = np.zeros((ds.sizes['nCells'], nz))
-    z_int_array[:, 0] = ssh
-    z_int_array[:, 1:] = np.add(
-        -layer_thickness.cumsum(dim='nVertLevels', skipna=False).values,
-        ssh[:, np.newaxis],
-    )
-    z_interface = xr.DataArray(
-        z_int_array,
-        dims=('nCells', 'nVertLevelsP1'),
-    )
-    z_mid = xr.DataArray(
-        z_int_array[:, :-1] - 0.5 * layer_thickness,
-        dims=('nCells', 'nVertLevels'),
-    )
-    if 'bottomDepth' in ds.keys():
-        z_bed_infer = z_interface.isel(nVertLevelsP1=-1)
-        z_bed_data = ds.bottomDepth
-        cell_diff = (z_bed_infer - z_bed_data).values
-        if np.max(np.abs(cell_diff)) > 1.0e-3:
-            print(
-                'The maximum discrepancy between bottom_depth and the lower'
-                f'boundary of z_interface is {np.max(np.abs(cell_diff))}'
-            )
-    return z_mid, z_interface

--- a/polaris/tasks/ocean/single_column/ekman/analysis.py
+++ b/polaris/tasks/ocean/single_column/ekman/analysis.py
@@ -6,6 +6,7 @@ import numpy as np
 from polaris.constants import get_constant
 from polaris.mpas import area_for_field
 from polaris.ocean.model import OceanIOStep, get_time_since_start
+from polaris.ocean.vertical.diagnostics import vertical_coord_from_location
 from polaris.viz import mplstyle_context
 
 
@@ -74,7 +75,11 @@ class Analysis(OceanIOStep):
             t_index = -1
             ds = ds.isel(Time=t_index)
             t_days = get_time_since_start(ds, units='days')
-            z_mid = ds.zMid.mean(dim='nCells').values
+            z_mid = (
+                vertical_coord_from_location(ds, 'cell-center')
+                .mean(dim='nCells')
+                .values
+            )
             if 'density' in ds.keys():
                 rho_0 = (
                     ds['density'].mean(dim='nCells').isel(nVertLevels=0).values

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -125,7 +125,7 @@ class Viz(OceanIOStep):
             ds_init = self.open_model_dataset('init.nc', config=self.config)
             ds_init = ds_init.isel(Time=0)
             z_mid_init = ds_init['zMid'].mean(dim='nCells')
-            z_interface_init = ds_init['zInterface'].mean(dim='nCells')
+            z_interface_init = ds_init['GeomZInterface'].mean(dim='nCells')
 
             z_mid_final = z_mid_init
             z_interface_final = z_interface_init

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -72,10 +72,18 @@ class Viz(OceanIOStep):
         self.add_input_file(
             filename='init.nc', work_dir_target=f'{init.path}/init.nc'
         )
+        self.init = init
         for comparison_name, comparison_path in self.comparisons.items():
             self.add_input_file(
                 filename=f'{comparison_name}.nc',
                 target=f'{comparison_path}/{output_file}',
+            )
+
+    def setup(self):
+        if self.config.get('ocean', 'model') == 'omega':
+            self.add_input_file(
+                filename='vert_coord.nc',
+                work_dir_target=f'{self.init.path}/vert_coord.nc',
             )
 
     def run(self):
@@ -118,6 +126,11 @@ class Viz(OceanIOStep):
             ds_init = self.open_model_dataset('init.nc', config=self.config)
             ds_init = ds_init.isel(Time=0)
 
+            if self.config.get('ocean', 'model') == 'omega':
+                ds_vert = self.open_model_dataset('vert_coord.nc')
+            else:
+                ds_vert = ds_init
+
             # The depth range of the plots, also used to select the data
             # that sets the x-axis range
             ymin = -100.0
@@ -153,7 +166,10 @@ class Viz(OceanIOStep):
                         )
                         var = ds_comp['velocityZonal'].mean(dim='nCells')
                         z = vertical_coord_from_location(
-                            ds_init, location_for_field(var)
+                            ds_comp,
+                            location_for_field(var),
+                            allow_reconstruct=True,
+                            ds_vert=ds_init,
                         ).mean(dim='nCells')
                         plt.plot(
                             var,
@@ -165,7 +181,10 @@ class Viz(OceanIOStep):
                         _add_visible_limits(x_limits, var, z, ymin, ymax)
                         var = ds_comp['velocityMeridional'].mean(dim='nCells')
                         z = vertical_coord_from_location(
-                            ds_init, location_for_field(var)
+                            ds_comp,
+                            location_for_field(var),
+                            allow_reconstruct=True,
+                            ds_vert=ds_vert,
                         ).mean(dim='nCells')
                         plt.plot(
                             var,
@@ -188,6 +207,7 @@ class Viz(OceanIOStep):
                             ds_comp,
                             location_for_field(var, field_name),
                             allow_reconstruct=True,
+                            ds_vert=ds_vert,
                         ).mean(dim='nCells')
                         # TODO delete this line when MPAS-O bug is fixed
                         if field_name == 'RiTopOfCell':
@@ -216,6 +236,8 @@ class Viz(OceanIOStep):
                             z_init = vertical_coord_from_location(
                                 ds_init,
                                 location_for_field(var_init, field_name),
+                                allow_reconstruct=True,
+                                ds_vert=ds_init,
                             ).mean(dim='nCells')
                             plt.plot(var_init, z_init, '--k', label='initial')
                             _add_visible_limits(

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -4,20 +4,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from polaris.ocean.model import OceanIOStep, get_time_since_start
+from polaris.ocean.vertical.diagnostics import (
+    location_for_field,
+    vertical_coord_from_location,
+)
 from polaris.viz import mplstyle_context
 
 # TODO import rho_0 from constants
-
-# Fields defined at the top of each layer that a model nonetheless writes on
-# ``nVertLevels``, leaving the bottom of the column off, rather than on
-# ``nVertLevelsP1``.  MPAS-Ocean writes ``BruntVaisalaFreqTop`` this way
-# while giving ``RiTopOfCell`` and ``vertViscTopOfCell`` the interface
-# dimension; Omega writes ``BruntVaisalaFreqTop`` on ``nVertLevelsP1``.
-# Dimensions cannot tell such a field from a layer average, so it is named
-# here.  A field is only ever read from this list when it arrives on
-# ``nVertLevels``, so listing one that a model writes at interfaces is
-# harmless.
-TOP_OF_LAYER_FIELDS = ('BruntVaisalaFreqTop',)
 
 
 class Viz(OceanIOStep):
@@ -124,15 +117,6 @@ class Viz(OceanIOStep):
                 ds_list.append(ds_comp.isel(Time=t_index))
             ds_init = self.open_model_dataset('init.nc', config=self.config)
             ds_init = ds_init.isel(Time=0)
-            z_mid_init = ds_init['zMid'].mean(dim='nCells')
-            z_interface_init = ds_init['GeomZInterface'].mean(dim='nCells')
-
-            z_mid_final = z_mid_init
-            z_interface_final = z_interface_init
-            self.logger.warn(
-                'Using the initial vertical coordinate; may not represent '
-                'the plotted state'
-            )
 
             # The depth range of the plots, also used to select the data
             # that sets the x-axis range
@@ -152,12 +136,6 @@ class Viz(OceanIOStep):
                     colors,
                     strict=False,
                 ):
-                    # TODO use this line when Omega zMid is correct
-                    # z_mid_final = ds_comp['zMid'].mean(dim='nCells')
-                    # TODO compare with z_mid computed from layerThickness
-                    # z_mid_final = depth_from_thickness(ds_comp).mean(
-                    #    dim='nCells'
-                    # )
                     if field_name == 'velocity':
                         if (
                             'velocityZonal' not in ds_comp.keys()
@@ -174,11 +152,8 @@ class Viz(OceanIOStep):
                             f'{comparison_name} at {t_days} days'
                         )
                         var = ds_comp['velocityZonal'].mean(dim='nCells')
-                        z = _vertical_coord(
-                            'velocityZonal',
-                            var,
-                            z_mid_final,
-                            z_interface_final,
+                        z = vertical_coord_from_location(
+                            ds_comp, location_for_field(var)
                         )
                         plt.plot(
                             var,
@@ -189,11 +164,8 @@ class Viz(OceanIOStep):
                         )
                         _add_visible_limits(x_limits, var, z, ymin, ymax)
                         var = ds_comp['velocityMeridional'].mean(dim='nCells')
-                        z = _vertical_coord(
-                            'velocityMeridional',
-                            var,
-                            z_mid_final,
-                            z_interface_final,
+                        z = vertical_coord_from_location(
+                            ds_comp, location_for_field(var)
                         )
                         plt.plot(
                             var,
@@ -212,8 +184,8 @@ class Viz(OceanIOStep):
                             )
                             continue
                         var = ds_comp[field_name].mean(dim='nCells')
-                        z = _vertical_coord(
-                            field_name, var, z_mid_final, z_interface_final
+                        z = vertical_coord_from_location(
+                            ds_comp, location_for_field(var, field_name)
                         )
                         # TODO delete this line when MPAS-O bug is fixed
                         if field_name == 'RiTopOfCell':
@@ -239,11 +211,9 @@ class Viz(OceanIOStep):
                             and 'initial' not in existing_labels
                         ):
                             var_init = ds_init[field_name].mean(dim='nCells')
-                            z_init = _vertical_coord(
-                                field_name,
-                                var_init,
-                                z_mid_init,
-                                z_interface_init,
+                            z_init = vertical_coord_from_location(
+                                ds_init,
+                                location_for_field(var_init, field_name),
                             )
                             plt.plot(var_init, z_init, '--k', label='initial')
                             _add_visible_limits(
@@ -278,36 +248,6 @@ class Viz(OceanIOStep):
                 )
                 plt.savefig(f'{field_name}.png', bbox_inches='tight')
                 plt.close()
-
-
-def _vertical_coord(field_name, var, z_mid, z_interface):
-    """
-    The vertical coordinate to plot ``var`` against
-
-    A field on ``nVertLevelsP1`` is defined at layer interfaces --- the top
-    of each layer, plus one more for the bottom of the column --- so it is
-    plotted at interface elevations.  A field in
-    :py:data:`TOP_OF_LAYER_FIELDS` is defined at the top of each layer but
-    written on ``nVertLevels``, so it is plotted at the top interface of
-    each layer.  Everything else is a layer quantity and is plotted at
-    layer midpoints.
-    """
-    if 'nVertLevelsP1' in var.dims:
-        return z_interface
-    if field_name in TOP_OF_LAYER_FIELDS:
-        return _layer_tops(z_interface)
-    return z_mid
-
-
-def _layer_tops(z_interface):
-    """
-    The elevation of the top interface of each layer, on ``nVertLevels``
-
-    ``isel()`` changes the length of the dimension but not its name, so the
-    result is renamed to the dimension the field it pairs with is on.
-    """
-    z_top = z_interface.isel(nVertLevelsP1=slice(0, -1))
-    return z_top.rename({'nVertLevelsP1': 'nVertLevels'})
 
 
 def _add_visible_limits(x_limits, var, z, ymin, ymax):

--- a/polaris/tasks/ocean/single_column/viz.py
+++ b/polaris/tasks/ocean/single_column/viz.py
@@ -153,8 +153,8 @@ class Viz(OceanIOStep):
                         )
                         var = ds_comp['velocityZonal'].mean(dim='nCells')
                         z = vertical_coord_from_location(
-                            ds_comp, location_for_field(var)
-                        )
+                            ds_init, location_for_field(var)
+                        ).mean(dim='nCells')
                         plt.plot(
                             var,
                             z,
@@ -165,8 +165,8 @@ class Viz(OceanIOStep):
                         _add_visible_limits(x_limits, var, z, ymin, ymax)
                         var = ds_comp['velocityMeridional'].mean(dim='nCells')
                         z = vertical_coord_from_location(
-                            ds_comp, location_for_field(var)
-                        )
+                            ds_init, location_for_field(var)
+                        ).mean(dim='nCells')
                         plt.plot(
                             var,
                             z,
@@ -185,8 +185,10 @@ class Viz(OceanIOStep):
                             continue
                         var = ds_comp[field_name].mean(dim='nCells')
                         z = vertical_coord_from_location(
-                            ds_comp, location_for_field(var, field_name)
-                        )
+                            ds_comp,
+                            location_for_field(var, field_name),
+                            allow_reconstruct=True,
+                        ).mean(dim='nCells')
                         # TODO delete this line when MPAS-O bug is fixed
                         if field_name == 'RiTopOfCell':
                             var[0] = np.nan
@@ -214,7 +216,7 @@ class Viz(OceanIOStep):
                             z_init = vertical_coord_from_location(
                                 ds_init,
                                 location_for_field(var_init, field_name),
-                            )
+                            ).mean(dim='nCells')
                             plt.plot(var_init, z_init, '--k', label='initial')
                             _add_visible_limits(
                                 x_limits, var_init, z_init, ymin, ymax

--- a/polaris/tasks/ocean/single_column/vmix/analysis.py
+++ b/polaris/tasks/ocean/single_column/vmix/analysis.py
@@ -5,9 +5,7 @@ from polaris.ocean.model import (
     OceanIOStep,
     get_time_since_start,
 )
-from polaris.ocean.vertical import (
-    compute_zint_zmid_from_layer_thickness,
-)
+from polaris.ocean.vertical.diagnostics import vertical_coord_from_location
 
 
 class Analysis(OceanIOStep):
@@ -65,7 +63,9 @@ class Analysis(OceanIOStep):
             ds_diags_1day = ds_diags.isel(Time=t_index)
             N_sq = ds_diags_1day['BruntVaisalaFreqTop'].mean(dim='nCells')
             if 'zTop' in ds_diags_1day.keys():
-                z_top_final = ds_diags_1day['zTop'].mean(dim='nCells')
+                z_top_final = vertical_coord_from_location(
+                    ds_diags_1day, 'cell-top'
+                ).mean(dim='nCells')
             else:
                 if ds_vert is None:
                     ds_vert = self.open_model_dataset(
@@ -73,16 +73,14 @@ class Analysis(OceanIOStep):
                         decode_times=False,
                         config=self.config,
                     )
-                z_int_final, _ = compute_zint_zmid_from_layer_thickness(
-                    layer_thickness=ds_diags_1day['layerThickness'],
-                    bottom_depth=ds_vert['bottomDepth'],
-                    min_level_cell=ds_vert['minLevelCell'] - 1,
-                    max_level_cell=ds_vert['maxLevelCell'] - 1,
+                ds_for_reconstruct = ds_diags_1day.assign(
+                    bottomDepth=ds_vert['bottomDepth'],
+                    minLevelCell=ds_vert['minLevelCell'] - 1,
+                    maxLevelCell=ds_vert['maxLevelCell'] - 1,
                 )
-                z_top_final = z_int_final[:-1].mean(dim='nCells')
-                z_top_final = z_top_final.rename(
-                    {'nVertLevelsP1': 'nVertLevels'}
-                )
+                z_top_final = vertical_coord_from_location(
+                    ds_for_reconstruct, 'cell-top', allow_reconstruct=True
+                ).mean(dim='nCells')
             index_bld = int(np.nanargmax(N_sq.values))
             bld = z_top_final.isel(nVertLevels=index_bld)
             self.logger.info(

--- a/polaris/tasks/ocean/single_column/vmix/analysis.py
+++ b/polaris/tasks/ocean/single_column/vmix/analysis.py
@@ -73,13 +73,11 @@ class Analysis(OceanIOStep):
                         decode_times=False,
                         config=self.config,
                     )
-                ds_for_reconstruct = ds_diags_1day.assign(
-                    bottomDepth=ds_vert['bottomDepth'],
-                    minLevelCell=ds_vert['minLevelCell'] - 1,
-                    maxLevelCell=ds_vert['maxLevelCell'] - 1,
-                )
                 z_top_final = vertical_coord_from_location(
-                    ds_for_reconstruct, 'cell-top', allow_reconstruct=True
+                    ds_diags_1day,
+                    'cell-top',
+                    allow_reconstruct=True,
+                    ds_vert=ds_vert,
                 ).mean(dim='nCells')
             index_bld = int(np.nanargmax(N_sq.values))
             bld = z_top_final.isel(nVertLevels=index_bld)

--- a/tests/ocean/test_single_column_viz.py
+++ b/tests/ocean/test_single_column_viz.py
@@ -6,24 +6,31 @@ with ``isel()`` and plotted against ``zMid``, which put it half a layer below
 where it is defined.  ``isel()`` also changes the length of a dimension but
 not its name, so building the x-axis range from a mask on ``nVertLevels``
 then raised an ``IndexError``.  Interface fields are now plotted against
-``zInterface``, which is both where they belong and the same dimension.
+``GeomZInterface``, which is both where they belong and the same dimension.
 
 A field written at layer tops on ``nVertLevels`` cannot be told from a
-layer average by its dimensions, so it is named in ``TOP_OF_LAYER_FIELDS``
-and paired with the top interface of each layer.
+layer average by its dimensions, so it is named in ``variables.yaml`` under
+``variables_at_layer_tops`` and paired with the top interface of each layer
+(``zTop``).
 """
 
 import numpy as np
 import pytest
 import xarray as xr
 
-from polaris.tasks.ocean.single_column.viz import (
-    _add_visible_limits,
-    _vertical_coord,
+from polaris.ocean.vertical.diagnostics import (
+    location_for_field,
+    vertical_coord_from_location,
 )
+from polaris.tasks.ocean.single_column.viz import _add_visible_limits
 
 # a field the models agree is a layer quantity
 MID = 'temperature'
+
+
+def _vertical_coord(field_name, var, ds):
+    location = location_for_field(var, field_name)
+    return vertical_coord_from_location(ds, location)
 
 
 def _interface_field(values):
@@ -44,71 +51,67 @@ def z_interface():
     return _interface_field([0.0, -20.0, -100.0, -200.0])
 
 
-def test_an_interface_field_is_plotted_at_interfaces(z_mid, z_interface):
-    z = _vertical_coord(
-        MID, _interface_field([1.0, 2.0, 3.0, 4.0]), z_mid, z_interface
+@pytest.fixture
+def ds(z_mid, z_interface):
+    z_top = _mid_level_field(z_interface.values[:-1])
+    return xr.Dataset(
+        data_vars=dict(zMid=z_mid, GeomZInterface=z_interface, zTop=z_top)
     )
+
+
+def test_an_interface_field_is_plotted_at_interfaces(ds, z_interface):
+    z = _vertical_coord(MID, _interface_field([1.0, 2.0, 3.0, 4.0]), ds)
     assert z.dims == ('nVertLevelsP1',)
     np.testing.assert_array_equal(z.values, z_interface.values)
 
 
-def test_a_mid_level_field_is_plotted_at_midpoints(z_mid, z_interface):
-    z = _vertical_coord(
-        MID, _mid_level_field([1.0, 2.0, 3.0]), z_mid, z_interface
-    )
+def test_a_mid_level_field_is_plotted_at_midpoints(ds, z_mid):
+    z = _vertical_coord(MID, _mid_level_field([1.0, 2.0, 3.0]), ds)
     assert z.dims == ('nVertLevels',)
     np.testing.assert_array_equal(z.values, z_mid.values)
 
 
-def test_a_named_top_of_layer_field_is_plotted_at_layer_tops(
-    z_mid, z_interface
-):
+def test_a_named_top_of_layer_field_is_plotted_at_layer_tops(ds, z_interface):
     # MPAS-Ocean writes BruntVaisalaFreqTop at layer tops but on
     # nVertLevels, so the dimensions alone would send it to zMid
     z = _vertical_coord(
-        'BruntVaisalaFreqTop',
-        _mid_level_field([1.0, 2.0, 3.0]),
-        z_mid,
-        z_interface,
+        'BruntVaisalaFreqTop', _mid_level_field([1.0, 2.0, 3.0]), ds
     )
     assert z.dims == ('nVertLevels',)
     np.testing.assert_array_equal(z.values, z_interface.values[:-1])
 
 
-def test_a_named_field_on_interfaces_is_left_on_interfaces(z_mid, z_interface):
+def test_a_named_field_on_interfaces_is_left_on_interfaces(ds, z_interface):
     # Omega writes the same field on nVertLevelsP1; the dimensions win, so
     # naming a field is harmless for the model that gets it right
     z = _vertical_coord(
-        'BruntVaisalaFreqTop',
-        _interface_field([1.0, 2.0, 3.0, 4.0]),
-        z_mid,
-        z_interface,
+        'BruntVaisalaFreqTop', _interface_field([1.0, 2.0, 3.0, 4.0]), ds
     )
     assert z.dims == ('nVertLevelsP1',)
     np.testing.assert_array_equal(z.values, z_interface.values)
 
 
-def test_an_interface_field_keeps_every_value(z_mid, z_interface):
+def test_an_interface_field_keeps_every_value(ds):
     # the bottom interface used to be dropped so that the field could be
     # plotted against zMid; nothing is dropped now
     var = _interface_field([1.0, 2.0, 3.0, 4.0])
-    z = _vertical_coord(MID, var, z_mid, z_interface)
+    z = _vertical_coord(MID, var, ds)
     assert var.sizes['nVertLevelsP1'] == z.sizes['nVertLevelsP1']
 
 
-def test_an_interface_field_can_be_masked_by_depth(z_mid, z_interface):
+def test_an_interface_field_can_be_masked_by_depth(ds):
     # this is the combination that used to raise an IndexError
     var = _interface_field([1.0, 2.0, 3.0, 4.0])
-    z = _vertical_coord(MID, var, z_mid, z_interface)
+    z = _vertical_coord(MID, var, ds)
     x_limits: list[tuple[float, float]] = []
     _add_visible_limits(x_limits, var, z, -100.0, 0.0)
     assert x_limits == [(1.0, 3.0)]
 
 
-def test_a_top_of_layer_field_can_be_masked_by_depth(z_mid, z_interface):
+def test_a_top_of_layer_field_can_be_masked_by_depth(ds):
     # the renamed coordinate has to match the field's own dimension
     var = _mid_level_field([1.0, 2.0, 3.0])
-    z = _vertical_coord('BruntVaisalaFreqTop', var, z_mid, z_interface)
+    z = _vertical_coord('BruntVaisalaFreqTop', var, ds)
     x_limits: list[tuple[float, float]] = []
     _add_visible_limits(x_limits, var, z, -100.0, 0.0)
     assert x_limits == [(1.0, 3.0)]
@@ -158,7 +161,7 @@ def test_limits_accumulate_over_several_curves():
     assert max(limits[1] for limits in x_limits) == 2.0
 
 
-def test_curves_on_different_coordinates_share_one_range(z_mid, z_interface):
+def test_curves_on_different_coordinates_share_one_range(ds):
     # a plot mixes an interface field with the mid-level initial state, so
     # each curve contributes on its own coordinate
     x_limits: list[tuple[float, float]] = []
@@ -166,7 +169,7 @@ def test_curves_on_different_coordinates_share_one_range(z_mid, z_interface):
     _add_visible_limits(
         x_limits,
         var,
-        _vertical_coord(MID, var, z_mid, z_interface),
+        _vertical_coord(MID, var, ds),
         -100.0,
         0.0,
     )
@@ -174,7 +177,7 @@ def test_curves_on_different_coordinates_share_one_range(z_mid, z_interface):
     _add_visible_limits(
         x_limits,
         var,
-        _vertical_coord(MID, var, z_mid, z_interface),
+        _vertical_coord(MID, var, ds),
         -100.0,
         0.0,
     )

--- a/tests/ocean/vertical/test_diagnostics.py
+++ b/tests/ocean/vertical/test_diagnostics.py
@@ -11,7 +11,11 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from polaris.ocean.vertical.diagnostics import pseudothickness_from_ds
+from polaris.ocean.vertical.diagnostics import (
+    location_for_field,
+    pseudothickness_from_ds,
+    vertical_coord_from_location,
+)
 
 
 def _make_config(eos_type='teos-10'):
@@ -90,3 +94,77 @@ def test_dataset_surface_pressure_is_used_by_default():
         src_var_name='restingThickness',
     )
     assert not np.allclose(at_zero.values, from_ds.values)
+
+
+def _make_vert_coord_ds(var_name, with_time=None):
+    """A dataset with a single vertical coordinate field on ``nCells``,
+    ``nVertLevels``, and optionally ``Time`` of the given length."""
+    values: list = [[0.0, -1.0], [0.0, -2.0]]
+    dims: tuple = ('nCells', 'nVertLevels')
+    if with_time is not None:
+        values = [values] * with_time
+        dims = ('Time',) + dims
+    return xr.Dataset(data_vars={var_name: (dims, values)})
+
+
+@pytest.mark.parametrize(
+    'location, var_name',
+    [
+        ('cell-center', 'zMid'),
+        ('cell-interfaces', 'GeomZInterface'),
+        ('cell-top', 'zTop'),
+    ],
+)
+def test_vertical_coord_from_location(location, var_name):
+    ds = _make_vert_coord_ds(var_name)
+    coord = vertical_coord_from_location(ds, location)
+    assert set(coord.dims) == {'nCells', 'nVertLevels'}
+    np.testing.assert_allclose(coord.values, [[0.0, -1.0], [0.0, -2.0]])
+
+
+def test_vertical_coord_from_location_unsupported_location():
+    ds = _make_vert_coord_ds('zMid')
+    with pytest.raises(ValueError, match='Unsupported variable location'):
+        vertical_coord_from_location(ds, 'cell-bottom')
+
+
+def test_vertical_coord_from_location_missing_field():
+    ds = _make_vert_coord_ds('zMid')
+    with pytest.raises(ValueError, match='GeomZInterface'):
+        vertical_coord_from_location(ds, 'cell-interfaces')
+
+
+def test_vertical_coord_from_location_retains_time_of_length_one():
+    ds = _make_vert_coord_ds('zMid', with_time=1)
+    coord = vertical_coord_from_location(ds, 'cell-center')
+    assert set(coord.dims) == {'Time', 'nCells', 'nVertLevels'}
+    assert coord.sizes['Time'] == 1
+
+
+def test_vertical_coord_from_location_rejects_multiple_times():
+    """A dataset carrying more than one time cannot be reduced to a single
+    vertical coordinate without picking a time, which is left to the
+    caller."""
+    ds = _make_vert_coord_ds('zMid', with_time=2)
+    with pytest.raises(ValueError, match='Time dimension'):
+        vertical_coord_from_location(ds, 'cell-center')
+
+
+def test_location_for_field_interfaces():
+    var = xr.DataArray(np.zeros(3), dims=('nVertLevelsP1',))
+    assert location_for_field(var) == 'cell-interfaces'
+
+
+def test_location_for_field_layer_top():
+    """BruntVaisalaFreqTop is listed in variables.yaml as an MPAS-Ocean
+    field written at the top of each layer despite being on
+    nVertLevels."""
+    var = xr.DataArray(np.zeros(3), dims=('nVertLevels',))
+    location = location_for_field(var, 'BruntVaisalaFreqTop')
+    assert location == 'cell-top'
+
+
+def test_location_for_field_defaults_to_cell_center():
+    var = xr.DataArray(np.zeros(3), dims=('nVertLevels',))
+    assert location_for_field(var, 'temperature') == 'cell-center'
+    assert location_for_field(var) == 'cell-center'

--- a/tests/ocean/vertical/test_diagnostics.py
+++ b/tests/ocean/vertical/test_diagnostics.py
@@ -11,7 +11,10 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from polaris.constants import get_constant
 from polaris.ocean.vertical.diagnostics import (
+    depth_from_thickness,
+    get_z_mid_and_interface,
     location_for_field,
     pseudothickness_from_ds,
     vertical_coord_from_location,
@@ -168,3 +171,104 @@ def test_location_for_field_defaults_to_cell_center():
     var = xr.DataArray(np.zeros(3), dims=('nVertLevels',))
     assert location_for_field(var, 'temperature') == 'cell-center'
     assert location_for_field(var) == 'cell-center'
+
+
+def _make_reconstruction_datasets():
+    ds = xr.Dataset(
+        data_vars=dict(
+            layerThickness=(('nCells', 'nVertLevels'), [[10.0, 10.0]]),
+        )
+    )
+    ds_vert = xr.Dataset(
+        data_vars=dict(
+            bottomDepth=('nCells', [20.0]),
+            minLevelCell=('nCells', [1]),
+            maxLevelCell=('nCells', [2]),
+        )
+    )
+    return ds, ds_vert
+
+
+def test_get_z_mid_and_interface_reconstruct():
+    ds, ds_vert = _make_reconstruction_datasets()
+    with pytest.raises(ValueError, match='no zMid, GeomZInterface'):
+        get_z_mid_and_interface(ds, allow_reconstruct=False)
+
+    with pytest.raises(
+        ValueError, match='without the vertical coordinate dataset'
+    ):
+        get_z_mid_and_interface(ds, allow_reconstruct=True, ds_vert=None)
+
+    z_mid, z_interface = get_z_mid_and_interface(
+        ds, allow_reconstruct=True, ds_vert=ds_vert
+    )
+    np.testing.assert_allclose(z_interface.values, [[0.0, -10.0, -20.0]])
+    np.testing.assert_allclose(z_mid.values, [[-5.0, -15.0]])
+
+
+def test_depth_from_thickness_with_ds_vert():
+    ds, ds_vert = _make_reconstruction_datasets()
+    with pytest.raises(
+        ValueError, match='without the vertical coordinate dataset'
+    ):
+        depth_from_thickness(ds, ds_vert=None)
+
+    z_mid = depth_from_thickness(ds, ds_vert=ds_vert)
+    np.testing.assert_allclose(z_mid.values, [[-5.0, -15.0]])
+
+
+def test_vertical_coord_from_location_reconstruct():
+    ds, ds_vert = _make_reconstruction_datasets()
+    with pytest.raises(
+        ValueError, match='without the vertical coordinate dataset'
+    ):
+        vertical_coord_from_location(
+            ds, 'cell-center', allow_reconstruct=True, ds_vert=None
+        )
+
+    z_center = vertical_coord_from_location(
+        ds, 'cell-center', allow_reconstruct=True, ds_vert=ds_vert
+    )
+    np.testing.assert_allclose(z_center.values, [[-5.0, -15.0]])
+
+    z_inter = vertical_coord_from_location(
+        ds, 'cell-interfaces', allow_reconstruct=True, ds_vert=ds_vert
+    )
+    np.testing.assert_allclose(z_inter.values, [[0.0, -10.0, -20.0]])
+
+    z_top = vertical_coord_from_location(
+        ds, 'cell-top', allow_reconstruct=True, ds_vert=ds_vert
+    )
+    np.testing.assert_allclose(z_top.values, [[0.0, -10.0]])
+
+
+def test_reconstruct_from_omega_state():
+    rho_sw = get_constant('seawater_density_reference')
+    spec_vol = 1.0 / rho_sw
+    ds = xr.Dataset(
+        data_vars=dict(
+            SpecVol=(('nCells', 'nVertLevels'), [[spec_vol, spec_vol]]),
+            PseudoThickness=(('nCells', 'nVertLevels'), [[10.0, 10.0]]),
+        )
+    )
+    ds_vert = xr.Dataset(
+        data_vars=dict(
+            bottomDepth=('nCells', [20.0]),
+        )
+    )
+    z_mid, z_interface = get_z_mid_and_interface(
+        ds, allow_reconstruct=True, ds_vert=ds_vert
+    )
+    np.testing.assert_allclose(z_interface.values, [[0.0, -10.0, -20.0]])
+    np.testing.assert_allclose(z_mid.values, [[-5.0, -15.0]])
+
+
+def test_reconstruct_missing_bottom_depth():
+    ds = xr.Dataset(
+        data_vars=dict(
+            layerThickness=(('nCells', 'nVertLevels'), [[10.0, 10.0]]),
+        )
+    )
+    ds_vert = xr.Dataset()
+    with pytest.raises(ValueError, match='bottomDepth is not present'):
+        get_z_mid_and_interface(ds, allow_reconstruct=True, ds_vert=ds_vert)

--- a/tests/ocean/vertical/test_elevation.py
+++ b/tests/ocean/vertical/test_elevation.py
@@ -82,7 +82,7 @@ def columns():
                 ('nCells', 'nVertLevels'),
                 np.where(_WATER, Z_MID, np.nan),
             ),
-            zInterface=(
+            GeomZInterface=(
                 ('nCells', 'nVertLevelsP1'),
                 np.where(_WATER_INTERFACE, Z_INTERFACE, np.nan),
             ),
@@ -293,7 +293,7 @@ def test_a_data_set_with_no_vertical_geometry_is_reported():
     """A simulation that did not write it cannot be analysed at an
     elevation at all, so this says so rather than reconstructing
     something."""
-    with pytest.raises(ValueError, match='no zMid, zInterface'):
+    with pytest.raises(ValueError, match='no zMid, GeomZInterface'):
         get_z_mid_and_interface(xr.Dataset())
 
 
@@ -304,7 +304,7 @@ def _interpolate(ds, elevation, field=None):
         da,
         parse_vertical_reduction(f'{elevation}'),
         z_mid=ds.zMid,
-        z_interface=ds.zInterface,
+        z_interface=ds.GeomZInterface,
         min_level_cell=ds.minLevelCell,
         max_level_cell=ds.maxLevelCell,
     )
@@ -571,7 +571,7 @@ def test_the_whole_column_is_the_same_with_the_geometry_and_without(columns):
 def _range_weights(ds, z_top, z_bot):
     """The weights of an elevation range, as an array"""
     return elevation_range_weights(
-        ds.zInterface,
+        ds.GeomZInterface,
         ds.layer_mass,
         ds.minLevelCell,
         ds.maxLevelCell,


### PR DESCRIPTION
This PR consolidates several inconsistent, duplicated ways of reading or reconstructing the vertical elevation of a field (`zMid`, `GeomZInterface`, `zTop`) into one lookup point, `vertical_coord_from_location()`, plus `location_for_field()` to decide which of the three a given field needs. Single-column `viz.py` and the `ekman` and `vmix` analysis steps now go through these instead of hand-rolled dimension and field-name checks.

Reconstructing the geometry from layer thickness previously had two definitions that disagreed: one anchored at `ssh` and summed downward, the other anchored at `bottomDepth` and summed upward. Reconstruction now always anchors at `bottomDepth`, and `compute_zint_zmid_from_layer_thickness` delegates to the same implementation instead of duplicating it. Layer thickness for reconstruction is obtained through `geom_thickness_from_ds()`, so it also works for Omega output (`SpecVol`/`PseudoThickness`), not just MPAS-Ocean's `layerThickness`.

Also drops `zInterface` from the MPAS-Ocean/Omega variable mapping, since MPAS-Ocean has no such variable; `GeomZInterface` is used directly.

Checklist
* [X] `Testing` comment in the PR documents testing used to verify the changes