### PR TITLE
Check Omega output for CF compliance

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -164,9 +164,11 @@ seaice/api
    Step.add_input_file
    Step.add_output_file
    Step.add_property_check
+   Step.add_cf_check
    Step.add_dependency
    Step.validate_baselines
    Step.check_properties
+   Step.check_cf
    Step.set_shared_config
 ```
 
@@ -254,6 +256,19 @@ seaice/api
 
    generate_site
    gallery_filename
+```
+
+### cf_check
+
+```{eval-rst}
+.. currentmodule:: polaris.cf_check
+
+.. autosummary::
+   :toctree: generated/
+
+   add_cf_tables
+   resolve_cf_check_files
+   check_cf_compliance
 ```
 
 ### config

--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -329,7 +329,9 @@ filename and add the files in an override of
 {py:meth}`polaris.Step.check_cf()` before calling the base-class method.
 {py:class}`polaris.ocean.model.OceanModelStep` does this for Omega: every
 step running Omega checks the first file of each stream in write mode in its
-`omega.yml`.  MPAS-Ocean output is not checked.
+`omega.yml`.  MPAS-Ocean output is not checked.  Omega writes the model
+start time as the origin of the `time` variable's units, and udunits rejects
+a year-0 origin, so a task that starts in year 0 cannot pass the check.
 
 The checker needs the CF standard-name, area-type and region-name tables.
 Their versions are pinned in the `[cf]` section of `default.cfg`, so a table

--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -301,3 +301,55 @@ error tolerance) in the step's work directory.  The full details of every
 check are also written to `property_check_results.json` and stored in the
 step's `property_check_results` attribute, so that other steps can summarize
 them.
