### PR TITLE
Make mesh and init files CF compliant

### DIFF
--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -258,6 +258,20 @@ seaice/api
    gallery_filename
 ```
 
+### cf
+
+```{eval-rst}
+.. currentmodule:: polaris.cf
+
+.. autosummary::
+   :toctree: generated/
+
+   add_cf_conventions
+   add_var_attrs
+   drop_inherited_attrs
+   read_var_attrs
+```
+
 ### cf_check
 
 ```{eval-rst}
@@ -351,6 +365,8 @@ seaice/api
 
    info.is_planar
    info.is_spherical
+
+   attrs.add_mesh_var_attrs
 
    planar.compute_planar_hex_nx_ny
 

--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -164,9 +164,11 @@ seaice/api
    Step.add_input_file
    Step.add_output_file
    Step.add_property_check
+   Step.add_cf_check
    Step.add_dependency
    Step.validate_baselines
    Step.check_properties
+   Step.check_cf
    Step.set_shared_config
 ```
 
@@ -254,6 +256,19 @@ seaice/api
 
    generate_site
    gallery_filename
+```
+
+### cf_check
+
+```{eval-rst}
+.. currentmodule:: polaris.cf_check
+
+.. autosummary::
+   :toctree: generated/
+
+   add_cf_tables
+   resolve_cf_check_files
+   check_cf_compliance
 ```
 
 ### config

--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -329,7 +329,9 @@ filename and add the files in an override of
 {py:meth}`polaris.Step.check_cf()` before calling the base-class method.
 {py:class}`polaris.ocean.model.OceanModelStep` does this for Omega: every
 step running Omega checks the first file of each stream in write mode in its
-`omega.yml`.  MPAS-Ocean output is not checked.
+`omega.yml`.  MPAS-Ocean output is not checked.  Omega writes the model
+start time as the origin of the `time` variable's units, and udunits rejects
+a year-0 origin, so a task that starts in year 0 cannot pass the check.
 
 The checker needs the CF standard-name, area-type and region-name tables.
 Their versions are pinned in the `[cf]` section of `default.cfg`, so a table

--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -334,6 +334,22 @@ step running Omega checks the first file of each stream in write mode in its
 start time as the origin of the `time` variable's units, and udunits rejects
 a year-0 origin, so a task that starts in year 0 cannot pass the check.
 
+The files Polaris writes itself are checked too: the meshes,
+vertical-coordinate and initial-condition files from the ocean init steps
+(see {ref}`dev-ocean-framework-cf-metadata`), the spherical base meshes and
+their reconstruction weights, and the culled meshes and remapped topography
+from `e3sm/init`.  A step that writes a netCDF file with xarray or
+`write_netcdf()` makes it pass by calling
+{py:func}`polaris.cf.add_cf_conventions()` on the dataset first, which adds
+`CF-1.8` to its `Conventions` attribute while keeping any other conventions
+listed (the `MPAS` entry from the MPAS-Tools mesh converter), and, for an
+MPAS mesh, {py:func}`polaris.mesh.attrs.add_mesh_var_attrs()`, which fills
+in `units` and `long_name` for the mesh variables that MPAS-Tools writes
+without them.  Both leave what a variable already has alone.  A units string
+must be one udunits parses: the plain CF form (`m s-1`, `N m-2`, `radians`)
+with `1` for a dimensionless quantity, never `unitless`, `dimensionless` or
+`PSU`.
+
 The checker needs the CF standard-name, area-type and region-name tables.
 Their versions are pinned in the `[cf]` section of `default.cfg`, so a table
 update cannot change what a check reports, and each is downloaded once per

--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -301,3 +301,55 @@ error tolerance) in the step's work directory.  The full details of every
 check are also written to `property_check_results.json` and stored in the
 step's `property_check_results` attribute, so that other steps can summarize
 them.
