### PR TITLE
Size a spherical plot's figure to its map

### DIFF
--- a/docs/developers_guide/framework/visualization.md
+++ b/docs/developers_guide/framework/visualization.md
@@ -234,4 +234,5 @@ class Viz(Step):
 ```
 
 The `<task>_viz` of the config file is the same as what's used by
-{py:func}`polaris.viz.plot_global_mpas_field()`.
+{py:func}`polaris.viz.plot_global_mpas_field()`, and the figure is sized to
+the map by `fig_width` or `fig_height` in the same way.

--- a/docs/developers_guide/framework/visualization.md
+++ b/docs/developers_guide/framework/visualization.md
@@ -154,6 +154,13 @@ The `central_longitude` defaults to `0.0` and can be set to another value
 (typically 180 degrees) for visualizing quantities that would otherwise be
 divided across the antimeridian.
 
+The figure is sized to the map.  Give either `fig_width` (the default is 8
+inches) or `fig_height`, and the other dimension is whatever leaves no empty
+canvas around the map once the title, the gridline labels and the colorbar
+have taken their room.  A global map in the `Robinson` projection therefore
+gets a taller figure than one in `PlateCarree`, and a polar map with a
+circular boundary a nearly square one.
+
 The `<task>_viz` section of the config file must contain config options for
 specifying the colormap:
 

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -14,7 +14,6 @@ from matplotlib import colormaps
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 from mpas_tools.io import open_dataset
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from pyremap.descriptor.utility import interp_extrap_corner
 from ruamel.yaml import YAML
 
@@ -153,13 +152,7 @@ def plot_global_mpas_field(
         For reuse with future plots. Patches are cached, so the Descriptor only
         needs to be created once per mesh file.
     """
-    if fig_width is not None and fig_height is not None:
-        raise ValueError(
-            'Give either fig_width or fig_height, not both: the other is '
-            'set by the aspect ratio of the map'
-        )
-    if fig_width is None and fig_height is None:
-        fig_width = 8.0
+    fig_width, fig_height = _check_figure_size(fig_width, fig_height)
 
     with mplstyle_context(dpi=dpi):
         transform = cartopy.crs.Geodetic()
@@ -282,7 +275,8 @@ def plot_global_lat_lon_field(
     title=None,
     plot_land=True,
     colorbar_label=None,
-    figsize=(8, 4.5),
+    fig_width=None,
+    fig_height=None,
 ):
     """
     Plots a data set as a longitude-latitude map
@@ -330,10 +324,18 @@ def plot_global_lat_lon_field(
     colorbar_label : str, optional
         Label on the colorbar
 
-    figsize : tuple, optional
-        The size of the figure in inches.  A size that matches the aspect
-        ratio of the map leaves the least empty canvas around it
+    fig_width : float, optional
+        The width of the figure in inches.  The height is whatever leaves no
+        empty canvas above and below the map, which depends on the extent
+        of the data and the title.  Defaults to 8 if neither ``fig_width``
+        nor ``fig_height`` is given.
+
+    fig_height : float, optional
+        The height of the figure in inches, as an alternative to
+        ``fig_width``.  The width is then whatever leaves no empty canvas to
+        either side of the map and its colorbar.
     """
+    fig_width, fig_height = _check_figure_size(fig_width, fig_height)
 
     with mplstyle_context():
         nlat, nlon = data_array.shape
@@ -357,9 +359,9 @@ def plot_global_lat_lon_field(
                 f'be either {nlat} or {nlat + 1}'
             )
 
-        fig = Figure(figsize=figsize)
-        if title is not None:
-            add_fitted_suptitle(fig, title)
+        # the figure is sized to the map once everything that takes up room
+        # around the map has been drawn
+        fig = Figure(constrained_layout=True)
 
         subplots = [111]
         ref_projection = cartopy.crs.PlateCarree()
@@ -400,23 +402,16 @@ def plot_global_lat_lon_field(
         if plot_land:
             _add_land_lakes_coastline(ax)
 
-        cax = inset_axes(
-            ax,
-            width='3%',
-            height='60%',
-            loc='center right',
-            bbox_to_anchor=(0.08, 0.0, 1, 1),
-            bbox_transform=ax.transAxes,
-            borderpad=0,
+        cbar = fig.colorbar(
+            plotHandle, ax=ax, label=colorbar_label, extend='both', shrink=0.6
         )
-
-        cbar = fig.colorbar(plotHandle, cax=cax, extend='both')
-        cbar.set_label(colorbar_label)
         if ticks is not None:
             cbar.set_ticks(ticks)
             cbar.set_ticklabels([f'{tick}' for tick in ticks])
 
-        fig.savefig(out_filename, bbox_inches='tight', pad_inches=0.2)
+        _fit_figure_to_map(fig, ax, cbar, title, fig_width, fig_height)
+
+        fig.savefig(out_filename)
 
 
 def setup_colormap(config, colormap_section):
@@ -491,6 +486,37 @@ def setup_colormap(config, colormap_section):
         colormap.set_over(over_color)
 
     return colormap, norm, ticks
+
+
+def _check_figure_size(fig_width, fig_height):
+    """
+    Check that only one dimension of a figure is given, and fill in the
+    default width if neither is
+
+    Parameters
+    ----------
+    fig_width : float or None
+        The width of the figure in inches
+
+    fig_height : float or None
+        The height of the figure in inches
+
+    Returns
+    -------
+    fig_width : float or None
+        The width of the figure in inches, 8 if neither dimension was given
+
+    fig_height : float or None
+        The height of the figure in inches
+    """
+    if fig_width is not None and fig_height is not None:
+        raise ValueError(
+            'Give either fig_width or fig_height, not both: the other is '
+            'set by the aspect ratio of the map'
+        )
+    if fig_width is None and fig_height is None:
+        fig_width = 8.0
+    return fig_width, fig_height
 
 
 def _fit_figure_to_map(

--- a/polaris/viz/spherical.py
+++ b/polaris/viz/spherical.py
@@ -11,6 +11,7 @@ import numpy as np
 import xarray as xr
 from cartopy.geodesic import Geodesic
 from matplotlib import colormaps
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 from mpas_tools.io import open_dataset
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
@@ -34,6 +35,12 @@ _CONNECTIVITY_ARRAYS = [
     'edgesOnVertex',
 ]
 
+# the sizing of a figure to its map settles in a few tries, and the layout
+# at each size in a few passes; these are only guards against either never
+# doing so
+_MAX_FIT_ITERATIONS = 10
+_MAX_LAYOUT_PASSES = 10
+
 
 def plot_global_mpas_field(
     da,
@@ -46,7 +53,8 @@ def plot_global_mpas_field(
     plot_land=True,
     colorbar_label='',
     central_longitude=0.0,
-    figsize=(8, 4.5),
+    fig_width=None,
+    fig_height=None,
     patch_edge_color=None,
     descriptor=None,
     projection_name='PlateCarree',
@@ -94,8 +102,16 @@ def plot_global_mpas_field(
     central_longitude : float, optional
         The longitude of the center of the plot
 
-    figsize : tuple, optional
-        The size of the figure in inches
+    fig_width : float, optional
+        The width of the figure in inches.  The height is whatever leaves no
+        empty canvas above and below the map, which depends on the
+        projection, the extent and the title.  Defaults to 8 if neither
+        ``fig_width`` nor ``fig_height`` is given.
+
+    fig_height : float, optional
+        The height of the figure in inches, as an alternative to
+        ``fig_width``.  The width is then whatever leaves no empty canvas to
+        either side of the map and its colorbar.
 
     dpi : int, optional
         Dots per inch for the output plot
@@ -116,9 +132,10 @@ def plot_global_mpas_field(
         Transect dataset produced by mpas_tools which will be traced on the
         global field
 
-    enforce_aspect_ratio : logical, optional
-        Whether to enforce the aspect ratio of the figure according to lat,
-        lon bounds
+    enforce_aspect_ratio : bool, optional
+        Whether to stretch the map so that its height and width are in the
+        ratio of the geodesic distances across the mesh's latitude and
+        longitude bounds
 
     extent : tuple of float, optional
         The ``(lon_min, lon_max, lat_min, lat_max)`` the map covers, in
@@ -136,6 +153,13 @@ def plot_global_mpas_field(
         For reuse with future plots. Patches are cached, so the Descriptor only
         needs to be created once per mesh file.
     """
+    if fig_width is not None and fig_height is not None:
+        raise ValueError(
+            'Give either fig_width or fig_height, not both: the other is '
+            'set by the aspect ratio of the map'
+        )
+    if fig_width is None and fig_height is None:
+        fig_width = 8.0
 
     with mplstyle_context(dpi=dpi):
         transform = cartopy.crs.Geodetic()
@@ -188,16 +212,15 @@ def plot_global_mpas_field(
                 use_latlon=True,
             )
 
-        fig = Figure(figsize=figsize, constrained_layout=True)
+        # the figure is sized to the map once everything that takes up room
+        # around the map has been drawn
+        fig = Figure(constrained_layout=True)
         ax = fig.add_subplot(111, projection=projection)
 
         if extent is not None:
             ax.set_extent(extent, crs=cartopy.crs.PlateCarree())
         if circular_boundary:
             _set_circular_boundary(ax)
-
-        if title is not None:
-            add_fitted_suptitle(fig, title)
 
         colormap, norm, ticks = setup_colormap(config, colormap_section)
 
@@ -232,28 +255,21 @@ def plot_global_mpas_field(
             )
 
         if enforce_aspect_ratio:
-            min_latitude = np.rad2deg(mesh_ds.latCell.min().values)
-            max_latitude = np.rad2deg(mesh_ds.latCell.max().values)
-            min_longitude = np.rad2deg(mesh_ds.lonCell.min().values)
-            max_longitude = np.rad2deg(mesh_ds.lonCell.max().values)
-            geod = Geodesic()
-            x_distance = geod.inverse(
-                [min_longitude, min_latitude], [max_longitude, min_latitude]
-            )[0, 0]
-            y_distance = geod.inverse(
-                [min_longitude, min_latitude], [min_longitude, max_latitude]
-            )[0, 0]
-            ax.set_aspect(y_distance / x_distance)
+            ax.set_aspect(_geodesic_aspect_ratio(descriptor))
 
         if ticks is not None:
             cbar.set_ticks(ticks)
             cbar.set_ticklabels([f'{tick}' for tick in ticks])
+
+        _fit_figure_to_map(fig, ax, cbar, title, fig_width, fig_height)
 
         # Let constrained_layout manage the margins; combining it with
         # bbox_inches='tight' on a fixed-aspect GeoAxes with an
         # attached colorbar can collapse the map axes so only part of
         # the globe is drawn.
         fig.savefig(out_filename)
+
+    return descriptor
 
 
 def plot_global_lat_lon_field(
@@ -475,6 +491,202 @@ def setup_colormap(config, colormap_section):
         colormap.set_over(over_color)
 
     return colormap, norm, ticks
+
+
+def _fit_figure_to_map(
+    fig, ax, cbar, title, fig_width, fig_height, tolerance=0.01
+):
+    """
+    Size a figure so that its map fills it
+
+    A map has a fixed aspect ratio, and the layout engine centers it in
+    whatever room is left once the title, the gridline labels and the
+    colorbar have taken theirs, so a figure of the wrong shape has empty
+    canvas above and below the map or to either side of it.  One dimension
+    is fixed by the caller and the other is chosen here to leave no such
+    room.
+
+    A first guess comes from the map's aspect ratio, widened by the fraction
+    of the figure the colorbar takes.  What that guess cannot know is how
+    much room the layout engine gives the labels and title, since that
+    depends on the font and on the projection, so the figure is then laid
+    out, the room the map did not fill is trimmed, and the process repeated
+    until the size settles.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure, with constrained layout
+
+    ax : cartopy.mpl.geoaxes.GeoAxes
+        The map axes, with everything already plotted on them
+
+    cbar : matplotlib.colorbar.Colorbar
+        The map's colorbar
+
+    title : str or None
+        The figure title, refitted to the figure each time its width changes
+
+    fig_width : float or None
+        The width of the figure in inches, if that is what is fixed
+
+    fig_height : float or None
+        The height of the figure in inches, if that is what is fixed
+
+    tolerance : float, optional
+        The room the map may leave empty in the free dimension, in inches
+    """
+    # measuring the layout needs a canvas that can produce a renderer; a
+    # bare figure carries one that cannot, and savefig would attach an Agg
+    # canvas anyway, so attaching it here changes nothing that is drawn
+    if not hasattr(fig.canvas, 'get_renderer'):
+        FigureCanvasAgg(fig)
+
+    # the map's height over its width, in inches; a map's aspect is 'equal'
+    # unless set to a number, and matplotlib stores 'equal' as 1
+    x0, x1 = ax.get_xlim()
+    y0, y1 = ax.get_ylim()
+    map_aspect = float(ax.get_aspect()) * abs(y1 - y0) / abs(x1 - x0)
+
+    # the colorbar is given this fraction of the map's width plus a pad, so
+    # the map gets the rest
+    cbar_info = cbar.ax._colorbar_info
+    map_fraction = 1.0 / (1.0 + cbar_info['fraction'] + cbar_info['pad'])
+
+    fixed_width = fig_width is not None
+    if fixed_width:
+        free = map_fraction * fig_width * map_aspect
+    else:
+        free = fig_height / map_aspect / map_fraction
+
+    # the layout engine reserves room for the gridline labels only where they
+    # overhang the map's layout cell, and a map centered in a cell it does
+    # not fill has its labels inside the cell; anchoring the map to the
+    # corner the labels are on keeps them overhanging
+    ax.set_anchor('SW')
+
+    # a size at which the map falls short of its cell and one at which the
+    # cell falls short of the map bracket the size wanted
+    too_big = None
+    too_small = None
+    for _ in range(_MAX_FIT_ITERATIONS):
+        if fixed_width:
+            fig.set_size_inches(fig_width, free)
+        else:
+            fig.set_size_inches(free, fig_height)
+        if title is not None:
+            add_fitted_suptitle(fig, title)
+        cell_width, cell_height = _settle_layout(fig, ax, tolerance)
+        # how much of the room the layout engine left the map it does not
+        # fill
+        if fixed_width:
+            slack = cell_height - cell_width * map_aspect
+        else:
+            slack = cell_width - cell_height / map_aspect
+        if abs(slack) < tolerance:
+            break
+        if slack > 0.0:
+            too_big = (free, slack)
+        else:
+            too_small = (free, slack)
+        if too_big is None or too_small is None:
+            # the room around the map depends only weakly on its size, so
+            # trimming the slack is nearly right
+            free -= slack
+        else:
+            # the room the layout engine reserves for a label changes
+            # abruptly as the map goes from filling its cell to not, so
+            # trimming the slack can overshoot; between the bracketing sizes
+            # the size is taken where the line through them has no slack
+            (small, small_slack), (big, big_slack) = too_small, too_big
+            free = small - small_slack * (big - small) / (
+                big_slack - small_slack
+            )
+
+
+def _settle_layout(fig, ax, tolerance):
+    """
+    Lay the figure out until the room left for the map stops changing
+
+    The layout is computed from bounding boxes, without drawing the field,
+    which is what takes the time.  Each pass measures the colorbar and the
+    gridline labels where the previous pass put them, and where a label
+    sits on a curved map boundary, where it lands depends on how big the
+    map is, so a single pass does not settle the layout and the pass that
+    ``savefig`` makes would differ from the one measured here.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure, with constrained layout
+
+    ax : cartopy.mpl.geoaxes.GeoAxes
+        The map axes
+
+    tolerance : float
+        The change in the map's cell, in inches, below which the layout has
+        settled
+
+    Returns
+    -------
+    cell_width : float
+        The width of the room left for the map, in inches
+
+    cell_height : float
+        The height of the room left for the map, in inches
+    """
+    layout_engine = fig.get_layout_engine()
+    previous = None
+    for _ in range(_MAX_LAYOUT_PASSES):
+        layout_engine.execute(fig)
+        cell = ax.get_position(original=True)
+        cell_width, cell_height = fig.get_size_inches() * (
+            cell.width,
+            cell.height,
+        )
+        if previous is not None:
+            change = max(
+                abs(cell_width - previous[0]), abs(cell_height - previous[1])
+            )
+            if change < tolerance:
+                break
+        previous = (cell_width, cell_height)
+    return cell_width, cell_height
+
+
+def _geodesic_aspect_ratio(descriptor):
+    """
+    The height over the width of a map of a mesh, taking the distance across
+    its latitude and longitude bounds in each direction as the measure
+
+    Parameters
+    ----------
+    descriptor : mosaic.Descriptor
+        The descriptor of the mesh, whose cell coordinates are in the map
+        projection
+
+    Returns
+    -------
+    aspect_ratio : float
+        The height over the width
+    """
+    # the descriptor keeps only the projected cell coordinates, so they are
+    # taken back to longitude and latitude in degrees
+    lon_lat = cartopy.crs.PlateCarree().transform_points(
+        descriptor.projection,
+        descriptor.ds.xCell.values,
+        descriptor.ds.yCell.values,
+    )
+    min_longitude, min_latitude = lon_lat[:, :2].min(axis=0)
+    max_longitude, max_latitude = lon_lat[:, :2].max(axis=0)
+    geod = Geodesic()
+    x_distance = geod.inverse(
+        [min_longitude, min_latitude], [max_longitude, min_latitude]
+    )[0, 0]
+    y_distance = geod.inverse(
+        [min_longitude, min_latitude], [min_longitude, max_latitude]
+    )[0, 0]
+    return y_distance / x_distance
 
 
 def _set_circular_boundary(ax):

--- a/tests/viz/test_figure_size.py
+++ b/tests/viz/test_figure_size.py
@@ -12,6 +12,7 @@ plots are actually drawn with.
 """
 
 import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from matplotlib.backends.backend_agg import FigureCanvasAgg
@@ -24,6 +25,7 @@ from polaris.viz.helper import get_projection, make_room_for_gridline_labels
 from polaris.viz.spherical import (
     _fit_figure_to_map,
     _set_circular_boundary,
+    plot_global_lat_lon_field,
     plot_global_mpas_field,
 )
 from polaris.viz.style import mplstyle_context
@@ -162,6 +164,55 @@ def test_giving_both_dimensions_is_an_error():
             fig_width=8.0,
             fig_height=4.0,
         )
+    with pytest.raises(ValueError, match='not both'):
+        plot_global_lat_lon_field(
+            lon=None,
+            lat=None,
+            data_array=None,
+            out_filename='unused.png',
+            config=config,
+            colormap_section='viz',
+            fig_width=8.0,
+            fig_height=4.0,
+        )
+
+
+def _colormap_config():
+    config = PolarisConfigParser()
+    config.add_section('viz')
+    config.set('viz', 'colormap_name', 'viridis')
+    config.set('viz', 'norm_type', 'linear')
+    config.set('viz', 'norm_args', '{"vmin": 0.0, "vmax": 0.1}')
+    return config
+
+
+def test_the_lat_lon_plot_is_written_at_the_given_width(tmp_path):
+    """The whole function, without the land features that would have to be
+    downloaded"""
+    lon = np.linspace(-180.0, 180.0, 13)
+    lat = np.linspace(-90.0, 90.0, 7)
+    data_array = np.zeros((lat.shape[0] - 1, lon.shape[0] - 1))
+    out_filename = str(tmp_path / 'plot.png')
+    with mplstyle_context():
+        dpi = plt.rcParams['savefig.dpi']
+
+    plot_global_lat_lon_field(
+        lon,
+        lat,
+        data_array,
+        out_filename,
+        _colormap_config(),
+        'viz',
+        title='a title',
+        plot_land=False,
+        fig_width=2.0,
+    )
+
+    with Image.open(out_filename) as image:
+        assert image.size[0] == round(2.0 * dpi)
+        # a PlateCarree map of the globe is twice as wide as it is tall, so
+        # the figure is a good deal shorter than it is wide
+        assert image.size[1] < round(2.0 * dpi) * 2 / 3
 
 
 def test_the_plot_is_written_at_the_given_width(tmp_path):
@@ -171,13 +222,9 @@ def test_the_plot_is_written_at_the_given_width(tmp_path):
     mesh_filename = str(tmp_path / 'mesh.nc')
     mesh_ds.to_netcdf(mesh_filename)
     da = mesh_ds.latCell
-    config = PolarisConfigParser()
+    config = _colormap_config()
     config.add_section('ocean')
     config.set('ocean', 'model', 'mpas-ocean')
-    config.add_section('viz')
-    config.set('viz', 'colormap_name', 'viridis')
-    config.set('viz', 'norm_type', 'linear')
-    config.set('viz', 'norm_args', '{"vmin": 0.0, "vmax": 0.1}')
     out_filename = str(tmp_path / 'plot.png')
 
     descriptor = plot_global_mpas_field(

--- a/tests/viz/test_figure_size.py
+++ b/tests/viz/test_figure_size.py
@@ -1,0 +1,202 @@
+"""
+Unit tests for sizing a spherical plot's figure to its map.
+
+A map has a fixed aspect ratio, and a figure of the wrong shape has empty
+canvas above and below it or to either side.  These check that the figure
+takes the dimension it is given, that the map fills the other, and that the
+labels, the title and the colorbar all land inside the figure, for a
+rectangular projection, one with a curved boundary and a circular polar map.
+
+They run in the Polaris style, since that is what sets the label size the
+plots are actually drawn with.
+"""
+
+import cartopy.crs as ccrs
+import numpy as np
+import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+from PIL import Image
+from test_cull_mesh_to_cells import _quad_mesh_dataset
+
+from polaris.config import PolarisConfigParser
+from polaris.viz.helper import get_projection, make_room_for_gridline_labels
+from polaris.viz.spherical import (
+    _fit_figure_to_map,
+    _set_circular_boundary,
+    plot_global_mpas_field,
+)
+from polaris.viz.style import mplstyle_context
+
+# a rectangular projection, one with a curved boundary and a polar one, since
+# where cartopy puts a label depends on the boundary
+PROJECTIONS = [
+    ('PlateCarree', None),
+    ('Robinson', None),
+    ('NorthPolarStereo', (-180.0, 180.0, 60.0, 90.0)),
+]
+
+# how much of the figure the map may leave empty in the free dimension; the
+# fit is to a hundredth of an inch, but the layout at the size settled on
+# can differ from the one measured by a little more than that
+EMPTY = 0.05
+
+
+def _figure(projection_name, extent, title, fig_width, fig_height):
+    """Build the figure ``plot_global_mpas_field()`` builds, and size it"""
+    projection = get_projection(projection_name)
+    fig = Figure(constrained_layout=True)
+    FigureCanvasAgg(fig)
+    ax = fig.add_subplot(111, projection=projection)
+    if extent is not None:
+        ax.set_extent(extent, crs=ccrs.PlateCarree())
+        _set_circular_boundary(ax)
+    gl = ax.gridlines(color='gray', linestyle=':', zorder=5, draw_labels=True)
+    gl.right_labels = False
+    gl.top_labels = False
+    make_room_for_gridline_labels(ax)
+
+    lon = np.linspace(-180.0, 180.0, 13)
+    lat = np.linspace(-90.0, 90.0, 7)
+    field = np.zeros((lat.shape[0] - 1, lon.shape[0] - 1))
+    pc = ax.pcolormesh(lon, lat, field, transform=ccrs.PlateCarree(), zorder=1)
+    cbar = fig.colorbar(
+        pc, ax=ax, label='a colorbar label', extend='both', shrink=0.6
+    )
+    _fit_figure_to_map(fig, ax, cbar, title, fig_width, fig_height)
+    # what savefig would do
+    fig.canvas.draw()
+    return fig, ax, cbar, gl
+
+
+def _empty_room(fig, ax):
+    """The width and height of the room around the map that it does not
+    fill, in inches"""
+    width, height = fig.get_size_inches()
+    cell = ax.get_position(original=True)
+    box = ax.get_position(original=False)
+    empty_width = (cell.width - box.width) * width
+    empty_height = (cell.height - box.height) * height
+    return empty_width, empty_height
+
+
+def _cropped_text(fig, ax, cbar, gl):
+    """The gridline labels, colorbar text and title not wholly inside the
+    figure"""
+    renderer = fig.canvas.get_renderer()
+    artists = [artist for artist in gl.label_artists if artist.get_visible()]
+    artists.extend(cbar.ax.get_yticklabels())
+    artists.append(cbar.ax.yaxis.label)
+    if fig._suptitle is not None:
+        artists.append(fig._suptitle)
+    cropped = []
+    for artist in artists:
+        extent = artist.get_window_extent(renderer=renderer)
+        if not fig.bbox.contains(extent.x0, extent.y0) or not (
+            fig.bbox.contains(extent.x1, extent.y1)
+        ):
+            cropped.append(artist.get_text())
+    return cropped
+
+
+@pytest.mark.parametrize('projection_name, extent', PROJECTIONS)
+@pytest.mark.parametrize('title', [None, 'a title'])
+def test_the_map_fills_a_figure_of_a_given_width(
+    projection_name, extent, title
+):
+    with mplstyle_context():
+        fig, ax, cbar, gl = _figure(
+            projection_name, extent, title, fig_width=8.0, fig_height=None
+        )
+        assert fig.get_size_inches()[0] == 8.0
+        empty_width, empty_height = _empty_room(fig, ax)
+        assert empty_height < EMPTY
+        assert empty_width < EMPTY
+        assert _cropped_text(fig, ax, cbar, gl) == []
+
+
+@pytest.mark.parametrize('projection_name, extent', PROJECTIONS)
+@pytest.mark.parametrize('title', [None, 'a title'])
+def test_the_map_fills_a_figure_of_a_given_height(
+    projection_name, extent, title
+):
+    with mplstyle_context():
+        fig, ax, cbar, gl = _figure(
+            projection_name, extent, title, fig_width=None, fig_height=4.0
+        )
+        assert fig.get_size_inches()[1] == 4.0
+        empty_width, empty_height = _empty_room(fig, ax)
+        assert empty_width < EMPTY
+        assert empty_height < EMPTY
+        assert _cropped_text(fig, ax, cbar, gl) == []
+
+
+def test_the_figure_is_taller_for_a_taller_map():
+    """The point of sizing the figure: a map of a different shape gets a
+    figure of a different shape rather than empty canvas"""
+    with mplstyle_context():
+        fig_global, _, _, _ = _figure(
+            'PlateCarree', None, None, fig_width=8.0, fig_height=None
+        )
+        fig_polar, _, _, _ = _figure(
+            'NorthPolarStereo',
+            (-180.0, 180.0, 60.0, 90.0),
+            None,
+            fig_width=8.0,
+            fig_height=None,
+        )
+        assert (
+            fig_polar.get_size_inches()[1]
+            > 1.5 * (fig_global.get_size_inches()[1])
+        )
+
+
+def test_giving_both_dimensions_is_an_error():
+    config = PolarisConfigParser()
+    with pytest.raises(ValueError, match='not both'):
+        plot_global_mpas_field(
+            da=None,
+            out_filename='unused.png',
+            config=config,
+            colormap_section='viz',
+            fig_width=8.0,
+            fig_height=4.0,
+        )
+
+
+def test_the_plot_is_written_at_the_given_width(tmp_path):
+    """The whole function, on a small mesh, without the land features that
+    would have to be downloaded"""
+    mesh_ds = _quad_mesh_dataset(4, 4)
+    mesh_filename = str(tmp_path / 'mesh.nc')
+    mesh_ds.to_netcdf(mesh_filename)
+    da = mesh_ds.latCell
+    config = PolarisConfigParser()
+    config.add_section('ocean')
+    config.set('ocean', 'model', 'mpas-ocean')
+    config.add_section('viz')
+    config.set('viz', 'colormap_name', 'viridis')
+    config.set('viz', 'norm_type', 'linear')
+    config.set('viz', 'norm_args', '{"vmin": 0.0, "vmax": 0.1}')
+    out_filename = str(tmp_path / 'plot.png')
+
+    descriptor = plot_global_mpas_field(
+        da,
+        out_filename,
+        config,
+        'viz',
+        mesh_filename=mesh_filename,
+        title='a title',
+        plot_land=False,
+        dpi=100,
+        fig_width=6.0,
+        extent=(-180.0, 180.0, -90.0, 90.0),
+    )
+
+    with Image.open(out_filename) as image:
+        assert image.size[0] == 600
+        # a PlateCarree map of the globe is twice as wide as it is tall, so
+        # the figure is a good deal shorter than it is wide
+        assert image.size[1] < 400
+    # the descriptor is returned so that it can be reused
+    assert descriptor is not None


### PR DESCRIPTION
`plot_global_mpas_field()` and `plot_global_lat_lon_field()` drew every map on an 8 by 4.5 inch figure, which left empty canvas around any map not of that shape (and the lat/lon function's `bbox_inches='tight'` then made the image whatever size that came to). Both now take `fig_width` or `fig_height` (mutually exclusive, width 8 by default) and size the other dimension so that the map fills the figure once the title, the gridline labels and the colorbar have taken their room. The first guess is the formula from #637 (aspect ratio, widened by the colorbar `fraction`); the layout engine's own margins are then measured and the slack trimmed, without drawing the field, until the size settles.

For reviewers:
* `figsize` is removed rather than deprecated, since nothing in the repo passes it.
* `enforce_aspect_ratio` raised `NameError` whenever a descriptor was passed; it now reads coordinates from the descriptor. It still only makes sense for a regional mesh, as before.
* the lat/lon function's inset colorbar is replaced by one the layout engine places, so its plots now look like the MPAS ones.

Other changes:
* `plot_global_mpas_field()` now returns the descriptor its docstring promised
* new tests in `tests/viz/test_figure_size.py`
* the new arguments are described in the Developer's Guide

Checklist
* [x] Developer's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes
* [x] New tests have been added to a test suite

Fixes #637
Fixes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)