+
+(dev-cf-check)=
+
+# CF compliance checks
+
+A step can have its output files checked for compliance with the
+[CF conventions](https://cfconventions.org/) after it runs, using the
+[CF checker](https://github.com/cedadev/cf-checker) (`cfchecks`).  A file
+passes when the checker reports no errors; warnings and informational
+messages go to the step's log but do not fail the check.  Unlike a property
+check, a failed CF check fails the task, so a suite cannot pass while a
+model writes non-compliant metadata.
+
+To opt in, call {py:meth}`polaris.Step.add_cf_check()` with each file to
+check.  A glob pattern stands for a series of files with the same metadata,
+such as a time series from one output stream, so only its first match is
+checked:
+
+```python
+self.add_cf_check('output.nc')
+self.add_cf_check('restarts/rst.*.nc')
+```
+
+A step that only knows its output files at run time can opt in with no
+filename and add the files in an override of
+{py:meth}`polaris.Step.check_cf()` before calling the base-class method.
+{py:class}`polaris.ocean.model.OceanModelStep` does this for Omega: every
+step running Omega checks the first file of each stream in write mode in its
+`omega.yml`.  MPAS-Ocean output is not checked.
+
+The checker needs the CF standard-name, area-type and region-name tables.
+Their versions are pinned in the `[cf]` section of `default.cfg`, so a table
+update cannot change what a check reports, and each is downloaded once per
+machine into the `cf/tables` database and linked into the step:
+
+```cfg
+# Options for checking netCDF files for CF compliance
+[cf]
+
+# Versions of the CF standard-name, area-type and region-name tables, pinned
+# so that a table update cannot change what a check reports
+standard_name_table_version = 94
+area_type_table_version = 13
+region_name_table_version = 5
+```
+
+The result of the check is written to `cf_check_passed.log` or
+`cf_check_failed.log` (which lists the errors for each failing file) in the
+step's work directory and stored in the step's `cf_check_results` attribute.
+When a suite runs, each step that ran a check gets a `CF compliance` line
+next to its property checks and baseline comparison, and tasks that failed
+the check are listed in the suite's pull-request summary.

--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -317,7 +317,8 @@ model writes non-compliant metadata.
 To opt in, call {py:meth}`polaris.Step.add_cf_check()` with each file to
 check.  A glob pattern stands for a series of files with the same metadata,
 such as a time series from one output stream, so only its first match is
-checked:
+checked, and a pattern with no match is skipped as a series that never
+started (a restart stream whose interval is longer than the run):
 
 ```python
 self.add_cf_check('output.nc')

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -764,6 +764,7 @@
    OceanModelStep
    OceanModelStep.setup
    OceanModelStep.check_properties
+   OceanModelStep.check_cf
    OceanModelStep.constrain_resources
    OceanModelStep.compute_cell_count
    OceanModelStep.map_yaml_options

--- a/docs/users_guide/ocean/suites.md
+++ b/docs/users_guide/ocean/suites.md
@@ -72,7 +72,9 @@ ocean/spherical/icos/cosine_bell/restart
 # omega_pr suite
 
 The `omega_pr` suite is designed to test changes in Omega or the affects of
-Polaris changes on Omega results.
+Polaris changes on Omega results.  Every file Omega writes in the suite is
+checked for CF compliance, and a task fails if the checker reports errors
+(see {ref}`dev-cf-check`).
 
 Here are the tests in the suite:
 ```none

--- a/polaris/cf_check.py
+++ b/polaris/cf_check.py
@@ -48,8 +48,10 @@ def resolve_cf_check_files(patterns: List[str], work_dir: str) -> List[str]:
     Resolve the file patterns registered for a CF check to the files to
     check.  A pattern with wildcards stands for a series of files with the
     same metadata (a time series from one output stream), so only its first
-    match is checked.  A pattern with no match is kept so the check can
-    report it as missing.
+    match is checked, and a pattern with no match is a series that never
+    started (a restart stream whose interval is longer than the run), so it
+    is skipped.  A plain filename is kept whether or not it exists, so the
+    check can report it as missing.
 
     Parameters
     ----------
@@ -69,8 +71,9 @@ def resolve_cf_check_files(patterns: List[str], work_dir: str) -> List[str]:
         path = os.path.join(work_dir, pattern)
         if glob.has_magic(pattern):
             matches = sorted(glob.glob(path))
-            if matches:
-                path = matches[0]
+            if not matches:
+                continue
+            path = matches[0]
         filename = os.path.relpath(path, work_dir)
         if filename.startswith('..'):
             filename = path

--- a/polaris/cf_check.py
+++ b/polaris/cf_check.py
@@ -1,0 +1,165 @@
+"""
+Check netCDF files for CF compliance with the CF checker (``cfchecker``)
+"""
+
+import glob
+import os
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+
+if TYPE_CHECKING:
+    from polaris.step import Step
+
+# the CF tables the checker needs, as (config option prefix, local filename)
+CF_TABLES: List[Tuple[str, str]] = [
+    ('standard_name_table', 'cf-standard-name-table.xml'),
+    ('area_type_table', 'cf-area-type-table.xml'),
+    ('region_name_table', 'cf-region-name-table.xml'),
+]
+
+
+def add_cf_tables(step: 'Step') -> None:
+    """
+    Add the CF standard-name, area-type and region-name tables as inputs of
+    a step.  They are downloaded at the versions pinned in the ``[cf]``
+    config section into the ``cf/tables`` database, so a table is fetched
+    once per machine rather than once per run.
+
+    Parameters
+    ----------
+    step : polaris.Step
+        The step that will run a CF check
+    """
+    config = step.config
+    for option, filename in CF_TABLES:
+        version = config.get('cf', f'{option}_version')
+        url = config.get('cf', f'{option}_url').format(version=version)
+        base, ext = os.path.splitext(filename)
+        step.add_input_file(
+            filename=filename,
+            target=f'{base}.{version}{ext}',
+            database='tables',
+            database_component='cf',
+            url=url,
+        )
+
+
+def resolve_cf_check_files(patterns: List[str], work_dir: str) -> List[str]:
+    """
+    Resolve the file patterns registered for a CF check to the files to
+    check.  A pattern with wildcards stands for a series of files with the
+    same metadata (a time series from one output stream), so only its first
+    match is checked.  A pattern with no match is kept so the check can
+    report it as missing.
+
+    Parameters
+    ----------
+    patterns : list of str
+        Filenames or glob patterns, relative to ``work_dir`` unless absolute
+
+    work_dir : str
+        The step's work directory
+
+    Returns
+    -------
+    filenames : list of str
+        The files to check, relative to ``work_dir`` where possible
+    """
+    filenames: List[str] = []
+    for pattern in patterns:
+        path = os.path.join(work_dir, pattern)
+        if glob.has_magic(pattern):
+            matches = sorted(glob.glob(path))
+            if matches:
+                path = matches[0]
+        filename = os.path.relpath(path, work_dir)
+        if filename.startswith('..'):
+            filename = path
+        if filename not in filenames:
+            filenames.append(filename)
+    return filenames
+
+
+def check_cf_compliance(
+    filenames: List[str], work_dir: str
+) -> List[Dict[str, Any]]:
+    """
+    Run the CF checker on each file.  A file passes when the checker
+    reports no errors; warnings and informational messages are recorded
+    but do not fail it.
+
+    Parameters
+    ----------
+    filenames : list of str
+        The files to check, relative to ``work_dir`` unless absolute
+
+    work_dir : str
+        The step's work directory, where the CF tables were linked
+
+    Returns
+    -------
+    results : list of dict
+        One entry per file with the keys ``filename``, ``passed``,
+        ``errors`` (a list of strings), ``warnings`` (an int) and
+        ``report`` (the full text of the checker's output)
+    """
+    # cfchecker pulls in cfunits and udunits, which nothing else in the
+    # framework needs, so it is imported only when a check runs
+    from cfchecker.cfchecks import CFChecker, CFVersion, FatalCheckerError
+
+    tables = {
+        option: os.path.join(work_dir, filename)
+        for option, filename in CF_TABLES
+    }
+
+    results: List[Dict[str, Any]] = []
+    for filename in filenames:
+        path = os.path.join(work_dir, filename)
+        if not os.path.exists(path):
+            results.append(
+                dict(
+                    filename=filename,
+                    passed=False,
+                    errors=['file not found'],
+                    warnings=0,
+                    report=f'{filename}: file not found\n',
+                )
+            )
+            continue
+        # a new checker per file, because an auto-detected CF version
+        # sticks to the checker object after its first file
+        checker = CFChecker(
+            cfStandardNamesXML=tables['standard_name_table'],
+            cfAreaTypesXML=tables['area_type_table'],
+            cfRegionNamesXML=tables['region_name_table'],
+            version=CFVersion(),
+            silent=True,
+        )
+        try:
+            checker.checker(path)
+        except FatalCheckerError:
+            pass
+        results.append(_summarize(filename, checker.results))
+    return results
+
+
+def _summarize(filename: str, raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Reduce the checker's nested results to one entry for the file."""
+    errors: List[str] = []
+    warnings = 0
+    lines = [f'{filename}:']
+    sections = [('global', raw['global'])]
+    sections.extend(raw['variables'].items())
+    for name, messages in sections:
+        for message in messages['FATAL'] + messages['ERROR']:
+            errors.append(f'{name}: {message}')
+        warnings += len(messages['WARN'])
+        for category in ('FATAL', 'ERROR', 'WARN', 'INFO'):
+            for message in messages[category]:
+                lines.append(f'  {category} {name}: {message}')
+    return dict(
+        filename=filename,
+        passed=len(errors) == 0,
+        errors=errors,
+        warnings=warnings,
+        report='\n'.join(lines) + '\n',
+    )

--- a/polaris/default.cfg
+++ b/polaris/default.cfg
@@ -43,6 +43,22 @@ format = NETCDF3_64BIT_DATA
 engine = netcdf4
 
 
+# Options for checking netCDF files for CF compliance
+[cf]
+
+# Versions of the CF standard-name, area-type and region-name tables, pinned
+# so that a table update cannot change what a check reports
+standard_name_table_version = 94
+area_type_table_version = 13
+region_name_table_version = 5
+
+# URLs the tables are downloaded from, with {version} replaced by the
+# versions above
+standard_name_table_url = https://cfconventions.org/Data/cf-standard-names/{version}/src/cf-standard-name-table.xml
+area_type_table_url = https://cfconventions.org/Data/area-type-table/{version}/src/area-type-table.xml
+region_name_table_url = https://cfconventions.org/Data/standardized-region-list/standardized-region-list.{version}.xml
+
+
 # Config options related to creating a job script
 [job]
 

--- a/polaris/io.py
+++ b/polaris/io.py
@@ -63,7 +63,11 @@ def download(url, dest_path, config, exceptions=True):  # noqa: C901
         pass
 
     try:
-        response = session.get(url, stream=True)
+        # ask for an uncompressed response so the content length is the
+        # size of the file, which the size check and progress bar assume
+        response = session.get(
+            url, stream=True, headers={'Accept-Encoding': 'identity'}
+        )
         total_size = response.headers.get('content-length')
     except requests.exceptions.RequestException:
         if exceptions:

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -1,6 +1,7 @@
 import importlib.resources as imp_res
 import json
 import os
+import re
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
@@ -27,6 +28,7 @@ from polaris.ocean.conservation import (
 )
 from polaris.ocean.model.ocean_model_files_mixin import OceanModelFilesMixin
 from polaris.ocean.model.time import get_time_since_start
+from polaris.yaml import PolarisYaml
 
 if TYPE_CHECKING:
     # Keep Ocean as a type-only import. Importing it at runtime pulls
@@ -211,6 +213,8 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
             self.streams_section = 'IOStreams'
             self._read_config_map()
             self.partition_graph = False
+            # every file Omega writes is checked for CF compliance
+            self.add_cf_check()
         elif model == 'mpas-ocean':
             self.config_models = ['ocean', 'mpas-ocean']
             self.make_yaml = False
@@ -497,6 +501,33 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
             'config_eos_type': eos_type,
         }
         return replacements
+
+    def check_cf(self):
+        """
+        Check every file Omega wrote for CF compliance: the first file of
+        each write stream in the step's ``omega.yml``, since the files of a
+        stream share their metadata.  MPAS-Ocean output is not checked.
+
+        Returns
+        -------
+        checked : bool
+            Whether any files were checked
+
+        success : bool
+            Whether every checked file was free of errors
+        """
+        if self.config.get('ocean', 'model') == 'omega':
+            yaml = PolarisYaml.read(
+                os.path.join(self.work_dir, self.yaml),
+                streams_section=self.streams_section,
+            )
+            for stream in yaml.streams.values():
+                if stream.get('Mode') != 'write':
+                    continue
+                # Omega's time template in a filename becomes a glob
+                pattern = re.sub(r'\$[YMDhms]', '*', stream['Filename'])
+                self.add_cf_check(pattern)
+        return super().check_cf()
 
     def check_properties(self):
         """

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -91,6 +91,7 @@ def run_tasks(
         total_tasks = len(suite['tasks'])
         exec_fail_tasks: List[str] = []
         diff_fail_tasks: List[str] = []
+        cf_fail_tasks: List[str] = []
         for task_name in suite['tasks']:
             stdout_logger.info(f'{task_name}')
 
@@ -110,6 +111,7 @@ def run_tasks(
                 task_time,
                 exec_failed,
                 diff_failed,
+                cf_failed,
             ) = _log_and_run_task(
                 task,
                 stdout_logger,
@@ -128,6 +130,8 @@ def run_tasks(
                 exec_fail_tasks.append(task_name)
             if diff_failed:
                 diff_fail_tasks.append(task_name)
+            if cf_failed:
+                cf_fail_tasks.append(task_name)
             task_times[task_name] = task_time
 
         suite_time = time.time() - suite_start
@@ -142,6 +146,7 @@ def run_tasks(
                 'total': total_tasks,
                 'failures': exec_fail_tasks,
                 'diffs': diff_fail_tasks,
+                'cf': cf_fail_tasks,
             },
         )
 
@@ -389,10 +394,11 @@ def _log_and_run_task(
         task_logger.info('')
         task_list = ', '.join(task.steps_to_run)
         task_logger.info(f'Running steps: {task_list}')
-        # Default in case execution fails before setting this
+        # Default in case execution fails before setting these
         baselines_passed = None
+        cf_passed = None
         try:
-            baselines_passed = _run_task(task, available_resources)
+            baselines_passed, cf_passed = _run_task(task, available_resources)
             run_status = success_str
             task_pass = True
         except Exception:
@@ -424,6 +430,17 @@ def _log_and_run_task(
                     f'POLARIS BASELINE: '
                     f'{"PASS" if baselines_passed else "FAIL"}'
                 )
+            if cf_passed is not None:
+                if cf_passed:
+                    cf_str = pass_str
+                else:
+                    cf_str = fail_str
+                    result_str = fail_str
+                    success = False
+                stdout_logger.info(f'  CF compliance:    {cf_str}')
+                task_logger.info(
+                    f'POLARIS CF COMPLIANCE: {"PASS" if cf_passed else "FAIL"}'
+                )
 
         else:
             stdout_logger.error(status)
@@ -441,7 +458,8 @@ def _log_and_run_task(
 
     exec_failed = not task_pass
     diff_failed = baselines_passed is False
-    return result_str, success, task_time, exec_failed, diff_failed
+    cf_failed = cf_passed is False
+    return result_str, success, task_time, exec_failed, diff_failed, cf_failed
 
 
 def _read_baseline_status_from_logs(step_work_dir: str) -> Optional[bool]:
@@ -484,6 +502,49 @@ def _read_property_status_from_logs(step_work_dir: str) -> Optional[bool]:
     if os.path.exists(property_check_fail_filename):
         return False
     return None
+
+
+def _read_cf_status_from_logs(step_work_dir: str) -> Optional[bool]:
+    """Get CF check status from existing log markers.
+
+    Returns
+    -------
+    Optional[bool]
+        True if ``cf_check_passed.log`` exists, False if
+        ``cf_check_failed.log`` exists, otherwise None.
+    """
+    if os.path.exists(os.path.join(step_work_dir, 'cf_check_passed.log')):
+        return True
+    if os.path.exists(os.path.join(step_work_dir, 'cf_check_failed.log')):
+        return False
+    return None
+
+
+def _cf_check_message(results, passed: bool, step_name: str) -> str:
+    """Build the contents of the CF check log file.
+
+    The files that passed are listed.  For a failing step, the errors the
+    checker reported for each failing file are listed first.  The full
+    report, including warnings, is in the step's log.
+    """
+    if passed:
+        lines = [f'CF check passed for step {step_name}', '']
+    else:
+        lines = [f'CF check failed for step {step_name}', '']
+        lines.append('The following files had errors:')
+        for result in results:
+            if result['passed']:
+                continue
+            lines.append(f'  {result["filename"]}')
+            for error in result['errors']:
+                lines.append(f'    {error}')
+        lines.append('')
+    passing = [result for result in results if result['passed']]
+    if passing:
+        lines.append('The following files passed:')
+        for result in passing:
+            lines.append(f'  {result["filename"]}')
+    return '\n'.join(lines) + '\n'
 
 
 def _property_check_message(results, passed: bool, step_name: str) -> str:
@@ -541,6 +602,7 @@ def _run_task(task, available_resources):
     cwd = os.getcwd()
     baselines_passed = None
     property_passed = None
+    cf_passed = None
     for step_name in task.steps_to_run:
         step = task.steps[step_name]
         complete_filename = os.path.join(
@@ -571,6 +633,9 @@ def _run_task(task, available_resources):
                 property_passed = _accumulate_baselines(
                     property_passed, property_status
                 )
+            cf_passed = _report_cf_status(
+                task, _read_cf_status_from_logs(step.work_dir), cf_passed
+            )
             continue
         if step.cached:
             _print_to_stdout(task, '          cached')
@@ -643,6 +708,11 @@ def _run_task(task, available_resources):
                     property_passed, properties_passed
                 )
 
+        if step.cf_check:
+            cf_passed = _report_cf_status(
+                task, _check_step_cf(step, step_name), cf_passed
+            )
+
         compared, status = step.validate_baselines()
         if compared:
             if status:
@@ -660,7 +730,50 @@ def _run_task(task, available_resources):
             f'{start_time_color}{step_time_str}{end_color}',
         )
 
-    return baselines_passed
+    return baselines_passed, cf_passed
+
+
+def _check_step_cf(step, step_name) -> Optional[bool]:
+    """
+    Run the step's CF check and leave a ``cf_check_passed.log`` or
+    ``cf_check_failed.log`` marker in its work directory.
+
+    Returns
+    -------
+    Optional[bool]
+        Whether the check passed, or None if the step checked no files
+    """
+    checked, files_passed = step.check_cf()
+    if not checked:
+        return None
+    passed_log = os.path.join(step.work_dir, 'cf_check_passed.log')
+    failed_log = os.path.join(step.work_dir, 'cf_check_failed.log')
+    if files_passed:
+        write_log, remove_log = passed_log, failed_log
+    else:
+        write_log, remove_log = failed_log, passed_log
+    message = _cf_check_message(
+        step.cf_check_results, passed=files_passed, step_name=step_name
+    )
+    with open(write_log, 'w') as f:
+        f.write(message)
+    if os.path.exists(remove_log):
+        os.remove(remove_log)
+    return files_passed
+
+
+def _report_cf_status(
+    task, status: Optional[bool], cf_passed: Optional[bool]
+) -> Optional[bool]:
+    """
+    Print a step's CF compliance line, if it ran a check, and fold its
+    status into the task's aggregate.
+    """
+    if status is None:
+        return cf_passed
+    cf_str = pass_str if status else fail_str
+    _print_to_stdout(task, f'          CF compliance:    {cf_str}')
+    return _accumulate_baselines(cf_passed, status)
 
 
 def _run_step(
@@ -886,28 +999,33 @@ def _write_output_for_pull_request(
 
     # If we have results, summarize them
     if results is not None and isinstance(results, dict):
-        total = int(results.get('total', 0) or 0)
-        failures: List[str] = list(results.get('failures', []) or [])
-        diffs: List[str] = list(results.get('diffs', []) or [])
-
-        if total > 0 and not failures and not diffs:
-            lines.append('- Result: All tests passed')
-        else:
-            lines.append('- Result:')
-            if failures:
-                lines.append(f'  - Failures ({len(failures)} of {total}):')
-                for name in failures:
-                    lines.append(f'    - `{name}`')
-            if diffs:
-                lines.append(f'  - Diffs ({len(diffs)} of {total}):')
-                for name in diffs:
-                    lines.append(f'    - `{name}`')
+        lines.extend(_result_lines(results))
 
     out_path = os.path.join(work_dir, f'{suite_name}_output_for_pr.md')
     print(f'Writing output useful for copy/paste into PRs to:\n  {out_path}')
     with open(out_path, 'w') as out:
         out.write('\n'.join(lines) + '\n')
     print('Done.')
+
+
+def _result_lines(results: dict) -> List[str]:
+    """The result lines of the pull-request summary."""
+    total = int(results.get('total', 0) or 0)
+    categories = [
+        ('Failures', list(results.get('failures', []) or [])),
+        ('Diffs', list(results.get('diffs', []) or [])),
+        ('CF compliance failures', list(results.get('cf', []) or [])),
+    ]
+    if total > 0 and not any(names for _, names in categories):
+        return ['- Result: All tests passed']
+    lines = ['- Result:']
+    for label, names in categories:
+        if not names:
+            continue
+        lines.append(f'  - {label} ({len(names)} of {total}):')
+        for name in names:
+            lines.append(f'    - `{name}`')
+    return lines
 
 
 def _parse_provenance_into(path, labels, target_values):

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -1087,7 +1087,8 @@ class Step:
             The relative path of the file within the step's work directory.
             A glob pattern stands for a series of files with the same
             metadata (a time series from one output stream), so only its
-            first match is checked.  With no filename, the step is only
+            first match is checked, and a pattern with no match is skipped
+            as a series that never started.  With no filename, the step is only
             opted into the check, for subclasses that find their output
             files at run time and add them in :py:meth:`check_cf()`.
         """

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -7,6 +7,11 @@ import warnings
 from mache import MachineInfo
 from mache.permissions import update_permissions
 
+from polaris.cf_check import (
+    add_cf_tables,
+    check_cf_compliance,
+    resolve_cf_check_files,
+)
 from polaris.config import PolarisConfigParser
 from polaris.io import download, symlink
 from polaris.validate import compare_variables
@@ -212,6 +217,19 @@ class Step:
         :py:meth:`check_properties()`, each a dictionary with at least the
         keys ``description``, ``relative_error``, ``tolerance`` and
         ``passed``
+
+    cf_check : bool
+        Whether to check output files for CF compliance after the step
+        runs, set by :py:meth:`add_cf_check()`
+
+    cf_check_files : list of str
+        Files or glob patterns, relative to the step's work directory, to
+        check for CF compliance, added with :py:meth:`add_cf_check()`
+
+    cf_check_results : list of dict
+        The results of the CF checks performed by :py:meth:`check_cf()`,
+        each a dictionary with at least the keys ``filename``, ``passed``,
+        ``errors`` and ``report``
 
     logger : logging.Logger
         A logger for output from the step
@@ -419,6 +437,9 @@ class Step:
         self.validate_vars = dict()
         self.properties_to_check = list()
         self.property_check_results = list()
+        self.cf_check = False
+        self.cf_check_files = list()
+        self.cf_check_results = list()
         self.setup_complete = False
 
         # these will be set before running the step, dummy placeholders for now
@@ -1054,6 +1075,26 @@ class Step:
             )
         )
 
