### PR TITLE
Write tracers in the barotropic channel's Omega output

### DIFF
--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -143,6 +143,7 @@ Omega:
       Contents:
       - AuxiliaryState
       - State
+      - Tracers
       - Eos
       - SshCell
       - VerticalPseudoVelocity


### PR DESCRIPTION
The `barotropic_channel` forward step validates `temperature` in `output.nc`, but the task's Omega `History` stream did not write the `Tracers` group, so every baseline comparison of `ocean/planar/barotropic_channel/short` in the Omega suites failed with `Variable temperature not in .../output.nc`. This PR adds `Tracers` to the stream, as `baroclinic_channel` already does.

Fixes #780.

Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