+
+(dev-cf-check)=
+
+# CF compliance checks
+
+A step can have its output files checked for compliance with the
+[CF conventions](https://cfconventions.org/) after it runs, using the
+[CF checker](https://github.com/cedadev/cf-checker) (`cfchecks`).  A file
+passes when the checker reports no errors; warnings and informational
+messages go to the step's log but do not fail the check.  Unlike a property
+check, a failed CF check fails the task, so a suite cannot pass while a
+model writes non-compliant metadata.
+
+To opt in, call {py:meth}`polaris.Step.add_cf_check()` with each file to
+check.  A glob pattern stands for a series of files with the same metadata,
+such as a time series from one output stream, so only its first match is
+checked:
+
+```python
+self.add_cf_check('output.nc')
+self.add_cf_check('restarts/rst.*.nc')
+```
+
+A step that only knows its output files at run time can opt in with no
+filename and add the files in an override of
+{py:meth}`polaris.Step.check_cf()` before calling the base-class method.
+{py:class}`polaris.ocean.model.OceanModelStep` does this for Omega: every
+step running Omega checks the first file of each stream in write mode in its
+`omega.yml`.  MPAS-Ocean output is not checked.
+
+The checker needs the CF standard-name, area-type and region-name tables.
+Their versions are pinned in the `[cf]` section of `default.cfg`, so a table
+update cannot change what a check reports, and each is downloaded once per
+machine into the `cf/tables` database and linked into the step:
+
+```cfg
+# Options for checking netCDF files for CF compliance
+[cf]
+
+# Versions of the CF standard-name, area-type and region-name tables, pinned
+# so that a table update cannot change what a check reports
+standard_name_table_version = 94
+area_type_table_version = 13
+region_name_table_version = 5
+```
+
+The result of the check is written to `cf_check_passed.log` or
+`cf_check_failed.log` (which lists the errors for each failing file) in the
+step's work directory and stored in the step's `cf_check_results` attribute.
+When a suite runs, each step that ran a check gets a `CF compliance` line
+next to its property checks and baseline comparison, and tasks that failed
+the check are listed in the suite's pull-request summary.

--- a/docs/developers_guide/framework/validation.md
+++ b/docs/developers_guide/framework/validation.md
@@ -317,7 +317,8 @@ model writes non-compliant metadata.
 To opt in, call {py:meth}`polaris.Step.add_cf_check()` with each file to
 check.  A glob pattern stands for a series of files with the same metadata,
 such as a time series from one output stream, so only its first match is
-checked:
+checked, and a pattern with no match is skipped as a series that never
+started (a restart stream whose interval is longer than the run):
 
 ```python
 self.add_cf_check('output.nc')

--- a/docs/developers_guide/ocean/api.md
+++ b/docs/developers_guide/ocean/api.md
@@ -764,6 +764,7 @@
    OceanModelStep
    OceanModelStep.setup
    OceanModelStep.check_properties
+   OceanModelStep.check_cf
    OceanModelStep.constrain_resources
    OceanModelStep.compute_cell_count
    OceanModelStep.map_yaml_options

--- a/docs/developers_guide/ocean/framework.md
+++ b/docs/developers_guide/ocean/framework.md
@@ -65,6 +65,37 @@ For standalone conversion of an existing MPAS-Ocean initial-condition file to
 Omega format outside a Polaris task, see
 {ref}`dev-ocean-convert-mpaso-ic-to-omega`.
 
+(dev-ocean-framework-cf-metadata)=
+
+#### CF metadata
+
+Every file these write methods produce passes the CF checker (see
+{ref}`dev-cf-check`), and the files that
+{py:meth}`polaris.ocean.model.OceanIOStep.add_output_files_for_ocean_model_input()`
+declares are checked after the step runs.  The methods take care of the
+metadata themselves, so an init step does not normally need to: they add
+`CF-1.8` to the `Conventions` attribute (keeping the `MPAS` entry the
+MPAS-Tools converter writes) and fill in `units` and `long_name` for any
+mesh variable (from
+[polaris/mesh/attrs.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/mesh/attrs.yaml))
+or vertical-coordinate, state or forcing variable (from
+[polaris/ocean/model/attrs.yaml](https://github.com/E3SM-Project/polaris/blob/main/polaris/ocean/model/attrs.yaml))
+that does not already have them.  `temperature` and `salinity` are labelled
+with the attributes of the model's tracer convention.  An attribute a
+variable already has is kept, except when a variable's attributes are
+identical to another variable's: xarray propagates attributes through
+arithmetic, `where()` and `ones_like()`, so such a variable was derived from
+the other (a `bottomDepth` made from `ones_like(xCell)`) and gets its own
+attributes from the table instead.
+
+A variable a task adds that is not in either table (a task-specific mask or
+forcing field) gets a `long_name` and, unless it is dimensionless or holds
+fields with different units, `units` where the task creates it, in the plain
+form udunits parses (`m s-1`, `N m-2`, `1`).  Add a variable that several
+tasks write to `attrs.yaml` instead.  Set the attributes wholesale (`da.attrs =
+{...}`) rather than one key at a time, so that nothing inherited from the
+variable it was derived from survives.
+
 #### Canonical staged files
 
 The three files that flow through the ocean pipeline — horizontal mesh,

--- a/docs/users_guide/ocean/suites.md
+++ b/docs/users_guide/ocean/suites.md
@@ -72,7 +72,9 @@ ocean/spherical/icos/cosine_bell/restart
 # omega_pr suite
 
 The `omega_pr` suite is designed to test changes in Omega or the affects of
-Polaris changes on Omega results.
+Polaris changes on Omega results.  Every file Omega writes in the suite is
+checked for CF compliance, and a task fails if the checker reports errors
+(see {ref}`dev-cf-check`).
 
 Here are the tests in the suite:
 ```none

--- a/docs/users_guide/ocean/suites.md
+++ b/docs/users_guide/ocean/suites.md
@@ -72,9 +72,10 @@ ocean/spherical/icos/cosine_bell/restart
 # omega_pr suite
 
 The `omega_pr` suite is designed to test changes in Omega or the affects of
-Polaris changes on Omega results.  Every file Omega writes in the suite is
-checked for CF compliance, and a task fails if the checker reports errors
-(see {ref}`dev-cf-check`).
+Polaris changes on Omega results.  Every file Omega writes in the suite, and
+every mesh, vertical-coordinate and initial-condition file Polaris writes for
+it, is checked for CF compliance, and a task fails if the checker reports
+errors (see {ref}`dev-cf-check`).
 
 Here are the tests in the suite:
 ```none

--- a/polaris/cf.py
+++ b/polaris/cf.py
@@ -1,0 +1,110 @@
+"""
+CF metadata for the netCDF files Polaris writes
+"""
+
+import importlib.resources as imp_res
+import re
+from functools import lru_cache
+from typing import Dict, Mapping
+
+import xarray as xr
+from ruamel.yaml import YAML
+
+#: The version of the CF conventions that Polaris writes.  It matches the
+#: version Omega writes and is the newest that the CF checker validates.
+CF_VERSION = '1.8'
+
+# a CF entry in a ``Conventions`` attribute, such as ``CF-1.8``
+_CF_ENTRY = re.compile(r'^CF-\d+\.\d+$')
+
+
+def add_cf_conventions(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Add ``CF-<version>`` to the ``Conventions`` global attribute of a dataset
+    that has no CF entry.  Any other conventions already listed (``MPAS``
+    from the MPAS-Tools mesh converter and cell culler) are kept, since the
+    attribute lists every convention a file follows.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset about to be written
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        A shallow copy of the dataset with the ``Conventions`` attribute set
+    """
+    ds = ds.copy()
+    existing = str(ds.attrs.get('Conventions', ''))
+    entries = [entry for entry in re.split(r'[\s,]+', existing) if entry]
+    if not any(_CF_ENTRY.match(entry) for entry in entries):
+        entries.insert(0, f'CF-{CF_VERSION}')
+    ds.attrs['Conventions'] = ' '.join(entries)
+    return ds
+
+
+def add_var_attrs(
+    ds: xr.Dataset, var_attrs: Mapping[str, Mapping[str, str]]
+) -> xr.Dataset:
+    """
+    Fill in attributes (``units``, ``long_name``, ...) for the variables of
+    a dataset from a table, without changing any attribute a variable
+    already has.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset about to be written
+
+    var_attrs : dict
+        The attributes to add to each variable, keyed by variable name.
+        Variables not in the dataset are ignored.
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        A shallow copy of the dataset with the attributes added
+    """
+    ds = ds.copy()
+    for name, attrs in var_attrs.items():
+        if name not in ds.variables:
+            continue
+        for attr, value in attrs.items():
+            if attr not in ds[name].attrs:
+                ds[name].attrs[attr] = value
+    return ds
+
+
+@lru_cache
+def read_var_attrs(package: str, filename: str) -> Dict[str, Dict[str, str]]:
+    """
+    Read a table of variable attributes from a YAML file in a package.  The
+    file maps each variable name to its attributes:
+
+    .. code-block:: yaml
+
+        xCell:
+          long_name: x coordinate of cell centers
+          units: m
+
+    Parameters
+    ----------
+    package : str
+        The package containing the file, such as ``polaris.mesh``
+
+    filename : str
+        The name of the YAML file
+
+    Returns
+    -------
+    var_attrs : dict
+        The attributes of each variable, keyed by variable name
+    """
+    text = imp_res.files(package).joinpath(filename).read_text()
+    yaml = YAML(typ='safe')
+    var_attrs = yaml.load(text)
+    return {
+        name: {attr: str(value) for attr, value in attrs.items()}
+        for name, attrs in var_attrs.items()
+    }

--- a/polaris/cf.py
+++ b/polaris/cf.py
@@ -5,7 +5,7 @@ CF metadata for the netCDF files Polaris writes
 import importlib.resources as imp_res
 import re
 from functools import lru_cache
-from typing import Dict, Mapping
+from typing import Dict, Iterable, Mapping
 
 import xarray as xr
 from ruamel.yaml import YAML
@@ -33,14 +33,15 @@ def add_cf_conventions(ds: xr.Dataset) -> xr.Dataset:
     Returns
     -------
     ds : xarray.Dataset
-        A shallow copy of the dataset with the ``Conventions`` attribute set
+        A shallow copy of the dataset with the ``Conventions`` attribute set,
+        or the dataset itself if it already names a CF version
     """
-    ds = ds.copy()
     existing = str(ds.attrs.get('Conventions', ''))
     entries = [entry for entry in re.split(r'[\s,]+', existing) if entry]
-    if not any(_CF_ENTRY.match(entry) for entry in entries):
-        entries.insert(0, f'CF-{CF_VERSION}')
-    ds.attrs['Conventions'] = ' '.join(entries)
+    if any(_CF_ENTRY.match(entry) for entry in entries):
+        return ds
+    ds = ds.copy()
+    ds.attrs['Conventions'] = ' '.join([f'CF-{CF_VERSION}'] + entries)
     return ds
 
 
@@ -73,6 +74,46 @@ def add_var_attrs(
         for attr, value in attrs.items():
             if attr not in ds[name].attrs:
                 ds[name].attrs[attr] = value
+    return ds
+
+
+def drop_inherited_attrs(ds: xr.Dataset, names: Iterable[str]) -> xr.Dataset:
+    """
+    Clear the attributes of each named variable whose attributes are
+    identical to another variable's.  xarray propagates attributes through
+    arithmetic, comparisons, ``where()`` and ``ones_like()``, so a variable
+    with exactly another's attributes was derived from it and describes
+    itself as that variable (a ``bottomDepth`` made from ``ones_like(xCell)``
+    calls itself the x coordinate of cell centers).  A label someone wrote
+    for a variable never duplicates another variable's whole attribute set,
+    so those are kept.  Use before :py:func:`add_var_attrs()` to give the
+    cleared variables their own attributes.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset about to be written
+
+    names : iterable of str
+        The variables to consider, typically the ones a table of attributes
+        can describe.  Variables not in the dataset are ignored.
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        A shallow copy of the dataset with the inherited attributes cleared
+    """
+    ds = ds.copy()
+    for name in names:
+        if name not in ds.variables:
+            continue
+        attrs = ds[name].attrs
+        if not attrs:
+            continue
+        for other, var in ds.variables.items():
+            if other != name and var.attrs == attrs:
+                ds[name].attrs = {}
+                break
     return ds
 
 

--- a/polaris/cf_check.py
+++ b/polaris/cf_check.py
@@ -48,8 +48,10 @@ def resolve_cf_check_files(patterns: List[str], work_dir: str) -> List[str]:
     Resolve the file patterns registered for a CF check to the files to
     check.  A pattern with wildcards stands for a series of files with the
     same metadata (a time series from one output stream), so only its first
-    match is checked.  A pattern with no match is kept so the check can
-    report it as missing.
+    match is checked, and a pattern with no match is a series that never
+    started (a restart stream whose interval is longer than the run), so it
+    is skipped.  A plain filename is kept whether or not it exists, so the
+    check can report it as missing.
 
     Parameters
     ----------
@@ -69,8 +71,9 @@ def resolve_cf_check_files(patterns: List[str], work_dir: str) -> List[str]:
         path = os.path.join(work_dir, pattern)
         if glob.has_magic(pattern):
             matches = sorted(glob.glob(path))
-            if matches:
-                path = matches[0]
+            if not matches:
+                continue
+            path = matches[0]
         filename = os.path.relpath(path, work_dir)
         if filename.startswith('..'):
             filename = path

--- a/polaris/cf_check.py
+++ b/polaris/cf_check.py
@@ -1,0 +1,165 @@
+"""
+Check netCDF files for CF compliance with the CF checker (``cfchecker``)
+"""
+
+import glob
+import os
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+
+if TYPE_CHECKING:
+    from polaris.step import Step
+
+# the CF tables the checker needs, as (config option prefix, local filename)
+CF_TABLES: List[Tuple[str, str]] = [
+    ('standard_name_table', 'cf-standard-name-table.xml'),
+    ('area_type_table', 'cf-area-type-table.xml'),
+    ('region_name_table', 'cf-region-name-table.xml'),
+]
+
+
+def add_cf_tables(step: 'Step') -> None:
+    """
+    Add the CF standard-name, area-type and region-name tables as inputs of
+    a step.  They are downloaded at the versions pinned in the ``[cf]``
+    config section into the ``cf/tables`` database, so a table is fetched
+    once per machine rather than once per run.
+
+    Parameters
+    ----------
+    step : polaris.Step
+        The step that will run a CF check
+    """
+    config = step.config
+    for option, filename in CF_TABLES:
+        version = config.get('cf', f'{option}_version')
+        url = config.get('cf', f'{option}_url').format(version=version)
+        base, ext = os.path.splitext(filename)
+        step.add_input_file(
+            filename=filename,
+            target=f'{base}.{version}{ext}',
+            database='tables',
+            database_component='cf',
+            url=url,
+        )
+
+
+def resolve_cf_check_files(patterns: List[str], work_dir: str) -> List[str]:
+    """
+    Resolve the file patterns registered for a CF check to the files to
+    check.  A pattern with wildcards stands for a series of files with the
+    same metadata (a time series from one output stream), so only its first
+    match is checked.  A pattern with no match is kept so the check can
+    report it as missing.
+
+    Parameters
+    ----------
+    patterns : list of str
+        Filenames or glob patterns, relative to ``work_dir`` unless absolute
+
+    work_dir : str
+        The step's work directory
+
+    Returns
+    -------
+    filenames : list of str
+        The files to check, relative to ``work_dir`` where possible
+    """
+    filenames: List[str] = []
+    for pattern in patterns:
+        path = os.path.join(work_dir, pattern)
+        if glob.has_magic(pattern):
+            matches = sorted(glob.glob(path))
+            if matches:
+                path = matches[0]
+        filename = os.path.relpath(path, work_dir)
+        if filename.startswith('..'):
+            filename = path
+        if filename not in filenames:
+            filenames.append(filename)
+    return filenames
+
+
+def check_cf_compliance(
+    filenames: List[str], work_dir: str
+) -> List[Dict[str, Any]]:
+    """
+    Run the CF checker on each file.  A file passes when the checker
+    reports no errors; warnings and informational messages are recorded
+    but do not fail it.
+
+    Parameters
+    ----------
+    filenames : list of str
+        The files to check, relative to ``work_dir`` unless absolute
+
+    work_dir : str
+        The step's work directory, where the CF tables were linked
+
+    Returns
+    -------
+    results : list of dict
+        One entry per file with the keys ``filename``, ``passed``,
+        ``errors`` (a list of strings), ``warnings`` (an int) and
+        ``report`` (the full text of the checker's output)
+    """
+    # cfchecker pulls in cfunits and udunits, which nothing else in the
+    # framework needs, so it is imported only when a check runs
+    from cfchecker.cfchecks import CFChecker, CFVersion, FatalCheckerError
+
+    tables = {
+        option: os.path.join(work_dir, filename)
+        for option, filename in CF_TABLES
+    }
+
+    results: List[Dict[str, Any]] = []
+    for filename in filenames:
+        path = os.path.join(work_dir, filename)
+        if not os.path.exists(path):
+            results.append(
+                dict(
+                    filename=filename,
+                    passed=False,
+                    errors=['file not found'],
+                    warnings=0,
+                    report=f'{filename}: file not found\n',
+                )
+            )
+            continue
+        # a new checker per file, because an auto-detected CF version
+        # sticks to the checker object after its first file
+        checker = CFChecker(
+            cfStandardNamesXML=tables['standard_name_table'],
+            cfAreaTypesXML=tables['area_type_table'],
+            cfRegionNamesXML=tables['region_name_table'],
+            version=CFVersion(),
+            silent=True,
+        )
+        try:
+            checker.checker(path)
+        except FatalCheckerError:
+            pass
+        results.append(_summarize(filename, checker.results))
+    return results
+
+
+def _summarize(filename: str, raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Reduce the checker's nested results to one entry for the file."""
+    errors: List[str] = []
+    warnings = 0
+    lines = [f'{filename}:']
+    sections = [('global', raw['global'])]
+    sections.extend(raw['variables'].items())
+    for name, messages in sections:
+        for message in messages['FATAL'] + messages['ERROR']:
+            errors.append(f'{name}: {message}')
+        warnings += len(messages['WARN'])
+        for category in ('FATAL', 'ERROR', 'WARN', 'INFO'):
+            for message in messages[category]:
+                lines.append(f'  {category} {name}: {message}')
+    return dict(
+        filename=filename,
+        passed=len(errors) == 0,
+        errors=errors,
+        warnings=warnings,
+        report='\n'.join(lines) + '\n',
+    )

--- a/polaris/default.cfg
+++ b/polaris/default.cfg
@@ -43,6 +43,22 @@ format = NETCDF3_64BIT_DATA
 engine = netcdf4
 
 
+# Options for checking netCDF files for CF compliance
+[cf]
+
+# Versions of the CF standard-name, area-type and region-name tables, pinned
+# so that a table update cannot change what a check reports
+standard_name_table_version = 94
+area_type_table_version = 13
+region_name_table_version = 5
+
+# URLs the tables are downloaded from, with {version} replaced by the
+# versions above
+standard_name_table_url = https://cfconventions.org/Data/cf-standard-names/{version}/src/cf-standard-name-table.xml
+area_type_table_url = https://cfconventions.org/Data/area-type-table/{version}/src/area-type-table.xml
+region_name_table_url = https://cfconventions.org/Data/standardized-region-list/standardized-region-list.{version}.xml
+
+
 # Config options related to creating a job script
 [job]
 

--- a/polaris/io.py
+++ b/polaris/io.py
@@ -63,7 +63,11 @@ def download(url, dest_path, config, exceptions=True):  # noqa: C901
         pass
 
     try:
-        response = session.get(url, stream=True)
+        # ask for an uncompressed response so the content length is the
+        # size of the file, which the size check and progress bar assume
+        response = session.get(
+            url, stream=True, headers={'Accept-Encoding': 'identity'}
+        )
         total_size = response.headers.get('content-length')
     except requests.exceptions.RequestException:
         if exceptions:

--- a/polaris/mesh/attrs.py
+++ b/polaris/mesh/attrs.py
@@ -1,0 +1,27 @@
+"""
+Metadata for the variables of an MPAS mesh
+"""
+
+import xarray as xr
+
+from polaris.cf import add_var_attrs, read_var_attrs
+
+
+def add_mesh_var_attrs(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Fill in the ``units`` and ``long_name`` attributes of the MPAS mesh
+    variables in a dataset, for those that do not already have them.  The
+    MPAS-Tools mesh creation, conversion and culling tools write none, so
+    this makes a mesh file self-describing before it is written.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A dataset containing MPAS mesh variables (with MPAS-Ocean names)
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        A shallow copy of the dataset with the attributes added
+    """
+    return add_var_attrs(ds, read_var_attrs('polaris.mesh', 'attrs.yaml'))

--- a/polaris/mesh/attrs.yaml
+++ b/polaris/mesh/attrs.yaml
@@ -1,0 +1,144 @@
+# The units and long_name attributes of MPAS mesh variables, added to a mesh
+# dataset before it is written when a variable does not already have them.
+# Index and connectivity variables have no units.  Units are in the CF plain
+# form that udunits parses (m2, radians s-1, 1 for dimensionless).
+
+# global indices
+indexToCellID:
+  long_name: global index of each cell
+indexToEdgeID:
+  long_name: global index of each edge
+indexToVertexID:
+  long_name: global index of each vertex
+
+# connectivity
+cellsOnCell:
+  long_name: cells that neighbor each cell
+nEdgesOnCell:
+  long_name: number of edges that border each cell
+edgesOnCell:
+  long_name: edges that border each cell
+verticesOnCell:
+  long_name: vertices that border each cell
+cellsOnEdge:
+  long_name: cells that straddle each edge
+edgesOnEdge:
+  long_name: edges that border the cells that straddle each edge
+nEdgesOnEdge:
+  long_name: number of edges that border the cells that straddle each edge
+verticesOnEdge:
+  long_name: vertices that straddle each edge
+cellsOnVertex:
+  long_name: cells that share each vertex
+edgesOnVertex:
+  long_name: edges that share each vertex
+
+# coordinates
+xCell:
+  long_name: x coordinate of cell centers
+  units: m
+yCell:
+  long_name: y coordinate of cell centers
+  units: m
+zCell:
+  long_name: z coordinate of cell centers
+  units: m
+latCell:
+  long_name: latitude of cell centers
+  units: radians
+lonCell:
+  long_name: longitude of cell centers
+  units: radians
+xEdge:
+  long_name: x coordinate of edge midpoints
+  units: m
+yEdge:
+  long_name: y coordinate of edge midpoints
+  units: m
+zEdge:
+  long_name: z coordinate of edge midpoints
+  units: m
+latEdge:
+  long_name: latitude of edge midpoints
+  units: radians
+lonEdge:
+  long_name: longitude of edge midpoints
+  units: radians
+xVertex:
+  long_name: x coordinate of vertices
+  units: m
+yVertex:
+  long_name: y coordinate of vertices
+  units: m
+zVertex:
+  long_name: z coordinate of vertices
+  units: m
+latVertex:
+  long_name: latitude of vertices
+  units: radians
+lonVertex:
+  long_name: longitude of vertices
+  units: radians
+
+# geometry
+areaCell:
+  long_name: area of each cell in the primal mesh
+  units: m2
+areaTriangle:
+  long_name: area of each triangle in the dual mesh
+  units: m2
+kiteAreasOnVertex:
+  long_name: area of the part of each dual cell in each cell on the vertex
+  units: m2
+dvEdge:
+  long_name: distance between the vertices at the ends of each edge
+  units: m
+dcEdge:
+  long_name: distance between the centers of the cells on each edge
+  units: m
+angleEdge:
+  long_name: angle between the normal of each edge and local east
+  units: radians
+weightsOnEdge:
+  long_name: weights for reconstructing tangential velocity from edges on edge
+  units: '1'
+meshDensity:
+  long_name: value of the density function used to generate the mesh
+  units: '1'
+
+# Coriolis
+fCell:
+  long_name: Coriolis parameter at cell centers
+  units: radians s-1
+fEdge:
+  long_name: Coriolis parameter at edges
+  units: radians s-1
+fVertex:
+  long_name: Coriolis parameter at vertices
+  units: radians s-1
+
+# masks
+cullCell:
+  long_name: mask of cells to be removed by the cell culler
+boundaryVertex:
+  long_name: mask of vertices with at least one inactive neighboring cell
+boundaryEdge:
+  long_name: mask of edges with only one active neighboring cell
+boundaryCell:
+  long_name: mask of cells with at least one inactive neighboring cell
+
+# mesh quality from the mesh converter
+cellQuality:
+  long_name: ratio of the shortest to the longest edge of each cell
+  units: '1'
+triangleQuality:
+  long_name: ratio of the shortest to the longest edge of each dual triangle
+  units: '1'
+triangleAngleQuality:
+  long_name: ratio of the smallest to the largest angle of each dual triangle
+  units: '1'
+obtuseTriangle:
+  long_name: mask of dual triangles with an obtuse angle
+gridSpacing:
+  long_name: mean distance from each cell center to its neighbors
+  units: m

--- a/polaris/mesh/reconstruct.py
+++ b/polaris/mesh/reconstruct.py
@@ -847,7 +847,7 @@ def compute_reconstruction_weights(
         weights,
         'weights used to reconstruct a Cartesian vector from '
         'edge-normal values on the reconstruction stencil',
-        units='unitless',
+        units='1',
     )
 
     elapsed = time.perf_counter() - start_time

--- a/polaris/mesh/spherical/__init__.py
+++ b/polaris/mesh/spherical/__init__.py
@@ -14,7 +14,9 @@ from mpas_tools.viz.colormaps import register_sci_viz_colormaps
 from mpas_tools.viz.paraview_extractor import extract_vtk
 
 from polaris import Step
+from polaris.cf import add_cf_conventions
 from polaris.constants import get_constant
+from polaris.mesh.attrs import add_mesh_var_attrs
 from polaris.mesh.reconstruct import (
     compute_reconstruction_weights,
     get_reconstruction_validate_vars,
@@ -124,6 +126,7 @@ class SphericalBaseStep(Step):
         for option, variables in validate_vars.items():
             filename = section.get(option)
             self.add_output_file(filename=filename, validate_vars=variables)
+        self.add_cf_check(section.get('mpas_mesh_filename'))
         if section.getboolean('generate_reconstruction_weights'):
             filename = section.get('reconstruction_weights_filename')
             self.add_output_file(
@@ -132,6 +135,7 @@ class SphericalBaseStep(Step):
                     location='cell'
                 ),
             )
+            self.add_cf_check(filename)
         self.add_output_file(filename='graph.info')
 
     def run(self):
@@ -168,6 +172,7 @@ class SphericalBaseStep(Step):
 
         angle_edge = recompute_angle_edge(ds_mesh)
         ds_mesh.angleEdge.values = angle_edge.values
+        ds_mesh = add_cf_conventions(add_mesh_var_attrs(ds_mesh))
         write_netcdf(ds_mesh, mpas_mesh_filename)
 
         self._check_cell_polygon_quality(ds_mesh=ds_mesh)
@@ -183,7 +188,9 @@ class SphericalBaseStep(Step):
             ds_weights = compute_reconstruction_weights(
                 ds_mesh, location='cell'
             )
-            write_netcdf(ds_weights, reconstruction_weights_filename)
+            write_netcdf(
+                add_cf_conventions(ds_weights), reconstruction_weights_filename
+            )
 
         if section.getboolean('add_mesh_density'):
             logger.info('Add meshDensity into the mesh file')

--- a/polaris/ocean/coriolis.py
+++ b/polaris/ocean/coriolis.py
@@ -220,7 +220,7 @@ def _add_coriolis_attrs(
         {
             'long_name': f'Coriolis parameter at {location}',
             'standard_name': 'coriolis_parameter',
-            'units': 'radians s^-1',
+            'units': 'radians s-1',
         }
     )
     return data_array

--- a/polaris/ocean/eos/teos10.py
+++ b/polaris/ocean/eos/teos10.py
@@ -27,7 +27,7 @@ TRACER_ATTRS = {
         },
         'salinity': {
             'long_name': 'practical salinity',
-            'units': 'PSU',
+            'units': '1',
         },
     },
 }

--- a/polaris/ocean/model/attrs.yaml
+++ b/polaris/ocean/model/attrs.yaml
@@ -1,0 +1,176 @@
+# The units and long_name attributes of the vertical-coordinate, state and
+# forcing variables that ocean init steps write, added before a dataset is
+# written when a variable does not already have them.  Names are MPAS-Ocean
+# names, since the attributes are added before any renaming for Omega, plus
+# the Omega-only fields Polaris adds itself.  Units are in the CF plain form
+# that udunits parses (m s-1, N m-2, 1 for dimensionless); integer masks and
+# indices have no units.
+
+# vertical coordinate
+minLevelCell:
+  long_name: index of the first active layer in each column
+maxLevelCell:
+  long_name: index of the last active layer in each column
+bottomDepth:
+  long_name: depth of the sea floor, positive downward
+  units: m
+bottomDepthObserved:
+  long_name: depth of the sea floor before any alteration for modeling
+  units: m
+vertCoordMovementWeights:
+  long_name: weights distributing sea surface height changes over layers
+  units: '1'
+restingThickness:
+  long_name: layer thickness with the ocean at rest
+  units: m
+layerThickness:
+  long_name: layer thickness
+  units: m
+RefPseudoThickness:
+  long_name: pseudo-thickness of each layer with the ocean at rest
+  units: m
+PseudoThickness:
+  long_name: pseudo-thickness of each layer
+  units: m
+refTopDepth:
+  long_name: reference depth of the top of each layer
+  units: m
+refBottomDepth:
+  long_name: reference depth of the bottom of each layer
+  units: m
+refZMid:
+  long_name: reference elevation of the middle of each layer
+  units: m
+refLayerThickness:
+  long_name: reference thickness of each layer
+  units: m
+refInterfaces:
+  long_name: reference elevation of each layer interface
+  units: m
+zMid:
+  long_name: elevation of the middle of each layer
+  units: m
+zInterface:
+  long_name: elevation of each layer interface
+  units: m
+GeomZMid:
+  long_name: geometric elevation of the middle of each layer
+  units: m
+GeomZInterface:
+  long_name: geometric elevation of each layer interface
+  units: m
+ZTildeMid:
+  long_name: pseudo-height of the middle of each layer
+  units: m
+cellMask:
+  long_name: mask of active cells in each layer
+
+# state
+ssh:
+  long_name: sea surface height
+  units: m
+normalVelocity:
+  long_name: horizontal velocity normal to each edge
+  units: m s-1
+velocityZonal:
+  long_name: zonal velocity
+  units: m s-1
+velocityMeridional:
+  long_name: meridional velocity
+  units: m s-1
+SurfacePressure:
+  long_name: sea surface pressure
+  units: Pa
+density:
+  long_name: in-situ density
+  units: kg m-3
+Density:
+  long_name: in-situ density
+  units: kg m-3
+SpecVol:
+  long_name: specific volume
+  units: m3 kg-1
+pressure:
+  long_name: pressure at the middle of each layer
+  units: Pa
+BottomPressure:
+  long_name: pressure at the sea floor
+  units: Pa
+
+# tracers other than temperature and salinity, whose attributes depend on
+# the tracer convention
+tracer1:
+  long_name: debug tracer 1
+  units: '1'
+tracer2:
+  long_name: debug tracer 2
+  units: '1'
+tracer3:
+  long_name: debug tracer 3
+  units: '1'
+idealAgeTracers:
+  long_name: ideal age tracers
+  units: s
+
+# forcing
+windStressZonal:
+  long_name: zonal wind stress at the sea surface
+  units: N m-2
+windStressMeridional:
+  long_name: meridional wind stress at the sea surface
+  units: N m-2
+atmosphericPressure:
+  long_name: atmospheric pressure at the sea surface
+  units: Pa
+tidalInputMask:
+  long_name: mask of cells where tidal forcing is applied
+  units: '1'
+temperatureSurfaceRestoringValue:
+  long_name: temperature to which the surface layer is restored
+  units: degC
+salinitySurfaceRestoringValue:
+  long_name: salinity to which the surface layer is restored
+  units: '1'
+temperaturePistonVelocity:
+  long_name: piston velocity of surface temperature restoring
+  units: m s-1
+salinityPistonVelocity:
+  long_name: piston velocity of surface salinity restoring
+  units: m s-1
+temperatureInteriorRestoringValue:
+  long_name: temperature to which the interior is restored
+  units: degC
+salinityInteriorRestoringValue:
+  long_name: salinity to which the interior is restored
+  units: '1'
+temperatureInteriorRestoringRate:
+  long_name: rate of interior temperature restoring
+  units: s-1
+salinityInteriorRestoringRate:
+  long_name: rate of interior salinity restoring
+  units: s-1
+
+# land ice
+landIceMask:
+  long_name: mask of cells with land ice
+landIceFloatingMask:
+  long_name: mask of cells with floating land ice
+landIceFraction:
+  long_name: fraction of each cell covered by land ice
+  units: '1'
+landIceFloatingFraction:
+  long_name: fraction of each cell covered by floating land ice
+  units: '1'
+landIcePressure:
+  long_name: pressure at the sea surface due to land ice
+  units: Pa
+landIceDraft:
+  long_name: elevation of the interface between land ice and the ocean
+  units: m
+sshAdjustmentMask:
+  long_name: mask of cells where the sea surface height may be adjusted
+modifyLandIcePressureMask:
+  long_name: mask of cells where the land-ice pressure may be adjusted
+effectiveDensityInLandIce:
+  long_name: effective density of land ice
+  units: kg m-3

--- a/polaris/ocean/model/ocean_io_step.py
+++ b/polaris/ocean/model/ocean_io_step.py
@@ -63,6 +63,9 @@ class OceanIOStep(OceanModelFilesMixin, Step):
         """
         Register output files that will be consumed by the ocean model as
         inputs (horizontal mesh, initial condition, and model-specific files).
+        Each netCDF file is also checked for CF compliance after the step
+        runs (see :py:meth:`polaris.Step.add_cf_check()`), which the
+        component's write methods make it pass by filling in the metadata.
 
         Parameters
         ----------
@@ -100,13 +103,16 @@ class OceanIOStep(OceanModelFilesMixin, Step):
 
         if base_mesh_filename is not None:
             self.add_output_file(filename=base_mesh_filename)
+            self.add_cf_check(base_mesh_filename)
         self.add_output_file(filename=horiz_mesh_filename)
+        self.add_cf_check(horiz_mesh_filename)
         if skip_validation:
             self.add_output_file(filename=init_filename)
         else:
             self.add_output_file(
                 filename=init_filename, validate_class='state'
             )
+        self.add_cf_check(init_filename)
         if model == 'omega':
             if skip_validation:
                 self.add_output_file(filename=vert_coord_filename)
@@ -114,6 +120,7 @@ class OceanIOStep(OceanModelFilesMixin, Step):
                 self.add_output_file(
                     filename=vert_coord_filename, validate_class='vert_coord'
                 )
+            self.add_cf_check(vert_coord_filename)
         if model == 'mpas-ocean' and graph_filename is not None:
             self.add_output_file(filename=graph_filename)
 

--- a/polaris/ocean/model/ocean_model_step.py
+++ b/polaris/ocean/model/ocean_model_step.py
@@ -1,6 +1,7 @@
 import importlib.resources as imp_res
 import json
 import os
+import re
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
@@ -27,6 +28,7 @@ from polaris.ocean.conservation import (
 )
 from polaris.ocean.model.ocean_model_files_mixin import OceanModelFilesMixin
 from polaris.ocean.model.time import get_time_since_start
+from polaris.yaml import PolarisYaml
 
 if TYPE_CHECKING:
     # Keep Ocean as a type-only import. Importing it at runtime pulls
@@ -211,6 +213,8 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
             self.streams_section = 'IOStreams'
             self._read_config_map()
             self.partition_graph = False
+            # every file Omega writes is checked for CF compliance
+            self.add_cf_check()
         elif model == 'mpas-ocean':
             self.config_models = ['ocean', 'mpas-ocean']
             self.make_yaml = False
@@ -497,6 +501,33 @@ class OceanModelStep(OceanModelFilesMixin, ModelStep):
             'config_eos_type': eos_type,
         }
         return replacements
+
+    def check_cf(self):
+        """
+        Check every file Omega wrote for CF compliance: the first file of
+        each write stream in the step's ``omega.yml``, since the files of a
+        stream share their metadata.  MPAS-Ocean output is not checked.
+
+        Returns
+        -------
+        checked : bool
+            Whether any files were checked
+
+        success : bool
+            Whether every checked file was free of errors
+        """
+        if self.config.get('ocean', 'model') == 'omega':
+            yaml = PolarisYaml.read(
+                os.path.join(self.work_dir, self.yaml),
+                streams_section=self.streams_section,
+            )
+            for stream in yaml.streams.values():
+                if stream.get('Mode') != 'write':
+                    continue
+                # Omega's time template in a filename becomes a glob
+                pattern = re.sub(r'\$[YMDhms]', '*', stream['Filename'])
+                self.add_cf_check(pattern)
+        return super().check_cf()
 
     def check_properties(self):
         """

--- a/polaris/run/serial.py
+++ b/polaris/run/serial.py
@@ -91,6 +91,7 @@ def run_tasks(
         total_tasks = len(suite['tasks'])
         exec_fail_tasks: List[str] = []
         diff_fail_tasks: List[str] = []
+        cf_fail_tasks: List[str] = []
         for task_name in suite['tasks']:
             stdout_logger.info(f'{task_name}')
 
@@ -110,6 +111,7 @@ def run_tasks(
                 task_time,
                 exec_failed,
                 diff_failed,
+                cf_failed,
             ) = _log_and_run_task(
                 task,
                 stdout_logger,
@@ -128,6 +130,8 @@ def run_tasks(
                 exec_fail_tasks.append(task_name)
             if diff_failed:
                 diff_fail_tasks.append(task_name)
+            if cf_failed:
+                cf_fail_tasks.append(task_name)
             task_times[task_name] = task_time
 
         suite_time = time.time() - suite_start
@@ -142,6 +146,7 @@ def run_tasks(
                 'total': total_tasks,
                 'failures': exec_fail_tasks,
                 'diffs': diff_fail_tasks,
+                'cf': cf_fail_tasks,
             },
         )
 
@@ -389,10 +394,11 @@ def _log_and_run_task(
         task_logger.info('')
         task_list = ', '.join(task.steps_to_run)
         task_logger.info(f'Running steps: {task_list}')
-        # Default in case execution fails before setting this
+        # Default in case execution fails before setting these
         baselines_passed = None
+        cf_passed = None
         try:
-            baselines_passed = _run_task(task, available_resources)
+            baselines_passed, cf_passed = _run_task(task, available_resources)
             run_status = success_str
             task_pass = True
         except Exception:
@@ -424,6 +430,17 @@ def _log_and_run_task(
                     f'POLARIS BASELINE: '
                     f'{"PASS" if baselines_passed else "FAIL"}'
                 )
+            if cf_passed is not None:
+                if cf_passed:
+                    cf_str = pass_str
+                else:
+                    cf_str = fail_str
+                    result_str = fail_str
+                    success = False
+                stdout_logger.info(f'  CF compliance:    {cf_str}')
+                task_logger.info(
+                    f'POLARIS CF COMPLIANCE: {"PASS" if cf_passed else "FAIL"}'
+                )
 
         else:
             stdout_logger.error(status)
@@ -441,7 +458,8 @@ def _log_and_run_task(
 
     exec_failed = not task_pass
     diff_failed = baselines_passed is False
-    return result_str, success, task_time, exec_failed, diff_failed
+    cf_failed = cf_passed is False
+    return result_str, success, task_time, exec_failed, diff_failed, cf_failed
 
 
 def _read_baseline_status_from_logs(step_work_dir: str) -> Optional[bool]:
@@ -484,6 +502,49 @@ def _read_property_status_from_logs(step_work_dir: str) -> Optional[bool]:
     if os.path.exists(property_check_fail_filename):
         return False
     return None
+
+
+def _read_cf_status_from_logs(step_work_dir: str) -> Optional[bool]:
+    """Get CF check status from existing log markers.
+
+    Returns
+    -------
+    Optional[bool]
+        True if ``cf_check_passed.log`` exists, False if
+        ``cf_check_failed.log`` exists, otherwise None.
+    """
+    if os.path.exists(os.path.join(step_work_dir, 'cf_check_passed.log')):
+        return True
+    if os.path.exists(os.path.join(step_work_dir, 'cf_check_failed.log')):
+        return False
+    return None
+
+
+def _cf_check_message(results, passed: bool, step_name: str) -> str:
+    """Build the contents of the CF check log file.
+
+    The files that passed are listed.  For a failing step, the errors the
+    checker reported for each failing file are listed first.  The full
+    report, including warnings, is in the step's log.
+    """
+    if passed:
+        lines = [f'CF check passed for step {step_name}', '']
+    else:
+        lines = [f'CF check failed for step {step_name}', '']
+        lines.append('The following files had errors:')
+        for result in results:
+            if result['passed']:
+                continue
+            lines.append(f'  {result["filename"]}')
+            for error in result['errors']:
+                lines.append(f'    {error}')
+        lines.append('')
+    passing = [result for result in results if result['passed']]
+    if passing:
+        lines.append('The following files passed:')
+        for result in passing:
+            lines.append(f'  {result["filename"]}')
+    return '\n'.join(lines) + '\n'
 
 
 def _property_check_message(results, passed: bool, step_name: str) -> str:
@@ -541,6 +602,7 @@ def _run_task(task, available_resources):
     cwd = os.getcwd()
     baselines_passed = None
     property_passed = None
+    cf_passed = None
     for step_name in task.steps_to_run:
         step = task.steps[step_name]
         complete_filename = os.path.join(
@@ -571,6 +633,9 @@ def _run_task(task, available_resources):
                 property_passed = _accumulate_baselines(
                     property_passed, property_status
                 )
+            cf_passed = _report_cf_status(
+                task, _read_cf_status_from_logs(step.work_dir), cf_passed
+            )
             continue
         if step.cached:
             _print_to_stdout(task, '          cached')
@@ -643,6 +708,11 @@ def _run_task(task, available_resources):
                     property_passed, properties_passed
                 )
 
+        if step.cf_check:
+            cf_passed = _report_cf_status(
+                task, _check_step_cf(step, step_name), cf_passed
+            )
+
         compared, status = step.validate_baselines()
         if compared:
             if status:
@@ -660,7 +730,50 @@ def _run_task(task, available_resources):
             f'{start_time_color}{step_time_str}{end_color}',
         )
 
-    return baselines_passed
+    return baselines_passed, cf_passed
+
+
+def _check_step_cf(step, step_name) -> Optional[bool]:
+    """
+    Run the step's CF check and leave a ``cf_check_passed.log`` or
+    ``cf_check_failed.log`` marker in its work directory.
+
+    Returns
+    -------
+    Optional[bool]
+        Whether the check passed, or None if the step checked no files
+    """
+    checked, files_passed = step.check_cf()
+    if not checked:
+        return None
+    passed_log = os.path.join(step.work_dir, 'cf_check_passed.log')
+    failed_log = os.path.join(step.work_dir, 'cf_check_failed.log')
+    if files_passed:
+        write_log, remove_log = passed_log, failed_log
+    else:
+        write_log, remove_log = failed_log, passed_log
+    message = _cf_check_message(
+        step.cf_check_results, passed=files_passed, step_name=step_name
+    )
+    with open(write_log, 'w') as f:
+        f.write(message)
+    if os.path.exists(remove_log):
+        os.remove(remove_log)
+    return files_passed
+
+
+def _report_cf_status(
+    task, status: Optional[bool], cf_passed: Optional[bool]
+) -> Optional[bool]:
+    """
+    Print a step's CF compliance line, if it ran a check, and fold its
+    status into the task's aggregate.
+    """
+    if status is None:
+        return cf_passed
+    cf_str = pass_str if status else fail_str
+    _print_to_stdout(task, f'          CF compliance:    {cf_str}')
+    return _accumulate_baselines(cf_passed, status)
 
 
 def _run_step(
@@ -886,28 +999,33 @@ def _write_output_for_pull_request(
 
     # If we have results, summarize them
     if results is not None and isinstance(results, dict):
-        total = int(results.get('total', 0) or 0)
-        failures: List[str] = list(results.get('failures', []) or [])
-        diffs: List[str] = list(results.get('diffs', []) or [])
-
-        if total > 0 and not failures and not diffs:
-            lines.append('- Result: All tests passed')
-        else:
-            lines.append('- Result:')
-            if failures:
-                lines.append(f'  - Failures ({len(failures)} of {total}):')
-                for name in failures:
-                    lines.append(f'    - `{name}`')
-            if diffs:
-                lines.append(f'  - Diffs ({len(diffs)} of {total}):')
-                for name in diffs:
-                    lines.append(f'    - `{name}`')
+        lines.extend(_result_lines(results))
 
     out_path = os.path.join(work_dir, f'{suite_name}_output_for_pr.md')
     print(f'Writing output useful for copy/paste into PRs to:\n  {out_path}')
     with open(out_path, 'w') as out:
         out.write('\n'.join(lines) + '\n')
     print('Done.')
+
+
+def _result_lines(results: dict) -> List[str]:
+    """The result lines of the pull-request summary."""
+    total = int(results.get('total', 0) or 0)
+    categories = [
+        ('Failures', list(results.get('failures', []) or [])),
+        ('Diffs', list(results.get('diffs', []) or [])),
+        ('CF compliance failures', list(results.get('cf', []) or [])),
+    ]
+    if total > 0 and not any(names for _, names in categories):
+        return ['- Result: All tests passed']
+    lines = ['- Result:']
+    for label, names in categories:
+        if not names:
+            continue
+        lines.append(f'  - {label} ({len(names)} of {total}):')
+        for name in names:
+            lines.append(f'    - `{name}`')
+    return lines
 
 
 def _parse_provenance_into(path, labels, target_values):

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -1087,7 +1087,8 @@ class Step:
             The relative path of the file within the step's work directory.
             A glob pattern stands for a series of files with the same
             metadata (a time series from one output stream), so only its
-            first match is checked.  With no filename, the step is only
+            first match is checked, and a pattern with no match is skipped
+            as a series that never started.  With no filename, the step is only
             opted into the check, for subclasses that find their output
             files at run time and add them in :py:meth:`check_cf()`.
         """

--- a/polaris/step.py
+++ b/polaris/step.py
@@ -7,6 +7,11 @@ import warnings
 from mache import MachineInfo
 from mache.permissions import update_permissions
 
+from polaris.cf_check import (
+    add_cf_tables,
+    check_cf_compliance,
+    resolve_cf_check_files,
+)
 from polaris.config import PolarisConfigParser
 from polaris.io import download, symlink
 from polaris.validate import compare_variables
@@ -212,6 +217,19 @@ class Step:
         :py:meth:`check_properties()`, each a dictionary with at least the
         keys ``description``, ``relative_error``, ``tolerance`` and
         ``passed``
+
+    cf_check : bool
+        Whether to check output files for CF compliance after the step
+        runs, set by :py:meth:`add_cf_check()`
+
+    cf_check_files : list of str
+        Files or glob patterns, relative to the step's work directory, to
+        check for CF compliance, added with :py:meth:`add_cf_check()`
+
+    cf_check_results : list of dict
+        The results of the CF checks performed by :py:meth:`check_cf()`,
+        each a dictionary with at least the keys ``filename``, ``passed``,
+        ``errors`` and ``report``
 
     logger : logging.Logger
         A logger for output from the step
@@ -419,6 +437,9 @@ class Step:
         self.validate_vars = dict()
         self.properties_to_check = list()
         self.property_check_results = list()
+        self.cf_check = False
+        self.cf_check_files = list()
+        self.cf_check_results = list()
         self.setup_complete = False
 
         # these will be set before running the step, dummy placeholders for now
@@ -1054,6 +1075,26 @@ class Step:
             )
         )
 
+    def add_cf_check(self, filename=None):
+        """
+        Check an output file for CF compliance after the step runs.  The
+        step fails its CF check if the CF checker reports any errors for the
+        file.
+
+        Parameters
+        ----------
+        filename : str, optional
+            The relative path of the file within the step's work directory.
+            A glob pattern stands for a series of files with the same
+            metadata (a time series from one output stream), so only its
+            first match is checked.  With no filename, the step is only
+            opted into the check, for subclasses that find their output
+            files at run time and add them in :py:meth:`check_cf()`.
+        """
+        self.cf_check = True
+        if filename is not None and filename not in self.cf_check_files:
+            self.cf_check_files.append(filename)
+
     def add_dependency(self, step, name=None):
         """
         Add `step` as a dependency of this step (i.e. this step can't run
@@ -1102,6 +1143,35 @@ class Step:
             Whether all checked properties were within tolerance
         """
         return False, True
+
+    def check_cf(self):
+        """
+        Check the files added with :py:meth:`add_cf_check()` for CF
+        compliance.  Each file's full report from the checker goes to the
+        step's logger, and the results are stored in
+        ``self.cf_check_results``.  Subclasses that find their output files
+        at run time can add to ``self.cf_check_files`` before calling this
+        method.
+
+        Returns
+        -------
+        checked : bool
+            Whether any files were checked
+
+        success : bool
+            Whether every checked file was free of errors
+        """
+        if not self.cf_check or not self.cf_check_files:
+            return False, True
+        filenames = resolve_cf_check_files(self.cf_check_files, self.work_dir)
+        results = check_cf_compliance(filenames, self.work_dir)
+        self.cf_check_results = results
+        logger = self.logger
+        success = True
+        for result in results:
+            logger.info(result['report'])
+            success = success and result['passed']
+        return True, success
 
     def validate_baselines(self):
         """
@@ -1216,6 +1286,9 @@ class Step:
                 self.add_input_file(
                     filename=output, target=target, database='polaris_cache'
                 )
+
+        if self.cf_check:
+            add_cf_tables(self)
 
         inputs = []
         databases_with_downloads = set()

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -901,7 +901,7 @@ class CombineStep(Step):
         for field in ['ice_draft', 'ice_thickness']:
             combined[field] = ds_antarctic[field]
         for field in ['base_elevation', 'ice_draft', 'ice_thickness']:
-            combined[field].attrs['unit'] = 'meters'
+            combined[field].attrs['units'] = 'm'
 
         # Add masks
         for field in ['ice_mask', 'grounded_mask']:

--- a/polaris/tasks/e3sm/init/topo/combine/step.py
+++ b/polaris/tasks/e3sm/init/topo/combine/step.py
@@ -11,6 +11,7 @@ from mpas_tools.logging import check_call
 from pyremap import ProjectionGridDescriptor, get_lat_lon_descriptor
 
 from polaris.archive import extract_zip_member
+from polaris.cf import add_cf_conventions
 from polaris.e3sm.init.topo import format_lat_lon_resolution_name
 from polaris.step import Step
 
@@ -926,6 +927,7 @@ class CombineStep(Step):
             combined[field] = combined[field].where(valid, fill_val)
 
         # Save combined bathy to NetCDF
+        combined = add_cf_conventions(combined)
         _write_netcdf_with_fill_values(combined, netcdf4_filename)
 
         # writing directly in NETCDF3_64BIT_DATA proved prohibitively slow

--- a/polaris/tasks/e3sm/init/topo/cull/cull.py
+++ b/polaris/tasks/e3sm/init/topo/cull/cull.py
@@ -9,6 +9,8 @@ from mpas_tools.mesh.cull import map_culled_to_base
 from pyremap import MpasCellMeshDescriptor
 
 from polaris import Step
+from polaris.cf import add_cf_conventions
+from polaris.mesh.attrs import add_mesh_var_attrs
 from polaris.mesh.reconstruct import (
     compute_reconstruction_weights,
     get_reconstruction_validate_vars,
@@ -84,6 +86,7 @@ class CullMeshStep(Step):
                 filename=f'culled_{prefix}_mesh.nc',
                 validate_vars=MPAS_MESH_VALIDATE_VARS,
             )
+            self.add_cf_check(f'culled_{prefix}_mesh.nc')
             self.add_output_file(
                 filename=f'{prefix}_map_culled_to_base.nc',
                 validate_vars=MAP_CULLED_TO_BASE_VALIDATE_VARS,
@@ -98,6 +101,7 @@ class CullMeshStep(Step):
                         location='cell'
                     ),
                 )
+                self.add_cf_check(f'culled_{prefix}_reconstruction_weights.nc')
 
     def setup(self):
         """
@@ -182,6 +186,7 @@ class CullMeshStep(Step):
         ds_culled_mesh = sort_mesh(ds_culled_mesh)
 
         out_filename = f'culled_{prefix}_mesh.nc'
+        ds_culled_mesh = add_cf_conventions(add_mesh_var_attrs(ds_culled_mesh))
         write_netcdf(ds_culled_mesh, out_filename)
         if prefix in SCRIP_PREFIXES:
             self._create_scrip_file(mesh_filename=out_filename, prefix=prefix)
@@ -208,7 +213,8 @@ class CullMeshStep(Step):
                 ds_culled_mesh, location='cell'
             )
             write_netcdf(
-                ds_weights, f'culled_{prefix}_reconstruction_weights.nc'
+                add_cf_conventions(ds_weights),
+                f'culled_{prefix}_reconstruction_weights.nc',
             )
 
     def _create_scrip_file(self, mesh_filename, prefix):

--- a/polaris/tasks/e3sm/init/topo/remap/remap.py
+++ b/polaris/tasks/e3sm/init/topo/remap/remap.py
@@ -7,6 +7,7 @@ from mpas_tools.logging import check_call
 from pyremap import MpasCellMeshDescriptor
 
 from polaris import Step
+from polaris.cf import add_cf_conventions
 from polaris.io import symlink
 from polaris.tasks.e3sm.init.topo.combine.step import (
     COMBINE_TOPO_VALIDATE_VARS,
@@ -140,6 +141,7 @@ class RemapTopoStep(Step):
             filename='topography_remapped.nc',
             validate_vars=get_remapped_topo_validate_vars(),
         )
+        self.add_cf_check('topography_remapped.nc')
         self.expand_distance = 0.0
         self.expand_factor = 1.0
         self.do_remapping = True
@@ -420,6 +422,6 @@ class RemapTopoStep(Step):
 
             ds_out[var_out].attrs = ds_in[var].attrs
 
-        write_netcdf(ds_out, 'topography_remapped.nc')
+        write_netcdf(add_cf_conventions(ds_out), 'topography_remapped.nc')
 
         logger.info('  Done.')

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -8,7 +8,12 @@ from mpas_tools.io import open_dataset, write_netcdf
 from ruamel.yaml import YAML
 
 from polaris import Component
-from polaris.cf import add_cf_conventions, add_var_attrs, read_var_attrs
+from polaris.cf import (
+    add_cf_conventions,
+    add_var_attrs,
+    drop_inherited_attrs,
+    read_var_attrs,
+)
 from polaris.constants import get_constant
 from polaris.mesh.attrs import add_mesh_var_attrs
 from polaris.mesh.info import is_planar, is_spherical
@@ -505,6 +510,14 @@ class Ocean(Component):
         """
         if self.model is None:
             self.model = config.get('ocean', 'model')
+        target = 'teos-10' if self.model == 'omega' else 'mpas-ocean'
+        # a state variable made from a mesh variable (``ones_like(xCell)``)
+        # inherits its attributes, so clear those while the mesh variables
+        # are still here to compare against
+        ocean_attrs = read_var_attrs('polaris.ocean.model', 'attrs.yaml')
+        ds = drop_inherited_attrs(
+            ds, list(ocean_attrs) + list(TRACER_ATTRS[target])
+        )
         ds = self._convert_tracers_for_model(
             ds,
             config,
@@ -534,7 +547,6 @@ class Ocean(Component):
         # tracers converted above already carry the attributes of the
         # model's convention; label any others with them too, since the
         # conventions only differ for the TEOS-10 equation of state
-        target = 'teos-10' if self.model == 'omega' else 'mpas-ocean'
         ds = add_var_attrs(ds, TRACER_ATTRS[target])
 
         self.write_model_dataset(ds, filename, config, contains_state=True)
@@ -793,13 +805,15 @@ class Ocean(Component):
         Fill in ``units`` and ``long_name`` for the mesh, vertical-coordinate,
         state and forcing variables that do not have them and add the CF
         version to the ``Conventions`` attribute, so that every file the
-        ocean component writes passes the CF checker.  This is done before
+        ocean component writes passes the CF checker.  A variable that
+        inherited another's attributes (``bottomDepth`` made from
+        ``ones_like(xCell)``) gets its own instead.  This is done before
         variables are renamed for Omega, so the tables use MPAS-Ocean names.
         """
+        ocean_attrs = read_var_attrs('polaris.ocean.model', 'attrs.yaml')
+        ds = drop_inherited_attrs(ds, ocean_attrs.keys())
         ds = add_mesh_var_attrs(ds)
-        ds = add_var_attrs(
-            ds, read_var_attrs('polaris.ocean.model', 'attrs.yaml')
-        )
+        ds = add_var_attrs(ds, ocean_attrs)
         return add_cf_conventions(ds)
 
     def _convert_tracers_for_model(

--- a/polaris/tasks/ocean/__init__.py
+++ b/polaris/tasks/ocean/__init__.py
@@ -8,14 +8,16 @@ from mpas_tools.io import open_dataset, write_netcdf
 from ruamel.yaml import YAML
 
 from polaris import Component
+from polaris.cf import add_cf_conventions, add_var_attrs, read_var_attrs
 from polaris.constants import get_constant
+from polaris.mesh.attrs import add_mesh_var_attrs
 from polaris.mesh.info import is_planar, is_spherical
 from polaris.mesh.reconstruct import (
     add_reconstruction_weights_to_dataset,
     cartesian_to_local_geographic,
     tangential_reconstruction,
 )
-from polaris.ocean.eos import convert_tracers
+from polaris.ocean.eos import TRACER_ATTRS, convert_tracers
 from polaris.ocean.init_state import pressure_for_tracer_conversion
 from polaris.ocean.surface_pressure import surface_pressure_from_config
 from polaris.ocean.vertical.diagnostics import (
@@ -246,6 +248,7 @@ class Ocean(Component):
                             )
                             ds[omega_var] = ds[mpas_var] / (spec_vol * RhoSw)
 
+        ds = self._add_cf_metadata(ds)
         ds = self.map_to_native_model_vars(ds)
 
         if contains_state:
@@ -320,6 +323,7 @@ class Ocean(Component):
                 ds = ds.merge(ds_recon)
             else:
                 ds = add_reconstruction_weights_to_dataset(ds, 'cell')
+        ds = self._add_cf_metadata(ds)
         ds = self.map_to_native_model_vars(ds)
         native_vars = self.map_var_list_to_native_model(self.horiz_mesh_vars)
         self._check_vars_present(ds, native_vars, 'write_horiz_mesh_dataset')
@@ -412,11 +416,12 @@ class Ocean(Component):
                 ),
                 dims=['Time', 'nVertLevels', 'nCells'],
                 attrs={
-                    'units': '',
+                    'units': '1',
                     'long_name': 'Vertical coordinate movement weights',
                 },
             )
 
+        ds_vc = self._add_cf_metadata(ds_vc)
         ds_vc = self.map_to_native_model_vars(ds_vc)
         self._check_vars_present(
             ds_vc, native_vars, 'write_vert_coord_dataset'
@@ -525,6 +530,12 @@ class Ocean(Component):
                 ds['SurfacePressure'] = surface_pressure_from_config(
                     config, ds.sizes['nCells']
                 )
+
+        # tracers converted above already carry the attributes of the
+        # model's convention; label any others with them too, since the
+        # conventions only differ for the TEOS-10 equation of state
+        target = 'teos-10' if self.model == 'omega' else 'mpas-ocean'
+        ds = add_var_attrs(ds, TRACER_ATTRS[target])
 
         self.write_model_dataset(ds, filename, config, contains_state=True)
 
@@ -776,6 +787,20 @@ class Ocean(Component):
             ds, out_var_names, ds_mesh
         )
         return ds
+
+    def _add_cf_metadata(self, ds):
+        """
+        Fill in ``units`` and ``long_name`` for the mesh, vertical-coordinate,
+        state and forcing variables that do not have them and add the CF
+        version to the ``Conventions`` attribute, so that every file the
+        ocean component writes passes the CF checker.  This is done before
+        variables are renamed for Omega, so the tables use MPAS-Ocean names.
+        """
+        ds = add_mesh_var_attrs(ds)
+        ds = add_var_attrs(
+            ds, read_var_attrs('polaris.ocean.model', 'attrs.yaml')
+        )
+        return add_cf_conventions(ds)
 
     def _convert_tracers_for_model(
         self, ds, config, tracer_convention, lon, lat, logger

--- a/polaris/tasks/ocean/baroclinic_channel/forward.py
+++ b/polaris/tasks/ocean/baroclinic_channel/forward.py
@@ -278,11 +278,11 @@ class Forward(OceanModelStep):
                 os.path.join(self.work_dir, '..', 'restarts')
             )
             os.makedirs(restart_dir, exist_ok=True)
-            restart_filename = f'{restart_dir}/ocn.rst.$Y-$M-$D_$h.$m.$s'
+            restart_filename = f'{restart_dir}/ocn.rst.$Y-$M-$D_$h.$m.$s.nc'
             restart_freq = int(dt)
         else:
             restart_interval = get_time_interval_string(days=1)
-            restart_filename = 'ocn.rst.$Y-$M-$D_$h.$m.$s'
+            restart_filename = 'ocn.rst.$Y-$M-$D_$h.$m.$s.nc'
             restart_freq = int(24 * 3600)
 
         if self.do_restart:

--- a/polaris/tasks/ocean/barotropic_channel/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_channel/forward.yaml
@@ -122,7 +122,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/barotropic_gyre/forward.yaml
+++ b/polaris/tasks/ocean/barotropic_gyre/forward.yaml
@@ -99,7 +99,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/cosine_bell/restart/forward.yaml
+++ b/polaris/tasks/ocean/cosine_bell/restart/forward.yaml
@@ -24,11 +24,11 @@ Omega:
     RestartRead:
       UsePointerFile: false
       UseStartEnd: {{ not_restart }}
-      Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s
+      Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s.nc
       StartTime: {{ restart_time }}
     RestartWrite:
       UsePointerFile: false
-      Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s
+      Filename: ../restarts/rst.$Y-$M-$D_$h.$m.$s.nc
       Freq: 1
       FreqUnits: seconds
     History:

--- a/polaris/tasks/ocean/horiz_press_grad/init.py
+++ b/polaris/tasks/ocean/horiz_press_grad/init.py
@@ -1,6 +1,5 @@
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
@@ -117,7 +116,7 @@ class Init(PStarInitStep, OceanIOStep):
         cull_cell[ncells - 2 * (nx + 2) : ncells + 1] = 1
         ds_mesh['cullCell'] = xr.DataArray(data=cull_cell, dims=['nCells'])
 
-        write_netcdf(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
             ds_mesh, graphInfoFileName='culled_graph.info', logger=logger

--- a/polaris/tasks/ocean/ice_shelf_2d/init.py
+++ b/polaris/tasks/ocean/ice_shelf_2d/init.py
@@ -150,10 +150,14 @@ class Init(OceanIOStep):
         normal_velocity = normal_velocity.expand_dims(dim='Time', axis=0)
 
         mask_variable = config.get('ssh_adjustment', 'mask_variable')
-        mask = xr.zeros_like(ds_mesh.yCell)
         mask = np.logical_and(ds.maxLevelCell > 0, ds_mesh.yCell < y3).astype(
             float
         )
+        # replace the attributes inherited from maxLevelCell
+        mask.attrs = {
+            'long_name': 'mask of cells where the sea surface height or '
+            'land-ice pressure is adjusted'
+        }
         ds[mask_variable] = mask
 
         ds['normalVelocity'] = normal_velocity

--- a/polaris/tasks/ocean/ice_shelf_2d/init.py
+++ b/polaris/tasks/ocean/ice_shelf_2d/init.py
@@ -1,6 +1,5 @@
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
@@ -72,7 +71,7 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=True
         )
-        write_netcdf(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(
@@ -178,7 +177,9 @@ class Init(OceanIOStep):
         ds_forcing['tidalInputMask'] = xr.where(
             y_cell > (y_max - 0.6 * dc), 1.0, 0.0
         )
-        write_netcdf(ds_forcing, 'init_mode_forcing_data.nc')
+        self.write_model_dataset(
+            ds_forcing, 'init_mode_forcing_data.nc', config
+        )
 
 
 def _compute_land_ice_pressure_from_draft(

--- a/polaris/tasks/ocean/inertial_gravity_wave/init.py
+++ b/polaris/tasks/ocean/inertial_gravity_wave/init.py
@@ -1,6 +1,5 @@
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
@@ -75,7 +74,7 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=False
         )
-        write_netcdf(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(

--- a/polaris/tasks/ocean/internal_wave/init.py
+++ b/polaris/tasks/ocean/internal_wave/init.py
@@ -1,6 +1,5 @@
 import numpy as np
 import xarray as xr
-from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
@@ -68,7 +67,7 @@ class Init(OceanIOStep):
         ds_mesh = make_planar_hex_mesh(
             nx=nx, ny=ny, dc=dc, nonperiodic_x=False, nonperiodic_y=True
         )
-        write_netcdf(ds_mesh, 'base_mesh.nc')
+        self.write_model_dataset(ds_mesh, 'base_mesh.nc', config)
 
         ds_mesh = cull(ds_mesh, logger=logger)
         ds_mesh = convert(

--- a/polaris/tasks/ocean/merry_go_round/forward.yaml
+++ b/polaris/tasks/ocean/merry_go_round/forward.yaml
@@ -130,7 +130,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double
@@ -152,7 +152,7 @@ Omega:
         - TotalVerticalPseudoVelocity
     Highfreq:
       UsePointerFile: false
-      Filename: ocn.hifreq.$Y-$M
+      Filename: ocn.hifreq.$Y-$M.nc
       Mode: write
       IfExists: append
       Precision: single

--- a/polaris/tasks/ocean/overflow/forward.yaml
+++ b/polaris/tasks/ocean/overflow/forward.yaml
@@ -96,7 +96,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/realistic_global/forward.yaml
+++ b/polaris/tasks/ocean/realistic_global/forward.yaml
@@ -152,7 +152,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: restart/ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: restart/ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/seamount/forward.yaml
+++ b/polaris/tasks/ocean/seamount/forward.yaml
@@ -93,7 +93,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/seamount/init_utils.py
+++ b/polaris/tasks/ocean/seamount/init_utils.py
@@ -126,7 +126,7 @@ def compute_tracers(
         )
         temperature.attrs['long_name'] = 'potential temperature'
         salinity.attrs['long_name'] = 'practical salinity'
-        salinity.attrs['units'] = 'PSU'
+        salinity.attrs['units'] = '1'
     elif eos_type == 'teos-10':
         temperature = ct_from_potential_density(density, salinity)
         salinity.attrs['long_name'] = 'absolute salinity'

--- a/polaris/tasks/ocean/single_column/forward.yaml
+++ b/polaris/tasks/ocean/single_column/forward.yaml
@@ -64,7 +64,7 @@ Omega:
     RestartWrite:
       UsePointerFile: true
       PointerFilename: ocn.pointer
-      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s
+      Filename: ocn.restart.$Y-$M-$D_$h.$m.$s.nc
       Mode: write
       IfExists: replace
       Precision: double

--- a/polaris/tasks/ocean/single_column/init.py
+++ b/polaris/tasks/ocean/single_column/init.py
@@ -216,9 +216,14 @@ class Init(OceanIOStep):
             restoring_values = np.zeros((2, ds.sizes['nCells']))
             restoring_values[0, :] = temperature_surface_restoring_value
             restoring_values[1, :] = salinity_surface_restoring_value
+            # the tracers have different units, so the array has none
             ds['TracersMonthlySurfClimoCell'] = xr.DataArray(
                 restoring_values[np.newaxis, :, :],
                 dims=('time', 'NTracers', 'NCells'),
+                attrs={
+                    'long_name': 'surface climatology the tracers are '
+                    'restored toward'
+                },
             )
         self.write_initial_state_dataset(ds, 'init.nc', config)
 

--- a/tests/ocean/eos/test_convert_tracers.py
+++ b/tests/ocean/eos/test_convert_tracers.py
@@ -69,7 +69,7 @@ def test_convert_tracers_to_mpas_ocean_nominal_location():
     assert ds_out.temperature.attrs['long_name'] == 'potential temperature'
     assert ds_out.temperature.attrs['units'] == 'degC'
     assert ds_out.salinity.attrs['long_name'] == 'practical salinity'
-    assert ds_out.salinity.attrs['units'] == 'PSU'
+    assert ds_out.salinity.attrs['units'] == '1'
 
 
 def test_convert_tracers_to_mpas_ocean_per_cell_location():

--- a/tests/ocean/test_init_cf.py
+++ b/tests/ocean/test_init_cf.py
@@ -1,0 +1,90 @@
+"""
+Tests that the mesh, vertical-coordinate and initial-state files an ocean
+init step writes pass the CF checker with no errors and no warnings, for
+both models.  The baroclinic channel init step is run for real on a coarse
+mesh, since the metadata only shows up in the files it writes.
+"""
+
+import logging
+import os
+
+import pytest
+import xarray as xr
+
+from polaris.cf_check import CF_TABLES, check_cf_compliance
+from polaris.config import PolarisConfigParser
+from polaris.tasks.ocean import Ocean
+from polaris.tasks.ocean.baroclinic_channel.init import Init
+from tests.test_cf_check import AREA_TYPES, REGION_NAMES, STANDARD_NAMES
+
+# the files the step declares for the CF check, per model
+CHECKED_FILES = {
+    'mpas-ocean': ['base_mesh.nc', 'culled_mesh.nc', 'init.nc'],
+    'omega': ['base_mesh.nc', 'culled_mesh.nc', 'vert_coord.nc', 'init.nc'],
+}
+
+
+def _make_config(model):
+    config = PolarisConfigParser()
+    config.add_from_package('polaris', 'default.cfg')
+    config.add_from_package('polaris.ocean', 'ocean.cfg')
+    config.add_from_package(
+        'polaris.tasks.ocean.baroclinic_channel', 'baroclinic_channel.cfg'
+    )
+    # the baroclinic channel tasks use a linear equation of state
+    config.add_from_package('polaris.ocean.eos', 'linear.cfg')
+    config.set('ocean', 'model', model)
+    # keep the test cheap; the metadata does not depend on the grid
+    config.set('vertical_grid', 'vert_levels', '3')
+    return config
+
+
+@pytest.fixture(scope='module', params=['mpas-ocean', 'omega'])
+def init_outputs(request, tmp_path_factory):
+    """Run the init step once per model and return the model name and the
+    directory the step wrote its files to, with the CF tables in it"""
+    model = request.param
+
+    component = Ocean()
+    component.model = model
+    component._read_variables_yaml()
+    if model == 'omega':
+        component._read_var_map()
+
+    step = Init(component=component, resolution=40.0, indir='init')
+    step.config = _make_config(model)
+    step.logger = logging.getLogger(f'baroclinic_channel_init_{model}')
+
+    workdir = tmp_path_factory.mktemp(f'baroclinic_channel_init_{model}')
+    for (_, filename), contents in zip(
+        CF_TABLES, [STANDARD_NAMES, AREA_TYPES, REGION_NAMES], strict=True
+    ):
+        (workdir / filename).write_text(contents)
+    cwd = os.getcwd()
+    os.chdir(workdir)
+    try:
+        step.run()
+    finally:
+        os.chdir(cwd)
+
+    return model, str(workdir)
+
+
+def test_init_variables_are_labelled_as_themselves(init_outputs):
+    """A state variable made from a mesh variable with ones_like() must not
+    keep the mesh variable's description"""
+    model, workdir = init_outputs
+    with xr.open_dataset(os.path.join(workdir, 'init.nc')) as ds_init:
+        for name, da in ds_init.data_vars.items():
+            long_name = da.attrs['long_name']
+            assert 'coordinates of' not in long_name, f'{name}: {long_name}'
+
+
+def test_init_files_pass_the_cf_check(init_outputs):
+    """No errors, which would fail the step, and no warnings either, so
+    that every variable is described"""
+    model, workdir = init_outputs
+    results = check_cf_compliance(CHECKED_FILES[model], workdir)
+    for result in results:
+        assert result['passed'], result['report']
+        assert result['warnings'] == 0, result['report']

--- a/tests/ocean/test_mesh_init_split.py
+++ b/tests/ocean/test_mesh_init_split.py
@@ -294,7 +294,7 @@ def test_write_initial_state_dataset_converts_tracers_for_mpas_ocean(tmp_path):
     assert_allclose(ds_out.temperature.values, pot_temp)
     assert_allclose(ds_out.salinity.values, prac_sal)
     assert ds_out.temperature.attrs['long_name'] == 'potential temperature'
-    assert ds_out.salinity.attrs['units'] == 'PSU'
+    assert ds_out.salinity.attrs['units'] == '1'
     # the in-memory dataset the step handed over is untouched
     assert_allclose(ds.temperature.values, CT)
     assert_allclose(ds.salinity.values, SA)

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -1,0 +1,109 @@
+import cfunits
+import pytest
+import xarray as xr
+from mpas_tools.planar_hex import make_planar_hex_mesh
+
+from polaris.cf import (
+    CF_VERSION,
+    add_cf_conventions,
+    add_var_attrs,
+    drop_inherited_attrs,
+    read_var_attrs,
+)
+from polaris.mesh.attrs import add_mesh_var_attrs
+
+# the tables of variable attributes Polaris fills in before writing a file
+TABLES = [
+    ('polaris.mesh', 'attrs.yaml'),
+    ('polaris.ocean.model', 'attrs.yaml'),
+]
+
+
+def test_conventions_added_when_missing():
+    ds = add_cf_conventions(xr.Dataset())
+    assert ds.attrs['Conventions'] == f'CF-{CF_VERSION}'
+
+
+def test_conventions_keeps_mpas():
+    """The mesh converter's MPAS entry stays, after the CF one"""
+    ds_in = xr.Dataset(attrs={'Conventions': 'MPAS'})
+    ds = add_cf_conventions(ds_in)
+    assert ds.attrs['Conventions'] == f'CF-{CF_VERSION} MPAS'
+    # the input is not modified
+    assert ds_in.attrs['Conventions'] == 'MPAS'
+
+
+@pytest.mark.parametrize('existing', ['CF-1.6', 'CF-1.6, UGRID-1.0'])
+def test_conventions_with_cf_entry_untouched(existing):
+    ds = add_cf_conventions(xr.Dataset(attrs={'Conventions': existing}))
+    assert ds.attrs['Conventions'] == existing
+
+
+def test_var_attrs_fill_only_what_is_missing():
+    ds_in = xr.Dataset(
+        data_vars=dict(
+            xCell=('nCells', [0.0, 1.0], {'long_name': 'from the tool'}),
+            yCell=('nCells', [0.0, 1.0]),
+        )
+    )
+    table = {
+        'xCell': {'long_name': 'x coordinate', 'units': 'm'},
+        'yCell': {'long_name': 'y coordinate', 'units': 'm'},
+        'zCell': {'long_name': 'z coordinate', 'units': 'm'},
+    }
+    ds = add_var_attrs(ds_in, table)
+    assert ds.xCell.attrs == {'long_name': 'from the tool', 'units': 'm'}
+    assert ds.yCell.attrs == {'long_name': 'y coordinate', 'units': 'm'}
+    assert 'zCell' not in ds
+    # the input is not modified
+    assert ds_in.xCell.attrs == {'long_name': 'from the tool'}
+    assert ds_in.yCell.attrs == {}
+
+
+def test_inherited_attrs_are_dropped():
+    """A variable derived from another with xarray carries that variable's
+    attributes; a variable labelled on its own keeps them"""
+    x_cell = xr.DataArray(
+        [0.0, 1.0], dims='nCells', attrs={'long_name': 'x', 'units': 'm'}
+    )
+    ds_in = xr.Dataset(
+        data_vars=dict(
+            xCell=x_cell,
+            bottomDepth=100.0 * xr.ones_like(x_cell),
+            ssh=('nCells', [0.0, 0.0], {'long_name': 'ssh'}),
+        )
+    )
+    ds = drop_inherited_attrs(ds_in, ['bottomDepth', 'ssh', 'missing'])
+    assert ds.bottomDepth.attrs == {}
+    assert ds.ssh.attrs == {'long_name': 'ssh'}
+    assert ds.xCell.attrs == x_cell.attrs
+    # the input is not modified
+    assert ds_in.bottomDepth.attrs == x_cell.attrs
+
+
+@pytest.mark.parametrize('package,filename', TABLES)
+def test_table_entries_are_valid(package, filename):
+    """Every entry has a long_name and any units are ones udunits parses, so
+    the CF checker will accept them"""
+    var_attrs = read_var_attrs(package, filename)
+    assert len(var_attrs) > 0
+    for name, attrs in var_attrs.items():
+        assert 'long_name' in attrs, name
+        if 'units' in attrs:
+            assert cfunits.Units(attrs['units']).isvalid, (
+                f'{name}: {attrs["units"]}'
+            )
+
+
+def test_planar_hex_mesh_gets_mesh_attrs():
+    """make_planar_hex_mesh() writes no attributes; every variable gets a
+    long_name and every non-integer one gets units"""
+    ds = add_mesh_var_attrs(
+        make_planar_hex_mesh(
+            nx=4, ny=4, dc=1e3, nonperiodic_x=False, nonperiodic_y=True
+        )
+    )
+    for name, da in ds.data_vars.items():
+        assert 'long_name' in da.attrs, name
+        if da.dtype.kind == 'f':
+            assert 'units' in da.attrs, name

--- a/tests/test_cf_check.py
+++ b/tests/test_cf_check.py
@@ -33,6 +33,9 @@ STANDARD_NAMES = """<?xml version="1.0"?>
   <entry id="sea_surface_height_above_geoid">
     <canonical_units>m</canonical_units>
   </entry>
+  <entry id="coriolis_parameter">
+    <canonical_units>s-1</canonical_units>
+  </entry>
 </standard_name_table>
 """
 

--- a/tests/test_cf_check.py
+++ b/tests/test_cf_check.py
@@ -100,12 +100,15 @@ def _noncompliant(path):
     )
 
 
-def test_resolve_keeps_explicit_files_and_missing_patterns(tmp_path):
+def test_resolve_keeps_explicit_files_and_skips_unmatched_patterns(
+    tmp_path,
+):
     (tmp_path / 'output.nc').touch()
     filenames = resolve_cf_check_files(
-        ['output.nc', 'restarts/rst.*.nc', 'output.nc'], str(tmp_path)
+        ['output.nc', 'missing.nc', 'restarts/rst.*.nc', 'output.nc'],
+        str(tmp_path),
     )
-    assert filenames == ['output.nc', 'restarts/rst.*.nc']
+    assert filenames == ['output.nc', 'missing.nc']
 
 
 def test_resolve_checks_only_the_first_file_of_a_series(tmp_path):

--- a/tests/test_cf_check.py
+++ b/tests/test_cf_check.py
@@ -1,0 +1,295 @@
+import logging
+import os
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from polaris.cf_check import (
+    CF_TABLES,
+    check_cf_compliance,
+    resolve_cf_check_files,
+)
+from polaris.component import Component
+from polaris.config import PolarisConfigParser
+from polaris.ocean.model.ocean_model_step import OceanModelStep
+from polaris.run.serial import (
+    _cf_check_message,
+    _check_step_cf,
+    _read_cf_status_from_logs,
+    _result_lines,
+)
+from polaris.step import Step
+from polaris.tasks.ocean import Ocean
+
+# minimal versions of the three CF tables, with only what the tests use
+STANDARD_NAMES = """<?xml version="1.0"?>
+<standard_name_table>
+  <version_number>94</version_number>
+  <last_modified>2026-06-09T17:23:36Z</last_modified>
+  <entry id="sea_water_potential_temperature">
+    <canonical_units>K</canonical_units>
+  </entry>
+  <entry id="sea_surface_height_above_geoid">
+    <canonical_units>m</canonical_units>
+  </entry>
+</standard_name_table>
+"""
+
+AREA_TYPES = """<?xml version="1.0"?>
+<area_type_table>
+  <version_number>13</version_number>
+  <date>20 March 2025</date>
+  <entry id="sea"/>
+</area_type_table>
+"""
+
+REGION_NAMES = """<?xml version="1.0"?>
+<standardized_region_list>
+  <version_number>5</version_number>
+  <date>12 November 2024</date>
+  <entry id="global_ocean"/>
+</standardized_region_list>
+"""
+
+
+@pytest.fixture
+def work_dir(tmp_path):
+    """A step work directory with the CF tables in it"""
+    for (_, filename), contents in zip(
+        CF_TABLES, [STANDARD_NAMES, AREA_TYPES, REGION_NAMES], strict=True
+    ):
+        (tmp_path / filename).write_text(contents)
+    return str(tmp_path)
+
+
+def _write(path, variables, conventions='CF-1.8'):
+    """Write a small file whose variables carry the given attributes"""
+    data_vars = {}
+    for name, attrs in variables.items():
+        data_vars[name] = ('nCells', np.zeros(3), attrs)
+    ds = xr.Dataset(data_vars)
+    if conventions is not None:
+        ds.attrs['Conventions'] = conventions
+    ds.to_netcdf(path)
+
+
+def _compliant(path):
+    _write(
+        path,
+        {
+            'temperature': dict(
+                units='degree_C',
+                standard_name='sea_water_potential_temperature',
+                long_name='potential temperature',
+            ),
+            'ssh': dict(units='m', long_name='sea surface height'),
+        },
+    )
+
+
+def _noncompliant(path):
+    _write(
+        path,
+        {
+            'stress': dict(units='N m^{-2}', long_name='surface stress'),
+            'velocity': dict(
+                units='m s-1', standard_name='sea_water_velocity'
+            ),
+        },
+    )
+
+
+def test_resolve_keeps_explicit_files_and_missing_patterns(tmp_path):
+    (tmp_path / 'output.nc').touch()
+    filenames = resolve_cf_check_files(
+        ['output.nc', 'restarts/rst.*.nc', 'output.nc'], str(tmp_path)
+    )
+    assert filenames == ['output.nc', 'restarts/rst.*.nc']
+
+
+def test_resolve_checks_only_the_first_file_of_a_series(tmp_path):
+    restarts = tmp_path / 'restarts'
+    restarts.mkdir()
+    for stamp in ['0001-01-03', '0001-01-01', '0001-01-02']:
+        (restarts / f'rst.{stamp}.nc').touch()
+    filenames = resolve_cf_check_files(['restarts/rst.*.nc'], str(tmp_path))
+    assert filenames == ['restarts/rst.0001-01-01.nc']
+
+
+def test_resolve_keeps_files_outside_the_work_dir_absolute(tmp_path):
+    step_dir = tmp_path / 'step'
+    step_dir.mkdir()
+    outside = tmp_path / 'restarts' / 'rst.0001-01-01.nc'
+    outside.parent.mkdir()
+    outside.touch()
+    pattern = str(tmp_path / 'restarts' / 'rst.*.nc')
+    assert resolve_cf_check_files([pattern], str(step_dir)) == [str(outside)]
+
+
+def test_compliant_file_passes(work_dir):
+    _compliant(os.path.join(work_dir, 'output.nc'))
+    results = check_cf_compliance(['output.nc'], work_dir)
+    assert len(results) == 1
+    result = results[0]
+    assert result['passed']
+    assert result['errors'] == []
+    assert 'output.nc' in result['report']
+
+
+def test_invalid_units_and_standard_name_are_errors(work_dir):
+    _noncompliant(os.path.join(work_dir, 'output.nc'))
+    result = check_cf_compliance(['output.nc'], work_dir)[0]
+    assert not result['passed']
+    assert any(
+        error.startswith('stress:') and 'Invalid units' in error
+        for error in result['errors']
+    )
+    assert any(
+        error.startswith('velocity:') and 'Invalid standard_name' in error
+        for error in result['errors']
+    )
+
+
+def test_missing_conventions_is_only_a_warning(work_dir):
+    path = os.path.join(work_dir, 'output.nc')
+    _write(
+        path,
+        {'ssh': dict(units='m', long_name='sea surface height')},
+        conventions=None,
+    )
+    result = check_cf_compliance(['output.nc'], work_dir)[0]
+    assert result['passed']
+    assert result['warnings'] > 0
+
+
+def test_missing_file_fails(work_dir):
+    result = check_cf_compliance(['missing.nc'], work_dir)[0]
+    assert not result['passed']
+    assert result['errors'] == ['file not found']
+
+
+def _step(work_dir):
+    step = Step(component=Component(name='ocean'), name='forward')
+    step.work_dir = work_dir
+    step.logger = logging.getLogger('test_cf_check')
+    return step
+
+
+def test_step_without_check_checks_nothing(work_dir):
+    step = _step(work_dir)
+    assert step.check_cf() == (False, True)
+    step.add_cf_check()
+    assert step.cf_check
+    assert step.check_cf() == (False, True)
+
+
+def test_step_checks_its_files(work_dir):
+    _compliant(os.path.join(work_dir, 'good.nc'))
+    _noncompliant(os.path.join(work_dir, 'bad.nc'))
+    step = _step(work_dir)
+    step.add_cf_check('good.nc')
+    assert step.check_cf() == (True, True)
+    step.add_cf_check('bad.nc')
+    step.add_cf_check('bad.nc')
+    assert step.cf_check_files == ['good.nc', 'bad.nc']
+    assert step.check_cf() == (True, False)
+    assert [r['filename'] for r in step.cf_check_results] == [
+        'good.nc',
+        'bad.nc',
+    ]
+
+
+OMEGA_YAML = """Omega:
+  IOStreams:
+    InitialState:
+      Filename: init.nc
+      Mode: read
+    RestartWrite:
+      Filename: {restarts}/ocn.rst.$Y-$M-$D_$h.$m.$s.nc
+      Mode: write
+    History:
+      Filename: output.nc
+      Mode: write
+"""
+
+
+def _omega_step(work_dir, model):
+    step = OceanModelStep(component=Ocean(), name='forward')
+    step.work_dir = work_dir
+    step.logger = logging.getLogger('test_cf_check')
+    step.yaml = 'omega.yml'
+    step.streams_section = 'IOStreams'
+    config = PolarisConfigParser()
+    config.add_from_package('polaris', 'default.cfg')
+    config.add_from_package('polaris.ocean', 'ocean.cfg')
+    config.set('ocean', 'model', model)
+    step.config = config
+    step.add_cf_check()
+    return step
+
+
+def test_omega_step_checks_the_first_file_of_each_write_stream(work_dir):
+    restarts = os.path.join(work_dir, 'restarts')
+    os.makedirs(restarts)
+    _compliant(os.path.join(work_dir, 'output.nc'))
+    _compliant(os.path.join(restarts, 'ocn.rst.0001-01-02_00.00.00.nc'))
+    _noncompliant(os.path.join(restarts, 'ocn.rst.0001-01-01_00.00.00.nc'))
+    with open(os.path.join(work_dir, 'omega.yml'), 'w') as f:
+        f.write(OMEGA_YAML.format(restarts=restarts))
+    step = _omega_step(work_dir, model='omega')
+    assert step.check_cf() == (True, False)
+    filenames = [r['filename'] for r in step.cf_check_results]
+    assert filenames == [
+        'restarts/ocn.rst.0001-01-01_00.00.00.nc',
+        'output.nc',
+    ]
+
+
+def test_mpas_ocean_step_is_not_checked(work_dir):
+    _noncompliant(os.path.join(work_dir, 'output.nc'))
+    step = _omega_step(work_dir, model='mpas-ocean')
+    assert step.check_cf() == (False, True)
+
+
+def test_check_step_cf_leaves_a_marker(work_dir):
+    _compliant(os.path.join(work_dir, 'good.nc'))
+    _noncompliant(os.path.join(work_dir, 'bad.nc'))
+    step = _step(work_dir)
+    assert _check_step_cf(step, 'forward') is None
+    assert _read_cf_status_from_logs(work_dir) is None
+
+    step.add_cf_check('good.nc')
+    assert _check_step_cf(step, 'forward') is True
+    assert _read_cf_status_from_logs(work_dir) is True
+
+    step.add_cf_check('bad.nc')
+    assert _check_step_cf(step, 'forward') is False
+    assert _read_cf_status_from_logs(work_dir) is False
+    with open(os.path.join(work_dir, 'cf_check_failed.log')) as f:
+        message = f.read()
+    assert 'bad.nc' in message
+    assert 'Invalid units' in message
+    assert 'The following files passed:\n  good.nc' in message
+
+
+def test_cf_check_message_lists_errors_then_passes():
+    results = [
+        dict(filename='good.nc', passed=True, errors=[]),
+        dict(filename='bad.nc', passed=False, errors=['x: bad units']),
+    ]
+    message = _cf_check_message(results, passed=False, step_name='forward')
+    assert message.index('bad.nc') < message.index('good.nc')
+    assert '    x: bad units' in message
+    message = _cf_check_message(results[:1], passed=True, step_name='forward')
+    assert message.startswith('CF check passed for step forward')
+
+
+def test_result_lines_report_cf_failures():
+    assert _result_lines({'total': 2}) == ['- Result: All tests passed']
+    lines = _result_lines({'total': 2, 'cf': ['ocean/task']})
+    assert lines == [
+        '- Result:',
+        '  - CF compliance failures (1 of 2):',
+        '    - `ocean/task`',
+    ]


### PR DESCRIPTION
This PR makes the mesh, vertical-coordinate and initial-condition files Polaris writes pass the CF checker, and opts them into the check from #776: every file an ocean init step declares with `add_output_files_for_ocean_model_input()`, the spherical base meshes and their reconstruction weights, and the culled meshes and remapped topography from `e3sm/init`. It is based on #776 and should be merged after it.

Reviewer decisions:
* Polaris carries `units` and `long_name` for the MPAS mesh variables (`polaris/mesh/attrs.yaml`) until MPAS-Tools writes them itself (MPAS-Dev/MPAS-Tools#757). The table only fills in what a variable lacks, so an upstream fix takes precedence.
* At write time, a variable whose attributes are identical to another variable's is treated as having inherited them through xarray and gets its own from the table. This is a safety net for #783, not the fix.

Changes:
* `Conventions = "CF-1.8 MPAS"` on every file, keeping the converter's `MPAS` entry
* `units` and `long_name` filled in from two tables in the ocean component's write methods, so no per-task changes; `temperature` and `salinity` labelled with the model's tracer convention
* three units strings udunits rejects replaced (`PSU`, `unitless`, and `unit` as an attribute name), so they do not become errors once `Conventions` is fixed
* four init steps that wrote `base_mesh.nc` with `write_netcdf()` directly now write it through the component
* the `combine` step's topography gets `Conventions` but is not checked, since it cannot be run off a supported machine and a failure at its end would cost hours

Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://e3sm-project.github.io/polaris/main/developers_guide/building_docs.html) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite

Fixes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)