+    def add_cf_check(self, filename=None):
+        """
+        Check an output file for CF compliance after the step runs.  The
+        step fails its CF check if the CF checker reports any errors for the
+        file.
+
+        Parameters
+        ----------
+        filename : str, optional
+            The relative path of the file within the step's work directory.
+            A glob pattern stands for a series of files with the same
+            metadata (a time series from one output stream), so only its
+            first match is checked.  With no filename, the step is only
+            opted into the check, for subclasses that find their output
+            files at run time and add them in :py:meth:`check_cf()`.
+        """
+        self.cf_check = True
+        if filename is not None and filename not in self.cf_check_files:
+            self.cf_check_files.append(filename)
+
     def add_dependency(self, step, name=None):
         """
         Add `step` as a dependency of this step (i.e. this step can't run
@@ -1102,6 +1143,35 @@ class Step:
             Whether all checked properties were within tolerance
         """
         return False, True
+
+    def check_cf(self):
+        """
+        Check the files added with :py:meth:`add_cf_check()` for CF
+        compliance.  Each file's full report from the checker goes to the
+        step's logger, and the results are stored in
+        ``self.cf_check_results``.  Subclasses that find their output files
+        at run time can add to ``self.cf_check_files`` before calling this
+        method.
+
+        Returns
+        -------
+        checked : bool
+            Whether any files were checked
+
+        success : bool
+            Whether every checked file was free of errors
+        """
+        if not self.cf_check or not self.cf_check_files:
+            return False, True
+        filenames = resolve_cf_check_files(self.cf_check_files, self.work_dir)
+        results = check_cf_compliance(filenames, self.work_dir)
+        self.cf_check_results = results
+        logger = self.logger
+        success = True
+        for result in results:
+            logger.info(result['report'])
+            success = success and result['passed']
+        return True, success
 
     def validate_baselines(self):
         """
@@ -1216,6 +1286,9 @@ class Step:
                 self.add_input_file(
                     filename=output, target=target, database='polaris_cache'
                 )
+
+        if self.cf_check:
+            add_cf_tables(self)
 
         inputs = []
         databases_with_downloads = set()

--- a/polaris/tasks/ocean/baroclinic_channel/forward.py
+++ b/polaris/tasks/ocean/baroclinic_channel/forward.py
@@ -278,11 +278,11 @@ class Forward(OceanModelStep):
                 os.path.join(self.work_dir, '..', 'restarts')
             )
             os.makedirs(restart_dir, exist_ok=True)
-            restart_filename = f'{restart_dir}/ocn.rst.$Y-$M-$D_$h.$m.$s'
+            restart_filename = f'{restart_dir}/ocn.rst.$Y-$M-$D_$h.$m.$s.nc'
             restart_freq = int(dt)
         else:
             restart_interval = get_time_interval_string(days=1)
-            restart_filename = 'ocn.rst.$Y-$M-$D_$h.$m.$s'
+            restart_filename = 'ocn.rst.$Y-$M-$D_$h.$m.$s.nc'
             restart_freq = int(24 * 3600)
 
         if self.do_restart:

--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -122,7 +122,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -99,7 +99,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/cosine_bell/restart/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/restart/forward.yaml
@@ -24,11 +24,11 @@ Omega:
     RestartRead:
       UsePointerFile: false
       UseStartEnd: {{ not_restart }}
-      Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s
+      Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s.nc
       StartTime: {{ restart_time }}
     RestartWrite:
       UsePointerFile: false
-      Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s
+      Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s.nc
       Freq: 1
       FreqUnits: seconds
     History:

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -130,7 +130,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double
@@ -152,7 +152,7 @@ Omega:
         - TotalVerticalPseudoVelocity
     Highfreq:
       UsePointerFile: false
-      Filename: ocn.hifreq.$Y-$M
+      Filename: ocn.hifreq.$Y-$M.nc
       Mode: write
       IfExists: append
       Precision: single

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -96,7 +96,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/realistic_global/forward.yaml
+++ b/polaris/tasks/ocean/realistic_global/forward.yaml
@@ -152,7 +152,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: restart/ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: restart/ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/seamount/forward.yaml
+++ b/polaris/tasks/ocean/seamount/forward.yaml
@@ -93,7 +93,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/single_column/forward.yaml
+++ b/polaris/tasks/ocean/single_column/forward.yaml
@@ -64,7 +64,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/tests/test_cf_check.py
+++ b/tests/test_cf_check.py
@@ -100,12 +100,15 @@ def _noncompliant(path):
     )
 
 
-def test_resolve_keeps_explicit_files_and_missing_patterns(tmp_path):
+def test_resolve_keeps_explicit_files_and_skips_unmatched_patterns(
+    tmp_path,
+):
     (tmp_path / 'output.nc').touch()
     filenames = resolve_cf_check_files(
-        ['output.nc', 'restarts/rst.*.nc', 'output.nc'], str(tmp_path)
+        ['output.nc', 'missing.nc', 'restarts/rst.*.nc', 'output.nc'],
+        str(tmp_path),
     )
-    assert filenames == ['output.nc', 'restarts/rst.*.nc']
+    assert filenames == ['output.nc', 'missing.nc']
 
 
 def test_resolve_checks_only_the_first_file_of_a_series(tmp_path):

--- a/tests/test_cf_check.py
+++ b/tests/test_cf_check.py
@@ -1,0 +1,295 @@
+import logging
+import os
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.cf_check import (
+    CF_TABLES,
+    check_cf_compliance,
+    resolve_cf_check_files,
+)
+from polaris.component import Component
+from polaris.config import PolarisConfigParser
+from polaris.ocean.model.ocean_model_step import OceanModelStep
+from polaris.run.serial import (
+    _cf_check_message,
+    _check_step_cf,
+    _read_cf_status_from_logs,
+    _result_lines,
+)
+from polaris.step import Step
+from polaris.tasks.ocean import Ocean
+
+# minimal versions of the three CF tables, with only what the tests use
+STANDARD_NAMES = """<?xml version="1.0"?>
+<standard_name_table>
+  <version_number>94</version_number>
+  <last_modified>2026-06-09T17:23:36Z</last_modified>
+  <entry id="sea_water_potential_temperature">
+    <canonical_units>K</canonical_units>
+  </entry>
+  <entry id="sea_surface_height_above_geoid">
+    <canonical_units>m</canonical_units>
+  </entry>
+</standard_name_table>
+"""
+
+AREA_TYPES = """<?xml version="1.0"?>
+<area_type_table>
+  <version_number>13</version_number>
+  <date>20 March 2025</date>
+  <entry id="sea"/>
+</area_type_table>
+"""
+
+REGION_NAMES = """<?xml version="1.0"?>
+<standardized_region_list>
+  <version_number>5</version_number>
+  <date>12 November 2024</date>
+  <entry id="global_ocean"/>
+</standardized_region_list>
+"""
+
+
+@pytest.fixture
+def work_dir(tmp_path):
+    """A step work directory with the CF tables in it"""
+    for (_, filename), contents in zip(
+        CF_TABLES, [STANDARD_NAMES, AREA_TYPES, REGION_NAMES], strict=True
+    ):
+        (tmp_path / filename).write_text(contents)
+    return str(tmp_path)
+
+
+def _write(path, variables, conventions='CF-1.8'):
+    """Write a small file whose variables carry the given attributes"""
+    data_vars = {}
+    for name, attrs in variables.items():
+        data_vars[name] = ('nCells', np.zeros(3), attrs)
+    ds = xr.Dataset(data_vars)
+    if conventions is not None:
+        ds.attrs['Conventions'] = conventions
+    ds.to_netcdf(path)
+
+
+def _compliant(path):
+    _write(
+        path,
+        {
+            'temperature': dict(
+                units='degree_C',
+                standard_name='sea_water_potential_temperature',
+                long_name='potential temperature',
+            ),
+            'ssh': dict(units='m', long_name='sea surface height'),
+        },
+    )
+
+
+def _noncompliant(path):
+    _write(
+        path,
+        {
+            'stress': dict(units='N m^{-2}', long_name='surface stress'),
+            'velocity': dict(
+                units='m s-1', standard_name='sea_water_velocity'
+            ),
+        },
+    )
+
+
+def test_resolve_keeps_explicit_files_and_missing_patterns(tmp_path):
+    (tmp_path / 'output.nc').touch()
+    filenames = resolve_cf_check_files(
+        ['output.nc', 'restarts/rst.*.nc', 'output.nc'], str(tmp_path)
+    )
+    assert filenames == ['output.nc', 'restarts/rst.*.nc']
+
+
+def test_resolve_checks_only_the_first_file_of_a_series(tmp_path):
+    restarts = tmp_path / 'restarts'
+    restarts.mkdir()
+    for stamp in ['0001-01-03', '0001-01-01', '0001-01-02']:
+        (restarts / f'rst.{stamp}.nc').touch()
+    filenames = resolve_cf_check_files(['restarts/rst.*.nc'], str(tmp_path))
+    assert filenames == ['restarts/rst.0001-01-01.nc']
+
+
+def test_resolve_keeps_files_outside_the_work_dir_absolute(tmp_path):
+    step_dir = tmp_path / 'step'
+    step_dir.mkdir()
+    outside = tmp_path / 'restarts' / 'rst.0001-01-01.nc'
+    outside.parent.mkdir()
+    outside.touch()
+    pattern = str(tmp_path / 'restarts' / 'rst.*.nc')
+    assert resolve_cf_check_files([pattern], str(step_dir)) == [str(outside)]
+
+
+def test_compliant_file_passes(work_dir):
+    _compliant(os.path.join(work_dir, 'output.nc'))
+    results = check_cf_compliance(['output.nc'], work_dir)
+    assert len(results) == 1
+    result = results[0]
+    assert result['passed']
+    assert result['errors'] == []
+    assert 'output.nc' in result['report']
+
+
+def test_invalid_units_and_standard_name_are_errors(work_dir):
+    _noncompliant(os.path.join(work_dir, 'output.nc'))
+    result = check_cf_compliance(['output.nc'], work_dir)[0]
+    assert not result['passed']
+    assert any(
+        error.startswith('stress:') and 'Invalid units' in error
+        for error in result['errors']
+    )
+    assert any(
+        error.startswith('velocity:') and 'Invalid standard_name' in error
+        for error in result['errors']
+    )
+
+
+def test_missing_conventions_is_only_a_warning(work_dir):
+    path = os.path.join(work_dir, 'output.nc')
+    _write(
+        path,
+        {'ssh': dict(units='m', long_name='sea surface height')},
+        conventions=None,
+    )
+    result = check_cf_compliance(['output.nc'], work_dir)[0]
+    assert result['passed']
+    assert result['warnings'] > 0
+
+
+def test_missing_file_fails(work_dir):
+    result = check_cf_compliance(['missing.nc'], work_dir)[0]
+    assert not result['passed']
+    assert result['errors'] == ['file not found']
+
+
+def _step(work_dir):
+    step = Step(component=Component(name='ocean'), name='forward')
+    step.work_dir = work_dir
+    step.logger = logging.getLogger('test_cf_check')
+    return step
+
+
+def test_step_without_check_checks_nothing(work_dir):
+    step = _step(work_dir)
+    assert step.check_cf() == (False, True)
+    step.add_cf_check()
+    assert step.cf_check
+    assert step.check_cf() == (False, True)
+
+
+def test_step_checks_its_files(work_dir):
+    _compliant(os.path.join(work_dir, 'good.nc'))
+    _noncompliant(os.path.join(work_dir, 'bad.nc'))
+    step = _step(work_dir)
+    step.add_cf_check('good.nc')
+    assert step.check_cf() == (True, True)
+    step.add_cf_check('bad.nc')
+    step.add_cf_check('bad.nc')
+    assert step.cf_check_files == ['good.nc', 'bad.nc']
+    assert step.check_cf() == (True, False)
+    assert [r['filename'] for r in step.cf_check_results] == [
+        'good.nc',
+        'bad.nc',
+    ]
+
+
+OMEGA_YAML = """Omega:
+  IOStreams:
+    InitialState:
+      Filename: init.nc
+      Mode: read
+    RestartWrite:
+      Filename: {restarts}/ocn.rst.$Y-$M-$D_$h.$m.$s.nc
+      Mode: write
+    History:
+      Filename: output.nc
+      Mode: write
+"""
+
+
+def _omega_step(work_dir, model):
+    step = OceanModelStep(component=Ocean(), name='forward')
+    step.work_dir = work_dir
+    step.logger = logging.getLogger('test_cf_check')
+    step.yaml = 'omega.yml'
+    step.streams_section = 'IOStreams'
+    config = PolarisConfigParser()
+    config.add_from_package('polaris', 'default.cfg')
+    config.add_from_package('polaris.ocean', 'ocean.cfg')
+    config.set('ocean', 'model', model)
+    step.config = config
+    step.add_cf_check()
+    return step
+
+
+def test_omega_step_checks_the_first_file_of_each_write_stream(work_dir):
+    restarts = os.path.join(work_dir, 'restarts')
+    os.makedirs(restarts)
+    _compliant(os.path.join(work_dir, 'output.nc'))
+    _compliant(os.path.join(restarts, 'ocn.rst.0001-01-02_00.00.00.nc'))
+    _noncompliant(os.path.join(restarts, 'ocn.rst.0001-01-01_00.00.00.nc'))
+    with open(os.path.join(work_dir, 'omega.yml'), 'w') as f:
+        f.write(OMEGA_YAML.format(restarts=restarts))
+    step = _omega_step(work_dir, model='omega')
+    assert step.check_cf() == (True, False)
+    filenames = [r['filename'] for r in step.cf_check_results]
+    assert filenames == [
+        'restarts/ocn.rst.0001-01-01_00.00.00.nc',
+        'output.nc',
+    ]
+
+
+def test_mpas_ocean_step_is_not_checked(work_dir):
+    _noncompliant(os.path.join(work_dir, 'output.nc'))
+    step = _omega_step(work_dir, model='mpas-ocean')
+    assert step.check_cf() == (False, True)
+
+
+def test_check_step_cf_leaves_a_marker(work_dir):
+    _compliant(os.path.join(work_dir, 'good.nc'))
+    _noncompliant(os.path.join(work_dir, 'bad.nc'))
+    step = _step(work_dir)
+    assert _check_step_cf(step, 'forward') is None
+    assert _read_cf_status_from_logs(work_dir) is None
+
+    step.add_cf_check('good.nc')
+    assert _check_step_cf(step, 'forward') is True
+    assert _read_cf_status_from_logs(work_dir) is True
+
+    step.add_cf_check('bad.nc')
+    assert _check_step_cf(step, 'forward') is False
+    assert _read_cf_status_from_logs(work_dir) is False
+    with open(os.path.join(work_dir, 'cf_check_failed.log')) as f:
+        message = f.read()
+    assert 'bad.nc' in message
+    assert 'Invalid units' in message
+    assert 'The following files passed:\n  good.nc' in message
+
+
+def test_cf_check_message_lists_errors_then_passes():
+    results = [
+        dict(filename='good.nc', passed=True, errors=[]),
+        dict(filename='bad.nc', passed=False, errors=['x: bad units']),
+    ]
+    message = _cf_check_message(results, passed=False, step_name='forward')
+    assert message.index('bad.nc') < message.index('good.nc')
+    assert '    x: bad units' in message
+    message = _cf_check_message(results[:1], passed=True, step_name='forward')
+    assert message.startswith('CF check passed for step forward')
+
+
+def test_result_lines_report_cf_failures():
+    assert _result_lines({'total': 2}) == ['- Result: All tests passed']
+    lines = _result_lines({'total': 2, 'cf': ['ocean/task']})
+    assert lines == [
+        '- Result:',
+        '  - CF compliance failures (1 of 2):',
+        '    - `ocean/task`',
+    ]


### PR DESCRIPTION
This PR runs the CF checker (`cfchecks`) on every file Omega writes in a Polaris run, so that non-compliant metadata fails the task that wrote it rather than surfacing months later in analysis. It requires the Omega fixes in E3SM-Project/Omega#546; until those are in, every Omega task fails the check.

The check is a framework capability: a step opts files in with `add_cf_check()`, an `OceanModelStep` running Omega opts in every write stream in its `omega.yml` automatically, and a step gets a `CF compliance` line in the suite summary next to its property checks. The CF tables are pinned by version in `default.cfg` and cached in the input database. MPAS-Ocean output is not checked.

Also in this PR:
* Omega restart and high-frequency filenames get a `.nc` suffix, which CF requires and the checker insists on
* `download()` asks servers for uncompressed responses, since cfconventions.org gzips its tables and the size check and progress bar assumed otherwise

Mesh and `e3sm/init` files are a follow-up, #774.

Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] `Testing` comment in the PR documents testing used to verify the changes

Fixes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
